### PR TITLE
demo(tab) display the delete button when hover on the tab instead of the...

### DIFF
--- a/docs/app/css/tab_demos.css
+++ b/docs/app/css/tab_demos.css
@@ -184,10 +184,22 @@ div.animate-switch-container div.animate-switch {
 }
 
 
-material-tab-label > button {
+material-tab  button {
+    position: absolute;
     display:none;
+    top: 0;
+    right: 0;
+    border: 0;
+    background: transparent none;
+    text-decoration: none;
+    cursor: pointer;
 }
 
-material-tab-label:hover > button {
+material-tab  button:hover {
+    border-radius: 50%;
+    background-color: #ffff68;
+}
+
+material-tab:hover  button {
     display:inline;
 }

--- a/src/components/tabs/demos/demo4/index.html
+++ b/src/components/tabs/demos/demo4/index.html
@@ -22,7 +22,7 @@
                  disabled="tab.disabled && allowDisable && tab.title=='Material'">
             <material-tab-label>
                 {{tab.title}}
-                <button ng-click="removeTab( tab )" style="margin-left: 5px;">X</button>
+                <button ng-click="removeTab( tab )" style="margin-left: 5px;">x</button>
             </material-tab-label>
             {{tab.content}}
         </material-tab>


### PR DESCRIPTION
demo(tab) display the delete button when hover on the tab instead of the label of the tab, and make the delete button look better

https://github.com/angular/material/issues/62, the 4th demo on tab page when mouse over the lable of the tab, it will show the delete button, but it's really not good for 2 reason.
1. when mouse over the gap between close button and lable, it will flash
2. the button break the layout of the tab.

so I make the button shown when mouse over the tab instead of the lable, and make the delete button looks little better, and when hover on the delete button, display a nice rounded yellow circle.
