### PR TITLE
docs(README): Correct wording on dependencies note

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In its current early state, use AngularJS Material Design at your own risk.  API
 
 When [v0.0.1 is released](https://github.com/angular/material/issues?milestone=2&state=open), the project will more usable.  But everything is subject to rapid change until beta is ready.
 
-Nevertheless, if you wish to use AngularJS Material Design, here are the steps (note that the dependencies are and how to use them will change soon):
+Nevertheless, if you wish to use AngularJS Material Design, here are the steps (note that what the dependencies are and how to use them will change soon):
 
 1. `npm install`
 1. `bower install`


### PR DESCRIPTION
It looks like the word "what" was dropped during a recent change, this adds it back in.
