### PR TITLE
fix(material-toolbar): accessibility improvements

### DIFF
--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -15,8 +15,8 @@
   <material-sidenav class="material-sidenav-left material-whiteframe-z3" component-id="left">
 
     <material-toolbar class="material-theme-light">
-        <span>Material Design</span>
-      <h1 class="material-toolbar-tools" ng-click="goHome()">
+      <h1 class="material-toolbar-tools">
+        <a href="#" ng-click="goHome()">Material Design</a>
       </h1>
     </material-toolbar>
 

--- a/src/components/toolbar/_toolbar.scss
+++ b/src/components/toolbar/_toolbar.scss
@@ -39,6 +39,10 @@ material-toolbar {
   h2, h3 {
     font-weight: normal;
   }
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
 
   .material-button {
     font-size: 16px;


### PR DESCRIPTION
To add structure to the page, toolbar components should include heading tags. Previously, `material-toolbar` contained `<span>` elements that did not contribute to the overall page outline. In addition, any items with `ng-click` should be accessible from the keyboard. With these changes, users can apply `ng-click` to an anchor element  in `material-toolbar` and see a visual style consistent with the rest of the docs.
