### PR TITLE
docs(): Make menu-items accessible buttons

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -10,26 +10,32 @@ body {
 }
 
 .menu-item {
-  cursor: pointer;
-  width: 100%;
-  line-height: 40px;
-  color: #333;
-  padding: 0px 28px;
-  margin-top: 0px;
-  z-index: 1;
   background-color: #fff;
+  border-width: 0;
+  cursor: pointer;
+  display: block;
+  color: #333;
+  font-size: inherit;
+  line-height: 40px;
+  margin-top: 0px;
+  outline: none;
+  padding: 0px 28px;
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  width: 100%;
+  z-index: 1;
   -webkit-transition: 0.25s linear;
   -webkit-transition-property: margin, background-color;
   -moz-transition: 0.25s linear;
   -moz-transition-property: margin, background-color;
   transition: 0.25s linear;
   transition-property: margin, background-color;
-  position: relative;
 }
 .menu-item.ng-hide {
   margin-top: -40px;
 }
-.menu-item:hover {
+.menu-item:hover, .menu-item:focus {
   color: #999;
 }
 

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -28,25 +28,25 @@
       <div ng-repeat-end 
         layout="vertical" layout-align="start" layout-fill
         ng-cloak
-        ng-repeat="component in category.components"
-        ng-click="path(component.docs[0].url)">
+        ng-repeat="component in category.components">
 
-        <div class="menu-item menu-main-item"
+        <button class="menu-item menu-main-item"
           style="user-select: none;"
-          ng-class="{active: path().indexOf(component.id) > -1}">
+          ng-class="{active: path().indexOf(component.id) > -1}"
+          ng-click="path(component.docs[0].url)">
           <span ng-bind="component.name" style="user-select: auto;"></span>
           <material-ripple initial-opacity="0.4" opacity-decay-velocity="1.75"></material-ripple>
-        </div>
+        </button>
 
         <div ng-if="component.docs.length > 1">
-          <div class="menu-item menu-sub-item"
+          <button class="menu-item menu-sub-item"
             ng-repeat="doc in component.docs"
             ng-click="goToDoc(doc); $event.stopImmediatePropagation()"
             ng-show="doc.docType !== 'readme' && path().indexOf(component.id) > -1"
             ng-class="{active: path() == doc.url}">
             {{doc.humanName}}
             <material-ripple initial-opacity="0.4" opacity-decay-velocity="1.75"></material-ripple>
-          </div>
+          </button>
         </div>
 
       </div>

--- a/src/base/_structure.scss
+++ b/src/base/_structure.scss
@@ -29,3 +29,7 @@ body {
 .inset {
   padding: 10px;
 }
+
+button {
+  font-family: $font-family;
+}


### PR DESCRIPTION
To make the sidenav accessible from the keyboard and a screen reader, `menu-item`s should use interactive elements instead of `div`s. With these changes, menu-items are now `button` elements; as a result, `ng-click` events can no longer be nested.
