### PR TITLE
fix(docs): make sidebar nav scroll

### DIFF
--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -11,7 +11,7 @@
 </head>
 <body layout="horizontal">
 
-  <material-sidenav class="material-sidenav-left material-whiteframe-z3" component-id="left">
+  <material-sidenav layout="vertical" class="material-sidenav-left material-whiteframe-z3" component-id="left">
 
     <material-toolbar class="material-theme-light material-medium-tall">
       <h1 class="material-toolbar-tools">


### PR DESCRIPTION
Quick fix to allow the docs' navigation to scroll if there isn't enough vertical space for the expanded section.
