### PR TITLE
docs(material-input): update usage

### DIFF
--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -54,8 +54,8 @@ function materialInputGroupDirective() {
  * @usage
  * <hljs lang="html">
  * <material-input-group>
- *   <material-input type="text" ng-model="user.fullName">
- *   <material-input type="text" ng-model="user.email">
+ *   <material-input type="text" ng-model="user.fullName"></material-input>
+ *   <material-input type="text" ng-model="user.email"></material-input>
  * </material-input-group>
  * </hljs>
  */


### PR DESCRIPTION
In [demo site](https://material.angularjs.org/#/material.components.form/directive/materialInput), the usage of `material-input` has some mistake.

Wrong:

``` html
<material-input-group>
  <material-input type="text" ng-model="user.fullName">
  <material-input type="text" ng-model="user.email">
</material-input></material-input></material-input-group>
```

Right:

``` html
<material-input-group>
  <material-input type="text" ng-model="user.fullName"></material-input>
  <material-input type="text" ng-model="user.email"></material-input>
</material-input-group>
```
