### PR TITLE
fix(buttons): separate ngDisabled and disabled attributes

### DIFF
--- a/src/components/buttons/buttons.js
+++ b/src/components/buttons/buttons.js
@@ -64,7 +64,8 @@ function MaterialButtonDirective(ngHrefDirectives) {
       } else {
         innerElement = angular.element('<button>');
         innerElement.attr('type', attr.type);
-        innerElement.attr('disabled', attr.ngDisabled || attr.disabled);
+        innerElement.attr('ng-disabled', attr.ngDisabled);
+        innerElement.attr('disabled', attr.disabled);
         innerElement.attr('form', attr.form);
       }
       innerElement.addClass('material-button-inner');


### PR DESCRIPTION
This way the `disabled` attribute of the inner `<button>` element gets updated in case the outer `<material-button>` element contains an expression in its `ngDisabled` attribute.
