### PR TITLE
Make material-list more accessible

### DIFF
--- a/src/components/list/demo1/index.html
+++ b/src/components/list/demo1/index.html
@@ -6,7 +6,7 @@
 
       <material-item ng-repeat="item in todos">
         <div class="material-tile-left">
-            <img ng-src="{{item.face}}" class="face">
+            <img ng-src="{{item.face}}" class="face" alt="{{item.who}}">
         </div>
         <div class="material-tile-content">
           <h2>{{item.what}}</h2>

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -27,7 +27,9 @@ angular.module('material.components.list', [])
  * <hljs lang="html">
  * <material-list>
  *  <material-item ng-repeat="item in todos">
- *
+ *    <div class="material-tile-left">
+ *      <img ng-src="{{item.face}}" class="face" alt="{{item.who}}">
+ *    </div>
  *    <div class="material-tile-content">
  *      <h2>{{item.what}}</h2>
  *      <h3>{{item.who}}</h3>


### PR DESCRIPTION
By adding the `alt` attribute to images in `material-list`, they are more accessible for users of assistive technologies.

Perhaps we should enforce this requirement with logging in Angular?
