### PR TITLE
WIP:  Accessibility to Material Slider

### DIFF
--- a/src/base/constants.js
+++ b/src/base/constants.js
@@ -4,13 +4,17 @@ var Constant = {
       BUTTON : 'button',
       CHECKBOX : 'checkbox',
       RADIO : 'radio',
-      RADIO_GROUP : 'radiogroup'
+      RADIO_GROUP : 'radiogroup',
+      SLIDER : 'slider'
     },
     PROPERTY : {
       CHECKED : 'aria-checked',
       HIDDEN : 'aria-hidden',
       EXPANDED : 'aria-expanded',
-      LABEL: 'aria-label'
+      LABEL: 'aria-label',
+      VALUE_MIN : 'aria-valuemin',
+      VALUE_NOW : 'aria-valuenow',
+      VALUE_MAX : 'aria-valuemax'
     },
     STATE: {}
   },

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -64,11 +64,13 @@ function materialSliderDirective($window) {
     var rangeEle = input[0];
     var trackEle = angular.element( element[0].querySelector('.material-track') );
 
-    trackEle.append('<div class="material-fill"><div class="material-thumb"></div></div>');
-    var fillEle = trackEle[0].querySelector('.material-fill');
+    trackEle.append('<div class="material-fill"><div class="material-thumb" tabIndex="0" role="slider"></div></div>');
+    var fillEle = trackEle[0].querySelector('.material-fill'),
+        thumbEle = trackEle.find('.material-thumb');
+
+    var settings = rangeSettings(rangeEle);
 
     if(input.attr('step')) {
-      var settings = rangeSettings(rangeEle);
       var tickCount = (settings.max - settings.min) / settings.step;
       var tickMarkersEle = angular.element('<div class="material-tick-markers"></div>');
       for(var i=0; i<tickCount; i++) {
@@ -79,6 +81,9 @@ function materialSliderDirective($window) {
       }
       trackEle.append(tickMarkersEle);
     }
+
+    thumbEle.attr(Constant.ARIA.PROPERTY.VALUE_MIN, settings.min);
+    thumbEle.attr(Constant.ARIA.PROPERTY.VALUE_MAX, settings.max);
 
     input.on('mousedown touchstart', function(e){
       trackEle.addClass(ACTIVE_CSS);
@@ -101,7 +106,7 @@ function materialSliderDirective($window) {
       } else {
         element.removeClass(MIN_VALUE_CSS);
       }
-
+      thumbEle.attr(Constant.ARIA.PROPERTY.VALUE_NOW, Math.round(fillRatio * 100));
     }
 
     scope.$watch( function () { return ngModelCtrl.$viewValue; }, render );


### PR DESCRIPTION
The Material Design slider needs a bit of work to be accessible. In it's current state, the control is not accessible via the keyboard, nor is the state communicated to users of assistive technologies.

About the `slider` role (repurposed from [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role)): this role is used for markup that allows a user to select a value from within a given range. The role is assigned to the "thumb," the control used to change the value–this control should also be part of the page's tab order. As the user interacts with the thumb, Angular must programmatically adjust the slider's `aria-valuenow` (and possibly `aria-valuetext`) attribute to reflect the current value. `aria-valuemin` and `aria-valuemax` should also be set to indicate the possible range for each component.
