### PR TITLE
WIP: Accessible Tabs

### DIFF
--- a/src/base/constants.js
+++ b/src/base/constants.js
@@ -4,19 +4,24 @@ var Constant = {
       BUTTON : 'button',
       CHECKBOX : 'checkbox',
       RADIO : 'radio',
-      RADIO_GROUP : 'radiogroup'
+      RADIO_GROUP : 'radiogroup',
+      TAB_LIST : 'tablist',
+      TAB : 'tab',
+      TAB_PANEL : 'tabpanel'
     },
     PROPERTY : {
       CHECKED : 'aria-checked',
       HIDDEN : 'aria-hidden',
       EXPANDED : 'aria-expanded',
-      LABEL: 'aria-label'
+      LABEL: 'aria-label',
+      SELECTED : 'aria-selected'
     },
     STATE: {}
   },
   KEY_CODE : {
     SPACE: 32,
     LEFT_ARROW : 37,
-    RIGHT_ARROW : 39
+    RIGHT_ARROW : 39,
+    ENTER: 13
   }
 };

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -88,8 +88,13 @@ material-tab {
   text-align: center;
   cursor: pointer;
   min-width: $tabs-tab-width;
+  border: 1px dotted transparent;
 
   @include not-selectable();
+
+  &:focus {
+    border-color: $input-focused-border-color;
+  }
 
   material-tab-label {
     @include flex(1);

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -186,6 +186,8 @@ function TabsDirective($compile, $timeout, $materialEffects, $window, $$rAF) {
         angular.element($window).on('resize', update);
         scope.$on('$materialTabsChanged', update);
 
+        element.attr('role', Constant.ARIA.ROLE.TAB_LIST);
+
         transcludeHeaderItems();
         transcludeContentItems();
 
@@ -637,12 +639,25 @@ function TabDirective( $attrBind ) {
     configureWatchers();
     updateTabContent(scope);
 
+    element.attr('role', Constant.ARIA.ROLE.TAB);
+    // scope.ariaId = tabsController.scope.$id + '_' + scope.$id;
+    element.attr('id', scope.$id);
+    // element.attr('aria-controls', tab_content_area_id);
+
     // Click support for entire <material-tab /> element
     element.on('click', function onRequestSelect() {
       if (!scope.disabled) {
         scope.$apply(function () {
           tabsController.select(scope);
         });
+      }
+    })
+    .on('keydown', function onRequestSelect(event) {
+      if(event.which === Constant.KEY_CODE.LEFT_ARROW) {
+        tabsController.previous(scope);
+      }
+      if(event.which === Constant.KEY_CODE.RIGHT_ARROW) {
+        tabsController.next(scope);
       }
     });
 
@@ -655,12 +670,21 @@ function TabDirective( $attrBind ) {
     /**
      * Auto select the next tab if the current tab is active and
      * has been disabled.
+     *
+     * Set tab index for the current tab (0), with all other tabs
+     * outside of the tab order (-1)
+     *
      */
     function configureWatchers() {
       var unwatch = scope.$watch('disabled', function (isDisabled) {
         if (scope.active && isDisabled) {
           tabsController.next(scope);
         }
+      });
+
+      scope.$watch('active', function (isActive) {
+        element.attr(Constant.ARIA.PROPERTY.SELECTED, isActive);
+        element.attr('tabIndex', isActive === true ? 0 : -1);
       });
 
       scope.$on("$destroy", function () {

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -25,6 +25,13 @@ describe('materialTabs directive', function() {
 
     });
 
+    it('should assign ARIA roles', function(){
+      // TODO: this needs more coverage for material-tab
+      var el = setup();
+
+      expect(el.eq(0).attr('role')).toBe('tablist');
+    });
+
     xit('should pass down "nobar" to hide the <div class="selectionBar">', function()
     {
       var tabs         = setup(''),


### PR DESCRIPTION
To be accessible from a keyboard and screen reader, `material-tabs`, `material-tab` and associated content panels require ARIA attributes and `tabIndex`. The expected keyboard interaction for a tab panel is to navigate to the current tab using the tab key, then to neighboring tabs with the arrow keys. The current tab has `tabIndex="0"` and the inactive tabs have `-1`, so only the current one is in the tab order. For assistive technologies, `aria-selected` is dynamically updated to communicate the currently selected tab to non-visual or low-vision users.

TODO: add `role="tabpanel"` to tab panel content areas and associate them with their corresponding tabs with `aria-labelledby="[tab_id]"` and `aria-owns="[tabpanel_id]"` on the tab.

For more information about accessible tabs: 
- http://www.w3.org/TR/wai-aria/roles#tablist
- http://www.marcozehe.de/2013/02/02/advanced-aria-tip-1-tabs-in-web-apps/
