### PR TITLE
WIP: Accessible Dialog

### DIFF
--- a/src/components/buttons/buttons.js
+++ b/src/components/buttons/buttons.js
@@ -78,8 +78,13 @@ function MaterialButtonDirective(ngHrefDirectives, $expectAria) {
         .append(element.contents());
 
       element
+        .attr('tabIndex', -1)
         .append(innerElement)
         .append('<material-ripple start="center" initial-opacity="0.25" opacity-decay-velocity="0.75"></material-ripple>');
+
+      element.on('focus', function(evt) {
+        innerElement.focus();
+      });
 
       return function postLink(scope, element, attr) {
         $expectAria(element, 'aria-label', element.text());

--- a/src/components/dialog/demo1/my-dialog.tmpl.html
+++ b/src/components/dialog/demo1/my-dialog.tmpl.html
@@ -5,7 +5,7 @@
       <p>Musa species are native to tropical Indomalaya and Australia, and are likely to have been first domesticated in Papua New Guinea. They are grown in at least 107 countries, primarily for their fruit, and to a lesser extent to make fiber, banana wine and banana beer and as ornamental plants.</p>
   </div>
   <div class="dialog-actions" layout="horizontal" layout-align="end">
-    <material-button ng-click="close()">
+    <material-button ng-click="close()" class="dialog-close">
       Okay
     </material-button>
   </div>

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -138,6 +138,7 @@ function MaterialDialogService($timeout, $materialCompiler, $rootElement, $rootS
       var popInTarget = options.targetEvent && options.targetEvent.target && 
         angular.element(options.targetEvent.target);
       var backdrop;
+      var closeButton = element[0].querySelector('.dialog-close');
 
       if (options.hasBackdrop) {
         backdrop = angular.element('<material-backdrop class="opaque ng-enter">');
@@ -150,6 +151,10 @@ function MaterialDialogService($timeout, $materialCompiler, $rootElement, $rootS
         if (options.clickOutsideToClose) {
           element.on('click', dialogClickOutside);
         }
+        if(closeButton !== null){
+          closeButton.focus();
+        }
+
       });
 
       return destroyDialog;


### PR DESCRIPTION
To make `material-dialog` accessible, focus must be handled to guide assistive tech and keyboard users through the interface. When the dialog opens, focus is sent from the "Open a Dialog" button to the "Okay" / close button. When the dialog closes, focus should be sent back to the original target element (still to be implemented). As part of this change, `tabIndex="-1"` and a `focus()` listener was added to `material-button` so that focus could be dynamically sent to the `innerElement` (a native button or anchor element).
