### PR TITLE
docs(sidenav): add missing attributes

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -144,7 +144,7 @@ function materialSidenavService($materialComponentRegistry) {
  * @usage
  * <hljs lang="html">
  * <div layout="horizontal" ng-controller="MyController">
- *   <material-sidenav class="material-sidenav-left">
+ *   <material-sidenav class="material-sidenav-left" component-id="left">
  *     Left Nav!
  *   </material-sidenav>
  *
@@ -155,7 +155,7 @@ function materialSidenavService($materialComponentRegistry) {
  *     </material-button>
  *   </material-content>
  *
- *   <material-sidenav class="material-sidenav-right">
+ *   <material-sidenav class="material-sidenav-right" component-id="right">
  *     Right Nav!
  *   </material-sidenav>
  * </div>


### PR DESCRIPTION
Missing attributes `component-id="xxxx"` in order to call `$materialSidenav('xxxx').toggle();` in the example
