### PR TITLE
Add semantics to material-list

### DIFF
--- a/src/base/constants.js
+++ b/src/base/constants.js
@@ -3,6 +3,8 @@ var Constant = {
     ROLE : {
       BUTTON : 'button',
       CHECKBOX : 'checkbox',
+      LIST : 'list',
+      LIST_ITEM : 'listitem',
       RADIO : 'radio',
       RADIO_GROUP : 'radiogroup',
       TAB_LIST : 'tablist',

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -47,6 +47,9 @@ function materialListDirective() {
   return {
     restrict: 'E',
     link: function($scope, $element, $attr) {
+      $element.attr({
+        'role' : Constant.ARIA.ROLE.LIST
+      });
     }
   };
 }
@@ -75,6 +78,9 @@ function materialItemDirective() {
   return {
     restrict: 'E',
     link: function($scope, $element, $attr) {
+      $element.attr({
+        'role' : Constant.ARIA.ROLE.LIST_ITEM
+      });
     }
   };
 }


### PR DESCRIPTION
By adding roles to `material-list`, users of assistive technologies can discern that it is a list containing multiple items. This creates a more accessible experience.
