### PR TITLE
feat:(docs) add version.json generation to build process

### DIFF
--- a/config/build.config.js
+++ b/config/build.config.js
@@ -30,6 +30,7 @@ module.exports = {
 
   docsDist: 'dist/docs',
   docsLib: 'dist/docs/lib',
+  docsVersionFile: './dist/docs/version.json', // Writing to dist/ to avoid version-managed docs
   docsAssets: {
     js: [
       'bower_components/angularytics/dist/angularytics.js',

--- a/docs/app/version.json
+++ b/docs/app/version.json
@@ -1,6 +1,5 @@
 {
-  "sha" : "",
-  "url" : "https://github.com/angular/material/commit/",
-
-  "_comment" : "Gulp tool should use command `git git rev-parse 'HEAD'` and inject SHA value above"
+  "sha":"",
+  "url":"https://github.com/angular/material/tree/",
+  "_comment": "see gulp task 'docs-version' for usage"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,8 @@ var glob = require('glob').sync;
 var gulp = require('gulp');
 var karma = require('karma').server;
 var pkg = require('./package.json');
+var exec = require('child_process').exec;
+var writeFile = require('fs').writeFile;
 
 var argv = require('minimist')(process.argv.slice(2));
 
@@ -48,7 +50,17 @@ gulp.task('watch', ['docs'], function() {
 /**
  * Docs
  */
-gulp.task('docs', ['docs-scripts', 'docs-html2js', 'docs-css', 'docs-html', 'docs-app'], function() {
+gulp.task('docs', ['docs-scripts', 'docs-html2js', 'docs-css', 'docs-html', 'docs-app', 'docs-version'], function() {
+});
+
+gulp.task('docs-version', ['docs-app'], function(done) {
+  exec('git rev-parse HEAD', { env: process.env }, function(err, stdout) {
+    if(err) throw err;
+    var sha = stdout.trim();
+    var json = require(buildConfig.docsVersionFile);
+    json.sha = sha;
+    writeFile(buildConfig.docsVersionFile, JSON.stringify(json), 'utf8', done);
+  });
 });
 
 gulp.task('docs-scripts', ['demo-scripts'], function() {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "conventional-changelog": "0.0.9",
     "dgeni": "~0.3.0",
     "dgeni-packages": "~0.9.2",
+    "esprima": "^1.2.2",
     "event-stream": "^3.1.5",
     "glob": "~4.0.2",
     "gulp": "^3.6.2",
@@ -18,6 +19,7 @@
     "gulp-if": "^1.2.0",
     "gulp-jshint": "^1.5.5",
     "gulp-minify-css": "^0.3.4",
+    "gulp-ng-html2js": "^0.1.8",
     "gulp-rename": "^1.2.0",
     "gulp-replace": "^0.3.0",
     "gulp-sass": "^0.7.1",
@@ -29,14 +31,12 @@
     "jshint-summary": "^0.3.0",
     "karma": "^0.12.16",
     "karma-chrome-launcher": "^0.1.4",
+    "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.1.5",
     "karma-phantomjs-launcher": "~0.1.4",
-    "karma-firefox-launcher": "^0.1.3",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "lodash": "^2.4.1",
-    "minimist": "^0.1.0",
-    "esprima": "^1.2.2",
-    "gulp-ng-html2js": "^0.1.8"
+    "minimist": "^0.1.0"
   }
 }


### PR DESCRIPTION
As per discussion with @ThomasBurleson, made the URL point to the code at the specific commit instead of the commit's page.

Also, doesn't touch `docs/app/version.json` to avoid making the repo dirty, instead only modifies `dist/docs/version.json`. Template / URL may be edited still by editing `docs/app/version.json`.
