### PR TITLE
Accessibility improvements for Material docs

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -75,6 +75,10 @@ material-toolbar.material-medium-tall {
   color: #AAA;
 }
 
+.menu-icon {
+  background-color: transparent;
+  border: none;
+}
 
 .menu-icon material-icon {
   top: 19px;

--- a/docs/app/index.html
+++ b/docs/app/index.html
@@ -34,7 +34,7 @@
           ng-show="menu.isSectionSelected(section)"
           ng-repeat="page in section.pages"
           ng-class="{active: menu.isPageSelected(section, page)}"
-          ng-click="menu.selectPage(section, page)"
+          ng-click="openPage(section, page)"
           ink-ripple>
           <span ng-bind="page.humanName || page.name"></span>
         </button>
@@ -44,20 +44,20 @@
 
   </material-sidenav>
 
-  <div layout="vertical" layout-fill>
+  <div layout="vertical" layout-fill tabIndex="-1" role="main">
     <material-toolbar class="material-theme-dark material-medium-tall">
 
-      <div class="material-toolbar-tools" ng-click="toggleMenu()">
-        <div class="menu-icon" hide-md>
+      <div class="material-toolbar-tools">
+        <button class="menu-icon" hide-md ng-click="toggleMenu()" aria-label="Toggle Menu">
           <material-icon icon="img/icons/ic_menu_24px.svg">
           </material-icon>
-        </div>
-        <h2 hide block-sm>
+        </button>
+        <h2 hide block-sm ng-if="menu.currentSection.name">
           {{menu.currentSection.name}}
         </h2>
         <span layout="vertical" layout-align="center center" class="menu-separator-icon"
           ng-show="menu.currentPage">
-          <img style="height: 16px;" src="img/docArrow.png" hide block-sm>
+          <img style="height: 16px;" src="img/docArrow.png" alt="" aria-hidden="true" hide block-sm>
         </span>
         <h3 ng-bind="menu.currentPage.humanName || menu.currentPage.name || 'Angular Material'" flex>
         </h3>

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -150,10 +150,18 @@ function($scope, COMPONENTS, $materialSidenav, $timeout, $materialDialog, menu, 
 
   $scope.menu = menu;
 
+  $scope.mainContentArea = document.querySelector("[role='main']");
+
   $scope.toggleMenu = function() {
     $timeout(function() {
       $materialSidenav('left').toggle();
     });
+  };
+
+  $scope.openPage = function(section, page) {
+    menu.selectPage(section, page);
+    $scope.toggleMenu();
+    $scope.mainContentArea.focus();
   };
 
   $scope.goHome = function($event) {

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -182,10 +182,13 @@ function materialSidenavDirective($timeout) {
       function openWatchAction(isOpen) {
         $element.toggleClass('open', !!isOpen);
         if (isOpen) {
-          $element.parent().append(backdrop);
+          $element.parent()
+            .on('keydown', onKeyDown)
+            .append(backdrop);
           backdrop.on('click', onBackdropClick);
         } else {
           backdrop.remove().off('click', onBackdropClick);
+          $element.parent().off('keydown', onKeyDown);
         }
       }
       function onBackdropClick() {
@@ -193,7 +196,15 @@ function materialSidenavDirective($timeout) {
           sidenavCtrl.close();
         });
       }
-
+      function onKeyDown(evt) {
+        if(evt.which === Constant.KEY_CODE.ESCAPE){
+          evt.preventDefault();
+          evt.stopPropagation();
+          $timeout(function() {
+            sidenavCtrl.close();
+          });
+        }
+      }
     }
   };
 }


### PR DESCRIPTION
This change covers a few accessibility fixes for the Material Design docs, including missing alt text, accessibility for the mobile menu button, an improved sidenav experience on page change, and a way to close the sidenav with the keyboard. A fuller-featured branch on `material-sidenav` is forthcoming, but at least wiring up the escape key made the docs sidenav easier to use. 
