### PR TITLE
docs(button): incorrect description

### DIFF
--- a/src/components/buttons/buttons.js
+++ b/src/components/buttons/buttons.js
@@ -31,7 +31,7 @@ angular.module('material.components.button', [
  * @param {string=} type Optional attribute to specific button types (useful for forms); such as 'submit', etc.
  * @param {string=} ng-href Optional attribute to support both ARIA and link navigation
  * @param {string=} href Optional attribute to support both ARIA and link navigation
- * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the radio button's text.
+ * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the button's text.
  *
  * @usage
  * <hljs lang="html">


### PR DESCRIPTION
replace `radio button's text` by `button's text`
