### PR TITLE
Material-toolbar demos need correct heading levels

### DIFF
--- a/src/components/toolbar/demo1/index.html
+++ b/src/components/toolbar/demo1/index.html
@@ -4,65 +4,65 @@
   <material-content>
 
     <material-toolbar class="material-theme-light">
-      <h1 class="material-toolbar-tools">
+      <h2 class="material-toolbar-tools">
         <span>Toolbar: light-theme (default)</span>
-      </h1>
+      </h2>
     </material-toolbar>
 
     <br>
 
     <material-toolbar class="material-theme-dark">
-      <h1 class="material-toolbar-tools">
+      <h2 class="material-toolbar-tools">
         <span>Toolbar: dark-theme</span>
-      </h1>
+      </h2>
     </material-toolbar>
 
     <br>
 
     <material-toolbar class="material-theme-green material-tall">
-      <h1 class="material-toolbar-tools">
+      <h2 class="material-toolbar-tools">
         <span>Toolbar: tall</span>
-      </h1>
+      </h2>
     </material-toolbar>
 
     <br>
 
     <material-toolbar class="material-theme-yellow material-tall">
       <span flex></span>
-      <h1 class="material-toolbar-tools material-toolbar-tools-bottom">
+      <h2 class="material-toolbar-tools material-toolbar-tools-bottom">
         <span class="material-flex">Toolbar: tall with actions pin to the bottom</span>
-      </h1>
+      </h2>
     </material-toolbar>
 
     <br>
 
     <material-toolbar class="material-theme-orange material-medium-tall">
-      <h1 class="material-toolbar-tools material-toolbar-tools-top">
+      <div class="material-toolbar-tools material-toolbar-tools-top">
         <material-icon style="width: 24px; height: 24px;">
           <svg-icon></svg-icon>
         </material-icon>
-      </h1>
+      </div>
       <span flex></span>
-      <h1 class="material-toolbar-tools material-toolbar-tools-bottom">
+      <h2 class="material-toolbar-tools material-toolbar-tools-bottom">
         <span>Toolbar: medium tall with label aligns to the bottom</span>
-      </h1>
+      </h2>
     </material-toolbar>
 
     <br>
 
     <material-toolbar class="material-theme-purple material-tall">
-      <h1 class="material-toolbar-tools material-toolbar-tools-top">
+      <div class="material-toolbar-tools material-toolbar-tools-top">
         <material-icon style="width: 24px; height: 24px;">
           <svg-icon></svg-icon>
         </material-icon>
-      </h1>
-      <h1 class="material-toolbar-tools" layout-arrange="center center">
+      </div>
+      <h2 class="material-toolbar-tools" layout-arrange="center center">
         <span>Toolbar: label aligns to the middle</span>
-      </h1>
+      </h2>
       <span flex></span>
-      <h1 class="material-toolbar-tools">
+      <h2 class="material-toolbar-tools">
         <div style="font-size: 18px">Some stuff aligns to the bottom</div>
-      </h1>
+      </h2>
     </material-toolbar>
 
   </material-content>

--- a/src/components/toolbar/demo2/index.html
+++ b/src/components/toolbar/demo2/index.html
@@ -2,7 +2,9 @@
 
   <material-toolbar scroll-shrink class="material-theme-light">
     <div class="material-toolbar-tools">
-      <span>My App Title</span>
+      <h3>
+        <span>My App Title</span>
+      </h3>
     </div>
   </material-toolbar>
 


### PR DESCRIPTION
To lead by example for accessibility, demos should use headings correctly. This change updates the heading hierarchy to not use multiple `h1`s and to remove heading tags from `material-icon`s that would otherwise produce empty headings.
