### PR TITLE
docs(materialSidenav): Fix mismatched controller name

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -165,7 +165,7 @@ function materialSidenavService($materialComponentRegistry) {
  *
  * <hljs lang="js">
  * var app = angular.module('myApp', ['ngMaterial']);
- * app.controller('MainController', function($scope, $materialSidenav) {
+ * app.controller('MyController', function($scope, $materialSidenav) {
  *   $scope.openLeftMenu = function() {
  *     $materialSidenav('left').toggle();
  *   };


### PR DESCRIPTION
The example markup includes `<div ... ng-controller="MyController">`, but the example controller definition was `app.controller('MainController', ...`. I changed the controller definition name to match that of the markup.
