### PR TITLE
regression of textField disallowing use as type="password"

### DIFF
--- a/src/components/textField/textField.js
+++ b/src/components/textField/textField.js
@@ -64,7 +64,7 @@ function materialInputDirective() {
   return {
     restrict: 'E',
     replace: true,
-    template: '<input type="text">',
+    template: '<input>',
     require: ['^?materialInputGroup', '?ngModel'],
     link: function(scope, element, attr, ctrls) {
       var inputGroupCtrl = ctrls[0];


### PR DESCRIPTION
while this may reduce boilerplate html (<material-input type="text"/> --> <material-input /> ), it no longer allowed for usage as <material-input type="password"/>. Let's just revert this line for now and maybe include type="text" as fallback in js part of directive if it is really necessary.
