### PR TITLE
cleaning up css from old demo

### DIFF
--- a/src/components/tabs/demos/demo1/style.css
+++ b/src/components/tabs/demos/demo1/style.css
@@ -100,10 +100,3 @@
 div.animate-switch-container div.animate-switch {
     padding:20px;
 }
-
-.title {
-  color: #999999;
-  font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
-}


### PR DESCRIPTION
new demo1 contains no .title element, so css rule is obsolete
