### PR TITLE
Fix button styles in Firefox for Android

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -26,7 +26,7 @@ material-toolbar.material-medium-tall {
 }
 
 .menu-item {
-  background-color: #fff;
+  background: none;
   border-width: 0;
   cursor: pointer;
   display: block;
@@ -76,7 +76,7 @@ material-toolbar.material-medium-tall {
 }
 
 .menu-icon {
-  background-color: transparent;
+  background: none;
   border: none;
 }
 .app-toolbar .material-toolbar-tools h3 {


### PR DESCRIPTION
Button elements in Firefox for Android need `background: none` to override background gradients. In the docs, the menu button and `material-sidenav` buttons did not have this style--this PR has a fix. See attached screenshot of the issue:

![Firefox Android buttons](https://cloud.githubusercontent.com/assets/2712395/4537621/80b2c246-4de0-11e4-8e3a-ef9444d1ecbb.png)
