### PR TITLE
fix: (sticky | subheader) - fix little bug on refreshElements()

### DIFF
--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -126,7 +126,7 @@ function MdSticky($document, $mdEffects, $compile, $$rAF, $mdUtil) {
       // be the same as their order of display.
       self.items.forEach(refreshPosition);
       self.items = self.items.sort(function(a, b) {
-        return a.top > b.top;
+        return a.top - b.top;
       });
 
       // Find which item in the list should be active, 


### PR DESCRIPTION
A bug in the refreshElements() function caused malfunction in the subheader component. It applies an order over the self.items array based on the top property calculated in refreshPosition(item). 

When sorting, the compare function returns a true/false value (a.top > b.top), but it should return an int value (a.top - b.top). Because of this the self.items array is misordered, self.current, self.prev and self.next are miscalculated and the subheader fails to acknowledge changes in sections.

Changing the compare function solves this issue
