### PR TITLE
docs(dialog): fix sample code

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -76,10 +76,10 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *     $mdDialog.show({
  *       targetEvent: $event,
  *       controller: 'DialogController',
- *       template: 
- *         '<md-dialog>
+ *       template:
+ *         '<md-dialog>' +
  *         '  <md-content>Hello!</md-content>' +
- *         '  <div class="md-actions">
+ *         '  <div class="md-actions">' +
  *         '    <md-button ng-click="closeDialog()">' +
  *         '      Close' +
  *         '    </md-button>' +


### PR DESCRIPTION
I've added missing single quote chars and concatenation to output valid sample code in docs.
