### PR TITLE
feat(input): add disabled support for input elements

### DIFF
--- a/src/components/form/_form.scss
+++ b/src/components/form/_form.scss
@@ -29,6 +29,9 @@ input[type="color"] {
   &:focus {
     outline: 0;
   }
+  &[disabled] {
+    border-bottom: 1px dashed #757575;
+  }
 }
 
 input, textarea {

--- a/src/components/form/demo1/index.html
+++ b/src/components/form/demo1/index.html
@@ -5,6 +5,8 @@
     <div class="material-toolbar-tools">
       <ig fid="t1" class="material-input-group-theme-light material-input-group-inverted"></ig>
       <ig fid="t2" class="material-input-group-theme-light-blue material-input-group-inverted"></ig>
+      <ig fid="t3" disabled="true" class="material-input-group-theme-light-blue material-input-group-inverted"
+          aria-disabled="true"></ig>
     </div>
   </material-toolbar>
 
@@ -18,6 +20,7 @@
       <ig fid="i6" class="material-input-group-theme-orange"></ig>
       <ig fid="i7" class="material-input-group-theme-purple"></ig>
       <ig fid="i8" class="material-input-group-theme-red"></ig>
+      <ig disabled="true" fid="i9" class="material-input-group-theme-light" aria-disabled="true"></ig>
     </form>
   </material-content>
 

--- a/src/components/form/demo1/script.js
+++ b/src/components/form/demo1/script.js
@@ -10,11 +10,12 @@ angular.module('app', ['ngMaterial'])
     restrict: 'E',
     replace: true,
     scope: {
-      fid: '@'
+      fid: '@',
+      disabled: '='
     },
     template: 
-      '<material-input-group>' +
-        '<label for="{{fid}}">Description</label>' +
+      '<material-input-group ng-disabled="{{disabled}}">' +
+        '<label for="{{fid}}"><span ng-show="disabled">Disabled </span>Description</label>' +
         '<material-input id="{{fid}}" type="text" ng-model="data.description">' +
       '</material-input-group>'
   };

--- a/src/components/form/form.js
+++ b/src/components/form/form.js
@@ -20,11 +20,18 @@ angular.module('material.components.form', [])
  * @description
  * Use the `<material-input-group>` directive as the grouping parent of an `<material-input>` elements
  *
+ * @param {boolean=} disabled Use of attribute indicates the input is disabled: no ink effects and not selectable
+ *
  * @usage 
  * <hljs lang="html">
  * <material-input-group>
  *   <material-input type="text" ng-model="myText">
  * </material-input-group>
+ *
+ * <material-input-group disabled aria-disabled="true">
+ *   <material-input type="text" ng-model="myText">
+ * </material-input-group>
+ * 
  * </hljs>
  */
 function materialInputGroupDirective() {
@@ -36,6 +43,9 @@ function materialInputGroupDirective() {
       };
       this.setHasValue = function(hasValue) {
         $element.toggleClass('material-input-has-value', !!hasValue);
+      };
+      this.isDisabled = function() {
+        return $element.attr('disabled') !== undefined;
       };
     }]
   };
@@ -71,6 +81,17 @@ function materialInputDirective() {
       if (!inputGroupCtrl) {
         return;
       }
+
+      scope.$watch(function() {
+        return inputGroupCtrl.isDisabled();
+      }, function(isDisabled) {
+        element.attr('aria-disabled', isDisabled);
+        if (isDisabled) {
+          element[0].setAttribute('disabled', '');
+        } else {
+          element.removeAttr('disabled');
+        }
+      });
 
       // When the input value changes, check if it "has" a value, and 
       // set the appropriate class on the input group

--- a/src/components/form/form.spec.js
+++ b/src/components/form/form.spec.js
@@ -41,4 +41,16 @@ describe('materialInputGroup directive', function() {
     input.scope().$apply('something = ""');
     expect(el.hasClass('material-input-has-value')).toBe(false);
   });
+
+  it('should set the disable the input when material-input-group is disabled', function() {
+    var el = setup();
+    var input = el.find('input');
+    expect(input.attr('disabled')).toBe(undefined);
+    el.attr('disabled', '');
+    input.scope().$digest();
+    expect(input.attr('disabled')).not.toBe(undefined);
+    el.removeAttr('disabled');
+    input.scope().$digest();
+    expect(input.attr('disabled')).toBe(undefined);
+  });
 });


### PR DESCRIPTION
This adds the disabled support for input elements by watching for the 'disabled' attribute on the
material-input-group element.

Closes #61
