### PR TITLE
fix (slider) - fixing slider default value in ng-repeat

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -258,6 +258,9 @@ function SliderController(scope, element, attr, $$rAF, $window, $mdEffects, $mdA
       ngModelCtrl.$setViewValue( minMaxValidator(stepValidator(value)) );
     }
     function ngModelRender() {
+      if (isNaN(ngModelCtrl.$viewValue)) {
+        ngModelCtrl.$viewValue = ngModelCtrl.$modelValue;
+      }
       var percent = (ngModelCtrl.$viewValue - min) / (max - min);
       scope.modelValue = ngModelCtrl.$viewValue;
       element.attr('aria-valuenow', ngModelCtrl.$viewValue);


### PR DESCRIPTION
md-slider does not work within ng-repeat.
when i have used md-slider without ng-repeat the slider sets on its proper position and aria-valuenow is also set with its proper value, but when i have used md-slider within ng-repeat the aria-valuenow="NaN" and slider is not set with its proper position.

Plunker demo of problem - http://plnkr.co/edit/PslB2p?p=preview

With this pull request the default value of md-slider in ng-repeat will be correct.
