### PR TITLE
Button accessibility fixes

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -72,7 +72,7 @@
         ng-if="path().indexOf('demo') > -1">
         <span flex></span>
         <md-button ng-repeat="doc in currentComponent.docs"
-          ng-href="#{{doc.url}}">
+          ng-href="#{{doc.url}}" aria-label="{{ doc | humanizeDoc }}">
           <span ng-bind="doc | humanizeDoc | directiveBrackets"></span>
         </md-button>
       </div>

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -64,11 +64,11 @@ function MdButtonDirective(ngHrefDirectives, $mdInkRipple, $mdAria, $mdUtil, $md
       // so this element can be clicked like a normal `<a>`.
       if (attr.ngHref || attr.href) {
         innerElement = angular.element('<a>');
-        attributesToCopy = ['ng-href', 'href', 'rel', 'target'];
+        attributesToCopy = ['ng-href', 'href', 'rel', 'target', 'title', 'aria-label'];
       // Otherwise, just add an inner button element (for form submission etc)
       } else {
         innerElement = angular.element('<button>');
-        attributesToCopy = ['type', 'disabled', 'ng-disabled', 'form'];
+        attributesToCopy = ['type', 'disabled', 'ng-disabled', 'form', 'aria-label'];
       }
 
       angular.forEach(attributesToCopy, function(name) {
@@ -101,7 +101,7 @@ function MdButtonDirective(ngHrefDirectives, $mdInkRipple, $mdAria, $mdUtil, $md
 
       return function postLink(scope, element, attr) {
         $mdTheming(element);
-        $mdAria.expect(element, 'aria-label', element.text());
+        $mdAria.expect(element, 'aria-label', true);
         $mdInkRipple.attachButtonBehavior(element);
       };
     }

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -22,7 +22,7 @@ describe('md-button', function() {
 
   it('should have inner-anchor with attrs if ng-href attr is given', inject(function($compile, $rootScope) {
 
-    var button = $compile('<md-button ng-href="/link" rel="foo" target="bar" something="baz">' +
+    var button = $compile('<md-button ng-href="/link" rel="foo" target="bar" something="baz" title="awesome">' +
                             '<div>content</div>' +
                           '</md-button>')($rootScope);
 
@@ -33,6 +33,7 @@ describe('md-button', function() {
 
     expect(anchor.attr('ng-href')).toBe('/link');
     expect(anchor.attr('rel')).toBe('foo');
+    expect(anchor.attr('title')).toBe('awesome');
     expect(anchor.attr('target')).toBe('bar');
     expect(anchor.attr('something')).toBeFalsy();
   }));
@@ -53,4 +54,14 @@ describe('md-button', function() {
     expect(innerButton.attr('form')).toBe('bar');
   }));
 
+  it('should have a label on inner-button', inject(function($compile, $rootScope){
+    var button = $compile('<md-button class="md-fab" aria-label="Time">' +
+                            '<md-icon icon=""></md-icon>' +
+                          '</md-button>')($rootScope);
+
+    $rootScope.$apply();
+    var innerButton = button.find('button');
+
+    expect(innerButton.attr('aria-label')).toBe('Time');
+  }));
 });

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -27,7 +27,7 @@
         <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg" style="width: 24px; height: 24px;"></md-icon>
       </md-button>
 
-        <md-button class="md-fab" disabled arial-label="Comment">
+        <md-button class="md-fab" disabled aria-label="Comment">
             <md-icon icon="/img/icons/ic_comment_24px.svg" style="width: 24px; height: 24px;"></md-icon>
         </md-button>
 


### PR DESCRIPTION
A few tweaky things for accessibility of buttons, including fixes for incorrect `aria-label` warnings. Known issues with focus styles: https://github.com/angular/material/issues/508 and https://github.com/angular/material/issues/142
