### PR TITLE
Make tooltip examples accessible

### DIFF
--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -3,7 +3,7 @@
   <md-toolbar md-theme="green">
     <h1 class="md-toolbar-tools">
       <span flex>Awesome Md App</span>
-      <md-button class="md-fab md-primary">
+      <md-button class="md-fab md-primary" aria-label="refresh">
         <md-tooltip>
           Refresh
         </md-tooltip>
@@ -18,13 +18,13 @@
       The tooltip is visible when the button is hovered, focused, or touched.
     </p>
 
-    <md-button class="md-fab md-fab-top-left left" >
+    <md-button class="md-fab md-fab-top-left left" aria-label="Insert Drive">
       <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg"></md-icon>
       <md-tooltip visible="showTooltip">
         Insert Drive
       </md-tooltip>
     </md-button>
-    <md-button class="md-fab md-fab-top-right right">
+    <md-button class="md-fab md-fab-top-right right" aria-label="Photos">
       <md-icon icon="/img/icons/ic_photo_24px.svg"></md-icon>
       <md-tooltip>
         Photos


### PR DESCRIPTION
This is a temporary accessibility fix for `<md-tooltip>`. Because of an outstanding accessibility issue with `<md-icon>` (https://github.com/angular/material/issues/427), `<md-button>` components used in conjunction with `<md-tooltip>` do not have accessible names and are read aloud in a screen reader simply as "button". 

The current fix is to add `aria-label` to the parent button element, but the ideal solution would be to require `<md-icon>` to label itself.
