### PR TITLE
docs(home): move commit link above the fold; add link to github issues search

### DIFF
--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -7,17 +7,17 @@
       The material design project for Angular is a complementary effort to the <a href="http://www.polymer-project.org/">Polymer</a> project's <a href="http://www.polymer-project.org/docs/elements/paper-elements.html">paper elements</a> collection. Our goal is to provide a set of AngularJS-native UI elements that implement the material design system.
     </p>
     <p>
-      For more, see our <a href="https://github.com/angular/material">repository on GitHub.</a>
+      To contribute, fork our GitHub <a href="https://github.com/angular/material">repository</a>.
+      <br>
+      For problems, <a href="https://github.com/angular/material/issues?q=is%3Aissue">search the issues</a> and/or create a new issue.
+      <br>
+      These docs were generated from the code in commit 
+      <a ng-href="{{BUILDCONFIG.repository}}/commit/{{BUILDCONFIG.commit}}" target="_blank">{{BUILDCONFIG.commit.substring(0,7)}}</a>.
     </p>
   </md-content>
 
   <md-content layout="horizontal" layout-align="center center" style="padding-top: 50px">
     <iframe width="560" height="315" title="Material Design" src="//www.youtube.com/embed/Q8TXgCzxEnw" frameborder="0" allowfullscreen></iframe>
   </md-content>
-
-   <p>
-     These docs were generated from the code in commit 
-     <a ng-href="{{BUILDCONFIG.repository}}/commit/{{BUILDCONFIG.commit}}" target="_blank">{{BUILDCONFIG.commit.substring(0,7)}}</a>.
-   </p>
 
 </div>


### PR DESCRIPTION
Move the paragraph with the commit hash above the video
 - this was below the fold on a 768px screen, making it easy to miss
Reword Github information
Add a link directing users with problems to the github issues search
 - this shows users where to look for solutions before creating a new issue

Resolves https://github.com/angular/material/issues/566

![material-docs-fix-566](https://cloud.githubusercontent.com/assets/7917920/4962672/b62eedb4-66e5-11e4-85bf-d01bafd646b5.gif)
