### PR TITLE
WIP: Make bottom sheet items accessible

### DIFF
--- a/src/components/bottomSheet/_bottomSheet.scss
+++ b/src/components/bottomSheet/_bottomSheet.scss
@@ -62,6 +62,11 @@ md-bottom-sheet {
     &:hover {
       cursor: pointer;
     }
+
+    .md-button {
+      color: inherit;
+      text-transform: none;
+    }
   }
 
   &.md-list {
@@ -114,7 +119,7 @@ md-bottom-sheet {
           }
         }
       }
-      
+
       @media screen and (max-width: $layout-breakpoint-sm) {
         @include grid-items-per-row(3, true);
       }
@@ -146,6 +151,7 @@ md-bottom-sheet {
         height: 6 * $baseline-grid;
         width: 6 * $baseline-grid;
         margin: $baseline-grid 0;
+        vertical-align: middle;
       }
 
       p.md-grid-text {

--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
@@ -1,12 +1,14 @@
 <md-bottom-sheet class="md-grid">
   <md-list>
-    <md-item ng-repeat="item in items" ng-click="listItemClick($index)">
-      <div class="md-item-content">
-        <div class="md-icon-container">
-            <md-inline-grid-icon icon="{{item.icon}}" />
+    <md-item ng-repeat="item in items">
+      <button class="md-button" ng-click="listItemClick($index)">
+        <div class="md-item-content">
+          <div class="md-icon-container">
+              <md-inline-grid-icon icon="{{item.icon}}" />
+          </div>
+          <p class="md-grid-text"> {{ item.name }} </p>
         </div>
-        <p class="md-grid-text"> {{ item.name }} </p>
-      </div>
+      </button>
     </md-item>
   </md-list>
 </md-bottom-sheet>

--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-list-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-list-template.html
@@ -1,12 +1,14 @@
 <md-bottom-sheet class="md-list md-has-header">
   <md-subheader>Comment Actions</md-subheader>
   <md-list>
-    <md-item ng-repeat="item in items" ng-click="listItemClick($index)">
-      <div class="md-icon-container">
-        <!-- Using custom inline icon until md-icon is ready. DONT USE ME! -->
-        <md-inline-list-icon icon="{{item.icon}}" />
-      </div>
-      {{ item.name }}
+    <md-item ng-repeat="item in items">
+      <button class="md-button" ng-click="listItemClick($index)">
+        <div class="md-icon-container">
+          <!-- Using custom inline icon until md-icon is ready. DONT USE ME! -->
+          <md-inline-list-icon icon="{{item.icon}}" />
+        </div>
+        {{ item.name }}
+      </button>
     </md-item>
   </md-list>
 </md-bottom-sheet>


### PR DESCRIPTION
As part of the accessibility improvements to `<md-bottom-sheet>`, this PR includes changes to the markup that make nested items into real interactive controls. 

Known issue regarding focus management: https://github.com/angular/material/issues/571
