### PR TITLE
use accent color for themed toolbar button text

### DIFF
--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -4,4 +4,8 @@ $toolbar-text-color: $primary-color-palette-contrast-color;
 md-toolbar.md-#{$theme-name}-theme {
   background-color: $toolbar-background-color;
   color: $primary-color-palette-contrast-color;
+
+  button {
+    color: $primary-color-palette-contrast-color;
+  }
 }


### PR DESCRIPTION
On Ubuntu 14.04, Firefox 33.0 & Chrome 38 & Chromium 37, the default button color style is overriding the theme style. This forces the theme color to be used.
