### PR TITLE
Make icon object same size of its parent

### DIFF
--- a/src/components/icon/_icon.scss
+++ b/src/components/icon/_icon.scss
@@ -6,6 +6,11 @@ md-icon {
   margin-top: 5px;
   background-repeat: no-repeat no-repeat;
   pointer-events: none;
+  
+  .md-icon {
+    height: inherit;
+    width: inherit;
+  }
 }
 svg, object {
   fill: currentColor;


### PR DESCRIPTION
when using svg I have to make sure that the svg size is the same as the parent object to make it fit into it.
