### PR TITLE
fix(mdTextField): set tabindex on input if set on mdTextFloat

### DIFF
--- a/src/components/textField/textField.js
+++ b/src/components/textField/textField.js
@@ -59,6 +59,11 @@ function mdTextFloatDirective($mdTheming, $mdUtil) {
             element.attr('disabled', true);
             scope.isDisabled = true;
           }
+            
+          if ( angular.isDefined(attrs.tabindex) ) {
+            scope.tabIndex = attrs.tabindex;
+          }
+          element.attr('tabindex', '-1');  
 
           scope.inputType = attrs.type || "text";
           element.removeAttr('type');
@@ -73,7 +78,7 @@ function mdTextFloatDirective($mdTheming, $mdUtil) {
     template:
     '<md-input-group ng-disabled="isDisabled" tabindex="-1">' +
     ' <label for="{{fid}}" >{{label}}</label>' +
-    ' <md-input id="{{fid}}" ng-model="value" type="{{inputType}}"></md-input>' +
+    ' <md-input id="{{fid}}" ng-model="value" type="{{inputType}}" tabindex="{{tabIndex}}"></md-input>' +
     '</md-input-group>'
   };
 }


### PR DESCRIPTION
This allows tabindex to be set on the initial mdTextFloat element and have it properly applied to the input element.

Closes: angular#583.

Because the template is changed, I can write tests once https://github.com/angular/material/issues/586 is resolved (or I understand why the current spec's template is correct).