### PR TITLE
refactor(): use ngDisabled internally instead of disabled

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -63,12 +63,11 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria) {
   }
   
   function getTemplate(element, attr) {
-    var tag = isAnchor(attr) ? 'a' : 'button';
-    //We need to manually pass disabled to the replaced element because
-    //of a bug where it isn't always passed.
-    var disabled = element[0].hasAttribute('disabled') ? ' disabled ' : ' ';
-
-    return '<' + tag + disabled + 'class="md-button" ng-transclude></' + tag + '>';
+    if (isAnchor(attr)) {
+      return '<a class="md-button" ng-transclude></a>';
+    } else {
+      return '<button class="md-button" ng-transclude></button>';
+    }
   }
 
   function postLink(scope, element, attr) {
@@ -84,9 +83,7 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria) {
     // For anchor elements, we have to set tabindex manually when the 
     // element is disabled
     if (isAnchor(attr)) {
-      scope.$watch(function() {
-        return node.hasAttribute('disabled');
-      }, function(isDisabled) {
+      scope.$watch(attr.ngDisabled, function(isDisabled) {
         element.attr('tabindex', isDisabled ? -1 : 0);
       });
     }

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -21,12 +21,6 @@ describe('md-button', function() {
     expect(button[0].tagName.toLowerCase()).toEqual('button');
   }));
 
-  it('should pass in disabled attribute (testing our DOM bug-fix)', inject(function($compile, $rootScope) {
-    var button = $compile('<md-button disabled>')($rootScope.$new());
-    $rootScope.$apply();
-    expect(button[0].hasAttribute('disabled')).toBe(true);
-  }));
-
   it('should expect an aria-label if element has no text', inject(function($compile, $rootScope, $log) {
     spyOn($log, 'warn');
     var button = $compile('<md-button><md-icon></md-icon></md-button>')($rootScope);

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -13,7 +13,7 @@
     <section layout="vertical" layout-sm="horizontal" layout-align="center center">
       <md-button class="md-raised">Button</md-button>
       <md-button class="md-raised md-primary">Primary</md-button>
-      <md-button disabled class="md-raised md-primary">Disabled</md-button>
+      <md-button ng-disabled="true" class="md-raised md-primary">Disabled</md-button>
       <md-button class="md-raised md-warn">Warn</md-button>
       <div class="label">raised</div>
     </section>
@@ -27,7 +27,7 @@
         <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg" style="width: 24px; height: 24px;"></md-icon>
       </md-button>
 
-        <md-button class="md-fab" disabled aria-label="Comment">
+        <md-button class="md-fab" ng-disabled="true" aria-label="Comment">
             <md-icon icon="/img/icons/ic_comment_24px.svg" style="width: 24px; height: 24px;"></md-icon>
         </md-button>
 

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -9,7 +9,7 @@ angular.module('material.components.checkbox', [
   'material.services.theming',
   'material.services.aria'
 ])
-  .directive('mdCheckbox', [ 
+  .directive('mdCheckbox', [
     'inputDirective',
     '$mdInkRipple',
     '$mdAria',
@@ -134,5 +134,3 @@ function MdCheckboxDirective(inputDirectives, $mdInkRipple, $mdAria, $mdConstant
     };
   }
 }
-
-

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -52,18 +52,19 @@ describe('mdCheckbox', function() {
 
   it('should be disabled with disabled attr', inject(function($compile, $rootScope) {
     var element = $compile('<div>' +
-                             '<md-checkbox disabled ng-model="blue">' +
+                             '<md-checkbox ng-disabled="isDisabled" ng-model="blue">' +
                              '</md-checkbox>' +
                            '</div>')($rootScope);
 
     var checkbox = element.find('md-checkbox');
+    $rootScope.$apply('isDisabled = true');
 
     $rootScope.$apply('blue = false');
 
     checkbox.triggerHandler('click');
     expect($rootScope.blue).toBe(false);
 
-    checkbox.removeAttr('disabled');
+    $rootScope.$apply('isDisabled = false');
 
     checkbox.triggerHandler('click');
     expect($rootScope.blue).toBe(true);

--- a/src/components/checkbox/demoBasicUsage/index.html
+++ b/src/components/checkbox/demoBasicUsage/index.html
@@ -9,11 +9,11 @@
     Checkbox 2: {{ data.cb2 }}
   </md-checkbox>
 
-  <md-checkbox disabled aria-label="Disabled checkbox">
+  <md-checkbox ng-disabled="true" aria-label="Disabled checkbox">
     Checkbox (Disabled)
   </md-checkbox>
 
-  <md-checkbox disabled aria-label="Disabled checked checkbox" ng-model="data.cb4" ng-init="data.cb4=true">
+  <md-checkbox ng-disabled="true" aria-label="Disabled checked checkbox" ng-model="data.cb4" ng-init="data.cb4=true">
     Checkbox (Disabled, Checked)
   </md-checkbox>
 

--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -117,9 +117,6 @@ function MdSticky($document, $mdEffects, $compile, $$rAF, $mdUtil) {
     }
 
     function refreshElements() {
-      var contentRect = contentEl[0].getBoundingClientRect();
-
-
       // Sort our collection of elements by their current position in the DOM.
       // We need to do this because our elements' order of being added may not
       // be the same as their order of display.

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -68,17 +68,11 @@ function MdSwitch(checkboxDirectives, radioButtonDirectives, $mdTheming) {
   };
 
   function compile(element, attr) {
-    
     var thumb = angular.element(element[0].querySelector('.md-switch-thumb'));
-    //Copy down disabled attributes for checkboxDirective to use
-    thumb.attr('disabled', attr.disabled);
-    thumb.attr('ngDisabled', attr.ngDisabled);
-
     var checkboxLink = checkboxDirective.compile(thumb, attr);
 
     return function (scope, element, attr, ngModelCtrl) {
       $mdTheming(element);
-      var thumb = angular.element(element[0].querySelector('.md-switch-thumb'));
       return checkboxLink(scope, thumb, attr, ngModelCtrl);
     };
   }

--- a/src/components/tabs/demoStaticTabs/index.html
+++ b/src/components/tabs/demoStaticTabs/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="AppCtrl">
 
-    <md-tabs selected="data.selectedIndex"  center>
+    <md-tabs selected="data.selectedIndex">
       <md-tab id="tab1" aria-controls="tab1-content">
         Item One
       </md-tab>

--- a/src/components/tabs/js/tabItemController.js
+++ b/src/components/tabs/js/tabItemController.js
@@ -4,13 +4,15 @@ angular.module('material.components.tabs')
 .controller('$mdTab', [
   '$scope',
   '$element',
+  '$attrs',
   '$compile',
   '$animate',
   '$mdUtil',
+  '$parse',
   TabItemController
 ]);
 
-function TabItemController(scope, element, $compile, $animate, $mdUtil) {
+function TabItemController(scope, element, attr, $compile, $animate, $mdUtil, $parse) {
   var self = this;
 
   // Properties
@@ -25,8 +27,9 @@ function TabItemController(scope, element, $compile, $animate, $mdUtil) {
   self.onSelect = onSelect;
   self.onDeselect = onDeselect;
 
+  var disabledParsed = $parse(attr.ngDisabled);
   function isDisabled() {
-    return element[0].hasAttribute('disabled');
+    return disabledParsed(scope.$parent);
   }
   
   /**

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -175,11 +175,11 @@ describe('<md-tabs>', function() {
       tabs.scope().$apply('disabled0 = true');
       expect(tabItems.eq(1)).toBeActiveTab();
       expect(tabItems.eq(0).attr('aria-disabled')).toBe('true');
-      expect(tabItems.eq(1).attr('aria-disabled')).toBe('false');
+      expect(tabItems.eq(1).attr('aria-disabled')).not.toBe('true');
 
       tabs.scope().$apply('disabled0 = false; disabled1 = true');
       expect(tabItems.eq(0)).toBeActiveTab();
-      expect(tabItems.eq(0).attr('aria-disabled')).toBe('false');
+      expect(tabItems.eq(0).attr('aria-disabled')).not.toBe('true');
       expect(tabItems.eq(1).attr('aria-disabled')).toBe('true');
     });
 


### PR DESCRIPTION
BREAKING CHANGE: For performance, the ng-disabled attribute is now read
to check if a component is disabled instead of the disabled attribute.

If you use the `disabled` attribute on a component to set whether
it is disabled, change it to an ng-disabled expression.

Change your code from this:

``` html
<md-checkbox disabled></md-checkbox>
```

To this:

``` html
<md-checkboxn ng-disabled="true"></md-checkbox>
```
