### PR TITLE
fix(card): made md-card themeable

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -6,8 +6,10 @@
  * Card components.
  */
 angular.module('material.components.card', [
+  'material.services.theming'
 ])
   .directive('mdCard', [
+    '$mdTheming',
     mdCardDirective 
   ]);
 
@@ -38,10 +40,11 @@ angular.module('material.components.card', [
  * </hljs>
  *
  */
-function mdCardDirective() {
+function mdCardDirective($mdTheming) {
   return {
     restrict: 'E',
     link: function($scope, $element, $attr) {
+      $mdTheming($element);
     }
   };
 }

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -1,2 +1,16 @@
 describe('mdCard directive', function() {
+
+  beforeEach(module('material.components.card'));
+
+  it('should have the default theme class when the md-theme attribute is not defined', inject(function($compile, $rootScope) {
+    var card = $compile('<md-card></md-card>')($rootScope.$new());
+    $rootScope.$apply();
+    expect(card.hasClass('md-default-theme')).toBe(true);
+  }));
+
+  it('should have the correct theme class when the md-theme attribute is defined', inject(function($compile, $rootScope) {
+    var card = $compile('<md-card md-theme="green"></md-card>')($rootScope.$new());
+    $rootScope.$apply();
+    expect(card.hasClass('md-green-theme')).toBe(true);
+  }));
 });


### PR DESCRIPTION
Hello There!

I'm really excited by what you have done so far with Angular Material Design. I've been working on building a POC for a 2015 project using angular and ngMaterial and I noticed that themes include css for md-card but md-card isn't themeable. This PR makes the md-card directive themable and adds two karma tests to confirm that it is themeable. Apologies in advance if I missed something or if md-card is intentionally not themeable, OR if I did not submit this issue/PR in the proper way.

Suggestions, feedback and schoolings in general always welcome as well! 

Thank you,

-Marc
