### PR TITLE
fix(mdDialog): fix scrollbar going behind dialog header

### DIFF
--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -40,6 +40,7 @@ md-dialog {
     padding: 24px;
     overflow: auto;
     -webkit-overflow-scrolling: touch;
+    z-index: 1;
 
     *:first-child {
       margin-top: 0px;


### PR DESCRIPTION
This simply adds z-index:1 to md-content of the dialog, so that the scrollbar stays on top of the header.