### PR TITLE
refactor(): switch to md-prefixed attributes for non-html5 attrs

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -16,8 +16,8 @@
 
   <md-sidenav layout="vertical"
     class="md-sidenav-left md-whiteframe-z2"
-    component-id="left"
-    is-locked-open="$media('md')">
+    md-component-id="left"
+    md-is-locked-open="$media('md')">
 
     <md-toolbar class="md-medium-tall">
       <h1 class="md-toolbar-tools" style="padding-top:25px;">

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -26,9 +26,9 @@ angular.module('material.components.button', [
  * If you supply a `href` or `ng-href` attribute, it will become an `<a>` element. Otherwise, it will
  * become a `<button>` element.
  *
- * @param {boolean=} noink If present, disable ripple ink effects.
+ * @param {boolean=} mdNoInk If present, disable ripple ink effects.
  * @param {boolean=} disabled If present, disable selection.
- * @param {string=} aria-label Publish the button label used by screen-readers for accessibility. Defaults to the button's text.
+ * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the button's text.
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -4,7 +4,7 @@
 
     <section layout="vertical" layout-sm="horizontal" layout-align="center center">
       <md-button>{{title1}}</md-button>
-      <md-button noink class="md-primary">Primary (noink)</md-button>
+      <md-button md-no-ink class="md-primary">Primary (md-noink)</md-button>
       <md-button ng-disabled="isDisabled" class="md-primary">Disabled</md-button>
       <md-button class="md-warn" ng-click="isDisabled = !isDisabled">{{title4}}</md-button>
       <div class="label">flat</div>

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -25,7 +25,7 @@ angular.module('material.components.checkbox', [
  * @param {expression=} ngTrueValue The value to which the expression should be set when selected.
  * @param {expression=} ngFalseValue The value to which the expression should be set when not selected.
  * @param {string=} ngChange Angular expression to be executed when input changes due to user interaction with the input element.
- * @param {boolean=} noink Use of attribute indicates use of ripple ink effects
+ * @param {boolean=} mdNoInk Use of attribute indicates use of ripple ink effects
  * @param {boolean=} disabled Use of attribute indicates the switch is disabled: no ink effects and not selectable
  * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the checkbox's text.
  *
@@ -35,7 +35,7 @@ angular.module('material.components.checkbox', [
  *   Finished ?
  * </md-checkbox>
  *
- * <md-checkbox noink ng-model="hasInk" aria-label="No Ink Effects">
+ * <md-checkbox md-no-ink ng-model="hasInk" aria-label="No Ink Effects">
  *   No Ink Effects
  * </md-checkbox>
  *
@@ -56,7 +56,7 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
     transclude: true,
     require: '?ngModel',
     template: 
-      '<div class="md-container" ink-ripple="checkbox">' +
+      '<div class="md-container" md-ink-ripple="checkbox">' +
         '<div class="md-icon"></div>' +
       '</div>' +
       '<div ng-transclude class="md-label"></div>',

--- a/src/components/checkbox/demoBasicUsage/index.html
+++ b/src/components/checkbox/demoBasicUsage/index.html
@@ -17,7 +17,7 @@
     Checkbox (Disabled, Checked)
   </md-checkbox>
 
-  <md-checkbox noink aria-label="Checkbox No Ink">
+  <md-checkbox md-no-ink aria-label="Checkbox No Ink">
     Checkbox (No Ink)
   </md-checkbox>
 

--- a/src/components/divider/_divider.scss
+++ b/src/components/divider/_divider.scss
@@ -3,7 +3,7 @@ md-divider {
   border-top: 1px solid;
   margin: 0;
 
-  &[inset] {
+  &[md-inset] {
     margin-left: $baseline-grid * 10;
   }
 }

--- a/src/components/divider/demoBasicUsage/index.html
+++ b/src/components/divider/demoBasicUsage/index.html
@@ -44,7 +44,7 @@
             </p>
           </div>
         </md-item-content>
-        <md-divider inset ng-if="!$last"></md-divider>
+        <md-divider md-inset ng-if="!$last"></md-divider>
       </md-item>
     </md-list>
   </md-content>

--- a/src/components/divider/divider.js
+++ b/src/components/divider/divider.js
@@ -22,12 +22,12 @@ function MdDividerController(){}
  * @description
  * Dividers group and separate content within lists and page layouts using strong visual and spatial distinctions. This divider is a thin rule, lightweight enough to not distract the user from content.
  *
- * @param {boolean=} inset Add this attribute to activate the inset divider style.
+ * @param {boolean=} mdInset Add this attribute to activate the inset divider style.
  * @usage
  * <hljs lang="html">
  * <md-divider></md-divider>
  *
- * <md-divider inset></md-divider>
+ * <md-divider md-inset></md-divider>
  * </hljs>
  *
  */

--- a/src/components/progressCircular/_progressCircular.scss
+++ b/src/components/progressCircular/_progressCircular.scss
@@ -48,7 +48,7 @@ md-progress-circular {
     border-radius: 50%;
   }
 
-  &[mode=indeterminate] {
+  &[md-mode=indeterminate] {
     .md-wrapper1, .md-wrapper2 {
       transform-origin: 50% 50%;
     }

--- a/src/components/progressCircular/demoBasicUsage/index.html
+++ b/src/components/progressCircular/demoBasicUsage/index.html
@@ -3,24 +3,24 @@
     <h4 style="margin-top:10px">Determinate</h4>
     <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
     <div layout="vertical" layout-sm="horizontal" layout-align="space-around">
-      <md-progress-circular mode="determinate" value="{{determinateValue}}"></md-progress-circular>
+      <md-progress-circular md-mode="determinate" value="{{determinateValue}}"></md-progress-circular>
     </div>
 
     <h4>Indeterminate</h4>
     <p>For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
     <div layout="vertical" layout-sm="horizontal" layout-align="space-around">
-      <md-progress-circular mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-mode="indeterminate"></md-progress-circular>
     </div>
 
     <h4>Theming</h4>
 
     <div layout="vertical" layout-sm="horizontal" layout-align="space-around">
-      <md-progress-circular md-theme="red" mode="indeterminate"></md-progress-circular>
-      <md-progress-circular md-theme="lime" mode="indeterminate"></md-progress-circular>
-      <md-progress-circular md-theme="orange" mode="indeterminate"></md-progress-circular>
-      <md-progress-circular md-theme="light-green" mode="indeterminate"></md-progress-circular>
-      <md-progress-circular md-theme="blue" mode="indeterminate"></md-progress-circular>
-      <md-progress-circular md-theme="purple" mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="red" md-mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="lime" md-mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="orange" md-mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="light-green" md-mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="blue" md-mode="indeterminate"></md-progress-circular>
+      <md-progress-circular md-theme="purple" md-mode="indeterminate"></md-progress-circular>
     </div>
 
 </div>

--- a/src/components/progressCircular/progressCircular.js
+++ b/src/components/progressCircular/progressCircular.js
@@ -24,19 +24,19 @@ angular.module('material.components.progressCircular', [
  *
  * For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.
  *
- * @param {string} mode Select from one of two modes: determinate and indeterminate.
+ * @param {string} mdMode Select from one of two modes: determinate and indeterminate.
  * @param {number=} value In determinate mode, this number represents the percentage of the circular progress. Default: 0
- * @param {number=} diameter This specifies the diamter of the circular progress. Default: 48
+ * @param {number=} mdDiameter This specifies the diamter of the circular progress. Default: 48
  *
  * @usage
  * <hljs lang="html">
- * <md-progress-circular mode="determinate" value="..."></md-progress-circular>
+ * <md-progress-circular md-mode="determinate" value="..."></md-progress-circular>
  *
- * <md-progress-circular mode="determinate" ng-value="..."></md-progress-circular>
+ * <md-progress-circular md-mode="determinate" ng-value="..."></md-progress-circular>
  *
- * <md-progress-circular mode="determinate" value="..." diameter="100"></md-progress-circular>
+ * <md-progress-circular md-mode="determinate" value="..." diameter="100"></md-progress-circular>
  *
- * <md-progress-circular mode="indeterminate"></md-progress-circular>
+ * <md-progress-circular md-mode="indeterminate"></md-progress-circular>
  * </hljs>
  */
 function MdProgressCircularDirective($$rAF, $mdConstant, $mdTheming) {
@@ -83,7 +83,7 @@ function MdProgressCircularDirective($$rAF, $mdConstant, $mdTheming) {
       fix = circle.querySelectorAll('.md-fill.md-fix'),
       i, clamped, fillRotation, fixRotation;
 
-    var diameter = attr.diameter || 48;
+    var diameter = attr.mdDiameter || 48;
     var scale = diameter/48;
 
     circle.style[$mdConstant.CSS.TRANSFORM] = 'scale(' + scale.toString() + ')';

--- a/src/components/progressLinear/_progressLinear.scss
+++ b/src/components/progressLinear/_progressLinear.scss
@@ -28,13 +28,13 @@ md-progress-linear {
     transition: all 0.2s linear;
   }
 
-  &[mode=determinate] {
+  &[md-mode=determinate] {
     .md-bar1 {
       display: none;
     }
   }
 
-  &[mode=indeterminate] {
+  &[md-mode=indeterminate] {
     .md-bar1 {
       animation: indeterminate1 4s infinite linear;
     }
@@ -44,7 +44,7 @@ md-progress-linear {
     }
   }
 
-  &[mode=buffer] {
+  &[md-mode=buffer] {
     .md-container {
       background-color: transparent !important;
     }
@@ -63,7 +63,7 @@ md-progress-linear {
     }
   }
 
-  &[mode=query] {
+  &[md-mode=query] {
     .md-bar2 {
       animation: query .8s infinite cubic-bezier(0.390, 0.575, 0.565, 1.000);
     }

--- a/src/components/progressLinear/demoBasicUsage/index.html
+++ b/src/components/progressLinear/demoBasicUsage/index.html
@@ -2,24 +2,24 @@
 
   <h4 style="margin-top:0px">Determinate</h4>
   <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
-  <md-progress-linear mode="determinate" ng-value="determinateValue" ></md-progress-linear>
+  <md-progress-linear md-mode="determinate" ng-value="determinateValue" ></md-progress-linear>
 
   <h4>Indeterminate</h4>
   <p>For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
-  <md-progress-linear mode="indeterminate"></md-progress-linear>
+  <md-progress-linear md-mode="indeterminate"></md-progress-linear>
 
   <h4>Buffer</h4>
-  <md-progress-linear mode="buffer" value="{{determinateValue}}" secondaryValue="{{determinateValue2}}"></md-progress-linear>
+  <md-progress-linear md-mode="buffer" value="{{determinateValue}}" md-buffer-value="{{determinateValue2}}"></md-progress-linear>
 
   <h4>Query Indeterminate and Determinate</h4>
-  <md-progress-linear mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
+  <md-progress-linear md-mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
 
   <h4>Themes</h4>
-  <md-progress-linear md-theme="red" mode="determinate" ng-value="determinateValue" ></md-progress-linear>
-  <md-progress-linear md-theme="deep-orange" mode="buffer" value="{{determinateValue}}" secondaryValue="{{determinateValue2}}"></md-progress-linear>
-  <md-progress-linear md-theme="yellow" mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
-  <md-progress-linear md-theme="green" mode="determinate" ng-value="determinateValue" ></md-progress-linear>
-  <md-progress-linear md-theme="blue" mode="buffer" value="{{determinateValue}}" secondaryValue="{{determinateValue2}}"></md-progress-linear>
-  <md-progress-linear md-theme="indigo" mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
+  <md-progress-linear md-theme="red" md-mode="determinate" ng-value="determinateValue" ></md-progress-linear>
+  <md-progress-linear md-theme="deep-orange" md-mode="buffer" value="{{determinateValue}}" md-buffer-value="{{determinateValue2}}"></md-progress-linear>
+  <md-progress-linear md-theme="yellow" md-mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
+  <md-progress-linear md-theme="green" md-mode="determinate" ng-value="determinateValue" ></md-progress-linear>
+  <md-progress-linear md-theme="blue" md-mode="buffer" value="{{determinateValue}}" md-buffer-value="{{determinateValue2}}"></md-progress-linear>
+  <md-progress-linear md-theme="indigo" md-mode="{{mode}}" value="{{determinateValue}}"></md-progress-linear>
 
 </div>

--- a/src/components/progressLinear/progressLinear-theme.scss
+++ b/src/components/progressLinear/progressLinear-theme.scss
@@ -11,7 +11,7 @@ md-progress-linear.md-#{$theme-name}-theme {
     background-color: $progress-linear-color;
   }
 
-  &[mode=buffer] {
+  &[md-mode=buffer] {
     .md-dashed:before {
       background: radial-gradient($progress-linear-alt-color 0%, $progress-linear-alt-color 16%, transparent 42%);
     }

--- a/src/components/progressLinear/progressLinear.js
+++ b/src/components/progressLinear/progressLinear.js
@@ -25,21 +25,21 @@ angular.module('material.components.progressLinear', [
  *
  * For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.
  *
- * @param {string} mode Select from one of four modes: determinate, indeterminate, buffer or query.
+ * @param {string} mdMode Select from one of four modes: determinate, indeterminate, buffer or query.
  * @param {number=} value In determinate and buffer modes, this number represents the percentage of the primary progress bar. Default: 0
- * @param {number=} secondaryValue In the buffer mode, this number represents the precentage of the secondary progress bar. Default: 0
+ * @param {number=} mdBufferValue In the buffer mode, this number represents the precentage of the secondary progress bar. Default: 0
  *
  * @usage
  * <hljs lang="html">
- * <md-progress-linear mode="determinate" value="..."></md-progress-linear>
+ * <md-progress-linear md-mode="determinate" value="..."></md-progress-linear>
  *
- * <md-progress-linear mode="determinate" ng-value="..."></md-progress-linear>
+ * <md-progress-linear md-mode="determinate" ng-value="..."></md-progress-linear>
  *
- * <md-progress-linear mode="indeterminate"></md-progress-linear>
+ * <md-progress-linear md-mode="indeterminate"></md-progress-linear>
  *
- * <md-progress-linear mode="buffer" value="..." secondaryValue="..."></md-progress-linear>
+ * <md-progress-linear md-mode="buffer" value="..." md-buffer-value="..."></md-progress-linear>
  *
- * <md-progress-linear mode="query"></md-progress-linear>
+ * <md-progress-linear md-mode="query"></md-progress-linear>
  * </hljs>
  */
 function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
@@ -68,7 +68,7 @@ function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
       container = angular.element(element[0].querySelector('.md-container'));
 
     attr.$observe('value', function(value) {
-      if (attr.mode == 'query') {
+      if (attr.mdMode == 'query') {
         return;
       }
 
@@ -77,7 +77,7 @@ function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
       bar2Style[$mdConstant.CSS.TRANSFORM] = transforms[clamped];
     });
 
-    attr.$observe('secondaryvalue', function(value) {
+    attr.$observe('mdBufferValue', function(value) {
       bar1Style[$mdConstant.CSS.TRANSFORM] = transforms[clamp(value)];
     });
 

--- a/src/components/progressLinear/progressLinear.spec.js
+++ b/src/components/progressLinear/progressLinear.spec.js
@@ -33,9 +33,9 @@ describe('mdProgressLinear', function() {
     expect(progress.eq(0).attr('aria-valuenow')).toEqual('50');
   }));
 
-  it('should set transform based on secondaryvalue', inject(function($compile, $rootScope, $mdConstant) {
+  it('should set transform based on buffer value', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}" secondaryvalue="{{progress2}}">' +
+      '<md-progress-linear value="{{progress}}" md-buffer-value="{{progress2}}">' +
       '</md-progress-linear>' +
       '</div>')($rootScope);
 
@@ -52,7 +52,7 @@ describe('mdProgressLinear', function() {
 
   it('should not set transform in query mode', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
-      '<md-progress-linear mode="query" value="{{progress}}">' +
+      '<md-progress-linear md-mode="query" value="{{progress}}">' +
       '</md-progress-linear>' +
       '</div>')($rootScope);
 

--- a/src/components/radioButton/demoBasicUsage/index.html
+++ b/src/components/radioButton/demoBasicUsage/index.html
@@ -5,7 +5,7 @@
     <md-radio-group ng-model="data.group1">
 
       <md-radio-button value="Apple" aria-label="Label 1">Apple</md-radio-button>
-      <md-radio-button value="Banana" noink> Banana </md-radio-button>
+      <md-radio-button value="Banana" md-no-ink> Banana </md-radio-button>
       <md-radio-button value="Mango" aria-label="Label 3">Mango</md-radio-button>
 
     </md-radio-group>

--- a/src/components/radioButton/radioButton.js
+++ b/src/components/radioButton/radioButton.js
@@ -26,7 +26,7 @@ angular.module('material.components.radioButton', [
  * `<md-radio-button>` tags.
  *
  * @param {string} ngModel Assignable angular expression to data-bind to.
- * @param {boolean=} noink Use of attribute indicates flag to disable ink ripple effects.
+ * @param {boolean=} mdNoInk Use of attribute indicates flag to disable ink ripple effects.
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/sidenav/demoBasicUsage/index.html
+++ b/src/components/sidenav/demoBasicUsage/index.html
@@ -3,7 +3,7 @@
 
   <section layout="horizontal" flex>
 
-    <md-sidenav class="md-sidenav-left md-whiteframe-z2" component-id="left" is-locked-open="$media('md')">
+    <md-sidenav class="md-sidenav-left md-whiteframe-z2" md-component-id="left" md-is-locked-open="$media('md')">
 
       <md-toolbar class="md-theme-indigo">
         <h1 class="md-toolbar-tools">Sidenav Left</h1>
@@ -44,7 +44,7 @@
 
     </md-content>
 
-    <md-sidenav class="md-sidenav-right md-whiteframe-z2" component-id="right">
+    <md-sidenav class="md-sidenav-right md-whiteframe-z2" md-component-id="right">
 
       <md-toolbar class="md-theme-light">
         <h1 class="md-toolbar-tools">Sidenav Right</h1>

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -31,7 +31,7 @@ function mdSidenavController($scope, $element, $attrs, $timeout, $mdSidenav, $md
 
   var self = this;
 
-  this.destroy = $mdComponentRegistry.register(this, $attrs.componentId);
+  this.destroy = $mdComponentRegistry.register(this, $attrs.mdComponentId);
 
   this.isOpen = function() {
     return !!$scope.isOpen;
@@ -109,7 +109,7 @@ function mdSidenavService($mdComponentRegistry) {
  * @usage
  * <hljs lang="html">
  * <div layout="horizontal" ng-controller="MyController">
- *   <md-sidenav component-id="left" class="md-sidenav-left">
+ *   <md-sidenav md-component-id="left" class="md-sidenav-left">
  *     Left Nav!
  *   </md-sidenav>
  *
@@ -120,8 +120,8 @@ function mdSidenavService($mdComponentRegistry) {
  *     </md-button>
  *   </md-content>
  *
- *   <md-sidenav component-id="right" 
- *     is-locked-open="$media('min-width: 333px')"
+ *   <md-sidenav md-component-id="right"
+ *     md-is-locked-open="$media('min-width: 333px')"
  *     class="md-sidenav-right">
  *     Right Nav!
  *   </md-sidenav>
@@ -137,9 +137,9 @@ function mdSidenavService($mdComponentRegistry) {
  * });
  * </hljs>
  *
- * @param {expression=} is-open A model bound to whether the sidenav is opened.
- * @param {string=} component-id componentId to use with $mdSidenav service.
- * @param {expression=} is-locked-open When this expression evalutes to true,
+ * @param {expression=} mdIsOpen A model bound to whether the sidenav is opened.
+ * @param {string=} mdComponentId componentId to use with $mdSidenav service.
+ * @param {expression=} mdIsLockedOpen When this expression evalutes to true,
  * the sidenav 'locks open': it falls into the content's flow instead
  * of appearing over it. This overrides the `is-open` attribute.
  *
@@ -147,15 +147,15 @@ function mdSidenavService($mdComponentRegistry) {
  * can be given a media query or one of the `sm`, `md` or `lg` presets.
  * Examples:
  *
- *   - `<md-sidenav is-locked-open="shouldLockOpen"></md-sidenav>`
- *   - `<md-sidenav is-locked-open="$media('min-width: 1000px')"></md-sidenav>`
- *   - `<md-sidenav is-locked-open="$media('sm')"></md-sidenav>` <!-- locks open on small screens !-->
+ *   - `<md-sidenav md-is-locked-open="shouldLockOpen"></md-sidenav>`
+ *   - `<md-sidenav md-is-locked-open="$media('min-width: 1000px')"></md-sidenav>`
+ *   - `<md-sidenav md-is-locked-open="$media('sm')"></md-sidenav>` <!-- locks open on small screens !-->
  */
 function mdSidenavDirective($timeout, $animate, $parse, $mdMedia, $mdConstant, $compile, $mdTheming) {
   return {
     restrict: 'E',
     scope: {
-      isOpen: '=?'
+      isOpen: '=?mdIsOpen'
     },
     controller: '$mdSidenavController',
     compile: function(element) {
@@ -166,7 +166,7 @@ function mdSidenavDirective($timeout, $animate, $parse, $mdMedia, $mdConstant, $
   };
 
   function postLink(scope, element, attr, sidenavCtrl) {
-    var isLockedOpenParsed = $parse(attr.isLockedOpen);
+    var isLockedOpenParsed = $parse(attr.mdIsLockedOpen);
     var backdrop = $compile(
       '<md-backdrop class="md-sidenav-backdrop md-opaque">'
     )(scope);
@@ -270,7 +270,7 @@ function mdMediaFactory($window, $mdUtil, $timeout) {
   function add(query) {
     return cache.put(query, !!$window.matchMedia(query).matches);
   }
-  
+
   function updateAll() {
     var keys = cache.keys();
     if (keys.length) {
@@ -283,7 +283,7 @@ function mdMediaFactory($window, $mdUtil, $timeout) {
   }
 
 }
-  
+
 function mdComponentRegistry($log) {
   var instances = [];
 

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -18,7 +18,7 @@ describe('mdSidenav', function() {
   describe('directive', function() {
 
     it('should bind isOpen attribute', inject(function($rootScope, $animate) {
-      var el = setup('is-open="show"');
+      var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
       $animate.triggerCallbacks();
@@ -32,7 +32,7 @@ describe('mdSidenav', function() {
     }));
 
     it('should close on escape', inject(function($rootScope, $animate, $mdConstant, $timeout) {
-      var el = setup('is-open="show"');
+      var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
       $animate.triggerCallbacks();
@@ -45,7 +45,7 @@ describe('mdSidenav', function() {
     }));
 
     it('should close on backdrop click', inject(function($rootScope, $animate, $timeout) {
-      var el = setup('is-open="show"');
+      var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
       $animate.triggerCallbacks();
@@ -56,7 +56,7 @@ describe('mdSidenav', function() {
 
     it('should focus sidenav on open', inject(function($rootScope, $animate, $document) {
       TestUtil.mockElementFocus(this);
-      var el = setup('is-open="show"');
+      var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
       $animate.triggerCallbacks();
@@ -64,7 +64,7 @@ describe('mdSidenav', function() {
     }));
 
     it('should lock open when is-locked-open is true', inject(function($rootScope, $animate, $document) {
-      var el = setup('is-open="show" is-locked-open="lock"');
+      var el = setup('md-is-open="show" md-is-locked-open="lock"');
       expect(el.hasClass('md-locked-open')).toBe(false);
       $rootScope.$apply('lock = true');
       expect(el.hasClass('md-locked-open')).toBe(true);
@@ -79,7 +79,7 @@ describe('mdSidenav', function() {
         $provide.value('$mdMedia', mdMediaSpy);
       });
       inject(function($rootScope, $animate, $document, $mdMedia) {
-        var el = setup('is-locked-open="$media(123)"');
+        var el = setup('md-is-locked-open="$media(123)"');
         expect($mdMedia).toHaveBeenCalledWith(123);
       });
     });
@@ -118,7 +118,7 @@ describe('mdSidenav', function() {
     });
 
     it('should deregister component when element is destroyed', inject(function($mdComponentRegistry) {
-      var el = setup('component-id="left"');
+      var el = setup('md-component-id="left"');
       el.triggerHandler('$destroy');
 
       var instance = $mdComponentRegistry.get('left');
@@ -129,7 +129,7 @@ describe('mdSidenav', function() {
 
   describe('$mdSidenav Service', function() {
     it('should grab instance', inject(function($mdSidenav) {
-      var el = setup('component-id="left"');
+      var el = setup('md-component-id="left"');
       var scope = el.isolateScope();
 
       var instance = $mdSidenav('left');

--- a/src/components/slider/_slider.scss
+++ b/src/components/slider/_slider.scss
@@ -204,7 +204,7 @@ md-slider {
     }
   }
 
-  &:not([discrete]) {
+  &:not([md-discrete]) {
     /* Hide the sign and ticks in non-discrete mode */
     .md-track-ticks,
     .md-sign {
@@ -233,7 +233,7 @@ md-slider {
     }
   }
 
-  &[discrete] {
+  &[md-discrete] {
     /* Hide the focus thumb in discrete mode */
     .md-focus-thumb,
     .md-focus-ring {

--- a/src/components/slider/demoBasicUsage/index.html
+++ b/src/components/slider/demoBasicUsage/index.html
@@ -40,7 +40,7 @@
     </div>
 
     <h3>Rating: {{rating}}/5</h3>
-    <md-slider discrete ng-model="rating" step="1" min="1" max="5" aria-label="rating">
+    <md-slider md-discrete ng-model="rating" step="1" min="1" max="5" aria-label="rating">
     </md-slider>
 
     <h3>Disabled</h3>
@@ -48,8 +48,8 @@
     <md-slider ng-model="disabled2" disabled aria-label="Disabled 2"></md-slider>
 
     <h3>Disabled, Discrete</h3>
-    <md-slider ng-model="disabled1" disabled step="3" discrete min="0" max="10" aria-label="Disabled discrete 1"></md-slider>
-    <md-slider ng-model="disabled2" disabled step="10" discrete aria-label="Disabled discrete 2"></md-slider>
+    <md-slider ng-model="disabled1" disabled step="3" md-discrete min="0" max="10" aria-label="Disabled discrete 1"></md-slider>
+    <md-slider ng-model="disabled2" disabled step="10" md-discrete aria-label="Disabled discrete 2"></md-slider>
 
   </md-content>
 </div>

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -23,7 +23,7 @@ angular.module('material.components.slider', [
  * of values, and 'discrete' mode, where the user slides between only a few
  * select values.
  *
- * To enable discrete mode, add the `discrete` attribute to a slider,
+ * To enable discrete mode, add the `md-discrete` attribute to a slider,
  * and use the `step` attribute to change the distance between
  * values the user is allowed to pick.
  *
@@ -35,11 +35,11 @@ angular.module('material.components.slider', [
  * </hljs>
  * <h4>Discrete Mode</h4>
  * <hljs lang="html">
- * <md-slider discrete ng-model="myDiscreteValue" step="10" min="10" max="130">
+ * <md-slider md-discrete ng-model="myDiscreteValue" step="10" min="10" max="130">
  * </md-slider>
  * </hljs>
  *
- * @param {boolean=} discrete Whether to enable discrete mode.
+ * @param {boolean=} mdDiscrete Whether to enable discrete mode.
  * @param {number=} step The distance between values the user is allowed to pick. Default 1.
  * @param {number=} min The minimum value the user is allowed to pick. Default 0.
  * @param {number=} max The maximum value the user is allowed to pick. Default 100.
@@ -180,7 +180,7 @@ function SliderController($scope, $element, $attrs, $$rAF, $window, $mdAria, $md
     // which could quickly become a performance bottleneck.
     var tickCanvas, tickCtx;
     function redrawTicks() {
-      if (!angular.isDefined($attrs.discrete)) return;
+      if (!angular.isDefined($attrs.mdDiscrete)) return;
 
       var numSteps = Math.floor( (max - min) / step );
       if (!tickCanvas) {
@@ -286,7 +286,7 @@ function SliderController($scope, $element, $attrs, $$rAF, $window, $mdAria, $md
      * Slide listeners
      */
     var isSliding = false;
-    var isDiscrete = angular.isDefined($attrs.discrete);
+    var isDiscrete = angular.isDefined($attrs.mdDiscrete);
 
     function onInput(ev) {
       if (!isSliding && ev.eventType === Hammer.INPUT_START &&

--- a/src/components/swipe/swipe.js
+++ b/src/components/swipe/swipe.js
@@ -118,7 +118,7 @@ function MdSwipeFactory() {
  * HammerJS horizontal swipe left and pan left support will be active. The swipe/pan action
  * can result in custom activity trigger by evaluating `expression`.
  *
- * @param {boolean=} noPan Use of attribute indicates flag to disable detection of `panleft` activity
+ * @param {boolean=} mdNoPan Use of attribute indicates flag to disable detection of `panleft` activity
  *
  * @usage
  * <hljs lang="html">
@@ -151,7 +151,7 @@ function MdSwipeLeftDirective($parse, $mdSwipe) {
  * that attaches HammerJS horizontal swipe right and pan right support to an element. The swipe/pan action
  * can result in activity trigger by evaluating `expression`
  *
- * @param {boolean=} noPan Use of attribute indicates flag to disable detection of `panright` activity
+ * @param {boolean=} mdNoPan Use of attribute indicates flag to disable detection of `panright` activity
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/switch/demoBasicUsage/index.html
+++ b/src/components/switch/demoBasicUsage/index.html
@@ -15,7 +15,7 @@
     Switch (Disabled, Active)
   </md-switch>
 
-  <md-switch noink aria-label="Switch No Ink">
+  <md-switch md-no-ink aria-label="Switch No Ink">
     Switch (No Ink)
   </md-switch>
 

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -28,7 +28,7 @@ angular.module('material.components.switch', [
  * @param {expression=} ngTrueValue The value to which the expression should be set when selected.
  * @param {expression=} ngFalseValue The value to which the expression should be set when not selected.
  * @param {string=} ngChange Angular expression to be executed when input changes due to user interaction with the input element.
- * @param {boolean=} noink Use of attribute indicates use of ripple ink effects.
+ * @param {boolean=} mdNoInk Use of attribute indicates use of ripple ink effects.
  * @param {boolean=} disabled Use of attribute indicates the switch is disabled: no ink effects and not selectable
  * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the switch's text.
  *
@@ -38,7 +38,7 @@ angular.module('material.components.switch', [
  *   Finished ?
  * </md-switch>
  *
- * <md-switch noink ng-model="hasInk" aria-label="No Ink Effects">
+ * <md-switch md-no-ink ng-model="hasInk" aria-label="No Ink Effects">
  *   No Ink Effects
  * </md-switch>
  *

--- a/src/components/tabs/demoDynamicTabs/index.html
+++ b/src/components/tabs/demoDynamicTabs/index.html
@@ -1,9 +1,9 @@
 <div ng-controller="AppCtrl" class="sample">
 
-  <md-tabs selected="selectedIndex">
+  <md-tabs md-selected="selectedIndex">
     <md-tab ng-repeat="tab in tabs"
-            on-select="announceSelected(tab)"
-            on-deselect="announceDeselected(tab)"
+            md-on-select="announceSelected(tab)"
+            md-on-deselect="announceDeselected(tab)"
             ng-disabled="tab.disabled"
             label="{{tab.title}}">
 

--- a/src/components/tabs/demoDynamicTabs/script.js
+++ b/src/components/tabs/demoDynamicTabs/script.js
@@ -21,7 +21,7 @@ angular.module('tabsDemo2', ['ngMaterial'])
 
     $scope.addTab = function (title, view) {
       view = view || title + " Content View";
-      tabs.push({ title: title, content: view, disabled: false, style:style});
+      tabs.push({ title: title, content: view, disabled: false});
     };
 
     $scope.removeTab = function (tab) {

--- a/src/components/tabs/demoStaticTabs/index.html
+++ b/src/components/tabs/demoStaticTabs/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="AppCtrl">
 
-    <md-tabs selected="data.selectedIndex"  center>
+    <md-tabs md-selected="data.selectedIndex"  center>
       <md-tab id="tab1" aria-controls="tab1-content">
         Item One
       </md-tab>

--- a/src/components/tabs/js/inkBarDirective.js
+++ b/src/components/tabs/js/inkBarDirective.js
@@ -3,7 +3,7 @@
 
 /**
  * Conditionally configure ink bar animations when the
- * tab selection changes. If `nobar` then do not show the
+ * tab selection changes. If `mdNoBar` then do not show the
  * bar nor animate.
  */
 angular.module('material.components.tabs')
@@ -13,7 +13,7 @@ function MdTabInkDirective($mdConstant, $window, $$rAF, $timeout) {
 
   return {
     restrict: 'E',
-    require: ['^?nobar', '^mdTabs'],
+    require: ['^?mdNoBar', '^mdTabs'],
     link: postLink
   };
 

--- a/src/components/tabs/js/tabItemDirective.js
+++ b/src/components/tabs/js/tabItemDirective.js
@@ -26,16 +26,16 @@ angular.module('material.components.tabs')
  * be initiated via data binding changes, programmatic invocation, or user gestures.
  *
  * @param {string=} label Optional attribute to specify a simple string as the tab label
- * @param {boolean=} active When evaluteing to true, selects the tab.
+ * @param {boolean=} mdActive When evaluteing to true, selects the tab.
  * @param {boolean=} disabled If present, disabled tab selection.
- * @param {expression=} deselected Expression to be evaluated after the tab has been de-selected.
- * @param {expression=} selected Expression to be evaluated after the tab has been selected.
+ * @param {expression=} mdOnDeselect Expression to be evaluated after the tab has been de-selected.
+ * @param {expression=} mdOnSelect Expression to be evaluated after the tab has been selected.
  *
  *
  * @usage
  *
  * <hljs lang="html">
- * <md-tab label="" disabled="" selected="" deselected="" >
+ * <md-tab label="" disabled="" md-on-select="" md-on-deselect="" >
  *   <h3>My Tab content</h3>
  * </md-tab>
  *
@@ -59,8 +59,8 @@ function MdTabDirective($mdInkRipple, $compile, $mdAria, $mdUtil, $mdConstant) {
     require: ['mdTab', '^mdTabs'],
     controller: '$mdTab',
     scope: {
-      onSelect: '&',
-      onDeselect: '&',
+      onSelect: '&mdOnSelect',
+      onDeselect: '&mdOnDeselect',
       label: '@'
     },
     compile: compile
@@ -110,7 +110,7 @@ function MdTabDirective($mdInkRipple, $compile, $mdAria, $mdUtil, $mdConstant) {
       if (angular.isNumber(scope.$parent.$index)) {
         watchNgRepeatIndex();
       }
-      if (angular.isDefined(attr.active)) {
+      if (angular.isDefined(attr.mdActive)) {
         watchActiveAttribute();
       }
       watchDisabled();
@@ -169,7 +169,7 @@ function MdTabDirective($mdInkRipple, $compile, $mdAria, $mdUtil, $mdConstant) {
       }
 
       function watchActiveAttribute() {
-        var unwatch = scope.$parent.$watch('!!(' + attr.active + ')', activeWatchAction);
+        var unwatch = scope.$parent.$watch('!!(' + attr.mdActive + ')', activeWatchAction);
         scope.$on('$destroy', unwatch);
         
         function activeWatchAction(isActive) {

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -45,20 +45,20 @@ angular.module('material.components.tabs')
  * *  If the currently active tab is the last tab, then next() action will select the first tab.
  * *  Any markup (other than **`<md-tab>`** tags) will be transcluded into the tab header area BEFORE the tab buttons.
  *
- * @param {integer=} selected Index of the active/selected tab
- * @param {boolean=} noink If present, disables ink ripple effects.
- * @param {boolean=} nobar If present, disables the selection ink bar.
- * @param {string=}  align-tabs Attribute to indicate position of tab buttons: bottom or top; default is `top`
+ * @param {integer=} mdSelected Index of the active/selected tab
+ * @param {boolean=} mdNoInk If present, disables ink ripple effects.
+ * @param {boolean=} mdNoBar If present, disables the selection ink bar.
+ * @param {string=}  mdAlignTabs Attribute to indicate position of tab buttons: bottom or top; default is `top`
  *
  * @usage
  * <hljs lang="html">
- * <md-tabs selected="selectedIndex" >
+ * <md-tabs md-selected="selectedIndex" >
  *   <img ng-src="/img/angular.png" class="centered">
  *
  *   <md-tab
  *      ng-repeat="tab in tabs | orderBy:predicate:reversed"
- *      on-select="onTabSelected(tab)"
- *      on-deselect="announceDeselected(tab)"
+ *      md-on-select="onTabSelected(tab)"
+ *      md-on-deselect="announceDeselected(tab)"
  *      disabled="tab.disabled" >
  *
  *       <md-tab-label>
@@ -83,7 +83,7 @@ function TabsDirective($parse, $mdTheming) {
     require: 'mdTabs',
     transclude: true,
     scope: {
-      selectedIndex: '=?selected'
+      selectedIndex: '=?mdSelected'
     },
     template:
       '<section class="md-header" ' +

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -130,7 +130,7 @@ describe('<md-tabs>', function() {
     });
 
     it('should bind to selected', function() {
-      var tabs = setup('<md-tabs selected="current">' +
+      var tabs = setup('<md-tabs md-selected="current">' +
                        '<md-tab></md-tab>' +
                        '<md-tab></md-tab>' +
                        '<md-tab></md-tab>' +
@@ -149,9 +149,9 @@ describe('<md-tabs>', function() {
 
     it('should use active binding', function() {
       var tabs = setup('<md-tabs>' +
-                       '<md-tab active="active0"></md-tab>' +
-                       '<md-tab active="active1"></md-tab>' +
-                       '<md-tab active="active2"></md-tab>' +
+                       '<md-tab md-active="active0"></md-tab>' +
+                       '<md-tab md-active="active1"></md-tab>' +
+                       '<md-tab md-active="active2"></md-tab>' +
                        '</md-tabs>');
       var tabItems = tabs.find('md-tab');
 

--- a/src/components/textField/textField.js
+++ b/src/components/textField/textField.js
@@ -26,7 +26,7 @@ angular.module('material.components.textField', [
  * @description
  * Use the `<md-text-float>` directive to quickly construct `Floating Label` text fields
  *
- * @param {string} fid Attribute used for accessibility link pairing between the Label and Input elements
+ * @param {string} mdFid Attribute used for accessibility link pairing between the Label and Input elements
  * @param {string=} type Optional value to define the type of input field. Defaults to string.
  * @param {string} label Attribute to specify the input text field hint.
  * @param {string=} ng-model Optional value to assign as existing input text string
@@ -47,14 +47,14 @@ function mdTextFloatDirective($mdTheming, $mdUtil) {
     restrict: 'E',
     replace: true,
     scope : {
-      fid : '@?',
+      fid : '@?mdFid',
       label : '@?',
       value : '=ngModel'
     },
     compile : function(element, attr) {
 
-      if ( angular.isUndefined(attr.fid) ) {
-        attr.fid = $mdUtil.nextUid();
+      if ( angular.isUndefined(attr.mdFid) ) {
+        attr.mdFid = $mdUtil.nextUid();
       }
 
       return {

--- a/src/components/textField/textField.spec.js
+++ b/src/components/textField/textField.spec.js
@@ -189,13 +189,13 @@ describe('Text Field directives', function() {
 
     it('should pair input and label for accessibility.', function() {
       var markup ='<md-text-float ' +
-                  '  fid="093" ' +
+                  '  md-fid="093" ' +
                   '  label="{{labels.firstName}}" ' +
                   '  ng-model="user.firstName" >' +
                   '</md-text-float>';
       var el = buildElement( markup, model);
       var input = el.find('input');
-      var label = el.find('label')
+      var label = el.find('label');
 
       expect( label.attr('for') ).toBe( "093" );
       expect( input.attr('id') ).toBe( label.attr('for') );

--- a/src/components/toolbar/demoScrollShrink/index.html
+++ b/src/components/toolbar/demoScrollShrink/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="AppCtrl" layout="vertical" layout-fill>
 
-  <md-toolbar scroll-shrink>
+  <md-toolbar md-scroll-shrink>
     <div class="md-toolbar-tools">
       <h3>
         <span>My App Title</span>

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -48,16 +48,16 @@ angular.module('material.components.toolbar', [
  * </div>
  * </hljs>
  *
- * @param {boolean=} scrollShrink Whether the header should shrink away as 
- * the user scrolls down, and reveal itself as the user scrolls up. 
- * Note: for scrollShrink to work, the toolbar must be a sibling of a 
+ * @param {boolean=} mdScrollShrink Whether the header should shrink away as
+ * the user scrolls down, and reveal itself as the user scrolls up.
+ * Note: for scrollShrink to work, the toolbar must be a sibling of a
  * `md-content` element, placed before it. See the scroll shrink demo.
  *
  *
- * @param {number=} shrinkSpeedFactor How much to change the speed of the toolbar's
+ * @param {number=} mdShrinkSpeedFactor How much to change the speed of the toolbar's
  * shrinking by. For example, if 0.25 is given then the toolbar will shrink
  * at one fourth the rate at which the user scrolls down. Default 0.5.
- */ 
+ */
 function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming) {
 
   return {
@@ -66,7 +66,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming) {
     link: function(scope, element, attr) {
       $mdTheming(element);
 
-      if (angular.isDefined(attr.scrollShrink)) {
+      if (angular.isDefined(attr.mdScrollShrink)) {
         setupScrollShrink();
       }
 
@@ -76,7 +76,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming) {
         // Store the last scroll top position
         var prevScrollTop = 0;
 
-        var shrinkSpeedFactor = attr.shrinkSpeedFactor || 0.5;
+        var shrinkSpeedFactor = attr.mdShrinkSpeedFactor || 0.5;
 
         var toolbarHeight;
         var contentElement;
@@ -114,7 +114,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming) {
           // As the user scrolls down, the content will be transformed up slowly
           // to put the content underneath where the toolbar was.
           contentElement.css(
-            'margin-top', 
+            'margin-top',
             (-toolbarHeight * shrinkSpeedFactor) + 'px'
           );
           onContentScroll();
@@ -126,16 +126,16 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming) {
           debouncedUpdateHeight();
 
           y = Math.min(
-            toolbarHeight / shrinkSpeedFactor, 
+            toolbarHeight / shrinkSpeedFactor,
             Math.max(0, y + scrollTop - prevScrollTop)
           );
 
           element.css(
-            $mdConstant.CSS.TRANSFORM, 
+            $mdConstant.CSS.TRANSFORM,
             'translate3d(0,' + (-y * shrinkSpeedFactor) + 'px,0)'
           );
           contentElement.css(
-            $mdConstant.CSS.TRANSFORM, 
+            $mdConstant.CSS.TRANSFORM,
             'translate3d(0,' + ((toolbarHeight - y) * shrinkSpeedFactor) + 'px,0)'
           );
 

--- a/src/components/toolbar/toolbar.spec.js
+++ b/src/components/toolbar/toolbar.spec.js
@@ -40,8 +40,8 @@ describe('<md-toolbar>', function() {
 
     // Manually link so we can give our own elements with spies on them
     mdToolbarDirective[0].link($rootScope, toolbar, { 
-      scrollShrink: true,
-      shrinkSpeedFactor: 1
+      mdScrollShrink: true,
+      mdShrinkSpeedFactor: 1
     });
 
     $rootScope.$broadcast('$mdContentLoaded', contentEl);

--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -20,7 +20,7 @@
 
     <md-button class="md-fab md-fab-top-left left" >
       <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg"></md-icon>
-      <md-tooltip visible="showTooltip">
+      <md-tooltip md-visible="showTooltip">
         Insert Drive
       </md-tooltip>
     </md-button>
@@ -35,7 +35,7 @@
 
     <p>
       <div>
-        Additionally, the Tooltip's `visible` attribute can use data-binding to programmatically
+        Additionally, the Tooltip's `md-visible` attribute can use data-binding to programmatically
         show/hide itself. Toggle the checkbox below...
       </div>
     </p>

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -30,7 +30,7 @@ angular.module('material.components.tooltip', [
  * </md-icon>
  * </hljs>
  *
- * @param {expression=} visible Boolean bound to whether the tooltip is 
+ * @param {expression=} mdVisible Boolean bound to whether the tooltip is
  * currently visible.
  */
 function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdTheming) {
@@ -45,11 +45,11 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     restrict: 'E',
     transclude: true,
     require: '^?mdContent',
-    template: 
+    template:
       '<div class="md-background"></div>' +
       '<div class="md-content" ng-transclude></div>',
     scope: {
-      visible: '=?'
+      visible: '=?mdVisible'
     },
     link: postLink
   };
@@ -76,13 +76,12 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       if (isVisible) showTooltip();
       else hideTooltip();
     });
-    
-    var debouncedOnResize = $$rAF.debounce(onWindowResize);
-    angular.element($window).on('resize', debouncedOnResize);
-    function onWindowResize() {
+
+    var debouncedOnResize = $$rAF.debounce(function windowResize() {
       // Reposition on resize
       if (scope.visible) positionTooltip();
-    }
+    });
+    angular.element($window).on('resize', debouncedOnResize);
 
     // Be sure to completely cleanup the element on destroy
     scope.$on('$destroy', function() {
@@ -121,7 +120,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       parent.attr('aria-describedby', element.attr('id'));
       tooltipParent.append(element);
 
-      // Wait until the element has been in the dom for two frames before 
+      // Wait until the element has been in the dom for two frames before
       // fading it in.
       // Additionally, we position the tooltip twice to avoid positioning bugs
       //positionTooltip();
@@ -145,7 +144,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       }, 200, false);
     }
 
-    function positionTooltip(rerun) {
+    function positionTooltip() {
       var tipRect = element[0].getBoundingClientRect();
       var parentRect = parent[0].getBoundingClientRect();
 
@@ -163,7 +162,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
 
       // If element bleeds over left/right of the window, place it on the edge of the window.
       newPosition.left = Math.min(
-        newPosition.left, 
+        newPosition.left,
         $window.innerWidth - tipRect.width - TOOLTIP_WINDOW_EDGE_SPACE
       );
       newPosition.left = Math.max(newPosition.left, TOOLTIP_WINDOW_EDGE_SPACE);

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -21,7 +21,7 @@ describe('<md-tooltip> directive', function() {
   it('should show and hide when visible is set', inject(function($compile, $rootScope, $timeout) {
     var element = $compile('<md-button>' +
                'Hello' +
-               '<md-tooltip visible="isVisible">Tooltip</md-tooltip>' +
+               '<md-tooltip md-visible="isVisible">Tooltip</md-tooltip>' +
              '</md-button>')($rootScope);
 
     $rootScope.$apply();
@@ -42,7 +42,7 @@ describe('<md-tooltip> directive', function() {
   it('should describe parent', inject(function($compile, $rootScope, $timeout) {
     var element = $compile('<md-button>' +
                'Hello' +
-               '<md-tooltip visible="isVisible">Tooltip</md-tooltip>' +
+               '<md-tooltip md-visible="isVisible">Tooltip</md-tooltip>' +
              '</md-button>')($rootScope);
 
     $rootScope.$apply('isVisible = true');
@@ -57,7 +57,7 @@ describe('<md-tooltip> directive', function() {
   it('should set visible on mouseenter and mouseleave', inject(function($compile, $rootScope, $timeout) {
     var element = $compile('<md-button>' +
                'Hello' +
-               '<md-tooltip visible="isVisible">Tooltip</md-tooltip>' +
+               '<md-tooltip md-visible="isVisible">Tooltip</md-tooltip>' +
              '</md-button>')($rootScope);
 
     $rootScope.$apply();
@@ -74,7 +74,7 @@ describe('<md-tooltip> directive', function() {
   it('should set visible on focus and blur', inject(function($compile, $rootScope, $timeout) {
     var element = $compile('<md-button>' +
                'Hello' +
-               '<md-tooltip visible="isVisible">Tooltip</md-tooltip>' +
+               '<md-tooltip md-visible="isVisible">Tooltip</md-tooltip>' +
              '</md-button>')($rootScope);
 
     $rootScope.$apply();
@@ -91,7 +91,7 @@ describe('<md-tooltip> directive', function() {
   it('should set visible on touchstart and touchend', inject(function($compile, $rootScope, $timeout) {
     var element = $compile('<md-button>' +
                'Hello' +
-               '<md-tooltip visible="isVisible">Tooltip</md-tooltip>' +
+               '<md-tooltip md-visible="isVisible">Tooltip</md-tooltip>' +
              '</md-button>')($rootScope);
 
     $rootScope.$apply();

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -4,14 +4,14 @@
 
 angular.module('material.core')
   .factory('$mdInkRipple', InkRippleService)
-  .directive('inkRipple', InkRippleDirective)
-  .directive('noink', attrNoDirective())
-  .directive('nobar', attrNoDirective())
-  .directive('nostretch', attrNoDirective());
+  .directive('mdInkRipple', InkRippleDirective)
+  .directive('mdNoInk', attrNoDirective())
+  .directive('mdNoBar', attrNoDirective())
+  .directive('mdNoStretch', attrNoDirective());
 
 function InkRippleDirective($mdInkRipple) {
   return function(scope, element, attr) {
-    if (attr.inkRipple == 'checkbox') {
+    if (attr.mdInkRipple == 'checkbox') {
       $mdInkRipple.attachCheckboxBehavior(element);
     } else {
       $mdInkRipple.attachButtonBehavior(element);
@@ -50,8 +50,8 @@ function InkRippleService($window, $$rAF, $mdUtil, $timeout, $mdConstant) {
   }
 
   function attach(element, options) {
-    // Parent element with noink attr? Abort.
-    if (element.controller('noink')) return angular.noop;
+    // Parent element with mdNoInk attr? Abort.
+    if (element.controller('mdNoInk')) return angular.noop;
     var contentParent = element.controller('mdContent');
 
     options = angular.extend({
@@ -165,7 +165,7 @@ function InkRippleService($window, $$rAF, $mdUtil, $timeout, $mdConstant) {
  *
  * @usage
  * <hljs lang="html">
- * <parent noink>
+ * <parent md-no-ink>
  *   <child detect-no>
  *   </child>
  * </parent>
@@ -174,15 +174,15 @@ function InkRippleService($window, $$rAF, $mdUtil, $timeout, $mdConstant) {
  * <hljs lang="js">
  * myApp.directive('detectNo', function() {
  *   return {
- *     require: ['^?noink', ^?nobar'],
+ *     require: ['^?mdNoInk', ^?mdNoBar'],
  *     link: function(scope, element, attr, ctrls) {
  *       var noinkCtrl = ctrls[0];
  *       var nobarCtrl = ctrls[1];
  *       if (noInkCtrl) {
- *         alert("the noink flag has been specified on an ancestor!");
+ *         alert("the md-no-ink flag has been specified on an ancestor!");
  *       }
  *       if (nobarCtrl) {
- *         alert("the nobar flag has been specified on an ancestor!");
+ *         alert("the md-no-bar flag has been specified on an ancestor!");
  *       }
  *     }
  *   };


### PR DESCRIPTION
## Notes:

1) Changed `noInk`, etc to `mdNoInk` (affects button, switch, and checkbox)

2) `inset` on `mdDivider` is now `mdInset`

3) `mdLinearProgress` renamed `secondaryValue` to `mdBufferValue`

4) `mdCircularProgress` and `mdLinearProgress` renamed `mode` to `md-mode`.

5) Prefixed `mdSideNav`'s attrs (`mdIsOpen`, `mdIsLockedOpen`, `mdComponentId`

6) Prefix tab `md-on-select`, `md-on-deselect`, and `md-active`.

7) Prefix tabs `md-selected`.

8) Fix bug in tabs demo on add tab to dynamic

9) switch `mdTextFloat`'s `fid` to `mdFid`
## Questions:

1) Does `nopan` actually do anything in swipe?

@ajoslin @ThomasBurleson 
