### PR TITLE
$mdAria.expect() checks visible child nodes for aria-label

### DIFF
--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -13,14 +13,15 @@ function AriaService($$rAF, $log) {
   };
 
   /**
-   * Check if expected attribute has been specified on the target element
+   * Check if expected attribute has been specified on the target element or child
    * @param element
    * @param attrName
    * @param {optional} defaultValue What to set the attr to if no value is found
    */
   function expect(element, attrName, defaultValue) {
     var node = element[0];
-    if (!node.hasAttribute(attrName)) {
+
+    if (!node.hasAttribute(attrName) && !childHasAttribute(node, attrName)) {
 
       defaultValue = angular.isString(defaultValue) && defaultValue.trim() || '';
       if (defaultValue.length) {
@@ -47,5 +48,28 @@ function AriaService($$rAF, $log) {
     });
   }
 
+  function childHasAttribute(node, attrName) {
+    var hasChildren = node.hasChildNodes(),
+        childHasAttribute = false;
+
+    function isHidden(el) {
+      var style = el.currentStyle ? el.currentStyle :
+                            getComputedStyle(el);
+      return (style.display === 'none');
+    }
+
+    if(hasChildren) {
+      var children = node.childNodes;
+      for(var i=0; i<children.length; i++){
+        var child = children[i];
+        if(child.nodeType === 1 && child.hasAttribute(attrName)) {
+          if(!isHidden(child)){
+            childHasAttribute = true;
+          }
+        }
+      }
+    }
+    return childHasAttribute;
+  }
 }
 })();

--- a/src/core/services/aria/aria.spec.js
+++ b/src/core/services/aria/aria.spec.js
@@ -1,0 +1,39 @@
+describe('$mdAria service', function() {
+  beforeEach(module('material.core'));
+
+  describe('expecting attributes', function(){
+    it('should warn if element is missing text', inject(function($compile, $rootScope, $log, $mdAria) {
+      spyOn($log, 'warn');
+      var button = $compile('<button><md-icon></md-icon></button>')($rootScope);
+
+      $mdAria.expect(button, 'aria-label');
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
+    it('should not warn if child element has attribute', inject(function($compile, $rootScope, $log, $mdAria) {
+      spyOn($log, 'warn');
+      var button = $compile('<button><md-icon aria-label="text"></md-icon></button>')($rootScope);
+
+      $mdAria.expect(button, 'aria-label');
+
+      expect($log.warn).not.toHaveBeenCalled();
+    }));
+
+    it('should warn if child with attribute is hidden', inject(function($compile, $rootScope, $log, $mdAria) {
+      spyOn($log, 'warn');
+      var container = angular.element(document.body);
+      var button = $compile('<button><md-icon aria-label="text" style="display:none;"></md-icon></button>')($rootScope);
+
+      container.append(button);
+
+      $mdAria.expect(button, 'aria-label');
+
+      expect($log.warn).toHaveBeenCalled();
+
+      button.remove();
+
+    }));
+  });
+
+});


### PR DESCRIPTION
If `aria-label` was included on a child node such as `<md-button><md-icon aria-label="New document"></md-button>`, the `$mdAria` service would warn the developer even though the button had valid accessible text. This PR addresses that fix with updated code and new test coverage.

Closes #567
