### PR TITLE
Fixed small documentation error

### DIFF
--- a/docs/app/partials/layout-container.tmpl.html
+++ b/docs/app/partials/layout-container.tmpl.html
@@ -23,7 +23,7 @@
   <p>
     Use the <code>layout</code> attribute on an element to arrange its children
     horizontally in a row (<code>layout="row"</code>), or vertically in
-    a column (<code>layout="vertical"</code>). The layout attribute's value
+    a column (<code>layout="column"</code>). The layout attribute's value
     describes what the "main axis" is for its children. It uses words that adhere
     to the flexbox specification.
   </p>


### PR DESCRIPTION
The description says that the column layout needs `layout="vertical"` while the right one is `column`, as correctly shown in the example
