### PR TITLE
Fix for preserving tabindex on radio button groups

### DIFF
--- a/src/components/radioButton/radioButton.js
+++ b/src/components/radioButton/radioButton.js
@@ -25,6 +25,11 @@ angular.module('material.components.radioButton', [
  * container for the 1..n grouped radio buttons; specified using nested
  * `<md-radio-button>` tags.
  *
+ * Note: `<md-radio-group>` and `<md-radio-button>` handle tabindex differently
+ * than the native `<input type='radio'>` controls. Whereas the native controls
+ * force the user to tab through all the radio buttons, `<md-radio-group>`
+ * is focusable, and by default the `<md-radio-button>`s are not.
+ *
  * @param {string} ngModel Assignable angular expression to data-bind to.
  * @param {boolean=} mdNoInk Use of attribute indicates flag to disable ink ripple effects.
  *
@@ -74,11 +79,9 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming) {
 
     rgCtrl.init(ngModelCtrl);
 
-    element.attr({
-      'role': 'radiogroup',
-      'tabIndex': '0'
-    })
-    .on('keydown', keydownListener);
+    element.attr({'role': 'radiogroup'});
+    element.attr({'tabIndex': element.attr('tabindex') || '0' });
+    element.on('keydown', keydownListener);
   }
 
   function RadioGroupController($element) {

--- a/src/components/radioButton/radioButton.spec.js
+++ b/src/components/radioButton/radioButton.spec.js
@@ -71,6 +71,16 @@ describe('radioButton', function() {
     expect(rbElements.eq(0).attr('aria-label')).toEqual('Blue');
   }));
 
+  it('should preserve tabindex', inject(function($compile, $rootScope, $mdConstant) {
+    var element = $compile('<md-radio-group ng-model="color" tabindex="3">' +
+                            '<md-radio-button value="blue"></md-radio-button>' +
+                            '<md-radio-button value="green"></md-radio-button>' +
+                          '</md-radio-group>')($rootScope);
+
+    var rbGroupElement = element.eq(0);
+    expect(rbGroupElement.attr('tabindex')).toEqual('3');
+  }));
+
   it('should be operable via arrow keys', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<md-radio-group ng-model="color">' +
                             '<md-radio-button value="blue"></md-radio-button>' +


### PR DESCRIPTION
With this change, developers can provide a custom tabindex value for `<md-radio-group>`. Previously, tabindex was always set to 0. Test added to assert functionality.

Closes #602
