### PR TITLE
docs(tabs): static tabs example uses mdSelected

### DIFF
--- a/src/components/tabs/demoStaticTabs/index.html
+++ b/src/components/tabs/demoStaticTabs/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="AppCtrl">
 
-    <md-tabs selected="data.selectedIndex">
+    <md-tabs md-selected="data.selectedIndex">
       <md-tab id="tab1" aria-controls="tab1-content">
         Item One
       </md-tab>


### PR DESCRIPTION
Due to eb2f2f8a8c668142742e4b4c1e18cf6d91a533db, all non-HTML5 attributes
are prefixed by md-

Closes #699 
