### PR TITLE
fix(docs): Landing page fixed in IE11

### DIFF
--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -1,5 +1,5 @@
 <div ng-controller="HomeCtrl" layout="column">
-    <md-content flex>
+    <md-content>
         <p>
             <a href="http://www.google.com/design/spec/material-design/">Material Design</a> is a specification for a
             unified system of visual, motion, and interaction design that adapts across different devices and different


### PR DESCRIPTION
The landing page is missing in IE11. Removing an extra `flex` attribute made the content appear and flow correctly at multiple screen sizes.
