### PR TITLE
feat(tooltip): add configurable tooltip delay

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -32,6 +32,8 @@ angular.module('material.components.tooltip', [
  *
  * @param {expression=} mdVisible Boolean bound to whether the tooltip is
  * currently visible.
+ * @param {number=} [mdTooltipDelay=400] Number of milliseconds to delay showing
+ * tooltip.
  */
 function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdTheming) {
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -49,7 +49,8 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       '<div class="md-background"></div>' +
       '<div class="md-content" ng-transclude></div>',
     scope: {
-      visible: '=?mdVisible'
+      visible: '=?mdVisible',
+      delay: '=?mdTooltipDelay'
     },
     link: postLink
   };
@@ -57,6 +58,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
   function postLink(scope, element, attr, contentCtrl) {
     $mdTheming(element);
     var parent = element.parent();
+    scope.delay = scope.delay || TOOLTIP_SHOW_DELAY;
 
     // We will re-attach tooltip when visible
     element.detach();
@@ -94,7 +96,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     // Methods
     // *******
 
-    // If setting visible to true, debounce to TOOLTIP_SHOW_DELAY ms
+    // If setting visible to true, debounce to scope.delay ms
     // If setting visible to false and no timeout is active, instantly hide the tooltip.
     function setVisible(value) {
       setVisible.value = !!value;
@@ -105,7 +107,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
           $timeout(function() {
             scope.visible = setVisible.value;
             setVisible.queued = false;
-          }, TOOLTIP_SHOW_DELAY);
+          }, scope.delay);
 
         } else {
           $timeout(function() { scope.visible = false; });


### PR DESCRIPTION
Currently, there is no way to configure the tooltip delay timeout. This provides a basic attribute, `md-tooltip-delay` for doing so. Granted, this could be better following some discussion on how you feel about rolling in a config provider into the directive.