### PR TITLE
fix(ripple): renames 'md-active' to 'md-highlight' for ripples

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -30,7 +30,7 @@
 
         <button class="menu-item menu-title md-menu-item"
           ng-click="menu.toggleSelectSection(section)"
-          md-active="menu.isSectionSelected(section)"
+          md-highlight="menu.isSectionSelected(section)"
           md-ink-ripple="#bbb">
           {{section.name}}
         </button>
@@ -39,7 +39,7 @@
           ng-show="menu.isSectionSelected(section)"
           ng-repeat="page in section.pages"
           ng-href="#{{page.url}}"
-          md-active="menu.isPageSelected(section, page)"
+          md-highlight="menu.isPageSelected(section, page)"
           md-ink-ripple="#bbb">
           <span ng-bind="page | humanizeDoc"></span>
         </a>

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -51,7 +51,7 @@ function InkRippleService($window, $timeout) {
         counter = 0,
         ripples = [],
         states = [],
-        isActiveExpr = element.attr('md-active'),
+        isActiveExpr = element.attr('md-highlight'),
         isActive = false,
         isHeld = false,
         node = element[0],


### PR DESCRIPTION
The md-active flag conflicted with tabs
