### PR TITLE
Fix sidenav not allowing flex children

### DIFF
--- a/src/components/sidenav/_sidenav.scss
+++ b/src/components/sidenav/_sidenav.scss
@@ -14,7 +14,7 @@ md-sidenav {
   }
   &.md-closed-add,
   &.md-closed-remove {
-    display: block;
+    display: flex;
     /* this is required as of 1.3x to properly
        apply all styling in a show/hide animation */
     transition: 0s all;
@@ -29,7 +29,7 @@ md-sidenav {
   &.md-locked-open.md-closed.md-sidenav-left,
   &.md-locked-open.md-closed.md-sidenav-right {
     position: static;
-    display: block;
+    display: flex;
     transform: translate3d(0, 0, 0);
   }
 


### PR DESCRIPTION
This fixes #734 which prevented you from aligning items to the bottom of a side nav because "flex" wouldn't work on child elements. The `display:flex` on `.md-closed-add` and `.md-closed-remove` also prevents you from seeing a pop from elements when you open/close the sidenav when you use `display:flex` on the open state.
