### PR TITLE
fix(mdButton): Set default ariaLabel to the elements text

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -70,10 +70,7 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria) {
     $mdTheming(element);
     $mdInkRipple.attachButtonBehavior(scope, element);
 
-    var elementHasText = node.textContent.trim();
-    if (!elementHasText) {
-      $mdAria.expect(element, 'aria-label');
-    }
+    $mdAria.expect(element, 'aria-label', node.textContent);
 
     // For anchor elements, we have to set tabindex manually when the 
     // element is disabled


### PR DESCRIPTION
`md-button` was not setting a default `ariaLabel` like the [docs](https://material.angularjs.org/#/api/material.components.button/directive/mdButton) say it does. This fixes #738     if we want `ariaLabel` to be semi optional. Where it will only warn you if an `md-button` doesn't have an `ariaLabel` and the element contains no text. For example if your button is just an icon but you forget to set the `ariaLabel`.
