### PR TITLE
docs(md-button): Clarifying aria-label usage

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -27,8 +27,9 @@ angular.module('material.components.button', [
  * become a `<button>` element.
  *
  * @param {boolean=} mdNoInk If present, disable ripple ink effects.
- * @param {expression=} ngDisabled En/Disable based on the expre
- * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the button's text.
+ * @param {expression=} ngDisabled En/Disable based on the expression
+ * @param {string=} ariaLabel Adds alternative text to button for accessibility, useful for icon buttons.
+ * If no default text is found, a warning will be logged.
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -26,7 +26,8 @@ angular.module('material.components.checkbox', [
  * @param {expression=} ngFalseValue The value to which the expression should be set when not selected.
  * @param {string=} ngChange Angular expression to be executed when input changes due to user interaction with the input element.
  * @param {boolean=} mdNoInk Use of attribute indicates use of ripple ink effects
- * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the checkbox's text.
+ * @param {string=} ariaLabel Adds label to checkbox for accessibility.
+ * Defaults to checkbox's text. If no default text is found, a warning will be logged.
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/radioButton/radioButton.js
+++ b/src/components/radioButton/radioButton.js
@@ -173,7 +173,8 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming) {
  *    be set when selected.*
  * @param {string} value The value to which the expression should be set when selected.
  * @param {string=} name Property name of the form under which the control is published.
- * @param {string=} ariaLabel Publish the button label used by screen-readers for accessibility. Defaults to the radio button's text.
+ * @param {string=} ariaLabel Adds label to radio button for accessibility.
+ * Defaults to radio button's text. If no default text is found, a warning will be logged.
  *
  * @usage
  * <hljs lang="html">


### PR DESCRIPTION
Clarifying doc to indicate the purpose and usage of `ariaLabel`. For `md-buttons` and other components, this utility enforces a text alternative by first checking for child text nodes (and child `aria-label` attributes), and then logging a warning to the developer if they are missing accessible text content. A few scenarios related to this utility:
- Md-button with default text: no warning, no aria-label needed
- Icon md-button with no default text: aria-label must be used
- Icon md-button with no default text and no ariaLabel: warning is logged
- Md-checkbox with text content: text is copied to `aria-label` for assistive tech labeling

Closes https://github.com/angular/material/issues/738
