### PR TITLE
docs(list): Add md-item-content to md-list usage example.

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -26,19 +26,20 @@ angular.module('material.components.list', [
  * @usage
  * <hljs lang="html">
  * <md-list>
- *  <md-item ng-repeat="item in todos">
- *    <div class="md-tile-left">
- *      <img ng-src="{{item.face}}" class="face" alt="{{item.who}}">
- *    </div>
- *    <div class="md-tile-content">
- *      <h3>{{item.what}}</h3>
- *      <h4>{{item.who}}</h4>
- *      <p>
- *        {{item.notes}}
- *      </p>
- *    </div>
- *
- *  </md-item>
+ *   <md-item ng-repeat="item in todos">
+ *     <md-item-content>
+ *       <div class="md-tile-left">
+ *         <img ng-src="{{item.face}}" class="face" alt="{{item.who}}">
+ *       </div>
+ *       <div class="md-tile-content">
+ *         <h3>{{item.what}}</h3>
+ *         <h4>{{item.who}}</h4>
+ *         <p>
+ *           {{item.notes}}
+ *         </p>
+ *       </div>
+ *     </md-item-content>
+ *   </md-item>
  * </md-list>
  * </hljs>
  *


### PR DESCRIPTION
Missing md-item-content breaks formatting of list.
