### PR TITLE
docs(fix): sidenav should not be hidden for large screens

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -19,7 +19,7 @@
               style="overflow: hidden; display: flex;"
               class="md-sidenav-left md-whiteframe-z2"
               md-component-id="left"
-              md-is-locked-open="$media('md')">
+              md-is-locked-open="$media('gt-sm')">
 
     <md-toolbar style="min-height: 64px; max-height:64px;" layout="column">
       <h1 class="md-toolbar-tools" flex layout="column">


### PR DESCRIPTION
FIX: Media for md-is-locked-open on md-sidenav should be bigger than small otherwise it is hidden for large screens
