### PR TITLE
docs(guides): several fixes (links, typos, syntax, line lengths)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # Material Design for AngularJS Apps [![Build Status](https://travis-ci.org/angular/material.svg)](https://travis-ci.org/angular/material)
 
-[Material Design](http://www.google.com/design/spec/material-design/) is a specification for a unified system of visual, motion, and interaction design that adapts across different devices. Our goal is to deliver a lean, lightweight set of AngularJS-native UI elements that implement the material design specification for use in Angular single-page applications (SPAs).
+[Material Design](https://www.google.com/design/spec/material-design/) is a specification for a
+unified system of visual, motion, and interaction design that adapts across different devices. Our
+goal is to deliver a lean, lightweight set of AngularJS-native UI elements that implement the
+material design specification for use in Angular single-page applications (SPAs).
 
 ![venn](https://cloud.githubusercontent.com/assets/210413/5077572/30dfc2f0-6e6a-11e4-9723-07c918128f4f.png)
 
-This project is in early pre-release. Angular Material is both a reference implementation of Material Design and a complementary effort to the [Polymer](http://www.polymer-project.org/) project's [Paper Elements](http://www.polymer-project.org/docs/elements/paper-elements.html) collection.
+This project is in early pre-release. Angular Material is both a reference implementation of
+Material Design and a complementary effort to the [Polymer](https://www.polymer-project.org/)
+project's [Paper Elements](https://www.polymer-project.org/docs/elements/paper-elements.html)
+collection.
 
 Quick Links:
 
@@ -14,37 +20,43 @@ Quick Links:
 *  [Installing](#installing)
 
 
-Please note that using Angular Material requires the use of **Angular 1.3.x** or higher. Angular Material is targeted for all browsers with versions n-1; where n is the current browser version.
+Please note that using Angular Material requires the use of **Angular 1.3.x** or higher. Angular
+Material is targeted for all browsers with versions n-1; where n is the current browser version.
 
 ## <a name="demos"></a> Online Documentation (and Demos)
 
 ![angularmaterial](https://cloud.githubusercontent.com/assets/210413/5148790/fb9ecf52-7187-11e4-9adc-fc5ef263b4ce.png)
 
-- Visit [Material.AngularJS.org](https://material.angularjs.org/) online to review the API, see the components in action with live Demos, and study the Layout system.
-- Or you can build the documentation and demos locally; see the [Build Docs & Demos](https://github.com/angular/material/tree/master/docs) for details.
+- Visit [Material.AngularJS.org](https://material.angularjs.org/) online to review the API, see the
+  components in action with live Demos, and study the Layout system.
+- Or you can build the documentation and demos locally; see
+  [Build Docs & Demos](https://github.com/angular/material/tree/master/docs/README.md) for details.
 
 ## <a name="contributing"></a> Contributing
 
-Developers interested in contributing should read the following guidelines
+Developers interested in contributing should read the following guidelines:
 
-- [Issue Guidelines](https://github.com/angular/material/blob/master/docs/guides/CONTRIBUTING.md#submit)
+- [Issue Guidelines](docs/guides/CONTRIBUTING.md#submit)
 - [Contributing Guidelines](docs/guides/CONTRIBUTING.md)
 - [Coding Guidelines](docs/guides/CODING.md)
-- [CHANGELOG](CHANGELOG.md)
+- [ChangeLog](CHANGELOG.md)
 
-> Please do **not** ask general questions in an issue. Issues are only to report bugs, request enhancements, or request new features. For general questions and discussions, use the [Angular Material Forum](https://groups.google.com/forum/#!forum/ngmaterial).
+> Please do **not** ask general questions in an issue. Issues are only to report bugs, request
+  enhancements, or request new features. For general questions and discussions, use the
+  [Angular Material Forum](https://groups.google.com/forum/#!forum/ngmaterial).
 
-It is important to note that for each release, the [ChangeLog](CHANGELOG.md) is a resource that will itemize all
+It is important to note that for each release, the [ChangeLog](CHANGELOG.md) is a resource that will
+itemize all:
 
-- Bug Fixes,
-- New Features,
+- Bug Fixes
+- New Features
 - Breaking Changes
 
 ## <a name="building"></a> Building
 
 Developers can easily build Angular Material using NPM and gulp.
 
-*  [Builds - Under the Hood](docs/guides/BUILD.md)
+* [Builds - Under the Hood](docs/guides/BUILD.md)
 
 First install or update your local project's **npm** tools:
 
@@ -56,7 +68,7 @@ npm install
 npm update
 ```
 
-The run the **gulp** tasks:
+Then run the **gulp** tasks:
 
 ```bash
 # To build `angular-material.js/.css` and `Theme` files in the `/dist` directory
@@ -66,13 +78,15 @@ gulp build
 gulp docs
 ```
 
-For more details on how the build process works and additional commands (available for testing and debugging) developers should read [Build Instructions](docs/guides/BUILD.md).
+For more details on how the build process works and additional commands (available for testing and
+debugging) developers should read the [Build Instructions](docs/guides/BUILD.md).
 
-## <a name="installing"></a>  Installing Build (Distribution Files)
+## <a name="installing"></a> Installing Build (Distribution Files)
 
 #### Bower 
 
-For developers not interested in building the Angular Material library... use **bower** to install and use the Angular Material distribution files.
+For developers not interested in building the Angular Material library... use **bower** to install
+and use the Angular Material distribution files.
 
 Change to your project's root directory.
 
@@ -84,26 +98,34 @@ bower install angular-material
 bower install angular-material#master
 ```
 
-Visit [Bower-Material](https://github.com/angular/bower-material/blob/master/README.md) for more details on how to install and use the Angular Material distribution files within your own local project.
+Visit [Bower-Material](https://github.com/angular/bower-material/blob/master/README.md) for more
+details on how to install and use the Angular Material distribution files within your own local
+project.
 
 #### CDN
 
-CDN versions of Angular Material are now available at [Google Hosted Libraries](https://developers.google.com/speed/libraries/devguide#angularmaterial). 
+CDN versions of Angular Material are now available at
+[Google Hosted Libraries](https://developers.google.com/speed/libraries/devguide#angularmaterial). 
 
-With the Google CDN, you will not need to download local copies of the distribution files. Instead simply reference the CDN urls to easily use those remote library files. This is especially useful when using online tools such as CodePen, Plunkr, or jsFiddle.
+With the Google CDN, you will not need to download local copies of the distribution files. Instead
+simply reference the CDN urls to easily use those remote library files. This is especially useful
+when using online tools such as [CodePen](http://codepen.io/), [Plunkr](http://plnkr.co/), or
+[JSFiddle](http://jsfiddle.net/).
 
 ```html
   <head>
-    
+
     <!-- Angulars Material CSS now available via Google CDN; version 0.6 used here -->
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/angular_material/0.6/angular-material.css">
-    
+    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/angular_material/0.6/angular-material.min.css">
+
   </head>
   <body>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/hammer.js/1.1.3/hammer.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular-animate.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular-aria.js"></script>
+  
+    <!-- Angular Material Dependencies -->
+    <script src="//cdn.jsdelivr.net/hammerjs/2.0.4/hammer.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-animate.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-aria.min.js"></script>
     
     <!-- Angular Material Javascript now available via Google CDN; version 0.6 used here -->
     <script src="//ajax.googleapis.com/ajax/libs/angular_material/0.6/angular-material.min.js"></script>
@@ -111,29 +133,30 @@ With the Google CDN, you will not need to download local copies of the distribut
   </body>
 ```
 
-Developers seeking the latest, most-current build versions can use [RawGit.com](rawgit.com) to pull directly from the distribution GitHub [Bower-Material](https://github.com/angular/bower-material) repository:
+Developers seeking the latest, most-current build versions can use [RawGit.com](//rawgit.com) to
+pull directly from the distribution GitHub
+[Bower-Material](https://github.com/angular/bower-material) repository:
 
 ```html
   <head>
-  
-    <!-- CSS using RawGit to load directly from `bower-material/master`  -->
+
+    <!-- Angulars Material CSS using RawGit to load directly from `bower-material/master` -->
     <link rel="stylesheet" href="//rawgit.com/angular/bower-material/master/angular-material.css">
-    
+
   </head>
   <body>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/hammer.js/1.1.3/hammer.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular-animate.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.0-rc.4/angular-aria.js"></script>
-    
-    <!-- Javascript using RawGit to load directly from `bower-material/master`  -->
-    <script src="//rawgit.com/angular/bower-material/master/angular-material.min.js"></script>
-    
+
+    <!-- Angular Material Dependencies -->
+    <script src="//cdn.jsdelivr.net/hammerjs/2.0.4/hammer.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-animate.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-aria.js"></script>
+
+    <!-- Angular Material Javascript using RawGit to load directly from `bower-material/master` -->
+    <script src="//rawgit.com/angular/bower-material/master/angular-material.js"></script>
+
   </body>
 ```
 
-> Please note that the above RawGit access is intended **ONLY**  for development purposes or sharing low-traffic, temporary examples or demos with small numbers of people.
-
-
-<br/>
-
+> Please note that the above RawGit access is intended **ONLY** for development purposes or sharing
+  low-traffic, temporary examples or demos with small numbers of people.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,34 +1,33 @@
 Documentation
 -------------
 
-The Angular Material **Live Docs** are generated from the source code and demos; and, in fact, the Live Docs actually uses the Angular Material components and themes.
+The Angular Material **Live Docs** are generated from the source code and demos; and, in fact, the
+Live Docs actually use the Angular Material components and themes.
 
-> Our build process uses **[dgeni](http://github.com/angular/dgeni)**, the wonderful documentation generator built by [Pete Bacon Darwin](https://github.com/petebacondarwin).
+> Our build process uses **[dgeni](https://github.com/angular/dgeni)**, the wonderful documentation
+generator built by [Pete Bacon Darwin](https://github.com/petebacondarwin).
 
 To view the Live Docs (locally):
 
 1. Build the docs using `gulp docs`
-2. Start an HTTP Server; the example below uses port 8000.
-3. Run `gulp watch` to auto-rebuild docs (Optional)
-4. Open browser at `http://localhost:8000`
+2. Run `gulp watch` to auto-rebuild docs (optional)
+3. Start an HTTP Server; the example below uses port 8080
+4. Open browser at `http://localhost:8080`
 
 ```bash
 # Build & deploy docs to `dist/docs`
-# Watch source dirs for changes and rebuild
-
 gulp docs
+
+# Watch source dirs for changes and rebuild
 gulp watch
 
 # Use the built-in gulp server with live reload
-# or install httpster globally; if not already isntalled
-# `npm install -g httpster`
-
 gulp server
 
-# And then launch webserver
+# Alternatively, install httpster globally; if not already installed
+npm install -g httpster
+
+# And then launch the webserver
 # NOTE: unlike `gulp server` this will not auto-reload the HTML
-
-httpster -p 8000 -d ./dist/docs
+httpster -p 8080 -d ./dist/docs
 ```
-
-

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -13,7 +13,8 @@
 
 ## <a name="intro"></a> Introduction
 
-Angular Material has a sophisticated collection of build process and commands available... to deploy distribution files, test components, and more.
+Angular Material has a sophisticated collection of build process and commands available... to deploy
+distribution files, test components, and more.
 
 These commands are defined within two (2) **gulp** files:
 
@@ -30,29 +31,33 @@ For each milestone release, always run:
 
 The following command line tasks are available:
 
-- `gulp build` (alias `gulp`) to build, add `--release` flag to uglify & strip console.log.
+- `gulp build` (alias `gulp`) to build, add `--release` flag to uglify & strip `console.log`
 - `gulp docs` to build the Live Docs into dist/docs
 - `gulp watch` to build & rebuild on changes
 
+<a separator></a>
 
 - `gulp karma` to test once
 - `gulp karma-watch` to test & watch for changes
 
-###<a name="livedocs"></a>  Building the Documentation
+###<a name="livedocs"></a> Building the Documentation
 
-The Angular Material **Live Docs** are generated from the source code and demos and actually uses the Angular Material components and themes.
+The Angular Material **Live Docs** are generated from the source code and demos and actually use the
+Angular Material components and themes.
 
-> Our build process uses **[dgeni](http://github.com/angular/dgeni)**, the wonderful documentation generator built by [Pete Bacon Darwin](https://github.com/petebacondarwin).
+> Our build process uses **[dgeni](https://github.com/angular/dgeni)**, the wonderful documentation
+  generator built by [Pete Bacon Darwin](https://github.com/petebacondarwin).
 
 See the [Building the Live Documentation](../README.md#docs) document for details.
 
-###<a name="builds"></a>  Building the Library
+###<a name="builds"></a> Building the Library
 
-Developers can be build the entire Angular Material library or individual component modules. The library comprises:
+Developers can build the entire Angular Material library or individual component modules. The
+library comprises:
 
-* angular-material.js - component
-* angular-material.css - styles and default theme stylesheet
-* /themes/**.css  - default theme override styesheets
+* `angular-material.js` - components
+* `angular-material.css` - styles and default theme stylesheet
+* `/themes/**.css` - default theme override styesheets
 
 To build from the source, simply use:
 
@@ -65,7 +70,7 @@ To build from the source, simply use:
 
 gulp build
 
-# Build MINIFIED assets
+# Build minified assets
 #
 # - `dist/angular-material.min.js`
 # - `dist/angular-material.min.css`
@@ -74,9 +79,10 @@ gulp build
 gulp build --release
 ```
 
-###<a name="bower"></a>  Using the Library with Bower
+###<a name="bower"></a> Using the Library with Bower
 
-For developers not interested in building the Angular Material library, use **bower** to install and use the Angular Material distribution files.
+For developers not interested in building the Angular Material library, use **bower** to install and
+use the Angular Material distribution files.
 
 Change to your project's root directory.
 
@@ -88,12 +94,16 @@ bower install angular-material
 bower install angular-material#master
 ```
 
-Visit [Bower-Material](https://github.com/angular/bower-material/blob/master/README.md) for more details on how to install and use the Angular Material distribution files within your own local project.
+Visit [Bower-Material](https://github.com/angular/bower-material/blob/master/README.md) for more
+details on how to install and use the Angular Material distribution files within your own local
+project.
 
 <br/>
 ##<a name="comp"></a> Introducing Components
 
-Angular Material supports the construction and deployment of individual component builds. Within Angular Material, each component is contained within its own module and specifies its own dependencies.
+Angular Material supports the construction and deployment of individual component builds. Within
+Angular Material, each component is contained within its own module and specifies its own
+dependencies.
 
 > At a minimum, all components have a dependecy upon the `core` module.
 
@@ -117,7 +127,7 @@ All component modules are compiled and distributed to:
           -- <component folder>
 ```
 
-Let's consider the the Slider component with its module definition:
+Let's consider the Slider component with its module definition:
 
 
 ```js
@@ -132,7 +142,8 @@ angular.module('material.components.slider', [
 
 First build all the component modules.
 
-To use - for example - the Slider component within your own application, simply load the stylesheets and JS from both the **slider** and the **core** modules:
+To use - for example - the Slider component within your own application, simply load the stylesheets
+and JS from both the **slider** and the **core** modules:
 
 
 ```text
@@ -150,9 +161,11 @@ To use - for example - the Slider component within your own application, simply 
 
 ###<a name="comp_debug"></a> Component Debugging
 
-Debugging a demo in the Live Docs is complicated due the multiple demos loading and initializing. A more practical approach is to open and debug a specific, standalone Component demo.
+Debugging a demo in the Live Docs is complicated due the multiple demos loading and initializing. A
+more practical approach is to open and debug a specific, standalone Component demo.
 
-To open a Component demo outside of the Docs application, just build, deploy and debug that compnents demo(s).
+To open a Component demo outside of the Docs application, just build, deploy and debug that
+compnent's demo(s).
 
 For example, to debug the **textfield** component:
 
@@ -164,7 +177,7 @@ For example, to debug the **textfield** component:
 #
 gulp watch-demo -c textfield
 
-# launch the liveReload server on port 8000
+# launch the liveReload server on port 8080
 #
 # Note: livereload will reload demos after updates are
 #       deployed (by watch-demo) to the dist/demos/
@@ -172,7 +185,8 @@ gulp watch-demo -c textfield
 gulp server
 ```
 
-The demo build process will deploy a *self-contained* Angular application that runs the specified component's demo(s). E.g.
+The demo build process will deploy a *self-contained* Angular application that runs the specified
+component's demo(s). E.g.:
 
 * `dist/demos/textfield/**/*.*`
 * `dist/demos/tabs/**/*.*`
@@ -180,12 +194,11 @@ The demo build process will deploy a *self-contained* Angular application that r
 
 After running `gulp server` to start a *LiveReload* server in your project root:
 
-* Open browser to url `http://localhost:8000/`
+* Open browser to url `http://localhost:8080/`
 * Navigate to `dist/demos/<component>/<demo>/index.html`
 * Open Dev Tools and debug...
 
 
 ##<a name="themes"></a> Theming
 
-http://material.angularjs.org/#/Theming/01_introduction
-
+https://material.angularjs.org/#/Theming/01_introduction

--- a/docs/guides/CODING.md
+++ b/docs/guides/CODING.md
@@ -18,11 +18,11 @@ All component modules are defined in:
           -- <component>.scss
           -- <component>-theme.scss
 
-          --/demo<name>
+          -- /demo<name>
 
-            -- index.html
-            -- style.css
-            -- script.js
+             -- index.html
+             -- style.css
+             -- script.js
 ```
 
 All component modules are compiled and distributed individually to:
@@ -50,7 +50,8 @@ Additionally, all component modules are compiled and deployed as a library to:
 
 #### Coding conventions:
 
-The best guidance is a coding approach that implements both code and comments in a clear, understandable, concise, and DRY fashion.
+The best guidance is a coding approach that implements both code and comments in a clear,
+understandable, concise, and DRY fashion.
 
 Below is a sample code that demonstrates some of our rules and conventions:
 
@@ -73,16 +74,13 @@ angular.module('material.components.slider', [
  * @module material.components.slider
  * @restrict E
  * @description
- * The `<md-slider>` component allows the user to choose from a range of
- * values.
+ * The `<md-slider>` component allows the user to choose from a range of values.
  *
- * It has two modes: 'normal' mode, where the user slides between a wide range
- * of values, and 'discrete' mode, where the user slides between only a few
- * select values.
+ * It has two modes: 'normal' mode, where the user slides between a wide range of values, and
+ * 'discrete' mode, where the user slides between only a few select values.
  *
- * To enable discrete mode, add the `md-discrete` attribute to a slider,
- * and use the `step` attribute to change the distance between
- * values the user is allowed to pick.
+ * To enable discrete mode, add the `md-discrete` attribute to a slider, and use the `step`
+ * attribute to change the distance between values the user is allowed to pick.
  *
  * @usage
  * <h4>Normal Mode</h4>
@@ -115,18 +113,27 @@ function SliderDirective($mdTheming) {
 })();
 ```
 
-*  With the exceptions listed in this document, follow the rules contained in [Google's JavaScript Style Guide][js-style-guide]
-*  All components must have unique, understandable module names; prefixed with 'material.components.'
+*  With the exceptions listed in this document, follow the rules contained in
+   [Google's JavaScript Style Guide](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+*  All components must have unique, understandable module names; prefixed with
+   'material.components.'.
 *  All components must depend upon the 'material.core' module.
-*  Do not use $inject to annotate arguments<br/>The build process uses ngAnnotate to create the annotations during the build proces.
-*  All public API methods **must** be documented with ngdoc, an extended version of jsdoc (we added support for markdown and templating via @ngdoc tag). To see how we document our APIs, please check out the existing ngdocs and see [this wiki page][ngDocs].
-*  All directives must use the `md-` prefix for both directive and any directive attributes<br/>  Directive **templates** should be defined inline.
+*  Do not use `$inject` to annotate arguments.<br/>
+   ngAnnotate is used as part of the build process to automatically create the annotations.
+*  All public API methods **must** be documented with ngdoc, an extended version of jsdoc (we added
+   support for markdown and templating via @ngdoc tag). To see how we document our APIs, please
+   check out the existing ngdocs and see
+   [this wiki page](https://github.com/angular/angular.js/wiki/Writing-AngularJS-Documentation).
+*  All directives must use the `md-` prefix for both the directive name and any directive
+   attributes.<br/>
+   Directive **templates** should be defined inline.
 
 
 #### Testing
 
 * All components must have valid, **passing** unit tests.
-* All features or bug fixes **must be tested** by one or more [specs][unit-testing].
+* All features or bug fixes **must be tested** by one or more
+  [specs](https://docs.angularjs.org/guide/unit-testing).
 
 #### Coding
 
@@ -142,20 +149,19 @@ function SliderDirective($mdTheming) {
 
 #### Patterns
 
-* All components should be wrapped in an anonymous closure using the Module Pattern
-* Use the **Revealing Pattern** as a coding style
-* Do **not** use the global variable namespace, export our API explicitly via Angular DI
+* All components should be wrapped in an anonymous closure using the Module Pattern.
+* Use the **Revealing Pattern** as a coding style.
+* Do **not** use the global variable namespace, export our API explicitly via Angular DI.
 * Instead of complex inheritance hierarchies, use **simple** objects.
 * Avoid prototypal inheritance unless warranted by performance or other considerations.
-* We **love** functions and closures and, whenever possible, prefer them over objects.
-  > Do not use anonymous functions. All closures should be named.
+* We **love** functions and closures and, whenever possible, prefer them over objects.<br/>
+
+    > Do not use anonymous functions. All closures should be named.
 
 #### Documentation
 
-* All non-trivial functions should have a jsdoc Description
+* All non-trivial functions should have a jsdoc description.
 * To write concise code that can be better minified, we **use aliases internally** that map to the
   external API.
-* Use of argument **type annotations** for private internal APIs is not encouraged, unless it's an internal API
-  that is used throughout Angular Material.
-
-
+* Use of argument **type annotations** for private internal APIs is not encouraged, unless it's an
+  internal API that is used throughout Angular Material.

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -10,13 +10,14 @@
 ## <a name="coc"></a> Code of Conduct
 Help us keep Angular open and inclusive.
 
-Please read and follow our [Code of Conduct](https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
+Please read and follow our
+[Code of Conduct](https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
 
 <br/>
 ## <a name="question"></a> Have a Question, Problem, or Idea?
 
-If you have questions or ideas regarding Angular Material, please direct these to the [Angular Material Google Group](https://groups.google.com/forum/#!forum/ngmaterial)
-discussion list.
+If you have questions or ideas regarding Angular Material, please direct these to the
+[Angular Material Forum](https://groups.google.com/forum/#!forum/ngmaterial).
 
 Otherwise, do you:
 
@@ -24,43 +25,62 @@ Otherwise, do you:
 - [Want a Feature ?](#feature)
 
 #### <a name="bug"></a> 1. Found a Bug or Issue?
-If you find a bug in the source code or a mistake in the documentation, we recommend that you first review the [Online Documentation](http://material.angularjs.org/).
+If you find a bug in the source code or a mistake in the documentation, we recommend that you first
+review the [Online Documentation](http://material.angularjs.org/).
 
-Otherwise you can help us improve by submitting an issue to our [GitHub Repository](https://github.com/angular/material/issues/new). Even better you can submit a **Pull Request** with a fix. Your custom changes can be crafted in a repository fork and submitted to [GitHub Repository](https://github.com/angular/material/compare) as a Pull Request.
+Otherwise you can help us improve by submitting an issue to our
+[GitHub Repository](https://github.com/angular/material/issues/new). Even better you can submit a
+**Pull Request** with a fix. Your custom changes can be crafted in a repository fork and submitted
+to the [GitHub Repository](https://github.com/angular/material/compare) as a Pull Request.
 
 
-> **Important: please review the [Submission Guidelines](#submit) below before contributing to the project**.
+> **Important: Please review the [Submission Guidelines](#submit) below, before contributing to the
+  project**.
 
 #### <a name="feature"></a> 2. Want a Feature?
-You can request a new feature by submitting an issue to our [GitHub Issues](https://github.com/angular/material/issues/new).  If you would like to implement a new feature then consider what kind of change it is:
+You can request a new feature by
+[submitting an issue](https://github.com/angular/material/issues/new). If you would like to
+implement a new feature then consider what kind of change it is:
 
 * **Major Changes** that you wish to contribute to the project should be discussed first on our
-[Angular Material Forum](https://groups.google.com/forum/#!forum/ngmaterial) so that we can better coordinate our efforts, prevent duplication of work, and help you to craft the change so that it is successfully accepted into the
-project.
-* **Small Changes** can be crafted and submitted to the [GitHub Repository](https://github.com/angular/material/compare) as a Pull Request.
+  [Angular Material Forum](https://groups.google.com/forum/#!forum/ngmaterial), so that we can better
+  coordinate our efforts, prevent duplication of work, and help you to craft the change so that it is
+  successfully accepted into the project.
+* **Small Changes** can be crafted and submitted to the
+  [GitHub Repository](https://github.com/angular/material/compare) as a Pull Request.
 
 ## <a name="submit"></a> Issue Guidelines
 
 Please note, this project is still in an early beta.
 
-We're not actively reviewing unsolicited PRs from the community, although we welcome your feature requests, doc corrections, and issue reports. If you're thinking of contributing code or docs to the project, please review [Submitting Pull Requests](#submitpr) before beginning any work.
+We're not actively reviewing unsolicited PRs from the community, although we welcome your feature
+requests, doc corrections, and issue reports. If you're thinking of contributing code or docs to the
+project, please review [Submitting Pull Requests](#submitpr) before beginning any work.
 
 #### Submitting an Issue
-Before you submit your issue **[search](https://github.com/angular/material/issues?q=is%3Aissue+is%3Aopen)** the issues archive; maybe your question was already answered. If your issue appears to be a bug, and hasn't been reported, open a new issue.
+Before you submit your issue,
+**[search](https://github.com/angular/material/issues?q=is%3Aissue+is%3Aopen)** the issues archive;
+maybe your question was already answered. If your issue appears to be a bug, and hasn't been
+reported, open a new issue.
 
-> Do not report duplicate issues; help us to maximize the effort we can spend fixing issues and adding new features.
+> Do not report duplicate issues; help us maximize the effort we can spend fixing issues and
+adding new features.
 
+Providing the following information will increase the chances of your issue being dealt with
+quickly:
 
-Providing the following information will increase the chances of your issue being dealt with quickly:
+* **Issue Title** - provide a concise issue title prefixed with a lower camelCase name of the
+                    associated target or component (if any): `<component>: <issue title>`.
 
-* **Issue Title** - provide a concise issue title prefixed with a lower camelCase name of the associated target or component (if any): `<component>: <issue title>`.
- 
-> e.g.
-> *  mdSideNav: Adding swipe functionality  [#35](https://github.com/angular/material/issues/35)
-> *  mdTextFloat: does not set required/ng-required [#847](https://github.com/angular/material/issues/847)
+  > e.g.
+  > *  mdSideNav: Adding swipe functionality [#35](https://github.com/angular/material/issues/35)
+  > *  mdTextFloat: does not set required/ng-required
+       [#847](https://github.com/angular/material/issues/847)
 
-* **Overview of the Issue** - if an error is being thrown a non-minified stack trace helps
-* **Angular Material Version(s)** - check the header of your `angular-material.js` file to determine your specific version #.
+* **Overview of the Issue** - if an error is being thrown, a non-minified stack trace helps.
+
+* **Angular Material Version** - check the header of your `angular-material.js` file to determine
+                                 your specific version #.
 
 ```js
 /*!
@@ -70,35 +90,43 @@ Providing the following information will increase the chances of your issue bein
  * v0.6.0-rc1-master-57f10f7
  */
  ```
-* **Browsers and Operating System** - is this a problem with all browsers or only IE8?
-* **Reproduce the Error** - provide a live example (using [CodePen](http://codepen.io/), [Plunker](http://plnkr.co/),
-  [JSFiddle](http://jsfiddle.net/)).
+* **Browsers and Operating System** - is this a problem with all browsers or only IE?
+* **Reproduce the Error** - provide a live example (using [CodePen](http://codepen.io/),
+  [Plunker](http://plnkr.co/), [JSFiddle](http://jsfiddle.net/)).
 * **Related Issues** - has a similar issue been reported before?
 * **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
-  causing the problem (line of code or commit)<br/><br/>
-Here is are two examples of a well-defined issue:
+  causing the problem (line of code or commit).<br/><br/>
+Here are two examples of well-defined issues:
   - https://github.com/angular/material/issues/629
   - https://github.com/angular/material/issues/277
 
 #### <a name="submitpr"></a>Submitting Pull Requests
 
-**Important**: With the exception of minor bugs and doc fixes, we are not actively reviewing unsolicited PRs to Angular Material.
+**Important**: With the exception of minor bugs and doc fixes, we are not actively reviewing
+unsolicited PRs to Angular Material.
 
-Please check with us via [the discussion forum] (https://groups.google.com/forum/#!forum/ngmaterial) before investing significant effort in any pre-1.0 PR contribution; it's likely that we are already working on a related PR.
+Please check with us via [the discussion forum](https://groups.google.com/forum/#!forum/ngmaterial)
+before investing significant effort in any pre-1.0 PR contribution; it's likely that we are already
+working on a related PR.
 
-* All contributions must be consistent with the Angular Material coding conventions. See [Coding Guidelines](CODING.md)
-* Submit proposed changes or additions as GitHub pull requests. See [Pull Request Guidelines](PULL_REQUESTS.md)
+* All contributions must be consistent with the Angular Material coding conventions. See the
+  [Coding Guidelines](CODING.md)
+* Submit proposed changes or additions as GitHub pull requests. See the
+  [Pull Request Guidelines](PULL_REQUESTS.md)
 
 <br/>
 ## <a name="commit"></a> Git Commit Guidelines
 
-We have very precise rules over how our git commit messages can be formatted.  This leads to **more
-readable messages** that are easy to follow when looking through the **project history**.  It is important to note that we use the git commit messages to **generate** the Angular Material [Changelog](../../CHANGELOG.md) document.
+We have very precise rules over how our git commit messages can be formatted. This leads to **more
+readable messages** that are easy to follow when looking through the **project history**. It is
+important to note that we use the git commit messages to **generate** the Angular Material
+[Changelog](../../CHANGELOG.md) document.
 
-> A detailed explanation of guidelines and conventions can be found in this [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#)
+> A detailed explanation of guidelines and conventions can be found in this
+  [document](https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#).
 
-### Commit Message Format
-Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
+### <a name="commit-message-format"></a> Commit Message Format
+Each commit message consists of a **header**, a **body** and a **footer**. The header has a special
 format that includes a **type**, a **scope** and a **subject**:
 
 ```html
@@ -109,8 +137,8 @@ format that includes a **type**, a **scope** and a **subject**:
 <footer>
 ```
 
-> Any line of the commit message cannot be longer 100 characters! <br/>This allows the message to be easier
-to read on github as well as in various git tools.
+> Any line of the commit message cannot be longer 100 characters!<br/>
+  This allows the message to be easier to read on github as well as in various git tools.
 
 ##### Type
 Must be one of the following:
@@ -120,14 +148,14 @@ Must be one of the following:
 * **docs**: Documentation only changes
 * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing
   semi-colons, etc)
-* **refactor**: A code change that neither fixes a bug or adds a feature
+* **refactor**: A code change that neither fixes a bug nor adds a feature
 * **perf**: A code change that improves performance
 * **test**: Adding missing tests
 * **chore**: Changes to the build process or auxiliary tools and libraries such as documentation
   generation
 
 ##### Scope
-The scope could be anything specifying place of the commit change.
+The scope could be anything specifying the place of the commit change.
 
 ##### Subject
 The subject contains succinct description of the change:
@@ -143,7 +171,9 @@ The body should include the motivation for the change and contrast this with pre
 ##### Footer
 The footer should contain any information about **Breaking Changes** and is also the place to
 reference GitHub issues that this commit **Closes**.
->Breaking Changes are intended to highlight (in the ChangeLog) changes that will require community users to modify their code with this commit.
+
+> Breaking Changes are intended to highlight (in the ChangeLog) changes that will require community
+  users to modify their code with this commit.
 
 <br/>
 ##### Sample Commit message:
@@ -155,15 +185,15 @@ refactor(content): prefix mdContent scroll- attributes
 
     Change your code from this:
 
-    '''html
+    ```html
     <md-content scroll-x scroll-y scroll-xy>
-    '''
+    ```
 
     To this:
 
-    '''html
+    ```html
     <md-content md-scroll-x md-scroll-y md-scroll-xy>
-    ''''
+    ```
 ```
 
 <br/>
@@ -172,8 +202,7 @@ refactor(content): prefix mdContent scroll- attributes
 Please sign our Contributor License Agreement (CLA) before sending pull requests. For any code
 changes to be accepted, the CLA must be signed. It's a quick process, we promise!
 
-* For individuals we have a [simple click-through form](https://cla.developers.google.com/about/google-individual?csw=1).
+* For individuals we have a
+  [simple click-through form](https://cla.developers.google.com/about/google-individual?csw=1).
 * For corporations we'll need you to
   [print, sign and one of scan+email, fax or mail the form](https://developers.google.com/open-source/cla/corporate?csw=1).
-
-

--- a/docs/guides/MERGE_REQUESTS.md
+++ b/docs/guides/MERGE_REQUESTS.md
@@ -22,9 +22,10 @@ in on top of your branch's local history:
 curl https://github.com/angular/material/pull/143.patch | git am -3
 ```
 
-If there are any conflicts, go to the resolving conflicts section below.
+If there are any conflicts, go to the [Dealing with conflicts](#conflicts) section below.
 
-If the merge succeeds, use `git diff origin/master` to see all the new changes that will happen post-merge.
+If the merge succeeds, use `git diff origin/master` to see all the new changes that will happen
+post-merge.
 
 ###<a name="squash"></a> Squashing everything into one commit
 
@@ -55,7 +56,7 @@ git pull --rebase origin master
 
 This may cause conflicts, see below for how to deal with these.
 
-###<a name="conflicts"></a> Dealing with Conflicts
+###<a name="conflicts"></a> Dealing with conflicts
 
 Run the following to see which files are conflicted:
 
@@ -91,7 +92,7 @@ git add -A
 git am --continue
 ```
 
-###<a name="merging"></a> Merging With Master
+###<a name="merging"></a> Merging with master
 
 Finally, after you've squashed the whole pull request into one commit and made sure
 it has no conflicts with the latest master and tests are run, you're ready to merge it in.
@@ -127,7 +128,8 @@ git commit --amend
 ```
 
 This will open the latest commit in your text editor and allow you to add
-text. Do **not** forget to add `Close #xxx` to also close the PR; in this case you will aadd `Close #143`.
+text. Do **not** forget to add `Close #xxx` to also close the PR; in this case you will add
+`Close #143`.
 
 For example:
 
@@ -150,7 +152,7 @@ For example:
 > ```
 
 For more examples of how to format commit messages, see
-[the guidelines in CONTRIBUTING.md](https://github.com/angular/material/blob/master/CONTRIBUTING.md#-git-commit-guidelines).
+[the guidelines in CONTRIBUTING.md](CONTRIBUTING.md#-git-commit-guidelines).
 
 ```sh
 git push origin master

--- a/docs/guides/PULL_REQUESTS.md
+++ b/docs/guides/PULL_REQUESTS.md
@@ -1,31 +1,39 @@
 ### Submitting a Pull Request
 Before you submit your pull request consider the following guidelines:
 
-* Search [GitHub](https://github.com/angular/angular.js/pulls) for an open or closed Pull Request
+* Search [GitHub](https://github.com/angular/material/pulls) for an open or closed Pull Request
   that relates to your submission. You don't want to duplicate effort.
-* Please sign our [Contributor License Agreement (CLA)](#cla) before sending pull
+
+* Please sign our [Contributor License Agreement (CLA)](CONTRIBUTING.md#cla) before sending pull
   requests. We cannot accept code without this.
-* Make your changes in a new git branch
+
+* Make your changes in a new git branch:
 
      ```shell
      git checkout -b my-fix-branch master
      ```
 
-* Follow our [Coding Rules](#rules).
-* **Include appropriate test cases**
-* Create your patch
-* Run the full Angular Material test suite, as described in the [developer documentation][dev-doc], and ensure that all tests pass.
+* Follow our [Coding Rules](CODING.md#rules).
+
+* **Include appropriate test cases.**
+
+* Create your patch.
+
+* Run the full Angular Material test suite, as described in the [developer documentation](BUILD.md),
+  and ensure that all tests pass.
+
 * Commit your changes using a descriptive commit message that follows our
-  [commit message conventions](#commit-message-format) and passes our commit message presubmit hook
-  `validate-commit-msg.js`. <br/>Adherence to the [commit message conventions](#commit-message-format)
-  is required because release notes are automatically generated from these messages.
+  [commit message conventions](CONTRIBUTING.md#commit-message-format) and passes our commit message
+  presubmit hook `validate-commit-msg.js`.<br/>
+  Adherence to the [commit message conventions](CONTRIBUTING.md#commit-message-format) is required
+  because release notes are automatically generated from these messages.
 
      ```shell
      git commit -a
      ```
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
-* Build your changes locally to ensure all the tests pass
+* Build your changes locally to ensure all the tests pass:
 
     ```shell
     gulp karma
@@ -38,9 +46,12 @@ Before you submit your pull request consider the following guidelines:
     ```
 
 * In GitHub, send a pull request to `angular:master`.
-* If we suggest changes then
+
+* If we suggest changes then:
   * Make the required updates.
+
   * Re-run the Angular Material test suite to ensure tests are still passing.
+
   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell


### PR DESCRIPTION
I started out fixing line-length to comply to the max. 100 chars per line rule (as discussed [here](https://github.com/angular/material/pull/819#issuecomment-65216793)), but this turned out to be a more generic error fixing:
- Fixes wrong or broken links
- Fixed typos/punctuation/syntactic errors
- Rephrazed at a couple of places, where the wording sounded unclear or confusing 
- Wrapped lines at 100 characters

<sub>The diff may seem a little weird due to the line-wrapping.</sub>
## 

I have re-read all the modified documents and tried all the links (and everything seems fine), but a 2nd pair of eyes is always irreplaceable :smiley: 
