### PR TITLE
docs($mdDialog): Fix show() argument docs

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -195,8 +195,8 @@ function MdDialogDirective($$rAF, $mdTheming) {
  * @description
  * Show a dialog with the specified options.
  *
- * @param {object} optionsOrPreset Either provide an `$mdDialogPreset` returned from `alert()`,
- * `confirm()`, and `build()`, or an options object with the following properties:
+ * @param {object} optionsOrPreset Either provide an `$mdDialogPreset` returned from `alert()`, and
+ * `confirm()`, or an options object with the following properties:
  *   - `templateUrl` - `{string=}`: The url of a template that will be used as the content
  *   of the dialog.
  *   - `template` - `{string=}`: Same as templateUrl, except this is an actual template string.


### PR DESCRIPTION
Fixes the `$mdDialog` docs saying `show()` requires an `$mdToastPreset`. Seems someone just forgot to change it when they made `mdDialog`. Since it looks like `mdDialog` was based on `mdToast`.