### PR TITLE
fix(mdSidenav): Focus management on close

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -195,6 +195,8 @@ function mdSidenavDirective($timeout, $animate, $parse, $mdMedia, $mdConstant, $
       $animate[isOpen ? 'enter' : 'leave'](backdrop, parent);
       backdrop[isOpen ? 'on' : 'off']('click', close);
 
+      scope.triggeringElement = document.activeElement;
+
       $animate[isOpen ? 'removeClass' : 'addClass'](element, 'md-closed').then(function() {
         // If we opened, and haven't closed again before the animation finished
         if (scope.isOpen) {
@@ -223,6 +225,7 @@ function mdSidenavDirective($timeout, $animate, $parse, $mdMedia, $mdConstant, $
     function close() {
       $timeout(function(){
         sidenavCtrl.close();
+        scope.triggeringElement && scope.triggeringElement.focus();
       });
     }
 


### PR DESCRIPTION
This change aims to improve keyboard focus management of sidenav components: https://github.com/angular/material/issues/728

@ajoslin I'm unsure how to test this, because focus has to be triggered from an element outside of the sidenav and sent back to it on close. Any suggestions?
