### PR TITLE
fix(dialog): fix dialog alignment in IE

### DIFF
--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -27,7 +27,6 @@ md-dialog {
   min-width: 240px;
   max-width: 80%;
   max-height: 80%;
-  margin: auto;
   position: relative;
 
 


### PR DESCRIPTION
#790

I ran into this issue in IE10 and IE11 and I found a simple solution; Remove margin auto from the md-dialog element. After removing the margin, the dialog is properly aligned in Chrome, Firefox and IE10/11
