### PR TITLE
Fix md-switch link function

### DIFF
--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -69,7 +69,7 @@ function MdSwitch(mdCheckboxDirective, mdRadioButtonDirective, $mdTheming) {
 
     return function (scope, element, attr, ngModelCtrl) {
       $mdTheming(element);
-      return checkboxLink(scope, thumb, attr, ngModelCtrl);
+      return checkboxLink(scope, angular.element(element[0].querySelector('.md-switch-thumb')), attr, ngModelCtrl);
     };
   }
 }


### PR DESCRIPTION
The problem appears when trying to combine famous-angular and angular-material libraries. At some point, the md-switch-thumb to process during link is not the same as the one at compile.
