### PR TITLE
Add .bowerrc

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}


### PR DESCRIPTION
When i run `bower install` the bower directory located in `app/bower_components` which breaks the doc website generation.
