### PR TITLE
fix(tabs): allow themes to override $tabs-highlight-color

### DIFF
--- a/src/components/tabs/tabs-theme.scss
+++ b/src/components/tabs/tabs-theme.scss
@@ -4,7 +4,7 @@ $tabs-inactive-color: map-get($tabs-color-palette, '100') !default;
 $tabs-active-color: $primary-color-palette-contrast-color !default;
 $tabs-disabled-color: $foreground-quarternary-color !default;
 $tabs-focus-color: $foreground-primary-color !default;
-$tabs-highlight-color: #ffff85;
+$tabs-highlight-color: #ffff85 !default;
 
 md-tabs.md-#{$theme-name}-theme {
   .md-header {


### PR DESCRIPTION
Allow themes to override the SASS variable $tabs-highlight-color.  In case a theme designer does not wish to use the default yellow color.