### PR TITLE
fix(mdToast): Puts index above dialog

### DIFF
--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -56,8 +56,8 @@ $whiteframe-zindex-z5: 5;
 //--------------------------------------------
 
 $z-index-tooltip: 100;
-$z-index-dialog: 90;
-$z-index-toast: 80;
+$z-index-dialog: 80;
+$z-index-toast: 90;
 $z-index-bottom-sheet: 70;
 $z-index-sidenav: 60;
 $z-index-backdrop: 50;


### PR DESCRIPTION
mdToast appears above all elements, including the mdDialog. This was accomplished by changing the z-index order.

Closes #903
