### PR TITLE
Fix layout-padding css

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -22,7 +22,7 @@
   flex-direction: row;
 }
 
-[layout-padding]
+[layout-padding],
 [layout-padding] > [flex] {
   padding: $layout-gutter-width / 2;
 }
@@ -31,7 +31,7 @@
   margin: $layout-gutter-width / 2;
 }
 
-[layout-padding] + [layout-padding], /* DEPRECATED */
+[layout-padding] + [layout-padding],
 [layout-margin] + [layout-margin] {
   margin-top: -($layout-gutter-width / 2);
 }


### PR DESCRIPTION
Adds a `,` which was missing in 5caa22b2c444485b3d340cda662d8808b1fc381d when `layout-padding` was readded. Also removes a comment saying `layout-padding` is depreciated since it has been readded.