### PR TITLE
fix(mdUtil): fix `throttle()` delay check

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -77,7 +77,7 @@ angular.module('material.core')
         var args = arguments;
         var now = Util.now();
 
-        if (!recent || recent - now > delay) {
+        if (!recent || (now - recent > delay)) {
           func.apply(context, args);
           recent = now;
         }


### PR DESCRIPTION
Previously, the check was `recent - now > delay`, but it would never evaluate to `true`, since `now > recent`.