### PR TITLE
fix(layout): change `layout-padding` selector

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -22,7 +22,7 @@
   flex-direction: row;
 }
 
-[layout-padding]
+[layout-padding],
 [layout-padding] > [flex] {
   padding: $layout-gutter-width / 2;
 }


### PR DESCRIPTION
`layout-padding` attribute is not working as expected because `layout-padding` is missing a comma in the css definition
