### PR TITLE
Only call watcher() when it's a function

### DIFF
--- a/src/components/tabs/js/paginationDirective.js
+++ b/src/components/tabs/js/paginationDirective.js
@@ -102,7 +102,9 @@ function TabPaginationDirective($mdConstant, $window, $$rAF, $$q, $timeout, $mdM
             function () {
               $timeout(function () {
                 if (element[0].offsetParent) {
-                  watcher();
+                  if (angular.isFunction(watcher)) {
+                    watcher();
+                  }
                   debouncedUpdatePagination();
                   watcher = null;
                 }


### PR DESCRIPTION
Fix for #1072, maybe not most elegant, but pretty simple and works fine.