### PR TITLE
docs(tabs): fixed md-stretch-tabs type

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -65,7 +65,7 @@ angular.module('material.components.tabs')
  * @param {boolean=} md-no-ink If present, disables ink ripple effects.
  * @param {boolean=} md-no-bar If present, disables the selection ink bar.
  * @param {string=}  md-align-tabs Attribute to indicate position of tab buttons: `bottom` or `top`; default is `top`
- * @param {boolean=} md-stretch-tabs Attribute to indicate whether or not to stretch tabs: `auto`, `always`, or `never`; default is `auto`
+ * @param {string=} md-stretch-tabs Attribute to indicate whether or not to stretch tabs: `auto`, `always`, or `never`; default is `auto`
  *
  * @usage
  * <hljs lang="html">


### PR DESCRIPTION
The `md-stretch-tabs` attribute is documented as a boolean:
![image](https://cloud.githubusercontent.com/assets/1788596/5610966/fe727250-94bf-11e4-8ad0-58b9d9747ed8.png)

but is in fact a string.