### PR TITLE
fixed sticky translate X

### DIFF
--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -244,7 +244,7 @@ function MdSticky($document, $mdConstant, $compile, $$rAF, $mdUtil) {
        item.translateY = amount;
        item.clone.css(
          $mdConstant.CSS.TRANSFORM, 
-         'translate3d(' + item.left + 'px,' + amount + 'px,0)'
+         'translate3d(0,' + amount + 'px,0)'
        );
      }
    }


### PR DESCRIPTION
In the case were sticky elements had a left margin to the container, the sticky elements were being translated to the right just before the next element arrives. But the sticky element gets a margin-left, when translating element up from the top as it scrolls into view, it was also translated to the right. (I don't know if I am clear, put subheader elements in a scrolling container where they are not aligned to the left but centered)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1151)
<!-- Reviewable:end -->
