### PR TITLE
feat(button): add md-mini-fab class

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -81,4 +81,8 @@ $button-fab-border-radius: 50% !default;
     background-color: transparent;
     cursor: not-allowed;
   }
+
+  &.md-mini-fab {
+    @extend .md-fab
+  }
 }

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -5,6 +5,8 @@ $button-padding: 2px 6px 3px !default;
 $button-fab-width: 56px !default;
 $button-fab-height: 56px !default;
 $button-fab-padding: 16px !default;
+$button-mini-fab-width: 40px !default;
+$button-mini-fab-height: 40px !default;
 
 $button-fab-toast-offset: $button-fab-height * 0.75;
 
@@ -103,6 +105,18 @@ $button-fab-toast-offset: $button-fab-height * 0.75;
     }
 
   }
+
+  &.md-mini-fab {
+    
+    @extend .md-fab;
+    
+    width: $button-mini-fab-width;
+    height: $button-mini-fab-height;
+
+    md-icon {
+      line-height: $button-mini-fab-height;
+    }
+  }  
 
   &:not([disabled]) {
     &.md-raised,

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -18,9 +18,6 @@
     </section>
 
     <section layout="row" layout-sm="column" layout-align="center center">
-        <md-button class="md-fab" aria-label="Time">
-            <md-icon icon="/img/icons/ic_access_time_24px.svg" style="width: 24px; height: 24px;"></md-icon>
-        </md-button>
 
       <md-button class="md-fab" aria-label="New document">
         <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg" style="width: 24px; height: 24px;"></md-icon>
@@ -33,6 +30,19 @@
         <md-button class="md-fab md-primary" md-theme="cyan" aria-label="Profile">
             <md-icon icon="/img/icons/ic_people_24px.svg" style="width: 24px; height: 24px;"></md-icon>
         </md-button>
+
+      <md-button class="md-mini-fab md-primary" ng-disabled="true" aria-label="More">
+          <md-icon icon="/img/icons/ic_more_vert_24px.svg" style="width: 24px; height: 24px;"></md-icon>
+      </md-button> 
+
+      <md-button class="md-mini-fab" aria-label="Take Photo">
+        <md-icon icon="/img/icons/ic_photo_24px.svg" style="width: 24px; height: 24px;"></md-icon>
+      </md-button>
+
+      <md-button class="md-mini-fab md-warn" aria-label="Refresh">
+          <md-icon icon="/img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;"></md-icon>
+      </md-button>
+
       <div class="label">FAB</div>
     </section>
 

--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -12,7 +12,7 @@ section {
 md-content {
   margin-right: 7px;
 }
-section .md-button:not(.md-fab) {
+section .md-button:not(.md-fab, .md-mini-fab) {
   min-width: 10em;
 }
 section .md-button {


### PR DESCRIPTION
To turn an mdButton into a [mini floating action button](http://www.google.com/design/spec/components/buttons.html#buttons-floating-action-button) add class `md-mini-fab`. 

Closes #1173 