### PR TITLE
fix(sticky): sticky subheader no longer behind toolbar on Chrome

### DIFF
--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -21,7 +21,7 @@ angular.module('material.components.sticky', [
  * @module material.components.sticky
  *
  * @description
- * The `$mdSticky`service provides a mixin to make elements sticky.
+ * The `$mdSticky`service provides a mixin to make elements placed inside `md-content` sticky.
  *
  * @returns A `$mdSticky` function that takes three arguments:
  *   - `scope`
@@ -96,7 +96,7 @@ function MdSticky($document, $mdConstant, $compile, $$rAF, $mdUtil) {
       };
       self.items.push(item);
 
-      contentEl.parent().prepend(item.clone);
+      contentEl.parent()[0].insertBefore(item.clone[0], contentCtrl.$element[0]);
 
       debouncedRefreshElements();
 

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -20,6 +20,10 @@ md-toolbar {
     height: $toolbar-tall-height;
     min-height: $toolbar-tall-height;
     max-height: $toolbar-tall-height;
+
+    ~.md-sticky-clone {
+      top: $toolbar-tall-height;
+    }
   }
 
   &.md-medium-tall {
@@ -32,10 +36,18 @@ md-toolbar {
       min-height: 48px;
       max-height: 48px;
     }
+
+    ~.md-sticky-clone {
+      top: $toolbar-medium-tall-height;
+    }
   }
 
   .md-indent {
     margin-left: $toolbar-indent-margin;
+  }
+
+  ~.md-sticky-clone {
+    top: $toolbar-height;
   }
 }
 


### PR DESCRIPTION
Resubmitting PR because of **gitfail**! Sorry for the spam...

For browsers that do not support `position: sticky` the `.md-sticky-clone` will now appear below an `md-toolbar` if one is adjacent to the `md-content` element that contains the sticky element (most likely an `md-subheader`), instead of behind it. Also updated documentation on `$mdSticky` to highlight dependency on `md-content`. 

Here is a plunkr show the defect (using Chrome): http://plnkr.co/edit/cIYP7m?p=preview
Here is a plunkr with my fix: http://plnkr.co/edit/XM4R6T?p=preview

_Two caveats:_
1. I tried to get `sticky.spec.js` working but `$mdSticky` has changed significantly since those tests were written/commented out and I ran out of steam trying to figure out how to retrofit the old tests onto the current service. I was thinking of writing some tests from scratch, particularly to test the fix in this PR, but they would likely not be compatible with the old tests so I just left them out. If you would prefer that I add new tests to this PR then let me know!
2. I had to add some css to adjust the position of the sticky clone when a `md-toolbar` is present. I wasn't sure where to put this, since it related to both the toolbar and the sticky components, but I decided on the `toolbar.scss` since I needed to reference some of the toolbar scss variables. Let me know if there is a different way you would like to structure this.

All feedback and improvements welcome!

Closes #580 
Closes #466 