### PR TITLE
Fix typos in CHANGELOG for md-textfloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 #### Breaking Changes
 
-* md-text-float has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issue/547)).
+* md-text-float has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issues/547)).
 
 To create an input, you now must use the native `<input>` and `<textarea>`
 elements, with a `<md-input-container>` parent around each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 #### Breaking Changes
 
-* md-textfloat has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issue/547).
+* md-text-float has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issue/547).
 
 To create an input, you now must use the native `<input>` and `<textarea>`
 elements, with a `<md-input-container>` parent around each
@@ -62,7 +62,7 @@ elements, with a `<md-input-container>` parent around each
 Change your code from this:
 
 ```html
-<md-textfloat label="First Name" ng-model="firstName"></md-textfloat>
+<md-text-float label="First Name" ng-model="firstName"></md-text-float>
 ```
 
 To this:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 #### Breaking Changes
 
-* md-text-float has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issue/547).
+* md-text-float has been deprecated due to flaws (explanation in [#547](https://github.com/angular/material/issue/547)).
 
 To create an input, you now must use the native `<input>` and `<textarea>`
 elements, with a `<md-input-container>` parent around each


### PR DESCRIPTION
The instructions say to change md-textfloat to the new implementation, but it was actually called md-text-float.

Fixing this to help others who are migrating to the new version so they won't be confused like I was.