### PR TITLE
md-input-container: add dotted line on disabled input for IE10

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -61,5 +61,6 @@ md-input-container.md-THEME_NAME-theme {
     border-bottom-color: transparent;
     color: '{{foreground-3}}';
     background-image: linear-gradient(to right, '{{foreground-4}}' 0%, '{{foreground-4}}' 33%, transparent 0%);
+    background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-4}}' 100%);
   }
 }


### PR DESCRIPTION
It looks like IE10 is not fully supporting `linear-gradient`. This fix resolve it.