### PR TITLE
Added max-ripple attribute support to limit the maximum amount of ripples at a time

### DIFF
--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -346,13 +346,27 @@ function InkRippleService($window, $timeout) {
        * @returns {boolean} true if the ripple is allowed, false if not
        */
       function isRippleAllowed() {
-        var parent = node.parentNode;
-        var grandparent = parent && parent.parentNode;
-        var ancestor = grandparent && grandparent.parentNode;
-        return !isDisabled(node) && !isDisabled(parent) && !isDisabled(grandparent) && !isDisabled(ancestor);
         function isDisabled (elem) {
           return elem && elem.hasAttribute && elem.hasAttribute('disabled');
         }
+
+        function hasTooManyRipples (elem) {
+          var allowedRipplesCount = elem && elem.hasAttribute && elem.hasAttribute('max-ripple')
+              && +elem.attributes['max-ripple'].value;
+
+          if((!allowedRipplesCount && allowedRipplesCount !== 0) || allowedRipplesCount < 0) {
+            return false;
+          }
+
+          return ripples.length >= allowedRipplesCount;
+        }
+
+        var parent = node.parentNode;
+        var grandparent = parent && parent.parentNode;
+        var ancestor = grandparent && grandparent.parentNode;
+
+        return !isDisabled(node) && !isDisabled(parent) && !isDisabled(grandparent) && !isDisabled(ancestor)
+            && !hasTooManyRipples(node);
       }
     }
   }


### PR DESCRIPTION
This may close #1177 . If this is somewhat approved and seen as useful I will add docs and examples.  To use it with md-tab for example you can set the attribute as follows `<md-tab max-ripple="1"></md-tab>`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1204)
<!-- Reviewable:end -->
