### PR TITLE
fix missing tabsdemoStaticTabs class in index.html

### DIFF
--- a/src/components/tabs/demoStaticTabs/index.html
+++ b/src/components/tabs/demoStaticTabs/index.html
@@ -1,4 +1,4 @@
-<div ng-controller="AppCtrl">
+<div ng-controller="AppCtrl" class="tabsdemoStaticTabs">
 
     <md-tabs class="md-accent" md-selected="data.selectedIndex">
       <md-tab id="tab1" aria-controls="tab1-content">


### PR DESCRIPTION
I was playing around with the tabs demo in my application and got hung up on the css component of the static tabs. The reason why the specific animation does not work is because the html is missing a class on the outer div. I'm not sure if this is by purpose or not, but I did get hung up on it and if this was just a hiccup, then I added the class to the html. Everything works great by the way!