### PR TITLE
style(tabs): md-tabs-content is now flex'd

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -127,7 +127,7 @@ function TabsDirective($mdTheming) {
         '</button>' +
 
       '</section>' +
-      '<section class="md-tabs-content"></section>',
+      '<section class="md-tabs-content" flex></section>',
     link: postLink
   };
 


### PR DESCRIPTION
At the moment, the content of an `<md-tabs>` component doesn't take all the vertical height of its parent:
![capture d ecran 2015-01-20 a 09 54 07](https://cloud.githubusercontent.com/assets/1788596/5814298/4cf96be2-a08a-11e4-93c8-322784f9aa70.png)
which creates an ugly transition between tabs that don't have the same height ([Plunker](http://plnkr.co/edit/rmmE7aNWc6GyP0me5XcM?p=preview
)):
![untitled](https://cloud.githubusercontent.com/assets/1788596/5814280/104ee2e4-a08a-11e4-96d5-8b482af59548.gif)

This commit simply adds a `flex` attribute to the `<section class="md-tabs-content">` element. So if you have `<md-tabs layout="column" layout-fill>`, the transition should look better:

![untitled](https://cloud.githubusercontent.com/assets/1788596/5814284/22c86602-a08a-11e4-892a-1c0a4e3d4658.gif)
