### PR TITLE
style(tabs): md-tabs-content is now flex'd

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -127,7 +127,7 @@ function TabsDirective($mdTheming) {
         '</button>' +
 
       '</section>' +
-      '<section class="md-tabs-content"></section>',
+      '<section class="md-tabs-content" flex></section>',
     link: postLink
   };
 


### PR DESCRIPTION
This makes transitions between tabs smoother, as the full tab's height is animated.

See my previous (botched) PR: #1235 for an explanation of what this does.

Note, in my app I am using this CSS to mock the functionality:

```css
.md-tabs-content {
  flex: 1;
  overflow: auto;
}
```