### PR TITLE
Update md-toolbar-tools min-height

### DIFF
--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -43,10 +43,8 @@ md-toolbar {
   display: flex;
   align-items: center;
   flex-direction: row;
-
   width: 100%;
   height: $toolbar-tools-height;
-  min-height: 100%;
   max-height: $toolbar-tools-height;
   font-size: inherit;
   font-weight: normal;


### PR DESCRIPTION
The md-toolbar-tools class min-height was 100% as seen [here](https://material.angularjs.org/#/demo/material.components.toolbar) 
This caused the bottom class and the regular class behave the same and be in the center of the tool bar:
![demos gt toolbar](https://cloud.githubusercontent.com/assets/6004537/5889520/656411b6-a434-11e4-82a4-056ece37f0b3.png)

The fix makes it look like this:
![demos gt toolbar 1](https://cloud.githubusercontent.com/assets/6004537/5889521/6b476844-a434-11e4-9224-315c35d2fdb5.png)\

