### PR TITLE
docs(): Change to dark code highlighting theme

### DIFF
--- a/docs/app/css/highlightjs-codepen.css
+++ b/docs/app/css/highlightjs-codepen.css
@@ -1,0 +1,115 @@
+/*
+  codepen.io Embed Theme
+  Author: Justin Perry <http://github.com/ourmaninamsterdam>
+  Original theme - https://github.com/chriskempson/tomorrow-theme
+*/
+
+.hljs, hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  background: #222;
+  color: #fff;
+  font-family: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
+  line-height: 1.45;
+  tab-size: 2;
+  -webkit-font-smoothing: auto;
+  -webkit-text-size-adjust: none;
+}
+
+hljs pre > code.highlight {
+  background: #222;
+}
+
+.hljs-comment,
+.hljs-title {
+  color: #ab875d;
+}
+
+.hljs-variable,
+.hljs-attribute,
+.hljs-tag,
+.hljs-regexp,
+.ruby .constant,
+.xml .tag .title,
+.xml .pi,
+.xml .doctype,
+.html .doctype {
+  color: #BC9A72;
+}
+
+.css .value {
+  color: #cd6a51;
+}
+
+.css .value .function,
+.css .value .string {
+  color: #a67f59;
+}
+
+.css .value .number {
+  color: #9b869c;
+}
+
+.css .id,
+.css .class,
+.css-pseudo,
+.css .selector,
+.css .tag {
+  color: #dfc48c;
+}
+
+.hljs-number,
+.hljs-preprocessor,
+.hljs-built_in,
+.hljs-literal,
+.hljs-params,
+.hljs-constant {
+  color: #ab875d;
+}
+
+.ruby .class .title,
+.css .rules .attribute {
+  color: #9b869b;
+}
+
+.hljs-string,
+.hljs-value,
+.hljs-inheritance,
+.hljs-header,
+.ruby .symbol,
+.xml .cdata {
+  color: #9EAA7D;
+}
+
+.css .hexcolor {
+  color: #cd6a51;
+}
+
+.function,
+.python .decorator,
+.python .title,
+.ruby .function .title,
+.ruby .title .keyword,
+.perl .sub,
+.javascript .title,
+.coffeescript .title {
+  color: #fff;
+}
+
+.hljs-keyword,
+.javascript .function {
+  color: #8f9c6c;
+}
+
+.coffeescript .javascript,
+.javascript,
+.javascript .xml,
+.tex .formula,
+.xml .javascript,
+.xml .vbscript,
+.xml .css,
+.xml .cdata {
+    background: transparent;
+    opacity: 1;
+}

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -49,17 +49,17 @@ pre > code.highlight {
 }
 
 pre, code {
-
   margin: 0;
   padding: 0;
+  font-family: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
   overflow-wrap: break-word;
-  font-family: monospace, serif;
 }
 
 
 pre > code.highlight {
-  padding: 10px;
+  background-color: transparent;
   font-weight: 400;
+  padding: 10px;
 }
 
 code {
@@ -76,6 +76,7 @@ code:not(.highlight) {
   color: #4285f4;
   margin-left: 1px;
   margin-right: 1px;
+  -webkit-font-smoothing: auto;
 }
 
 .md-sidenav-inner {
@@ -407,6 +408,10 @@ ul.methods li h3 {
   min-height: 100%;
 }
 
+md-content.demo-source-container {
+  background-color: transparent;
+  border: none;
+}
 md-content.demo-source-container > hljs > pre > code.highlight {
   position : absolute;
   top : 0px;

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -120,7 +120,7 @@ module.exports = function(gulp, IS_RELEASE_BUILD) {
     return gulp.src([
       'dist/angular-material.css',
       'dist/themes/*.css',
-      'docs/app/css/highlightjs-github.css',
+      'docs/app/css/highlightjs-codepen.css',
       'docs/app/css/layout-demo.css',
       'docs/app/css/style.css'
     ])

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -24,28 +24,31 @@ angular.module('material.components.sidenav', [
  * @module material.components.sidenav
  *
  * @description
- * $mdSidenav makes it easy to interact with multiple sidenavs
+ * `$mdSidenav` makes it easy to interact with multiple sidenavs
  * in an app.
  *
  * @usage
- *
- * ```javascript
+ * <hljs lang="js">
  * // Toggle the given sidenav
  * $mdSidenav(componentId).toggle();
- *
+ * </hljs>
+ * <hljs lang="js">
  * // Open the given sidenav
  * $mdSidenav(componentId).open();
- *
+ * </hljs>
+ * <hljs lang="js">
  * // Close the given sidenav
  * $mdSidenav(componentId).close();
- *
+ * </hljs>
+ * <hljs lang="js">
  * // Exposes whether given sidenav is set to be open
  * $mdSidenav(componentId).isOpen();
- *
+ * </hljs>
+ * <hljs lang="js">
  * // Exposes whether given sidenav is locked open
  * // If this is true, the sidenav will be open regardless of isOpen()
  * $mdSidenav(componentId).isLockedOpen();
- * ```
+ * </hljs>
  */
 function SidenavService($mdComponentRegistry, $q) {
   return function(handle) {


### PR DESCRIPTION
By making code blocks dark, they stand out on the page more. This reduces cognitive load on the reader by making it clear where code examples are on the page. The highlight.js theme chosen matches Codepen embeds, which are pretty good for accessibility and will be used on new Getting Started page starting in https://github.com/angular/material/pull/1116. 