### PR TITLE
feat(icon): svg icons with styles and simple img elements

### DIFF
--- a/config/fixtures/logo.svg
+++ b/config/fixtures/logo.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve">
+<g id="Layer_1">
+  <path d="M 50 0 L 100 14 L 92 80 L 50 100 L 8 80 L 0 14 Z" fill="#b2b2b2"></path>
+  <path d="M 50 5 L 6 18 L 13.5 77 L 50 94 Z" fill="#E42939" md-fill-level="700"></path>
+  <path d="M 50 5 L 94 18 L 86.5 77 L 50 94 Z" fill="#B72833" md-fill-level="900"></path>
+  <path d="M 50 7 L 83 75 L 72 75 L 65 59 L 50 59 L 50 50 L 61 50 L 50 26 Z" fill="#b2b2b2"></path>
+  <path d="M 50 7 L 17 75 L 28 75 L 35 59 L 50 59 L 50 50 L 39 50 L 50 26 Z" fill="#fff"></path>
+</g>
+</svg>

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,6 +1,6 @@
 
 module.exports = function(config) {
-  
+
   var UNCOMPILED_SRC = [
       'config/test-utils.js',
       'src/core/**/*.js',
@@ -35,8 +35,13 @@ module.exports = function(config) {
       'bower_components/angular-animate/angular-animate.js',
       'bower_components/angular-aria/angular-aria.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'bower_components/hammerjs/hammer.js'
+      'bower_components/hammerjs/hammer.js',
+       {pattern: 'config/fixtures/**/*.*', watched: false, included: false, served: true}
     ].concat(testSrc),
+
+    proxies: {
+      '/fixtures/': '/base/config/fixtures/'
+    },
 
     port: 9876,
     reporters: ['progress'],

--- a/docs/app/img/icons/ic_border_color_24px.svg
+++ b/docs/app/img/icons/ic_border_color_24px.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px"
+	 height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<g id="Header">
+	<g>
+		<rect x="-618" y="-1720" fill="none" width="1400" height="3600"/>
+	</g>
+</g>
+<g id="Label">
+	<g>
+		<path d="M17.8,7L14,3.2l-10,10V17h3.8L17.8,7z M20.7,4c0.4-0.4,0.4-1,0-1.4l-2.3-2.3c-0.4-0.4-1-0.4-1.4,0l-2,2L18.8,6L20.7,4z"/>
+		<rect fill="none" width="24" height="24"/>
+		<rect y="20" fill="#A3A3A3" width="24" height="4"/>
+	</g>
+</g>
+<g id="Icon">
+</g>
+<g id="Grid" display="none">
+	<g display="inline">
+	</g>
+</g>
+</svg>

--- a/src/components/icon/demoBasicUsage/index.html
+++ b/src/components/icon/demoBasicUsage/index.html
@@ -1,0 +1,25 @@
+
+<div ng-controller="AppCtrl">
+  <md-content class="md-padding">
+    <h4>Embed as SVG</h4>
+    <section layout="row" layout-sm="column" layout-align="center center">
+        <md-icon icon="/img/logo.svg" type="svg"></md-icon>
+    </section>
+    <h4>Embed as IMG</h4>
+    <section layout="row" layout-sm="column" layout-align="center center">
+      <md-icon icon="/img/logo.svg" type="image"></md-icon>
+    </section>
+    <h4>Use in fab Buttons</h4>
+    <section layout="row" layout-sm="column" layout-align="space-around center">
+      <md-button class="md-fab" aria-label="Time">
+        <md-icon icon="/img/icons/ic_access_time_24px.svg"></md-icon>
+      </md-button>
+      <md-button class="md-fab" aria-label="New document">
+        <md-icon icon="/img/icons/ic_insert_drive_file_24px.svg"></md-icon>
+      </md-button>
+      <md-button class="md-fab md-primary" md-theme="cyan" aria-label="Profile">
+        <md-icon icon="/img/icons/ic_people_24px.svg"></md-icon>
+      </md-button>
+    </section>
+  </md-content>
+</div>

--- a/src/components/icon/demoBasicUsage/script.js
+++ b/src/components/icon/demoBasicUsage/script.js
@@ -1,0 +1,7 @@
+
+angular.module('iconDemoBasicUsage', ['ngMaterial'])
+
+.controller('AppCtrl', function($scope) {
+
+});
+

--- a/src/components/icon/demoBasicUsage/style.css
+++ b/src/components/icon/demoBasicUsage/style.css
@@ -1,0 +1,17 @@
+
+section {
+  margin: 1em;
+  padding-bottom: 10px;
+}
+
+md-button.md-fab md-icon {
+  width: 24px;
+  height: 24px;
+}
+md-icon svg {
+ width:256px;
+ fill:rgba(0,0,0,0.8);
+}
+md-icon img {
+ width:256px;
+}

--- a/src/components/icon/demoStyles/index.html
+++ b/src/components/icon/demoStyles/index.html
@@ -5,7 +5,7 @@
     <md-icon class="filter" icon="/img/logo.svg" type="svg" style="width:256px;height:256px;"></md-icon>
   </section>
   <h3>Control SVG child element fill</h3>
-  <div layout-fill layout layout-align="center center" ng-attr-style="fill: rgb({{color.red}},{{color.green}},{{color.blue}});">
+  <div layout layout-align="center center" ng-attr-style="fill: rgb({{color.red}},{{color.green}},{{color.blue}});">
     <md-icon class="custom" icon="/img/icons/ic_border_color_24px.svg" type="svg"></md-icon>
   </div>
   <div layout>

--- a/src/components/icon/demoStyles/index.html
+++ b/src/components/icon/demoStyles/index.html
@@ -1,0 +1,32 @@
+<md-content ng-controller="AppCtrl" class="md-padding">
+
+  <h3>Apply CSS filters</h3>
+  <section layout="row" layout-sm="column" layout-align="center center">
+    <md-icon class="filter" icon="/img/logo.svg" type="svg" style="width:256px;height:256px;"></md-icon>
+  </section>
+  <h3>Control SVG child element fill</h3>
+  <div layout-fill layout layout-align="center center" ng-attr-style="fill: rgb({{color.red}},{{color.green}},{{color.blue}});">
+    <md-icon class="custom" icon="/img/icons/ic_border_color_24px.svg" type="svg"></md-icon>
+  </div>
+  <div layout>
+      <div flex="5" layout layout-align="center center">
+          <span>R</span>
+      </div>
+      <md-slider flex min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider" class="md-warn">
+      </md-slider>
+  </div>
+  <div layout>
+      <div flex="5" layout layout-align="center center">
+          <span>G</span>
+      </div>
+      <md-slider flex ng-model="color.green" min="0" max="255" aria-label="green" id="green-slider" class="md-accent">
+      </md-slider>
+  </div>
+  <div layout>
+      <div flex="5" layout layout-align="center center">
+          <span>B</span>
+      </div>
+      <md-slider flex ng-model="color.blue" min="0" max="255" aria-label="blue" id="blue-slider">
+      </md-slider>
+  </div>
+</md-content>

--- a/src/components/icon/demoStyles/script.js
+++ b/src/components/icon/demoStyles/script.js
@@ -1,0 +1,12 @@
+
+angular.module('iconDemoStyles', ['ngMaterial'])
+
+.controller('AppCtrl', function($scope) {
+
+  $scope.color = {
+    red: Math.floor(Math.random() * 255),
+    green: Math.floor(Math.random() * 255),
+    blue: Math.floor(Math.random() * 255)
+  };
+
+});

--- a/src/components/icon/demoStyles/style.css
+++ b/src/components/icon/demoStyles/style.css
@@ -1,0 +1,16 @@
+md-icon.custom svg {
+  width:256px;
+  height:256px;
+  fill:inherit;
+}
+md-icon.custom path {
+  fill:rgba(0, 0, 0, 0.9);
+}
+md-icon.custom rect[y="20"] {
+  fill:inherit;
+}
+md-icon.filter svg {
+  width:256px;
+  filter: blur(2px) hue-rotate(180deg);
+  -webkit-filter: blur(2px) hue-rotate(180deg);
+}

--- a/src/components/icon/icon.js
+++ b/src/components/icon/icon.js
@@ -10,7 +10,7 @@
 angular.module('material.components.icon', [
   'material.core'
 ])
-  .directive('mdIcon', mdIconDirective);
+.directive('mdIcon', mdIconDirective);
 
 /*
  * @ngdoc directive
@@ -22,21 +22,43 @@ angular.module('material.components.icon', [
  * @description
  * The `<md-icon>` directive is an element useful for SVG icons
  *
+ * @param {string} md-type The type of icon to display, either `image` or `svg`.  If the attribute
+ * is not present, the default will be `svg`.  When using the `image` type, the icon will not be applicable
+ * for customization with CSS styles, but may perform better in some cases.
+ *
  * @usage
  * <hljs lang="html">
- *  <md-icon icon="/img/icons/ic_access_time_24px.svg">
- *  </md-icon>
+ *  <md-icon icon="/img/icons/ic_access_time_24px.svg"></md-icon>
+ *  <md-icon icon="/img/icons/ic_access_time_24px.svg" type="image"></md-icon>
  * </hljs>
  *
  */
 function mdIconDirective() {
   return {
     restrict: 'E',
-    template: '<object class="md-icon"></object>',
+    template: '<div class="md-icon"/>',
     compile: function(element, attr) {
-      var object = angular.element(element[0].children[0]);
-      if(angular.isDefined(attr.icon)) {
-        object.attr('data', attr.icon);
+      if(!angular.isDefined(attr.icon)) {
+        return;
+      }
+      var type = angular.isDefined(attr.type) ? attr.type : 'svg';
+      var child = angular.element(element[0].children[0]);
+      if(type === 'svg') {
+        var httpRequest = new XMLHttpRequest();
+        httpRequest.onreadystatechange = function loadIconState() {
+          if (httpRequest.readyState === 4) {
+            if (httpRequest.status === 200 && httpRequest.responseXML instanceof Document) {
+              var svg = angular.element(httpRequest.responseXML).find('svg');
+              child.replaceWith(svg);
+            }
+          }
+        };
+        httpRequest.open('GET', attr.icon);
+        httpRequest.send();
+      }
+      else if(type === 'image') {
+        var img = angular.element('<img src="' + attr.icon + '"/>');
+        child.replaceWith(img);
       }
     }
   };

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -8,17 +8,12 @@ md-icon {
   pointer-events: none;
   display: flex;
   z-index: 0;
-
-  object.md-icon {
-    display: inline-block;
+  svg {
+    fill: inherit;
+    color: inherit;
   }
-}
-svg, object {
-  fill: currentColor;
-  color: currentColor;
-}
-
-md-class-icon {
-  // display: block;
-  // margin: 0 auto;
+  svg.md-icon, img.md-icon {
+    display: inline-block;
+    width:inherit;
+  }
 }

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -1,2 +1,34 @@
-describe('mdIcon directive', function() {
+describe('md-icon directive', function() {
+  beforeEach(module('material.components.icon'));
+
+  var validIconUrl = '/fixtures/logo.svg';
+
+  var $rootScope = null;
+  var $compile = null;
+  var $document = null;
+  beforeEach(inject(function($injector) {
+    $rootScope = $injector.get('$rootScope').$new();
+    $compile = $injector.get('$compile');
+    $document = $injector.get('$document');
+  }));
+
+  afterEach(function() {
+    $rootScope.$destroy();
+  });
+
+  it('should load svg icon from file', function() {
+    var el = $compile('<md-icon icon="' + validIconUrl + '"></md-icon>')($rootScope);
+    $rootScope.$apply();
+    waitsFor(function checkLoaded() {
+      return el.find('svg').length > 0  && el.find('path').length > 0;
+    },1500);
+  });
+
+  it('should load static svg icon in img container', function() {
+    var el = $compile('<md-icon type="image" icon="' + validIconUrl + '"></md-icon>')($rootScope);
+    $rootScope.$apply();
+    waitsFor(function checkLoaded() {
+      return el.find('img').length > 0;
+    },1500);
+  });
 });

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -6,29 +6,46 @@ describe('md-icon directive', function() {
   var $rootScope = null;
   var $compile = null;
   var $document = null;
+
+  function setup(type,url,then) {
+    var el = $compile('<md-icon type="' + type + '" icon="' + url + '"></md-icon>')($rootScope);
+    $rootScope.$apply();
+    angular.element($document[0].body).append(el);
+    waitsFor(function() {
+      var loaded = type === 'image' ? el.find('img')[0].complete : el.find('svg').children().length > 0;
+      if(loaded){
+        el.detach();
+        then(el);
+      }
+      return loaded;
+    },1500);
+  }
+
   beforeEach(inject(function($injector) {
     $rootScope = $injector.get('$rootScope').$new();
     $compile = $injector.get('$compile');
     $document = $injector.get('$document');
   }));
-
   afterEach(function() {
     $rootScope.$destroy();
   });
 
+  it('defaults to svg if type is not specified', function(){
+    setup('svg',validIconUrl,function(el) {
+      expect(el.find('svg').length).toBeGreaterThan(0);
+      expect(el.find('path').length).toBeGreaterThan(0);
+    });
+  });
+
   it('should load svg icon from file', function() {
-    var el = $compile('<md-icon icon="' + validIconUrl + '"></md-icon>')($rootScope);
-    $rootScope.$apply();
-    waitsFor(function checkLoaded() {
-      return el.find('svg').length > 0  && el.find('path').length > 0;
-    },1500);
+    setup('svg',validIconUrl,function(el) {
+      expect(el.find('svg').length).toBeGreaterThan(0);
+    });
   });
 
   it('should load static svg icon in img container', function() {
-    var el = $compile('<md-icon type="image" icon="' + validIconUrl + '"></md-icon>')($rootScope);
-    $rootScope.$apply();
-    waitsFor(function checkLoaded() {
-      return el.find('img').length > 0;
-    },1500);
+    setup('image',validIconUrl,function(el) {
+      expect(el.find('img').length).toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
Update the md-icon directive to support CSS styling and loading of .svg file icons directly.  Add documentation, tests, and examples.

Questions:
- the directive currently defaults to render icons as `svg` so that styling may be applied to svg elements.  is it better to default to the `img` rendering, which would pollute the dom less but not svg element styling?
- sizing of the svg/img elements that are rendered seems to be unintuitive.  e.g. if you use CSS to size the md-icon element, the svg or img child elements won't always size as expected.   does it make sense to size the child elements to fit the parent md-icon container?
- what is the desired behavior when an icon url is invalid?  should this case be handled, and how?