### PR TITLE
layout-margin/layout-padding won't work with flex variants #1281

### DIFF
--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -1,4 +1,5 @@
 $sidenav-default-width: 304px !default;
+$sidenav-min-space: 56px !default;
 
 md-sidenav {
   position: absolute;
@@ -89,5 +90,11 @@ md-sidenav {
   transform: translate3d(-100%, 0, 0);
   &.md-closed {
     transform: translate3d(0%, 0, 0);
+  }
+}
+
+@media (max-width: $sidenav-default-width + $sidenav-min-space) {
+  md-sidenav {
+    width: 85%;
   }
 }

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -23,39 +23,18 @@
 }
 
 [layout-padding],
-[layout-padding] > [flex] {
-  padding: $layout-gutter-width / 2;
-}
-[layout-margin],
-[layout-margin] > [flex] {
-  margin: $layout-gutter-width / 2;
-}
-
-[layout-padding],
-[layout-padding] > [flex-md] {
-  padding: $layout-gutter-width / 2;
-}
-[layout-margin],
-[layout-margin] > [flex-md] {
-  margin: $layout-gutter-width / 2;
-}
-
-[layout-padding],
-[layout-padding] > [flex-sm] {
-  padding: $layout-gutter-width / 3;
-}
-[layout-margin],
-[layout-margin] > [flex-sm] {
-  margin: $layout-gutter-width / 3;
-}
-
-[layout-padding],
+[layout-padding] > [flex],
+[layout-padding] > [flex-sm],
+[layout-padding] > [flex-md],
 [layout-padding] > [flex-lg] {
-  padding: $layout-gutter-width;
+  padding: $layout-gutter-width / 2;
 }
 [layout-margin],
+[layout-margin] > [flex],
+[layout-margin] > [flex-sm],
+[layout-margin] > [flex-md],
 [layout-margin] > [flex-lg] {
-  margin: $layout-gutter-width;
+  margin: $layout-gutter-width / 2;
 }
 
 [layout-wrap] {


### PR DESCRIPTION
Added different padding and margins for flex-sm, flex-md and flex-lg
To fix issue #1281 (layout-margin/layout-padding won't work with flex variants)

flex-lg = $layout-gutter-width
flex-md = $layout-gutter-width /2
flex-sm = $layout-gutter-width/3