### PR TITLE
docs(layout): subheaders over the code section

### DIFF
--- a/docs/app/css/layout-demo.css
+++ b/docs/app/css/layout-demo.css
@@ -39,6 +39,7 @@ demo-include {
   height: 200px;
   width: 100%;
   position: relative;
+  z-index: 2;
 }
 [ng-panel] {
   transition: 0.45s cubic-bezier(0.35, 0, 0.25, 1);


### PR DESCRIPTION
As you can see here
![sample](https://cloud.githubusercontent.com/assets/6004537/5964563/dbe957d4-a7fd-11e4-99b8-ddf74dfc4ce0.gif)

I marked the subheader labels so it will be easy to see,
the subheader z-index is prior to the layout-panel-parent so i added z-index: 2