### PR TITLE
docs(theming, md-tabs): fix typos in both sections

### DIFF
--- a/docs/content/Theming/03_configuring_a_theme.md
+++ b/docs/content/Theming/03_configuring_a_theme.md
@@ -61,8 +61,8 @@ angular.module('myApp', ['ngMaterial'])
 ### Defining Custom Palettes
 
 As mentioned before, Angular Material ships with the Material Design
-Spec's color palettes built in. In the event that you need to define a color
-custom palette, you can use `$mdThemingProvider` to define it, thereby making 
+Spec's color palettes built in. In the event that you need to define a custom
+color palette, you can use `$mdThemingProvider` to define it, thereby making 
 it available to your theme for use in its intention groups. Note that you must
 specify all hues in the definition map.
 

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -23,7 +23,7 @@ angular.module('material.components.tabs')
  *    <md-tab label="Tab #1"></md-tab>
  *    <md-tab label="Tab #2"></md-tab>
  *    <md-tab label="Tab #3"></md-tab>
- *  <md-tabs>
+ *  </md-tabs>
  *  </hljs>
  *
  * Tabs supports three (3) usage scenarios:


### PR DESCRIPTION
The bug that's currently visible
![screen shot 2015-02-01 at 3 18 13 pm](https://cloud.githubusercontent.com/assets/2349718/5994377/bf43ed7c-aa25-11e4-92c6-ab81944db2c5.png)

and the fix:
![screen shot 2015-02-01 at 3 17 46 pm](https://cloud.githubusercontent.com/assets/2349718/5994379/c40180ea-aa25-11e4-9148-46ac5ae24e4f.png)

Also switched two words in the theming docs that seemed confusing, hopefully it's helpful.

Thanks for making this available!