### PR TITLE
fix(tabs): Fix tabs swipping when using JQuery

### DIFF
--- a/src/components/tabs/js/tabItemController.js
+++ b/src/components/tabs/js/tabItemController.js
@@ -65,7 +65,8 @@ function TabItemController($scope, $element, $attrs, $compile, $animate, $mdUtil
         'aria-selected': true,
         'tabIndex': 0
       })
-      .on('$md.swipeleft $md.swiperight', onSwipe);
+      .on('$md.swipeleft', onSwipeLeft)
+      .on('$md.swiperight', onSwipeRight);
 
     toggleAnimationClass(rightToLeft);
     $animate.removeClass(self.contentContainer, 'ng-hide');
@@ -83,7 +84,8 @@ function TabItemController($scope, $element, $attrs, $compile, $animate, $mdUtil
         'aria-selected': false,
         'tabIndex': -1
       })
-      .off('$md.swipeleft $md.swiperight', onSwipe);
+      .off('$md.swipeleft', onSwipeLeft)
+      .off('$md.swiperight', onSwipeRight);
 
     toggleAnimationClass(rightToLeft);
     $animate.addClass(self.contentContainer, 'ng-hide');
@@ -92,14 +94,15 @@ function TabItemController($scope, $element, $attrs, $compile, $animate, $mdUtil
   }
 
   ///// Private functions
-
-  function onSwipe(ev) {
+  function onSwipeLeft(ev) {
     $scope.$apply(function() {
-      if (/left/.test(ev.type)) {
-        tabsCtrl.select(tabsCtrl.next());
-      } else {
-        tabsCtrl.select(tabsCtrl.previous());
-      }
+      tabsCtrl.select(tabsCtrl.next());
+    });
+  }
+
+  function onSwipeRight(ev) {
+    $scope.$apply(function() {
+      tabsCtrl.select(tabsCtrl.previous());
     });
   }
  


### PR DESCRIPTION
When using dots in JQuery events name, an [event namespace](http://api.jquery.com/event.namespace/) is created and Event.type doesn't give the same name as using jqLite. JQuery removes the namespace from Event.type, but JQlite doesn't support namespace and keep the whole dotted value.

This cause an issue in tabs swipping, because onSwipe listener is checking Event.type property value.

For consistency with jqLite and jQuery, it's better to avoid checking the Event.type value, and use two distinct listeners for right and left swipping.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1372)
<!-- Reviewable:end -->
