### PR TITLE
chore(gulp): Run gulp karma with minified build and JQuery dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "angular-route": "1.3.x",
     "angular-mocks": "1.3.x",
     "angularytics": "^0.3.0",
-    "angular-messages": "~1.3.8"
+    "angular-messages": "~1.3.8",
+    "jquery": "~2.1.x"
   }
 }

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -1,4 +1,3 @@
-
 module.exports = function(config) {
   
   var UNCOMPILED_SRC = [
@@ -23,20 +22,26 @@ module.exports = function(config) {
   ];
   
   // releaseMode is a custom configuration option.
-  var testSrc = config.releaseMode ? COMPILED_SRC : UNCOMPILED_SRC;
+  var testSrc = process.env['MATERIAL_RELEASE_MODE'] ? COMPILED_SRC : UNCOMPILED_SRC;
+
+  var dependencies = [];
+  if (process.env['MATERIAL_JQUERY']) {
+    dependencies.push('bower_components/jquery/dist/jquery.js');
+  }
+
+  var dependencies = dependencies.concat([
+    'bower_components/angular/angular.js',
+    'bower_components/angular-animate/angular-animate.js',
+    'bower_components/angular-aria/angular-aria.js',
+    'bower_components/angular-mocks/angular-mocks.js',
+    'config/test-utils.js'
+  ]);
 
   config.set({
 
     basePath: __dirname + '/..',
     frameworks: ['jasmine'],
-    files: [
-      // Dependencies
-      'bower_components/angular/angular.js',
-      'bower_components/angular-animate/angular-animate.js',
-      'bower_components/angular-aria/angular-aria.js',
-      'bower_components/angular-mocks/angular-mocks.js',
-      'config/test-utils.js'
-    ].concat(testSrc),
+    files: dependencies.concat(testSrc),
 
     port: 9876,
     reporters: ['progress'],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -155,8 +155,22 @@ gulp.task('karma', function(done) {
   function testMinified() {
     gutil.log('Running unit tests on minified source.');
     buildJs(true);
-    karmaConfig.releaseMode = true;
-    karma.start(karmaConfig, done);
+    process.env['MATERIAL_RELEASE_MODE'] = 'true';
+    karma.start(karmaConfig, testMinifiedJQuery);
+  }
+
+  function testMinifiedJQuery() {
+    gutil.log('Running unit tests on minified source using JQuery.');
+    buildJs(true);
+    process.env['MATERIAL_RELEASE_MODE'] = 'true';
+    process.env['MATERIAL_JQUERY'] = 'true';
+    karma.start(karmaConfig, clearEnv);
+  }
+
+  function clearEnv() {
+    process.env['MATERIAL_RELEASE_MODE'] = undefined;
+    process.env['MATERIAL_JQUERY'] = undefined;
+    done();
   }
 });
 


### PR DESCRIPTION
This fix an issue (#1370) causing minified build test to run against non minified sources, and adds a 3rd test configuration with JQuery dependency.

Others PRs (#1367, #1371, #1372) are there to make the tests to pass with JQuery.