### PR TITLE
Update toast.scss

### DIFF
--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -1,7 +1,7 @@
 // See height set globally, depended on by buttons
 md-toast {
   display: flex;
-  position:absolute;
+  position:fixed;
   box-sizing: border-box;
   align-items: center;
 


### PR DESCRIPTION
I propose replace `absolute` with `fixed`, because the toast doesn't move when user scroll the page and it finds himself in the middle of the page (it's ugly).

Currently => 
Start: http://img4.hostingpics.net/pics/767337good.png
Scroll: http://img4.hostingpics.net/pics/503064bad.png

With fixed =>
Scroll : http://img4.hostingpics.net/pics/992306withfixed.png

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1386)
<!-- Reviewable:end -->
