### PR TITLE
Copy update to ngDoc for $mdDialog#show

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -227,7 +227,7 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *     finished.
  *
  * @returns {promise} A promise that can be resolved with `$mdDialog.hide()` or
- * rejected with `mdDialog.cancel()`.
+ * rejected with `$mdDialog.cancel()`.
  */
 
 /**


### PR DESCRIPTION
The return value mentions a promise that can be resolved with $mdDialog.hide and mdDialog.show.. tweaked the copy to read $mdDialog.show instead.