### PR TITLE
fix(docs): toolbar buttons overlap on mobile 

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -37,6 +37,20 @@ th {
   background-color: #f5f5f5;
 }
 
+ul {
+  margin: 0;
+  padding: 0;
+}
+ul li {
+  margin-left: 16px;
+  padding: 0;
+  margin-top: 3px;
+  list-style-position: inside;
+}
+ul li:first-child {
+  margin-top: 0;
+}
+
 pre {
   white-space: pre;
   white-space: pre-wrap;
@@ -83,20 +97,29 @@ code:not(.highlight) {
   -webkit-font-smoothing: auto;
 }
 
-.md-sidenav-inner {
-  background: #fff;
-}
-
 .layout-content,
 .doc-content {
   max-width: 864px;
   margin: auto;
 }
-.layout-label {
-  width: 120px;
-}
 .layout-content code.highlight {
   margin-bottom: 15px;
+}
+
+.extraPad {
+  padding-left:32px !important;
+  padding-right:32px !important;
+}
+
+.site-sidenav,
+.site-sidenav.md-locked-open-add-active,
+.site-sidenav.md-locked-open {
+  width: 254px;
+  min-width: 254px;
+  max-width: 254px;
+}
+.site-sidenav > * {
+  min-width: 218px;
 }
 
 /* Begin Docs Menu */
@@ -336,21 +359,7 @@ md-toolbar.demo-toolbar .md-button {
   background-color: #f6f6f6;
   height: 400px;
 }
-
-.demo-source-content {
-  height: 400px;
 }
-.demo-source-content,
-.demo-source-content pre,
-.demo-source-content code {
-  background: #f6f6f6;
-  font-family: monospace;
-}
-.demo-source-content pre {
-  max-width: 100%;
-  overflow-wrap: break-word;
-}
-
 .show-source div[demo-include] {
   border-top: #ddd solid 2px;
 }
@@ -358,10 +367,6 @@ md-toolbar.demo-toolbar .md-button {
 
 .menu-separator-icon {
   margin: 0;
-}
-.menu-module-name {
-  opacity: 0.6;
-  font-size: 18px;
 }
 
 /***************
@@ -434,17 +439,6 @@ code.api-type {
   font-weight: bold;
 }
 
-ul {
-  margin: 0;
-}
-ul li {
-  margin-top: 3px;
-  list-style-position: inside;
-}
-ul li:first-child {
-  margin-top: 0;
-}
-
 .layout-title {
   color: #999999;
   font-size: 14px;
@@ -466,9 +460,6 @@ ul.methods .method-function-syntax {
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
 }
-ul.methods li h3 {
-  /* border-bottom: 1px solid #eee; */
-}
 
 @media (max-width: 600px) {
   ul.methods > li {
@@ -479,12 +470,6 @@ ul.methods li h3 {
   ul.methods .method-function-syntax {
     font-size: 14px;
   }
-}
-
-.version {
-    padding-left: 10px;
-    text-decoration: underline;
-    font-size: 0.95em;
 }
 
 .demo-source-container pre,
@@ -503,33 +488,15 @@ md-content.demo-source-container > hljs > pre > code.highlight {
   right: 0px;
 }
 
-
-.extraPad {
-  padding-left:32px !important;
-  padding-right:32px !important;
+.dashed-bottom {
+  border-bottom: dashed 1px rgb(224, 224, 224);;
+  padding-bottom: 10px;
 }
 
-.site-sidenav,
-.site-sidenav.md-locked-open-add-active,
-.site-sidenav.md-locked-open {
-  width: 254px;
-  min-width: 254px;
-  max-width: 254px;
+.dashed-top {
+  border-top: dashed 1px rgb(224, 224, 224);
+  margin-top: 10px;
 }
-.site-sidenav > * {
-  min-width: 218px;
-}
-
-.dashed_bottom {
-    border-bottom: dashed 1px rgb(224, 224, 224);;
-        padding-bottom: 10px;
-}
-
-.dashed_top {
-    border-top: dashed 1px rgb(224, 224, 224);
-    margin-top: 10px;
-}
-
 
 .api-section h3 {
     padding-top:20px;

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -122,7 +122,9 @@ code:not(.highlight) {
   min-width: 218px;
 }
 
-/* Begin Docs Menu */
+/************
+ * DOCS MENU
+ ************/
 .docs-menu,
 .docs-menu ul {
   list-style: none;
@@ -211,16 +213,33 @@ code:not(.highlight) {
 }
 /* End Docs Menu */
 
-.menu-icon {
+.docs-logotype {
+  line-height:40px;
+  text-indent: 15px;
+}
+.docs-menu-icon {
   background: none;
   border: none;
   margin-right: 16px;
   padding: 0;
 }
-.app-toolbar .md-toolbar-tools h3 {
-  -webkit-margin-before: 0;
-  -webkit-margin-after: 0;
+.docs-menu-separator-icon {
+  margin: 0;
+  padding: 0 10px;
 }
+.docs-menu-separator-icon img {
+  height: 16px;
+}
+.md-breadcrumb-page {
+  display: inline-block;
+  word-wrap: break-word;
+}
+@media (max-width: 400px) {
+  .docs-tools {
+    display: none;
+  }
+}
+
 docs-demo {
   display: block;
   margin-top: 16px;
@@ -364,10 +383,6 @@ md-toolbar.demo-toolbar .md-button {
   border-top: #ddd solid 2px;
 }
 
-
-.menu-separator-icon {
-  margin: 0;
-}
 
 /***************
  * Landing Page

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -31,7 +31,7 @@
             <path d="M 50 7 L 83 75 L 72 75 L 65 59 L 50 59 L 50 50 L 61 50 L 50 26 Z" fill="#b2b2b2"></path>
             <path d="M 50 7 L 17 75 L 28 75 L 35 59 L 50 59 L 50 50 L 39 50 L 50 26 Z" fill="#fff"></path>
           </svg>
-          <div style="line-height:40px; text-indent: 15px;">Material Design</div>
+          <div class="docs-logotype">Material Design</div>
         </a>
       </h1>
     </md-toolbar>
@@ -60,7 +60,7 @@
     <md-toolbar>
 
       <div class="md-toolbar-tools" ng-click="openMenu()">
-        <button class="menu-icon" hide-gt-sm aria-label="Toggle Menu">
+        <button class="docs-menu-icon" hide-gt-sm aria-label="Toggle Menu">
           <md-icon md-svg-src="img/icons/ic_menu_24px.svg"></md-icon>
         </button>
 
@@ -68,16 +68,16 @@
           <div class="md-toolbar-item md-breadcrumb">
             <span ng-if="menu.currentPage.name !== menu.currentSection.name">
               <span hide-sm hide-md>{{menu.currentSection.name}}</span>
-              <span class="menu-separator-icon" style="padding: 0 10px;" hide-sm hide-md>
-                <img style="height: 16px;" src="img/docArrow.png" alt="" aria-hidden="true">
+              <span class="docs-menu-separator-icon" style="" hide-sm hide-md>
+                <img src="img/docArrow.png" alt="" aria-hidden="true">
               </span>
             </span>
-            <span style="display: inline-block;">{{(menu.currentPage | humanizeDoc) || 'Angular Material' }}</span>
+            <span class="md-breadcrumb-page">{{(menu.currentPage | humanizeDoc) || 'Angular Material' }}</span>
           </div>
 
           <span flex></span> <!-- use up the empty space -->
 
-          <div class="md-toolbar-item md-tools" layout="row">
+          <div class="md-toolbar-item md-tools docs-tools" layout="column" layout-gt-md="row">
             <div ng-repeat="doc in currentComponent.docs">
               <md-button ng-href="#{{doc.url}}"
                 ng-class="{hide: path().indexOf('demo') == -1}"

--- a/docs/config/template/ngdoc/lib/macros.html
+++ b/docs/config/template/ngdoc/lib/macros.html
@@ -31,7 +31,7 @@
 {%- macro paramTable(params) %}
 <md-list>
   <md-item>
-    <md-item-content class="dashed_bottom">
+    <md-item-content class="dashed-bottom">
       <div class="api-params-label api-params-title"  flex="20" layout layout-align="center center" >
         Parameter
       </div>
@@ -78,7 +78,7 @@
 {%- macro returnTable(fn) -%}
 <md-list>
   <md-item>
-    <md-item-content class="dashed_top">
+    <md-item-content class="dashed-top">
       <div class="api-params-label api-params-title" layout layout-align="center center" flex="20" flex-sm="20">
         Returns
       </div>


### PR DESCRIPTION
When a demo has multiple directives associated with it (or just a long name), it overlaps pretty bad on small screens. 
![Docs autocomplete toolbar shows overlap](https://cloud.githubusercontent.com/assets/1045233/6180788/a0f00a74-b2de-11e4-90e5-ccbc89811dd9.png)

This PR also includes docs CSS cleanup & organization: removing unused classes and grouping related items.