### PR TITLE
fix(autocomplete) select item on mouse click

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -58,8 +58,8 @@
           <li ng-repeat="(index, item) in $mdAutocompleteCtrl.matches"\
               ng-class="{ selected: index === $mdAutocompleteCtrl.index }"\
               ng-if="searchText && !$mdAutocompleteCtrl.hidden"\
-              ng-click="$mdAutocompleteCtrl.select(index)"\
               ng-transclude\
+              md-autocomplete-list-item-index="{{index}}"\
               md-autocomplete-list-item="$mdAutocompleteCtrl.itemName">\
           </li>\
         </ul>\

--- a/src/components/autocomplete/js/listItemDirective.js
+++ b/src/components/autocomplete/js/listItemDirective.js
@@ -12,11 +12,15 @@
       scope: false
     };
     function link (scope, element, attr, ctrl) {
-      var newScope = ctrl.parent.$new(false, ctrl.parent);
-      var itemName = ctrl.scope.$eval(attr.mdAutocompleteListItem);
+      var newScope = ctrl.parent.$new(false, ctrl.parent),
+          itemName = ctrl.scope.$eval(attr.mdAutocompleteListItem),
+          itemIndex = ctrl.scope.$eval(attr.mdAutocompleteListItemIndex);
       newScope[itemName] = scope.item;
       $compile(element.contents())(newScope);
       element.attr({ 'role': 'option', 'id': 'item_' + $mdUtil.nextUid() });
+      element.on('click', function() {
+          newScope.$apply(function() { ctrl.select(itemIndex); });
+      });
     }
   }
 })();


### PR DESCRIPTION
The ng-if on the list item was removing the item on the md-autocomplete blur due to $mdAutocompleteCtrl.hidden being set to true. The ng-click handler for the list item was never called.