### PR TITLE
fix(autocomplete): set tabindex 1000 for the clear button

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -51,7 +51,8 @@
           <button\
               type="button"\
               ng-if="searchText"\
-              ng-click="$mdAutocompleteCtrl.clear()">\
+              ng-click="$mdAutocompleteCtrl.clear()"\
+			  tabindex="1000">\
               <md-icon md-svg-icon="cancel"></md-icon>\
               <span class="visually-hidden">Clear</span>\
               </button>\


### PR DESCRIPTION
Autocomplete tabulation stops on the clear button instead go to the next form element. It is definitely wrong as clear button is not pretend to be next input element.