### PR TITLE
fix(tabs): add component.icon to module

### DIFF
--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -25,6 +25,7 @@
  * @see js folder for tabs implementation
  */
 angular.module('material.components.tabs', [
-  'material.core'
+  'material.core',
+  'material.components.icon'
 ]);
 })();


### PR DESCRIPTION
The tabs directive is using md-icon but its module was not requiring material.component.icon.