### PR TITLE
fix(md-input-container): Correctly style invalid inputs

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -44,7 +44,7 @@ md-input-container.md-THEME_NAME-theme {
       }
     }
   }
-  &.md-input-invalid {
+  &.md-input-invalid.md-input-touched {
     .md-input {
       border-color: '{{warn-500}}';
     }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -64,6 +64,9 @@ function mdInputContainerDirective($mdTheming, $parse) {
     self.setFocused = function(isFocused) {
       $element.toggleClass('md-input-focused', !!isFocused);
     };
+    self.setTouched = function(isTouched) {
+      $element.toggleClass('md-input-touched', !!isTouched);
+    };
     self.setHasValue = function(hasValue) {
       $element.toggleClass('md-input-has-value', !!hasValue);
     };
@@ -186,6 +189,7 @@ function inputTextareaDirective($mdUtil, $window) {
 
           // Error text should not appear before user interaction with the field.
           // So we need to check on focus also
+          containerCtrl.setTouched(true);
           ngModelCtrl.$setTouched();
           if ( isErrorGetter() ) containerCtrl.setInvalid(true);
 


### PR DESCRIPTION
Set a touched class on the md-input-container and base the error styling off of whether or not the input has been touched. Workaround for issue #1485 