### PR TITLE
fix(md-input-container): Correctly style invalid input

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -44,7 +44,7 @@ md-input-container.md-THEME_NAME-theme {
       }
     }
   }
-  &.md-input-invalid {
+  &.md-input-invalid.md-input-touched {
     .md-input {
       border-color: '{{warn-500}}';
     }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -64,6 +64,9 @@ function mdInputContainerDirective($mdTheming, $parse) {
     self.setFocused = function(isFocused) {
       $element.toggleClass('md-input-focused', !!isFocused);
     };
+    self.setTouched = function(isTouched) {
+      $element.toggleClass('md-input-touched', !!isTouched);
+    };
     self.setHasValue = function(hasValue) {
       $element.toggleClass('md-input-has-value', !!hasValue);
     };
@@ -186,6 +189,7 @@ function inputTextareaDirective($mdUtil, $window) {
 
           // Error text should not appear before user interaction with the field.
           // So we need to check on focus also
+          containerCtrl.setTouched(true);
           ngModelCtrl.$setTouched();
           if ( isErrorGetter() ) containerCtrl.setInvalid(true);
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -173,7 +173,11 @@ function inputTextareaDirective($mdUtil, $window) {
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-      return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+      if (!ngModelCtrl.$touched) {
+        return true;
+      } else {
+        return ngModelCtrl.$invalid;
+      }
     };
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 


### PR DESCRIPTION
Fixes styling on invalid inputs by adding touched class to md-input-container and only applying error style once the input has been touched to prevent style from being applied on page load. More detailed information with line comments.