### PR TITLE
fix(md-input-container): Properly set and unset when input is invalid

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -187,7 +187,7 @@ function inputTextareaDirective($mdUtil, $window) {
           // Error text should not appear before user interaction with the field.
           // So we need to check on focus also
           ngModelCtrl.$setTouched();
-          if ( isErrorGetter() ) containerCtrl.setInvalid(true);
+          scope.$digest();
 
         })
         .on('blur', function(ev) {


### PR DESCRIPTION
This is to prevent isErrorGetter being called twice and allow the watch
function only to control if the input has an error.
Fixes #1485 