### PR TITLE
Updated to 0.5 for compatibility with NodeJS 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-insert": "^0.4.0",
     "gulp-jshint": "^1.5.5",
     "gulp-minify-css": "^0.3.4",
-    "gulp-ng-annotate": "^0.3.5",
+    "gulp-ng-annotate": "^0.5.x",
     "gulp-ng-html2js": "^0.1.8",
     "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",


### PR DESCRIPTION
Fixes `gulp build` on Node 0.12.x

Fixes #1543 