### PR TITLE
fix(autocomplete): trigger input event when clearing value

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -298,6 +298,9 @@
     function clearValue () {
       $scope.searchText = '';
       select(-1);
+      var eventObj = document.createEvent('CustomEvent');
+      eventObj.initCustomEvent('input', true, true, {value: $scope.searchText});
+      elements.input.dispatchEvent(eventObj);
       elements.input.focus();
     }
 


### PR DESCRIPTION
input event should be triggered when clearing value with (X) button.