### PR TITLE
fix(button): Use md-raised colors for md-fab included in md-toolbar

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -1,8 +1,15 @@
 $button-border-radius: 3px !default;
 $button-fab-border-radius: 50% !default;
 
-md-toolbar .md-button.md-THEME_NAME-theme.md-fab {
-  background-color: white;
+.md-button.md-THEME_NAME-theme.md-fab {
+  color: '{{background-contrast}}';
+  background-color: '{{background-50}}';
+  &:not([disabled]) {
+    &:hover,
+    &:focus {
+      background-color: '{{background-200}}';
+    }
+  }
 }
 
 .md-button.md-THEME_NAME-theme {


### PR DESCRIPTION
Instead of using a white background, use the same styles as md-raised buttons for md-fab buttons included in md-toolbar.

It allows md-fab buttons included in md-toolbar to support all rendering effects properly.

Close #1687