### PR TITLE
fix(layout): Use consistent CSS priorities for all flex classes

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -103,23 +103,26 @@
     }
   }
 
+  [#{$flexName}="33"], [#{$flexName}="34"] {
+    flex: 0 0 33.33%;
+  }
+  [#{$flexName}="66"], [#{$flexName}="67"] {
+    flex: 0 0 66.66%;
+  }
+
   [layout="row"] {
     > [#{$flexName}="33"], > [#{$flexName}="34"] {
-      flex: 0 0 33.33%;
       max-width: 33.33%;
     }
     > [#{$flexName}="66"], > [#{$flexName}="67"] {
-      flex: 0 0 66.66%;
       max-width: 66.66%;
     }
   }
   [layout="column"] {
     > [#{$flexName}="33"], > [#{$flexName}="34"] {
-      flex: 0 0 33.33%;
       max-height: 33.33%;
     }
     > [#{$flexName}="66"], > [#{$flexName}="67"] {
-      flex: 0 0 66.66%;
       max-height: 66.66%;
     }
   }


### PR DESCRIPTION
This make CSS priorities consistent between `flex-[5*n]` classes and `flex-[33|34|66|67]`.

See this [plunkr that reproduce the issue](http://plnkr.co/edit/mxml3VRUjWHDuPPm3QBf?p=preview). Responsive design is not working properly, because some CSS style are overidden by others (and it should not).