### PR TITLE
feat(script): Set ngModule to Closure namespace.

### DIFF
--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -173,13 +173,19 @@ exports.addClosurePrefixes = function() {
     var moduleInfo = getModuleInfo(file.contents);
     if (moduleInfo.module) {
 
-      var provide = 'goog.provide(\'' + moduleNameToClosureName(moduleInfo.module) + '\');';
+      var closureModuleName = moduleNameToClosureName(moduleInfo.module);
+      var provide = 'goog.provide(\'' + closureModuleName + '\');';
       var requires = (moduleInfo.dependencies || []).sort().map(function(dep) {
         return dep.indexOf(moduleInfo.module) === 0 ? '' : 'goog.require(\'' + moduleNameToClosureName(dep) + '\');';
       }).join('\n');
+      
+      var contents = file.contents.toString();
+
+      // Assign the module to the provided Closure namespace:
+      contents = contents.replace('angular.module', closureModuleName + ' = angular.module');
 
       file.contents = new Buffer(
-        provide + '\n' + requires + '\n' + file.contents.toString()
+        provide + '\n' + requires + '\n' + contents
       );
     }
     this.push(file);


### PR DESCRIPTION
When using Closure, it is common to reference Angular module dependencies by the name property of the module.
This looks like:
```
goog.provide('bar.module');
goog.require('foo.module');
bar.module = angular.module('bar.module', [foo.module.name]);
```
This change makes it possible for this kind of reference instead of having to refer to the dependent module as a string.