### PR TITLE
feat: BiDirectional Provider to fix bi-directional problem + md-tabs ink bar for RTL pages

### DIFF
--- a/src/components/tabs/js/inkBarDirective.js
+++ b/src/components/tabs/js/inkBarDirective.js
@@ -9,7 +9,7 @@
 angular.module('material.components.tabs')
   .directive('mdTabsInkBar', MdTabInkDirective);
 
-function MdTabInkDirective($$rAF) {
+function MdTabInkDirective($$rAF, $mdBiDirectional) {
 
   var lastIndex = 0;
 
@@ -40,14 +40,26 @@ function MdTabInkDirective($$rAF) {
       if (scope.pagination && scope.pagination.tabData) {
         var index = tabsCtrl.getSelectedIndex();
         var data = scope.pagination.tabData.tabs[index] || { left: 0, right: 0, width: 0 };
-        var right = element.parent().prop('offsetWidth') - data.right;
         var classNames = ['md-transition-left', 'md-transition-right', 'md-no-transition'];
         var classIndex = lastIndex > index ? 0 : lastIndex < index ? 1 : 2;
+        var to;
+
+        if($mdBiDirectional.isLTR()) {
+          to = {
+            left: data.left + 'px',
+            right: (element.parent().prop('offsetWidth') - data.right) + 'px'
+          };
+        } else {
+          to = {
+            left: (element.parent().prop('offsetWidth') - data.right) + 'px',
+            right: data.left + 'px'
+          };
+        }
 
         element
             .removeClass(classNames.join(' '))
             .addClass(classNames[classIndex])
-            .css({ left: data.left + 'px', right: right + 'px' });
+            .css(to);
 
         lastIndex = index;
       }

--- a/src/core/services/biDirectional/biDirectional.js
+++ b/src/core/services/biDirectional/biDirectional.js
@@ -9,36 +9,32 @@
    * service. Allows configuration of direction.
    */
   function BiDirectionalProvider() {
-    return createBiDirectionalProvider;
+    var provider = {
+      rtlMode: rtlMode,
+      $get: factory
+    };
 
-    function createBiDirectionalProvider() {
-      var provider = {
-        rtlMode: rtlMode,
-        $get: factory
-      };
+    var direction = 'ltr';
 
-      var direction = 'ltr';
-
-      /**
-       * Enables rtl mode if true is passed
-       *
-       * @param {Boolean} mode
-       */
-      function rtlMode(mode) {
-        if (mode) {
-          direction = 'rtl';
-        }
+    /**
+     * Enables rtl mode if true is passed
+     *
+     * @param {Boolean} mode
+     */
+    function rtlMode(mode) {
+      if (mode) {
+        direction = 'rtl';
       }
-
-      /**
-       * Creates an instance of BiDirectional
-       */
-      function factory() {
-        return new BiDirectional(direction);
-      }
-
-      return provider;
     }
+
+    /**
+     * Creates an instance of BiDirectional
+     */
+    function factory() {
+      return new BiDirectional(direction);
+    }
+
+    return provider;
   }
 
   /**

--- a/src/core/services/biDirectional/biDirectional.js
+++ b/src/core/services/biDirectional/biDirectional.js
@@ -1,0 +1,72 @@
+(function () {
+  'use strict';
+
+  angular.module('material.core')
+    .provider('$mdBiDirectional', BiDirectionalProvider);
+
+  /**
+   * Returns a new provider which allows configuration of a new BiDirectional
+   * service. Allows configuration of direction.
+   */
+  function BiDirectionalProvider() {
+    return createBiDirectionalProvider;
+
+    function createBiDirectionalProvider() {
+      var provider = {
+        rtlMode: rtlMode,
+        $get: factory
+      };
+
+      var direction = 'ltr';
+
+      /**
+       * Enables rtl mode if true is passed
+       *
+       * @param {Boolean} mode
+       */
+      function rtlMode(mode) {
+        if (mode) {
+          direction = 'rtl';
+        }
+      }
+
+      /**
+       * Creates an instance of BiDirectional
+       */
+      function factory() {
+        return new BiDirectional(direction);
+      }
+
+      return provider;
+    }
+  }
+
+  /**
+   * BiDirectional function service to declare direction mode
+   *
+   * @param direction
+   * @constructor
+   */
+  function BiDirectional(direction) {
+    this.direction = direction;
+  }
+
+  /**
+   * Check if direction is set to rtl
+   *
+   * @returns {boolean}
+   */
+  BiDirectional.prototype.isRTL = function () {
+    return this.direction === 'rtl';
+  };
+
+  /**
+   * Check if direction is set to ltr
+   *
+   * @returns {boolean}
+   */
+  BiDirectional.prototype.isLTR = function () {
+    return this.direction === 'ltr';
+  };
+
+})();

--- a/src/core/services/biDirectional/biDirectional.spec.js
+++ b/src/core/services/biDirectional/biDirectional.spec.js
@@ -1,0 +1,47 @@
+describe('$mdBiDirectional service', function () {
+  beforeEach(module('material.core'));
+
+
+  function createBiDirectionalProvider(providerName, rtlMode) {
+    var biDirectionalProvider;
+
+    module(function ($mdBiDirectionalProvider, $provide) {
+      biDirectionalProvider = $mdBiDirectionalProvider;
+      biDirectionalProvider.rtlMode(rtlMode || false);
+      $provide.provider(providerName, biDirectionalProvider);
+    });
+
+    return biDirectionalProvider;
+  }
+
+  it('should create an object of BiDirectional', function () {
+    createBiDirectionalProvider('biDirectional');
+
+    inject(function (biDirectional) {
+      expect(biDirectional.isRTL).toBeOfType('function');
+      expect(biDirectional.isLTR).toBeOfType('function');
+      expect(biDirectional.direction).toBeOfType('string');
+    });
+  });
+
+  it('should set rtl as the direction', function () {
+    createBiDirectionalProvider('biDirectional', true);
+
+    inject(function (biDirectional) {
+      expect(biDirectional.isRTL()).toBe(true);
+      expect(biDirectional.isLTR()).toBe(false);
+      expect(biDirectional.direction).toBe('rtl');
+    });
+  });
+
+  it('should set ltr as the direction', function () {
+    createBiDirectionalProvider('biDirectional', false);
+
+    inject(function (biDirectional) {
+      expect(biDirectional.isRTL()).toBe(false);
+      expect(biDirectional.isLTR()).toBe(true);
+      expect(biDirectional.direction).toBe('ltr');
+    });
+  });
+
+});


### PR DESCRIPTION
These commits fix #1080 basic issue by defining a new provider named `$mdBiDirectionalProvider`. You can use this provider to set direction of your page.

```js
app.config(function($mdBiDirectionalProvider) {
  $mdBiDirectionalProvider.rtlMode(true);
}
```

By now #1078 is fixed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1711)
<!-- Reviewable:end -->
