### PR TITLE
docs(): improved keyboard/focus management

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -51,6 +51,31 @@ ul li:first-child {
   margin-top: 0;
 }
 
+ul.skip-links li {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+ul.skip-links li a {
+  background-color: #fff;
+  display: block;
+  font-size: 1.25em;
+  margin: 0.5em 0 0.5em 0.5em;
+  opacity: 0;
+  left: 0;
+  padding: 0.75em 0 0.75em 0.5em;
+  position: absolute;
+  top: 0;
+  width: 96%;
+  -webkit-transition: opacity   0.15s linear;
+  -moz-transition: opacity  0.15s linear;
+  transition: opacity   0.15s linear;
+}
+ul.skip-links li a:focus {
+  opacity: 1;
+  z-index: 2;
+}
+
 pre {
   white-space: pre;
   white-space: pre-wrap;

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -287,6 +287,12 @@ function(COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
       $scope.isSelected = function() {
         return controller.isSelected($scope.section);
       };
+
+      $scope.focusSection = function() {
+        // set flag to be used later when
+        // $locationChangeSuccess calls openPage()
+        controller.autoFocusContent = true;
+      };
     }
   };
 })
@@ -328,6 +334,8 @@ function(COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
   '$rootScope',
   '$log',
 function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu, $location, $rootScope, $log) {
+  var self = this;
+
   $scope.COMPONENTS = COMPONENTS;
   $scope.BUILDCONFIG = BUILDCONFIG;
   $scope.menu = menu;
@@ -339,11 +347,14 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   $scope.isSectionSelected = isSectionSelected;
 
   $rootScope.$on('$locationChangeSuccess', openPage);
+  $scope.focusMainContent = focusMainContent;
 
   // Methods used by menuLink and menuToggle directives
   this.isOpen = isOpen;
   this.isSelected = isSelected;
   this.toggleOpen = toggleOpen;
+  this.autoFocusContent = false;
+
 
   var mainContentArea = document.querySelector("[role='main']");
 
@@ -370,6 +381,17 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
 
   function openPage() {
     $scope.closeMenu();
+
+    if (self.autoFocusContent) {
+      focusMainContent();
+      self.autoFocusContent = false;
+    }
+  }
+
+  function focusMainContent($event) {
+    // prevent skip link from redirecting
+    if ($event) { $event.preventDefault(); }
+
     mainContentArea.focus();
   }
 

--- a/docs/app/partials/menu-link.tmpl.html
+++ b/docs/app/partials/menu-link.tmpl.html
@@ -1,5 +1,5 @@
 <md-button ng-class="{'active' : isSelected()}"
-  ng-href="#{{section.url}}">
+  ng-href="#{{section.url}}" ng-click="focusSection()">
   {{section | humanizeDoc}}
   <span class="visually-hidden"
     ng-if="isSelected()">

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -36,7 +36,13 @@
       </h1>
     </md-toolbar>
 
-    <md-content flex>
+    <ul class="skip-links">
+      <li class="md-whiteframe-z2">
+        <a ng-click="focusMainContent($event)" href="#">Skip to content</a>
+      </li>
+    </ul>
+
+    <md-content flex role="navigation">
       <ul class="docs-menu">
         <li ng-repeat="section in menu.sections" class="parent-list-item" ng-class="{'parentActive' : isSectionSelected(section)}">
           <h2 class="menu-heading" ng-if="section.type === 'heading'" id="heading_{{ section.name | nospace }}">


### PR DESCRIPTION
With this change, focus is only sent to the main content area on click of a nav link. There is also a "Skip to Content" link that allows users to skip past the sidebar navigation.

![Skip to content link](https://cloud.githubusercontent.com/assets/1045233/6428724/8ce7f67a-bf60-11e4-936d-c25056ba7458.png)


Closes #1723 