### PR TITLE
Docs toolbar buttons: Version/SHA and Skip link

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -59,19 +59,19 @@ ul.skip-links li {
 ul.skip-links li a {
   background-color: #fff;
   display: block;
-  font-size: 1.25em;
   margin: 0.5em 0 0.5em 0.5em;
   opacity: 0;
   left: 0;
-  padding: 0.75em 0 0.75em 0.5em;
   position: absolute;
+  text-decoration: none;
   top: 0;
-  width: 96%;
+  width: 92%;
   -webkit-transition: opacity   0.15s linear;
   -moz-transition: opacity  0.15s linear;
   transition: opacity   0.15s linear;
 }
 ul.skip-links li a:focus {
+  background-color: #fff !important;
   opacity: 1;
   z-index: 2;
 }

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -38,7 +38,7 @@
 
     <ul class="skip-links">
       <li class="md-whiteframe-z2">
-        <a ng-click="focusMainContent($event)" href="#">Skip to content</a>
+        <md-button ng-click="focusMainContent($event)" href="#">Skip to content</md-button>
       </li>
     </ul>
 

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -82,8 +82,14 @@
           </div>
 
           <span flex></span> <!-- use up the empty space -->
-
           <div class="md-toolbar-item md-tools docs-tools" layout="column" layout-gt-md="row">
+            <div>
+              <md-button ng-if="!menu.currentPage || menu.currentSection.name === 'Getting Started'"
+                         target="_blank"
+                         ng-href="{{BUILDCONFIG.repository}}/commit/{{BUILDCONFIG.commit}}" >
+                  {{BUILDCONFIG.version}}  -  SHA {{BUILDCONFIG.commit.substring(0,7)}}
+              </md-button>
+            </div>
             <div ng-repeat="doc in currentComponent.docs">
               <md-button ng-href="#{{doc.url}}"
                 ng-class="{hide: path().indexOf('demo') == -1}"

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -72,6 +72,6 @@ md-toolbar {
     margin-left: auto;
   }
   .md-button {
-    font-size: 14px;
+    font-size: 16px;
   }
 }


### PR DESCRIPTION
@ThomasBurleson I added a version button to the docs toolbar on the Home and Getting Started pages. There is a bit of a flash when you go from either of those pages to a Demo page, probably because there wasn't an easy way to target both without a complex `ng-if`. If you have suggestions on how to improve performance while still having it show up in both places, I'm all ears.

Font size changed for `md-button` inside of `md-toolbar` from 14px to 16px to match the new global type style.

I also converted the Skip to Content link to an md-button on @robertmesserle's suggestion. 

![new SHA button in Angular Material toolbar](https://cloud.githubusercontent.com/assets/1045233/6453013/9f4aed06-c0ee-11e4-87da-5dd845eeddb9.png)
