### PR TITLE
feat(core): add $mdTraversable service; use it to turn any element into ...

### DIFF
--- a/src/core/services/traversable/traversable.js
+++ b/src/core/services/traversable/traversable.js
@@ -1,0 +1,121 @@
+(function() {
+'use strict';
+angular.module('material.core')
+  .factory('$mdTraversable', mdTraversableService);
+
+var proxyEl = angular.element(document.getElementById('md-traversable-proxy'));
+
+if (proxyEl.length < 1) {
+  proxyEl = angular.element(document.createElement('a'))
+    .attr('id', 'md-traversable-proxy');
+  angular.element(document.body).append(proxyEl);
+}
+
+/**
+ * @ngdoc service
+ * @name $mdTraversable
+ * @module material.core
+ *
+ * @description Handles click-to-navigate events for an element and its child
+ * nodes in a way that is compatible with middle mouse buttons and keyboard
+ * modifiers (when used to open a link in a tab). In short, it makes any
+ * element capable of behaving as if it is a hyperlink.
+ *
+ * @example
+   function myTraversingDirective($mdTraversable) {
+     restrict: 'E',
+     compile: function (element, attrs) {
+       if (!attrs.href) {
+         return;
+       }
+   
+       var link = $parse(attrs.href);
+   
+       return function (scope, element, attrs) {
+         function onClick(event) {
+           $mdElidable.traverse(event, link(scope), attrs.target);
+         }
+   
+         element.on('click', onClick);
+       }
+     }
+   }
+ */
+
+/**
+ * @ngdoc method
+ * @name $mdTraversable#traverse
+ * @param {Event} event The original event that triggered this traversal.
+ * @param {string} href The destination that will be navigated to.
+ * @param {string} [target='_self'] The browsing context (tab, window, iframe)
+ *   in which to navigate (for example, `_self` or `_blank`).
+ *
+ * @description Navigates to the location specified by `href` in the browsing
+ * context specified by `target`.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+ */
+
+function mdTraversableService() {
+  return {
+    traverse: function traverse(event, href, target) {
+      if (isIgnorable(event)) {
+        return;
+      }
+
+      proxyEl.attr('href', href);
+
+      if (target) {
+        proxyEl.attr('target', target);
+      } else {
+        proxyEl.removeAttr('target');
+      }
+
+      proxyEl[0].dispatchEvent(createDispatchable(event));
+    }
+  }
+}
+
+/**
+ * Determines if `event` should be ignored because it is bubbling up from an
+ * interactive descendent of the traversable element.
+ *
+ * @param {Event}
+ *
+ * @private
+ */
+function isIgnorable(event) {
+  // Ignores click events that bubble up from hyperlink descendents.
+  var target = event.target;
+  return target !== event.currentTarget && target.hasAttribute('href');
+}
+
+/**
+ * Create a copy of `event` that can be dispatched to our proxy hyperlink.
+ *
+ * @param {Event}
+ *
+ * @private
+ */
+function createDispatchable(event) {
+  var dispatchable = document.createEvent('MouseEvent');
+  dispatchable.initMouseEvent(
+    'click',
+    event.bubbles,
+    event.cancelable,
+    event.view,
+    event.detail,
+    event.screenX,
+    event.screenY,
+    event.clientX,
+    event.clientY,
+    event.ctrlKey,
+    event.altKey,
+    event.shiftKey,
+    event.metaKey,
+    event.button,
+    event.relatedTarget);
+
+  return dispatchable;
+}
+})();

--- a/src/core/services/traversable/traversable.spec.js
+++ b/src/core/services/traversable/traversable.spec.js
@@ -1,0 +1,102 @@
+describe('$mdTraversable', function() {
+  var EVENT_DETAIL = 13;
+  var TARGET = '_blank';
+  var URL = 'https://google.com';
+
+  var traversableService, proxyElement, dispatchedByIt;
+
+  function logEvent(event) {
+    dispatchedByIt = event.detail === EVENT_DETAIL;
+  }
+
+  function createMockEvent(detail) {
+    return new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      detail: detail !== undefined ? detail : -1,
+      view: window
+    });
+  }
+
+  function preventDefault(event) {
+    event.preventDefault();
+  }
+
+  beforeEach(module('material.core'));
+
+  beforeEach(inject(function ($compile, $rootScope, $mdTraversable) {
+    // Don’t actually navigate.
+    proxyElement = document.getElementById('md-traversable-proxy');
+    proxyElement.addEventListener('click', preventDefault, false);
+    traversableService = $mdTraversable;
+    dispatchedByIt = false;
+  }));
+
+  afterEach(function () {
+    proxyElement.removeEventListener('click', preventDefault, false);
+    proxyElement.removeEventListener('click', logEvent, false);
+  });
+
+  it('should append a hyperlink proxy element to the document body', function () {
+    expect(proxyElement.nodeName.toLowerCase()).toBe('a');
+  });
+
+  it('should define a `traverse` method', function () {
+    expect(traversableService.traverse).toEqual(jasmine.any(Function));
+  });
+
+  it('should set the hyperlink proxy href when `traverse` is called', function () {
+    traversableService.traverse(createMockEvent(), URL);
+
+    expect(angular.element(proxyElement).attr('href')).toBe(URL);
+    expect(angular.element(proxyElement).attr('target')).toBeUndefined();
+  });
+
+  it('should set the hyperlink proxy target when `traverse` is called with a target', function () {
+    traversableService.traverse(createMockEvent(), URL, TARGET);
+
+    expect(angular.element(proxyElement).attr('target')).toBe(TARGET);
+  });
+
+  it('should dispatch an event to the proxy hyperlink element when `traverse` is called', function () {
+    proxyElement.addEventListener('click', logEvent, false);
+
+    traversableService.traverse(createMockEvent(EVENT_DETAIL), URL, TARGET);
+
+    expect(dispatchedByIt).toBe(true);
+  });
+
+  describe('nested hyperlink', function () {
+    var scope, element;
+    var template =
+      '<div href="https://google.com/" target="_blank">' +
+        '<a href="http://arstechnica.com/" target="_blank">...</a>' +
+      '</div>';
+
+    beforeEach(inject(function ($compile, $rootScope) {
+      scope = $rootScope.$new();
+      element = $compile(template)(scope);
+      angular.element(document.body).append(element);
+    }));
+
+    afterEach(function () {
+      scope.$destroy();
+      element.remove();
+    });
+
+    it('should be followed without triggering the parent hyperlink', inject(function () {
+      var proxySpy = jasmine.createSpy('proxySpy');
+      var childSpy = jasmine.createSpy('childSpy');
+      var childElement = element.find('a');
+
+      angular.element(proxyElement).on('click', proxySpy);
+      childElement.on('click', childSpy);
+      childElement.on('click', preventDefault);
+
+      childElement[0].dispatchEvent(createMockEvent());
+
+      expect(childSpy).toHaveBeenCalled();
+      expect(proxySpy).not.toHaveBeenCalled();
+    }));
+  });
+});


### PR DESCRIPTION
...a link

`$mdTraversable.traverse()` handles click-to-navigate events for an element and
its child nodes in a way that is compatible with middle mouse buttons and
keyboard modifiers (when used to open a link in a tab).