### PR TITLE
fix(icon):  fix fill attribute for svg icons who do have a fill attribute in their path object

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -8,6 +8,10 @@ md-icon {
   width: 3 * $baseline-grid;
 }
 
+md-icon path {
+    fill: currentcolor;
+}
+
 //
 //@font-face {
 //  font-family:"material";


### PR DESCRIPTION

For svg icons having a fill attribute in their path object the current
color settings do not work. To override this, the setting needs to be
applied directly to the path fill attribute, rather than just to
md-icon.