### PR TITLE
fix(gesture): don't stop hijacking clicks on ios & android when jquery is loaded

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -24,7 +24,7 @@ if (shouldHijackClicks) {
   document.addEventListener('click', function(ev) {
     // Space/enter on a button, and submit events, can send clicks
     var isKeyClick = ev.clientX === 0 && ev.clientY === 0;
-    if (window.jQuery || isKeyClick || ev.$material) return;
+    if (isKeyClick || ev.$material) return;
 
     // Prevent clicks unless they're sent by material
     ev.preventDefault();


### PR DESCRIPTION
fix(gesture)
	Remove window.jQuery from check for hijacking clicks on mobile devices.
	Touch clicks were emitted twice when jQuery was loaded which made checkboxes and buttons unusable on mobile devices.

	Addressing Issue https://github.com/angular/material/issues/1842 Utilizing proposed fix