### PR TITLE
fix(md-select): Track disabled state

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -118,6 +118,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $interpolate, $compile,
 
     return function postLink(scope, element, attr, ctrls) {
       var isOpen;
+      var isDisabled;
 
       var mdSelectCtrl = ctrls[0];
       var ngModel = ctrls[1];
@@ -158,6 +159,11 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $interpolate, $compile,
         if (typeof disabled == "string") {
           disabled = true;
         }
+        // Prevent click event to be registered twice
+        if (isDisabled !== undefined && isDisabled === disabled) {
+          return;
+        }
+        isDisabled = disabled;
         if (disabled) {
           element.attr('tabindex', -1);
           element.off('click', openSelect);


### PR DESCRIPTION
    Track the component disabled state in order to avoid a double
    registration of click and key events on the md-select element in the
    disabled $observe listener.