### PR TITLE
update peerDependencies to permit beta

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "dist/angular-material.css"
   ],
   "dependencies": {
-    "angular": "^1.3.0",
+    "angular": "^1.3.0 || >1.4.0-beta.0",
     "angular-animate": "^1.3.0",
     "angular-aria": "^1.3.0"
   },


### PR DESCRIPTION
Fixes #1848 

This allows users to use the package with the beta version of Angular 1.4.0.

I have a version of the bower-material package up to demo this. You can get it by running:

```
npm install --save git://github.com/linclark/bower-material.git#semver-beta-test
```

Then you should be able to run the following without errors:

```
npm install angular@beta
```