### PR TITLE
Fix for shouldHijackClicks

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -18,7 +18,7 @@ document.contains || (document.contains = function(node) {
 var userAgent = navigator.userAgent || navigator.vendor || window.opera;
 var isIos = userAgent.match(/iPad/i) || userAgent.match(/iPhone/i) || userAgent.match(/iPod/i);
 var isAndroid = userAgent.match(/Android/i);
-var shouldHijackClicks = isIos || isAndroid;
+var shouldHijackClicks = (isIos || isAndroid) && !window.jQuery;
 
 if (shouldHijackClicks) {
   document.addEventListener('click', function(ev) {


### PR DESCRIPTION
Checks if jquery is defined in the when defining shouldHijackClicks. This avoids the event hijack when jquery is defined and avoids the bind of the click event that was causing the click being triggered twice.