### PR TITLE
chore(gulp): Generate sourcemaps to non-release build files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,6 +29,7 @@ var rename = require('gulp-rename');
 var sass = require('gulp-sass');
 var uglify = require('gulp-uglify');
 var webserver = require('gulp-webserver');
+var sourcemaps = require('gulp-sourcemaps');
 
 /** Local dependencies */
 var buildConfig = require('./config/build.config');
@@ -358,7 +359,9 @@ function buildJs(isRelease) {
     .pipe(ngAnnotate());
 
   return series(jsBuildStream, themeBuildStream())
+    .pipe(gulpif(!isRelease, sourcemaps.init()))
     .pipe(concat('angular-material.js'))
+    .pipe(gulpif(!isRelease, sourcemaps.write()))
     .pipe(gulp.dest(config.outputDir))
     .pipe(gulpif(isRelease, lazypipe()
       .pipe(uglify, { preserveComments: 'some' })

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-plumber": "^0.6.6",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "ajoslin/gulp-sass#master",
+    "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^0.3.0",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.8.3",


### PR DESCRIPTION
Make debuging easier with sourcemaps.

It's only generated on non release mode.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1920)
<!-- Reviewable:end -->
