### PR TITLE
fix(dialog): fix backdrop position

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -423,6 +423,7 @@ function MdDialogProvider($$interimElementProvider) {
                            && $document[0].documentElement.scrollTop) ? angular.element($document[0].documentElement) : options.parent;
         var parentOffset = computeFrom.prop('scrollTop');
         options.backdrop = angular.element('<md-backdrop class="md-dialog-backdrop md-opaque">');
+        options.backdrop.css('top', parentOffset +'px');
         $mdTheming.inherit(options.backdrop, options.parent);
         $animate.enter(options.backdrop, options.parent);
         element.css('top', parentOffset +'px');


### PR DESCRIPTION
After recent fixes by @marcysutton backdrop is not following alert (tested on Chrome and IE10). 
![Screen](http://i.imgur.com/xDXTcCC.png)

This commit should fix it.