### PR TITLE
Added tap listener for checkbox; wasn't working properly in ionic app.

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -99,7 +99,8 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
       }, attr, [ngModelCtrl]);
 
       element.on('click', listener)
-        .on('keypress', keypressHandler);
+        .on('keypress', keypressHandler)
+        .on('tap', listener);
       ngModelCtrl.$render = render;
 
       function keypressHandler(ev) {


### PR DESCRIPTION
Added a tap listener. The ripple effect was firing but the listener function in this directive wasn't being called because of the ionic gesture detection system. I would imagine that most gesture libraries use the 'tap' event type and md should probably support those.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/1941)
<!-- Reviewable:end -->
