### PR TITLE
fixing typo in gridlist demo

### DIFF
--- a/src/components/gridList/demoBasicUsage/index.html
+++ b/src/components/gridList/demoBasicUsage/index.html
@@ -2,7 +2,7 @@
   <md-grid-list
         md-cols-sm="1" md-cols-md="2" md-cols-gt-md="6"
         md-row-height-gt-md="1:1" md-row-height="2:2"
-        md-gutter="12x" md-gutter-gt-sm="8px" >
+        md-gutter="12px" md-gutter-gt-sm="8px" >
 
     <md-grid-tile class="gray"
         md-rowspan="3" md-colspan="2">


### PR DESCRIPTION
it prevented md-cols-sm=1 to be rendered correctly..