### PR TITLE
CSS Refactor: Minimize global styles, support high contrast mode, new typography feature

### DIFF
--- a/docs/app/css/layout-demo.css
+++ b/docs/app/css/layout-demo.css
@@ -66,3 +66,8 @@ demo-include {
 [ng-panel] .demo-content {
   background: white;
 }
+@media screen and (-ms-high-contrast: active) {
+  .layout-content demo-include [layout] > div {
+    border: 1px solid #fff !important;
+  }
+}

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -4,17 +4,7 @@ body {
   overflow: hidden;
   max-width: 100%;
   max-height: 100%;
-  font-size: 16px;
 }
-
-a {
-  color: #3f51b5;
-  text-decoration: none;
-}
-a:hover, a:focus {
-  text-decoration: underline;
-}
-
 table {
   margin-bottom: 20px;
   max-width: 100%;
@@ -35,20 +25,6 @@ tr:nth-child(even) td {
 th {
   border-bottom: 1px solid #ccc;
   background-color: #f5f5f5;
-}
-
-ul {
-  margin: 0;
-  padding: 0;
-}
-ul li {
-  margin-left: 16px;
-  padding: 0;
-  margin-top: 3px;
-  list-style-position: inside;
-}
-ul li:first-child {
-  margin-top: 0;
 }
 
 ul.skip-links li {
@@ -166,6 +142,7 @@ code:not(.highlight) {
   color: inherit;
   cursor: pointer;
   font-weight: 400;
+  display: block;
   line-height: 40px;
   margin: 0;
   max-height: 40px;
@@ -175,9 +152,6 @@ code:not(.highlight) {
   text-decoration: none;
   white-space: normal;
   width: 100%;
-}
-.docs-menu a.md-button {
-  display: block;
 }
 .docs-menu button.md-button::-moz-focus-inner {
   padding: 0;
@@ -222,26 +196,31 @@ code:not(.highlight) {
   text-transform: none;
 }
 .md-button-toggle .md-toggle-icon {
-  background: transparent url(img/icons/list_control_down.png) no-repeat center center;
-  background-size: 100% auto;
-  display: inline-block;
-  height: 24px;
-  margin: auto 0 auto auto;
+  display: block;
+  margin-left: auto;
   speak: none;
-  width: 24px;
+  vertical-align: middle;
+  transform: rotate(180deg);
+  -webkit-transform: rotate(180deg);
   transition: transform 0.3s ease-in-out;
   -webkit-transition: -webkit-transform 0.3s ease-in-out;
 }
 .md-button-toggle .md-toggle-icon.toggled {
-  transform: rotate(180deg);
-  -webkit-transform: rotate(180deg);
+  transform: rotate(0deg);
+  -webkit-transform: rotate(0deg);
 }
 /* End Docs Menu */
 
-.docs-logotype {
-  line-height:40px;
-  text-indent: 15px;
+.docs-logo:focus {
+  outline: none;
 }
+  .docs-logo md-icon {
+    margin: 0 16px 0 0;
+  }
+  .docs-logotype {
+    line-height: 40px;
+    text-indent: 15px;
+  }
 .docs-menu-icon {
   background: none;
   border: none;
@@ -264,7 +243,6 @@ code:not(.highlight) {
     display: none;
   }
 }
-
 docs-demo {
   display: block;
   margin-top: 16px;
@@ -480,7 +458,6 @@ code.api-type {
 }
 
 .layout-title {
-  color: #999999;
   font-size: 14px;
   font-weight: bold;
   text-transform: uppercase;
@@ -539,5 +516,5 @@ md-content.demo-source-container > hljs > pre > code.highlight {
 }
 
 .api-section h3 {
-    padding-top:20px;
+  padding-top: 20px;
 }

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -82,7 +82,7 @@ pre > code.highlight {
 }
 
 code {
-  font-size: 14px;
+  font-size: 0.875rem;
   background: #f6f6f6;
 }
 
@@ -141,7 +141,6 @@ code:not(.highlight) {
   border-radius: 0;
   color: inherit;
   cursor: pointer;
-  font-weight: 400;
   display: block;
   line-height: 40px;
   margin: 0;
@@ -160,10 +159,7 @@ code:not(.highlight) {
   color: #03a9f4;
 }
 .menu-heading {
-  color: #888;
   display: block;
-  font-size: inherit;
-  font-weight: 500;
   line-height: 40px;
   margin: 0;
   padding: 0px 16px;
@@ -192,6 +188,7 @@ code:not(.highlight) {
 }
 .docs-menu .menu-toggle-list a.md-button {
   display: block;
+  font-weight: 400;
   padding: 0 16px 0 32px;
   text-transform: none;
 }
@@ -342,7 +339,6 @@ md-tabs.demo-source-tabs .active md-tab-label {
 .small-demo .md-toolbar-tools {
   min-height: 48px;
   max-height: 48px;
-  font-size: 20px;
 }
 
 .show-source md-toolbar.demo-toolbar {
@@ -455,12 +451,6 @@ ul.buckets li a:focus {
 }
 code.api-type {
   font-weight: bold;
-}
-
-.layout-title {
-  font-size: 14px;
-  font-weight: bold;
-  text-transform: uppercase;
 }
 
 .api-params-content ul {

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -518,3 +518,13 @@ md-content.demo-source-container > hljs > pre > code.highlight {
 .api-section h3 {
   padding-top: 20px;
 }
+
+/* Styles for Windows High Contrast mode */
+@media screen and (-ms-high-contrast: active) {
+  a {
+    text-decoration: underline;
+  }
+  iframe, hljs pre {
+    border: 1px solid #fff;
+  }
+}

--- a/docs/app/partials/docs-demo.tmpl.html
+++ b/docs/app/partials/docs-demo.tmpl.html
@@ -13,13 +13,14 @@
           <span>{{demoCtrl.demoTitle}}</span>
           <span flex></span>
           <md-button
-            style="min-width: 72px;"
-            layout="row" layout-align="center center"
+            style="min-width: 72px; margin-left: auto;"
             ng-click="demoCtrl.$showSource = !demoCtrl.$showSource">
-            <md-icon md-svg-src="img/icons/ic_visibility_24px.svg"
-               style="margin: 0 4px 0 0;">
-            </md-icon>
-            Source
+            <div flex layout="row" layout-align="center center">
+              <md-icon md-svg-src="img/icons/ic_visibility_24px.svg"
+                 style="margin: 0 4px 0 0;">
+              </md-icon>
+              Source
+            </div>
           </md-button>
         </div>
       </md-toolbar>

--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -38,7 +38,7 @@
           </li>
         </ul>
 
-        <h2>What is Material Design?</h2>
+        <h2 class="md-title">What is Material Design?</h2>
         <p>
             <a href="http://www.google.com/design/spec/material-design/">Material Design</a> is a specification for a
             unified system of visual, motion, and interaction design that adapts across different devices and different

--- a/docs/app/partials/layout-container.tmpl.html
+++ b/docs/app/partials/layout-container.tmpl.html
@@ -1,6 +1,6 @@
 <div ng-controller="LayoutCtrl" layout="column" layout-fill class="layout-content">
 
-  <h3 class="layout-title">Overview</h3>
+  <h3>Overview</h3>
   <p>
     Angular Material's responsive CSS layout is built on
     <a href="http://www.w3.org/TR/css3-flexbox/">flexbox</a>.
@@ -13,7 +13,7 @@
   </p>
 
   <md-divider></md-divider>
-  <h3 class="layout-title">Layout Attribute</h3>
+  <h3>Layout Attribute</h3>
   <p>
     Use the <code>layout</code> attribute on an element to arrange its children
     horizontally in a row (<code>layout="row"</code>), or vertically in

--- a/docs/app/partials/menu-toggle.tmpl.html
+++ b/docs/app/partials/menu-toggle.tmpl.html
@@ -1,11 +1,15 @@
 <md-button class="md-button-toggle"
   ng-click="toggle()"
   aria-controls="docs-menu-{{section.name | nospace}}"
-  flex layout="row"
   aria-expanded="{{isOpen()}}">
-  {{section.name}}
-  <span aria-hidden="true" class="md-toggle-icon"
-  ng-class="{'toggled' : isOpen()}"></span>
+  <div flex layout="row">
+    {{section.name}}
+    <span flex=""></span>
+    <span aria-hidden="true" class="md-toggle-icon"
+    ng-class="{'toggled' : isOpen()}">
+      <md-icon md-svg-src="toggle-arrow"></md-icon>
+    </span>
+  </div>
   <span class="visually-hidden">
     Toggle {{isOpen()? 'expanded' : 'collapsed'}}
   </span>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -11,7 +11,7 @@
 
 <script src="docs.js"></script>
 <script src="docs-demo-scripts.js"></script>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:400,500,700,400italic">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
 <link rel="stylesheet" href="docs.css">
 </head>
 <body layout="row">
@@ -38,7 +38,7 @@
     <md-content flex role="navigation">
       <ul class="docs-menu">
         <li ng-repeat="section in menu.sections" class="parent-list-item" ng-class="{'parentActive' : isSectionSelected(section)}">
-          <h2 class="menu-heading" ng-if="section.type === 'heading'" id="heading_{{ section.name | nospace }}">
+          <h2 class="menu-heading md-subhead" ng-if="section.type === 'heading'" id="heading_{{ section.name | nospace }}">
             {{section.name}}
           </h2>
           <menu-link section="section" ng-if="section.type === 'link'"></menu-link>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -22,15 +22,8 @@
 
     <md-toolbar>
       <h1 class="md-toolbar-tools">
-        <a ng-href="/" layout="row" flex>
-          <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" enable-background="new 0 0 100 100" xml:space="preserve" style="
-              width: 40px; height: 40px;">
-            <path d="M 50 0 L 100 14 L 92 80 L 50 100 L 8 80 L 0 14 Z" fill="#b2b2b2"></path>
-            <path d="M 50 5 L 6 18 L 13.5 77 L 50 94 Z" fill="#E42939"></path>
-            <path d="M 50 5 L 94 18 L 86.5 77 L 50 94 Z" fill="#B72833"></path>
-            <path d="M 50 7 L 83 75 L 72 75 L 65 59 L 50 59 L 50 50 L 61 50 L 50 26 Z" fill="#b2b2b2"></path>
-            <path d="M 50 7 L 17 75 L 28 75 L 35 59 L 50 59 L 50 50 L 39 50 L 50 26 Z" fill="#fff"></path>
-          </svg>
+        <a ng-href="/" layout="row" flex class="docs-logo">
+          <md-icon md-svg-src="menu"></md-icon>
           <div class="docs-logotype">Material Design</div>
         </a>
       </h1>
@@ -65,7 +58,7 @@
   <div layout="column" tabIndex="-1" role="main" flex>
     <md-toolbar>
 
-      <div class="md-toolbar-tools" ng-click="openMenu()">
+      <div class="md-toolbar-tools docs-toolbar-tools" ng-click="openMenu()" tabIndex="-1">
         <button class="docs-menu-icon" hide-gt-sm aria-label="Toggle Menu">
           <md-icon md-svg-src="img/icons/ic_menu_24px.svg"></md-icon>
         </button>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,6 +66,7 @@ var config = {
     'src/core/style/variables.scss',
     'src/core/style/mixins.scss',
     'src/core/style/structure.scss',
+    'src/core/style/typography.scss',
     'src/core/style/layout.scss'
   ],
   scssStandaloneFiles: [

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -117,6 +117,8 @@ md-autocomplete {
       z-index: -1;
     }
     &:focus {
+      outline: none;
+
       &:after {
         transform: scale(1);
         opacity: 1;

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -181,4 +181,14 @@ md-autocomplete {
       }
     }
   }
+  @media screen and (-ms-high-contrast: active) {
+    $border-color: #fff;
+
+    input {
+      border: 1px solid $border-color;
+    }
+    li:focus {
+      color: #fff;
+    }
+  }
 }

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -66,7 +66,6 @@ $button-fab-toast-offset: $button-fab-height * 0.75;
   &.ng-hide {
     transition: none;
   }
-;
 
   &.md-cornered {
     border-radius: 0;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -41,9 +41,9 @@ $button-fab-toast-offset: $button-fab-height * 0.75;
   // Always uppercase buttons
   text-transform: uppercase;
   font-weight: 500;
+  font-size: $body-font-size-base;
   font-style: inherit;
   font-variant: inherit;
-  font-size: inherit;
   font-family: inherit;
   line-height: inherit;
   text-decoration: none;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -187,3 +187,9 @@ $button-fab-toast-offset: $button-fab-height * 0.75;
     border-radius: 0px 2px 2px 0px;
   }
 }
+@media screen and (-ms-high-contrast: active) {
+  .md-button.md-raised,
+  .md-button.md-fab {
+    border: 1px solid #fff;
+  }
+}

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -21,3 +21,10 @@ md-card {
     padding: $card-padding;
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-card {
+    border: 1px solid #fff;
+  }
+}
+

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -2,12 +2,19 @@ $checkbox-width: 18px !default;
 $checkbox-height: $checkbox-width !default;
 
 md-checkbox {
+  box-sizing: border-box;
   display: block;
   margin: 15px;
   white-space: nowrap;
   cursor: pointer;
   outline: none;
   user-select: none;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
 
   .md-container {
     position: relative;

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -66,3 +66,9 @@ md-dialog {
   }
 
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-dialog {
+    border: 1px solid #fff;
+  }
+}

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -42,6 +42,10 @@ md-dialog {
     &:not([layout=row]) > *:first-child:not(.md-subheader) {
       margin-top: 0px;
     }
+
+    &:focus {
+      outline: none;
+    }
   }
 
   .md-actions {

--- a/src/components/gridList/gridList.scss
+++ b/src/components/gridList/gridList.scss
@@ -1,6 +1,13 @@
 md-grid-list {
+  box-sizing: border-box;
   display: block;
   position: relative;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
 
   md-grid-tile {
     display: block;

--- a/src/components/gridList/gridList.scss
+++ b/src/components/gridList/gridList.scss
@@ -69,3 +69,12 @@ md-grid-list {
 
 }
 
+@media screen and (-ms-high-contrast: active) {
+  md-grid-tile {
+    border: 1px solid #fff;
+  }
+  md-grid-tile-footer {
+    border-top: 1px solid #fff;
+  }
+}
+

--- a/src/components/icon/demoFontIcons/style.css
+++ b/src/components/icon/demoFontIcons/style.css
@@ -3,6 +3,11 @@
     padding:25px;
     width: 100%;
 }
+.appDemoFontIcons,
+.appDemoFontIcons *:before,
+.appDemoFontIcons *:after {
+  box-sizing: border-box;
+}
 
     /* Bootstrap Overrides */
     [class^="icon-"]:before,

--- a/src/components/icon/iconService.js
+++ b/src/components/icon/iconService.js
@@ -218,17 +218,27 @@
        {
          id : 'tabs-arrow',
          url: 'tabs-arrow.svg',
-         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g id="tabs-arrow"><polygon points="15.4,7.4 14,6 8,12 14,18 15.4,16.6 10.8,12 "/></g></svg>'
+         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g><polygon points="15.4,7.4 14,6 8,12 14,18 15.4,16.6 10.8,12 "/></g></svg>'
        },
        {
          id : 'close',
          url: 'close.svg',
-         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g id="close"><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z"/></g></svg>'
+         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g><path d="M19 6.41l-1.41-1.41-5.59 5.59-5.59-5.59-1.41 1.41 5.59 5.59-5.59 5.59 1.41 1.41 5.59-5.59 5.59 5.59 1.41-1.41-5.59-5.59z"/></g></svg>'
        },
        {
          id:  'cancel',
          url: 'cancel.svg',
-         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g id="cancel"><path d="M12 2c-5.53 0-10 4.47-10 10s4.47 10 10 10 10-4.47 10-10-4.47-10-10-10zm5 13.59l-1.41 1.41-3.59-3.59-3.59 3.59-1.41-1.41 3.59-3.59-3.59-3.59 1.41-1.41 3.59 3.59 3.59-3.59 1.41 1.41-3.59 3.59 3.59 3.59z"/></g></svg>'
+         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 24 24"><g><path d="M12 2c-5.53 0-10 4.47-10 10s4.47 10 10 10 10-4.47 10-10-4.47-10-10-10zm5 13.59l-1.41 1.41-3.59-3.59-3.59 3.59-1.41-1.41 3.59-3.59-3.59-3.59 1.41-1.41 3.59 3.59 3.59-3.59 1.41 1.41-3.59 3.59 3.59 3.59z"/></g></svg>'
+       },
+       {
+         id:  'menu',
+         url: 'menu.svg',
+         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 100 100" style="width: 40px; height: 40px;"><path d="M 50 0 L 100 14 L 92 80 L 50 100 L 8 80 L 0 14 Z" fill="#b2b2b2"></path><path d="M 50 5 L 6 18 L 13.5 77 L 50 94 Z" fill="#E42939"></path><path d="M 50 5 L 94 18 L 86.5 77 L 50 94 Z" fill="#B72833"></path><path d="M 50 7 L 83 75 L 72 75 L 65 59 L 50 59 L 50 50 L 61 50 L 50 26 Z" fill="#b2b2b2"></path><path d="M 50 7 L 17 75 L 28 75 L 35 59 L 50 59 L 50 50 L 39 50 L 50 26 Z" fill="#fff"></path></svg>'
+       },
+       {
+         id:  'toggle-arrow',
+         url: 'toggle-arrow-svg',
+         svg: '<svg version="1.1" x="0px" y="0px" viewBox="0 0 48 48"><path d="M24 16l-12 12 2.83 2.83 9.17-9.17 9.17 9.17 2.83-2.83z"/><path d="M0 0h48v48h-48z" fill="none"/></svg>'
        }
      ];
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -183,3 +183,9 @@ md-input-container {
     }
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-input-container.md-default-theme > md-icon {
+    fill: #fff;
+  }
+}

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -3,10 +3,17 @@ $radio-height: $radio-width !default;
 
 md-radio-button,
 .md-switch-thumb { // Used in switch
+  box-sizing: border-box;
   display: block;
   margin: 15px;
   white-space: nowrap;
   cursor: pointer;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
 
   input {
     display: none;
@@ -23,7 +30,7 @@ md-radio-button,
     .md-ripple-container {
       position: absolute;
       display: block;
-      width: $radio-width * 3; 
+      width: $radio-width * 3;
       height: $radio-width * 3;
       left: -$radio-width;
       top: -$radio-width;

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -90,3 +90,9 @@ md-radio-group {
 .radioButtondemoBasicUsage  md-radio-group {
   border: none;
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-radio-button.md-default-theme .md-on {
+    background-color: #fff;
+  }
+}

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -162,3 +162,9 @@ md-optgroup {
     padding-left: $baseline-grid + $select-option-padding;
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  .md-select-backdrop {
+    background-color: transparent;
+  }
+}

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -49,6 +49,9 @@ $select-max-visible-options: 5;
 md-select {
   display: inline-block;
   margin-top: 1.4em;
+  &:focus {
+    outline: none;
+  }
   &[disabled]:hover {
     cursor: default;
   }
@@ -131,6 +134,10 @@ md-option {
   display: flex;
   align-items: center;
   width: auto;
+
+  &:focus {
+    outline: none;
+  }
 
   .md-text {
     width: auto;

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -111,3 +111,12 @@ md-sidenav {
     width: 85%;
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  .md-sidenav-left {
+    border-right: 1px solid #fff;
+  }
+  .md-sidenav-right {
+    border-left: 1px solid #fff;
+  }
+}

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -2,6 +2,7 @@ $sidenav-default-width: 304px !default;
 $sidenav-min-space: 56px !default;
 
 md-sidenav {
+  box-sizing: border-box;
   position: absolute;
 
   width: $sidenav-default-width;
@@ -12,6 +13,16 @@ md-sidenav {
   background-color: white;
   overflow: auto;
   flex-direction: column;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
+  ul {
+    list-style: none;
+  }
 
   &.md-closed {
     display: none;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -272,3 +272,10 @@ md-slider {
     }
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-slider.md-default-theme .md-track {
+    border-bottom: 1px solid #fff;
+  }
+}
+

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -94,3 +94,15 @@ md-switch {
   }
 
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-switch.md-default-theme .md-bar {
+    background-color: #666;
+  }
+  md-switch.md-default-theme.md-checked .md-bar {
+    background-color: #9E9E9E;
+  }
+  md-switch.md-default-theme .md-thumb {
+    background-color: #fff;
+  }
+}

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -4,10 +4,17 @@ $tabs-tab-width: $baseline-grid * 12 !default;
 $tabs-header-height: 48px !default;
 
 md-tabs {
+  box-sizing: border-box;
   display: block;
   width: 100%;
   font-weight: 500;
   overflow: auto;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
 }
 
 .md-header {
@@ -32,6 +39,10 @@ md-tabs {
   background-position: center center;
 
   position: absolute;
+
+  &:focus {
+    outline: none;
+  }
   &.md-prev {
     left: 0;
   }

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -128,3 +128,9 @@ md-toast {
     }
   }
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-toast {
+    border: 1px solid #fff;
+  }
+}

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -6,6 +6,7 @@ $toolbar-indent-margin: 64px !default;
 $toolbar-padding: 16px !default;
 
 md-toolbar {
+  box-sizing: border-box;
   display: flex;
   flex-direction: column;
 
@@ -17,6 +18,12 @@ md-toolbar {
   width: 100%;
 
   box-shadow: $whiteframe-shadow-z1;
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
 
   &.md-tall {
     height: $toolbar-tall-height;

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -80,5 +80,7 @@ md-toolbar {
   }
   .md-button {
     font-size: 16px;
+  @media screen and (-ms-high-contrast: active) {
+    border-bottom: 1px solid #fff;
   }
 }

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -49,6 +49,8 @@ md-toolbar {
 }
 
 .md-toolbar-tools {
+  @extend .md-title;
+  font-weight: 400;
   display: flex;
   align-items: center;
   flex-direction: row;
@@ -56,17 +58,9 @@ md-toolbar {
   width: 100%;
   height: $toolbar-tools-height;
   max-height: $toolbar-tools-height;
-  font-size: inherit;
-  font-weight: normal;
   padding: 0 $toolbar-padding;
   margin: 0;
 
-  > * {
-    font-size: inherit;
-  }
-  h2, h3 {
-    font-weight: normal;
-  }
   a {
     color: inherit;
     text-decoration: none;
@@ -78,8 +72,6 @@ md-toolbar {
   .md-tools {
     margin-left: auto;
   }
-  .md-button {
-    font-size: 16px;
   @media screen and (-ms-high-contrast: active) {
     border-bottom: 1px solid #fff;
   }

--- a/src/components/whiteframe/whiteframe.scss
+++ b/src/components/whiteframe/whiteframe.scss
@@ -13,3 +13,9 @@
 .md-whiteframe-z5 {
   box-shadow: $whiteframe-shadow-z5;
 }
+
+@media screen and (-ms-high-contrast: active) {
+  md-whiteframe {
+    border: 1px solid #fff;
+  }
+}

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -11,6 +11,11 @@
 
 [layout] {
   box-sizing: border-box;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -moz-box;
+  display: -moz-flex;
+  display: -ms-flexbox;
   display: flex;
 }
 
@@ -40,7 +45,7 @@
   min-height: 100%;
   width: 100%;
 }
-@-moz-document url-prefix() { 
+@-moz-document url-prefix() {
   [layout-fill] {
     margin: 0;
     width: 100%;
@@ -69,6 +74,11 @@
 @mixin layout-for-name($name) {
   [layout-#{$name}] {
     box-sizing: border-box;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -moz-box;
+    display: -moz-flex;
+    display: -ms-flexbox;
     display: flex;
   }
   [layout-#{$name}=column] {
@@ -86,6 +96,7 @@
   }
 
   [#{$flexName}] {
+    box-sizing: border-box;
     flex: 1;
   }
 

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -17,3 +17,32 @@
     color: $color;
   }
 }
+@function map-to-string($map) {
+  $map-str: '{';
+  $keys: map-keys($map);
+  $len: length($keys);
+  @for $i from 1 through $len {
+    $key: nth($keys, $i);
+    $value: map-get($map, $key);
+    $map-str: $map-str + '_' + $key + '_: _' + map-get($map, $key) + '_';
+    @if $i != $len {
+      $map-str: $map-str + ',';
+    }
+  }
+  @return $map-str + '}';
+}
+
+@function map-to-string($map) {
+  $map-str: '{';
+  $keys: map-keys($map);
+  $len: length($keys);
+  @for $i from 1 through $len {
+    $key: nth($keys, $i);
+    $value: map-get($map, $key);
+    $map-str: $map-str + '_' + $key + '_: _' + map-get($map, $key) + '_';
+    @if $i != $len {
+      $map-str: $map-str + ',';
+    }
+  }
+  @return $map-str + '}';
+}

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -31,18 +31,3 @@
   }
   @return $map-str + '}';
 }
-
-@function map-to-string($map) {
-  $map-str: '{';
-  $keys: map-keys($map);
-  $len: length($keys);
-  @for $i from 1 through $len {
-    $key: nth($keys, $i);
-    $value: map-get($map, $key);
-    $map-str: $map-str + '_' + $key + '_: _' + map-get($map, $key) + '_';
-    @if $i != $len {
-      $map-str: $map-str + ',';
-    }
-  }
-  @return $map-str + '}';
-}

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -1,61 +1,8 @@
-$h1-font-size-base: 2em !default;
-$h1-margin-base: 0.67em 0 !default;
-
-$h2-font-size-base: 1.5em !default;
-$h2-margin-base: 0.83em 0 !default;
-
-$h3-font-size-base: 1.17em !default;
-$h3-margin-base: 1em 0 !default;
-
-$h4-font-size-base: 1em !default;
-$h4-margin-base: 1.33em 0 !default;
-
-$h5-font-size-base: 0.83em !default;
-$h5-margin-base: 1.67em 0 !default;
-
-$h6-font-size-base: 0.75em !default;
-$h6-margin-base: 2.33em 0 !default;
-
-*,
-*:before,
-*:after {
-  box-sizing: border-box;
-}
-
-:focus {
-  outline: none;
-}
-
 html, body {
   height: 100%;
   color: rgba(0,0,0,0.87);
   background: white;
   position: relative;
-
-  -webkit-tap-highlight-color: rgba(0,0,0,0);
-  -webkit-touch-callout: none;
-  -webkit-text-size-adjust: 100%;
-  -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
-
-  p {
-    line-height: 1.846;
-  }
-
-  h3 {
-    display: block;
-    @include margin-selectors();
-    font-size: 1.17em;
-    font-weight: bold;
-  }
-}
-
-button,
-select,
-html,
-textarea,
-input {
-  font-family: $font-family;
 }
 
 body {
@@ -63,52 +10,17 @@ body {
   padding: 0;
   outline: none;
 }
-
-.inset {
-  padding: 10px;
-}
-
-button {
-  font-family: $font-family;
-}
-
-a {
-  background: transparent;
+[tabindex='-1']:focus {
   outline: none;
 }
-
-h1 {
-  font-size: $h1-font-size-base;
-  margin: $h1-margin-base;
-}
-h2 {
-  font-size: $h2-font-size-base;
-  margin: $h2-margin-base;
-}
-h3 {
-  font-size: $h3-font-size-base;
-  margin: $h3-margin-base;
-}
-h4 {
-  font-size: $h4-font-size-base;
-  margin: $h4-margin-base;
-}
-h5 {
-  font-size: $h5-font-size-base;
-  margin: $h5-margin-base;
-}
-h6 {
-  font-size: $h6-font-size-base;
-  margin: $h6-margin-base;
+.inset {
+  padding: 10px;
 }
 
 select,
 button,
 textarea,
 input {
-  margin: 0;
-  font-size: 100%;
-  font-family: inherit;
   vertical-align: baseline;
 }
 
@@ -131,12 +43,6 @@ textarea {
 }
 
 input {
-  &[type="radio"],
-  &[type="checkbox"] {
-    padding: 0;
-    box-sizing: border-box;
-  }
-
   &[type="search"] {
     -webkit-appearance: textfield;
     box-sizing: content-box;
@@ -221,39 +127,4 @@ input {
   &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
     opacity: 0.20;
   }
-}
-
-/*
-md-tab {
-  > .md-ripple-container {
-    .md-ripple {
-      box-sizing: content-box;
-      background-color: transparent !important;
-      border-width: 0;
-      border-style: solid;
-      opacity: 0.20;
-      transform: none !important;
-      &.md-ripple-placed {}
-      &.md-ripple-scaled {}
-      &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
-        opacity: 0.20;
-      }
-    }
-  }
-}
-*/
-
-@function map-to-string($map) {
-  $map-str: '{';
-  $keys: map-keys($map);
-  $len: length($keys);
-  @for $i from 1 through $len {
-    $key: nth($keys, $i);
-    $value: map-get($map, $key);
-    $map-str: $map-str + '_' + $key + '_: _' + map-get($map, $key) + '_';
-    @if $i != $len {
-      $map-str: $map-str + ',';
-    }
-  }
-  @return $map-str + '}';
 }

--- a/src/core/style/typography.scss
+++ b/src/core/style/typography.scss
@@ -1,0 +1,94 @@
+$h1-font-size-base: 2em !default;
+$h1-margin-base: 0.67em 0 !default;
+
+$h2-font-size-base: 1.5em !default;
+$h2-margin-base: 0.83em 0 !default;
+
+$h3-font-size-base: 1.17em !default;
+$h3-margin-base: 1em 0 !default;
+
+$h4-font-size-base: 1em !default;
+$h4-margin-base: 1.33em 0 !default;
+
+$h5-font-size-base: 0.83em !default;
+$h5-margin-base: 1.67em 0 !default;
+
+$h6-font-size-base: 0.75em !default;
+$h6-margin-base: 2.33em 0 !default;
+
+html, body {
+  font-size: 16px;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  -webkit-touch-callout: none;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+
+  p {
+    line-height: 1.846;
+  }
+}
+
+h1 {
+  font-size: $h1-font-size-base;
+  margin: $h1-margin-base;
+}
+h2 {
+  font-size: $h2-font-size-base;
+  margin: $h2-margin-base;
+}
+h3 {
+  font-size: $h3-font-size-base;
+  margin: $h3-margin-base;
+}
+h4 {
+  font-size: $h4-font-size-base;
+  margin: $h4-margin-base;
+}
+h5 {
+  font-size: $h5-font-size-base;
+  margin: $h5-margin-base;
+}
+h6 {
+  font-size: $h6-font-size-base;
+  margin: $h6-margin-base;
+}
+
+button,
+select,
+html,
+textarea,
+input {
+  font-family: $font-family;
+}
+
+select,
+button,
+textarea,
+input {
+  font-size: 100%;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
+
+  li {
+    margin-left: 16px;
+    padding: 0;
+    margin-top: 3px;
+    list-style-position: inside;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+}
+
+a {
+  color: #3f51b5;
+  text-decoration: none;
+}
+a:hover, a:focus {
+  text-decoration: underline;
+}

--- a/src/core/style/typography.scss
+++ b/src/core/style/typography.scss
@@ -1,21 +1,3 @@
-$h1-font-size-base: 2em !default;
-$h1-margin-base: 0.67em 0 !default;
-
-$h2-font-size-base: 1.5em !default;
-$h2-margin-base: 0.83em 0 !default;
-
-$h3-font-size-base: 1.17em !default;
-$h3-margin-base: 1em 0 !default;
-
-$h4-font-size-base: 1em !default;
-$h4-margin-base: 1.33em 0 !default;
-
-$h5-font-size-base: 0.83em !default;
-$h5-margin-base: 1.67em 0 !default;
-
-$h6-font-size-base: 0.75em !default;
-$h6-margin-base: 2.33em 0 !default;
-
 html, body {
   font-size: 16px;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
@@ -29,28 +11,83 @@ html, body {
   }
 }
 
+.md-display-1 {
+  font-size: $display-1-font-size-base;
+  font-weight: 400;
+
+  line-height: 2.5rem;
+}
+.md-display-2 {
+  font-size: $display-2-font-size-base;
+  font-weight: 400;
+  line-height: 3rem;
+}
+.md-display-3 {
+  font-size: $display-3-font-size-base;
+  font-weight: 400;
+  letter-spacing: -0.005em;
+}
+.md-display-4 {
+  font-size: $display-4-font-size-base;
+  font-weight: 300;
+  letter-spacing: -0.010em;
+}
+.md-headline {
+  font-size: $headline-font-size-base;
+  font-weight: 400;
+}
+.md-title {
+  font-size: $title-font-size-base;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+}
+.md-subhead {
+  font-size: $subhead-font-size-base;
+  font-weight: 400;
+  letter-spacing: 0.010em;
+  line-height: 1.5rem;
+}
+.md-body-1 {
+  font-size: $body-font-size-base;
+  font-weight: 400;
+  letter-spacing: 0.010em;
+  line-height: 1.25rem;
+}
+.md-body-2 {
+  font-size: $body-font-size-base;
+  font-weight: 500;
+  letter-spacing: 0.010em;
+  line-height: 1.5rem;
+}
+.md-caption {
+  font-size: $caption-font-size-base;
+  letter-spacing: 0.020em;
+}
+.md-button {
+  letter-spacing: 0.010em;
+}
+
 h1 {
-  font-size: $h1-font-size-base;
+  @extend .md-display-1;
+  font-weight: 400;
   margin: $h1-margin-base;
 }
 h2 {
-  font-size: $h2-font-size-base;
+  @extend .md-headline;
   margin: $h2-margin-base;
 }
 h3 {
-  font-size: $h3-font-size-base;
+  @extend .md-title;
   margin: $h3-margin-base;
 }
 h4 {
-  font-size: $h4-font-size-base;
+  @extend .md-subhead;
   margin: $h4-margin-base;
 }
 h5 {
-  font-size: $h5-font-size-base;
   margin: $h5-margin-base;
 }
 h6 {
-  font-size: $h6-font-size-base;
   margin: $h6-margin-base;
 }
 

--- a/src/core/style/typography.scss
+++ b/src/core/style/typography.scss
@@ -4,13 +4,20 @@ html, body {
   -webkit-touch-callout: none;
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
-  text-rendering: optimizeLegibility;
 
   p {
     line-height: 1.846;
   }
 }
 
+md-select, md-card, md-list, md-toolbar,
+ul, ol, p, h1, h2, h3, h4, h5, h6 {
+  text-rendering: optimizeLegibility;
+}
+
+/************
+ * Headings
+ ************/
 .md-display-1 {
   font-size: $display-1-font-size-base;
   font-weight: 400;
@@ -47,6 +54,9 @@ html, body {
   letter-spacing: 0.010em;
   line-height: 1.5rem;
 }
+/************
+ * Body Copy
+ ************/
 .md-body-1 {
   font-size: $body-font-size-base;
   font-weight: 400;
@@ -66,6 +76,10 @@ html, body {
 .md-button {
   letter-spacing: 0.010em;
 }
+
+/************
+ * Defaults
+ ************/
 
 h1 {
   @extend .md-display-1;

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -1,5 +1,23 @@
-// Font Variables
+// Typography
+// ------------------------------
 $font-family: RobotoDraft, Roboto, 'Helvetica Neue', sans-serif !default;
+
+$display-4-font-size-base: 7rem !default;
+$display-3-font-size-base: 3.5rem !default;
+$display-2-font-size-base: 2.813rem !default;
+$display-1-font-size-base: 2.125rem !default;
+$headline-font-size-base:  1.500rem !default;
+$title-font-size-base:     1.250rem !default;
+$subhead-font-size-base:   1rem !default;
+$body-font-size-base:      0.875rem !default;
+$caption-font-size-base:   0.750rem !default;
+
+$h1-margin-base:           0.67em 0 !default;
+$h2-margin-base:           0.83em 0 !default;
+$h3-margin-base:           1em 0 !default;
+$h4-margin-base:           1.33em 0 !default;
+$h5-margin-base:           1.67em 0 !default;
+$h6-margin-base:           2.33em 0 !default;
 
 // Layout
 // ------------------------------


### PR DESCRIPTION
Includes: 
 * Framework typography stylesheet
 * SVG icons in the docs (menu, list toggle)
 * Flex styles for `layout.scss` in Safari
 * Docs menu & demo source button bug fixes (Safari, Firefox, IE)
 * Media queries for Windows high contrast mode
 * Relegates `text-rendering` to specific elements concerned with typography

Closes #1442, #1561, #1128, #1989, Refs #1718