### PR TITLE
bug(backdrop): Position should be fixed to account for scrolling.

### DIFF
--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -15,7 +15,7 @@ md-backdrop {
 
   background-color: rgba(0,0,0,0);
 
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   right: 0;


### PR DESCRIPTION
If the position is absolute, after scrolling the backdrop does not cover the entire viewport.

I assume this is not an oversight, so what am I doing wrong?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2023)
<!-- Reviewable:end -->
