### PR TITLE
Typography page and defaults

### DIFF
--- a/docs/app/css/layout-demo.css
+++ b/docs/app/css/layout-demo.css
@@ -27,7 +27,6 @@ demo-include {
 .layout-demo :not([layout]) {
   border: 1px solid #eee;
   padding: 8px;
-  font-size: 16px;
 }
 
 .layout-content .demo-box {

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -27,6 +27,9 @@ th {
   background-color: #f5f5f5;
 }
 
+/************
+ * UTILS
+ ************/
 ul.skip-links li {
   list-style: none;
   margin: 0;
@@ -51,7 +54,13 @@ ul.skip-links li a:focus {
   opacity: 1;
   z-index: 2;
 }
-
+.extraPad {
+  padding-left:32px !important;
+  padding-right:32px !important;
+}
+/*******************
+ * CODE HIGHLIGHTING
+ *******************/
 pre {
   white-space: pre;
   white-space: pre-wrap;
@@ -97,21 +106,12 @@ code:not(.highlight) {
   margin-right: 1px;
   -webkit-font-smoothing: auto;
 }
-
-.layout-content,
-.doc-content {
-  max-width: 864px;
-  margin: auto;
-}
 .layout-content code.highlight {
   margin-bottom: 15px;
 }
-
-.extraPad {
-  padding-left:32px !important;
-  padding-right:32px !important;
-}
-
+/************
+ * DOCS MENU
+ ************/
 .site-sidenav,
 .site-sidenav.md-locked-open-add-active,
 .site-sidenav.md-locked-open {
@@ -123,9 +123,6 @@ code:not(.highlight) {
   min-width: 218px;
 }
 
-/************
- * DOCS MENU
- ************/
 .docs-menu,
 .docs-menu ul {
   list-style: none;
@@ -212,7 +209,9 @@ code:not(.highlight) {
   outline: none;
 }
   .docs-logo md-icon {
-    margin: 0 16px 0 0;
+    height: 40px;
+    margin: 0;
+    width: 40px;
   }
   .docs-logotype {
     line-height: 40px;
@@ -239,6 +238,11 @@ code:not(.highlight) {
   .docs-tools {
     display: none;
   }
+}
+.layout-content,
+.doc-content {
+  max-width: 864px;
+  margin: auto;
 }
 docs-demo {
   display: block;
@@ -377,7 +381,6 @@ md-toolbar.demo-toolbar .md-button {
   background-color: #f6f6f6;
   height: 400px;
 }
-}
 .show-source div[demo-include] {
   border-top: #ddd solid 2px;
 }
@@ -412,7 +415,6 @@ ul.buckets li a:focus {
   background-color: #03a9f4;
   color: white;
 }
-
 /************
  * API DOCS
  ************/

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -13,7 +13,51 @@ table {
   border-collapse: collapse;
   background-color: transparent;
 }
-
+/***************
+ * TYPE DEFAULTS
+ ***************/
+a {
+  color: #3f51b5;
+  text-decoration: none;
+}
+a:hover, a:focus {
+  text-decoration: underline;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+}
+h1 {
+  font-size: 3.400rem;
+  font-weight: 400;
+  line-height: 4rem;
+}
+h2 {
+  font-size: 2.400rem;
+  font-weight: 400;
+  line-height: 3.2rem;
+}
+h3 {
+  font-size: 2.000rem;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+}
+h4 {
+  font-size: 1.600rem;
+  font-weight: 400;
+  letter-spacing: 0.010em;
+  line-height: 2.4rem;
+}
+p {
+  font-size: 1.6rem;
+  font-weight: 400;
+  letter-spacing: 0.010em;
+  line-height: 2.2rem;
+  margin: 1.6rem 0;
+}
+strong {
+  font-weight: 500;
+}
 td, th {
   padding: 12px 6px;
   text-align: left;
@@ -21,12 +65,16 @@ td, th {
 tr:nth-child(even) td {
   background-color: #f5f5f5;
 }
-
 th {
   border-bottom: 1px solid #ccc;
   background-color: #f5f5f5;
 }
-
+blockquote {
+  border-left: 3px solid rgba(0, 0, 0, 0.12);
+  font-style: italic;
+  margin-left: 0;
+  padding-left: 16px;
+}
 /************
  * UTILS
  ************/
@@ -91,7 +139,7 @@ pre > code.highlight {
 }
 
 code {
-  font-size: 0.875rem;
+  font-size: 1.4rem;
   background: #f6f6f6;
 }
 
@@ -384,7 +432,19 @@ md-toolbar.demo-toolbar .md-button {
 .show-source div[demo-include] {
   border-top: #ddd solid 2px;
 }
-
+.docs-list {
+  padding: 16px;
+}
+.docs-descriptions h4 {
+  margin: 0;
+}
+.docs-list md-divider {
+  margin: 8px 0;
+}
+.docs-list li {
+  list-style: none;
+  margin: 0 0 8px;
+}
 
 /***************
  * Landing Page
@@ -464,7 +524,7 @@ ul.methods > li {
 
 ul.methods .method-function-syntax {
   font-weight: normal;
-  font-size: 20px;
+  font-size: 2.0rem;
   margin: 0;
   -webkit-margin-before: 0;
   -webkit-margin-after: 0;
@@ -477,7 +537,7 @@ ul.methods .method-function-syntax {
     list-style: default;
   }
   ul.methods .method-function-syntax {
-    font-size: 14px;
+    font-size: 1.4rem;
   }
 }
 

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -249,7 +249,6 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
     },
 
     selectPage: function(section, page) {
-      page && page.url && $location.path(page.url);
       self.currentSection = section;
       self.currentPage = page;
     },

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -144,6 +144,14 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
     name: 'Customization',
     type: 'heading',
     children: [{
+      name: 'CSS',
+      type: 'toggle',
+      pages: [{
+        name: 'Typography',
+        url: '/CSS/typography',
+        type: 'link'
+      }]
+    },{
       name: 'Theming',
       type: 'toggle',
       pages: [{

--- a/docs/app/partials/docs-demo.tmpl.html
+++ b/docs/app/partials/docs-demo.tmpl.html
@@ -10,7 +10,7 @@
 
       <md-toolbar class="demo-toolbar">
         <div class="md-toolbar-tools">
-          <span>{{demoCtrl.demoTitle}}</span>
+          <h3>{{demoCtrl.demoTitle}}</h3>
           <span flex></span>
           <md-button
             style="min-width: 72px; margin-left: auto;"

--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -2,13 +2,12 @@
 
   <p>
     The <code>layout-align</code> attribute takes two words.
-    The first word says how the children will be aligned in the layout's direction, and the second word says how the children will be aligned perpindicular to the layout's direction.
-    <br/>
-    Only one word is required for the attribute. For example, <code>layout="row" layout-align="center"</code> would make the elements center horizontally and use the default behavior vertically.
-    <br/>
-    <code>layout="column" layout-align="center end"</code> would make
-    children align along the center vertically and along the end (right) horizontally.
-  </p>
+    The first word says how the children will be aligned in the layout's direction, and the second word says how the children will be aligned perpindicular to the layout's direction.</p>
+
+    <p>Only one word is required for the attribute. For example, <code>layout="row" layout-align="center"</code> would make the elements center horizontally and use the default behavior vertically.</p>
+
+    <p><code>layout="column" layout-align="center end"</code> would make
+    children align along the center vertically and along the end (right) horizontally.</p>
   <table>
     <tr>
       <td>layout-align</td>

--- a/docs/app/partials/layout-container.tmpl.html
+++ b/docs/app/partials/layout-container.tmpl.html
@@ -8,7 +8,7 @@
 
   <p>
     The layout system is based upon element attributes rather than CSS classes.
-    Attributes provide an easy way to set a value (eg `layout="row"`), and additionally
+    Attributes provide an easy way to set a value (eg <code>layout="row"</code>), and additionally
     helps us separate concerns: attributes define layout, and classes define styling.
   </p>
 
@@ -34,41 +34,4 @@
   <p>
     See <a href="#/layout/options">Layout Options</a> for information on responsive layouts and other options.
   </p>
-
-  <!--
-  <md-divider>
-  <docs-demo demo-title="Example App Layout" class="small-demo">
-    <demo-file name="index.html">
-      <div layout="column" layout-fill class="layout-demo">
-        <header>
-          Header
-        </header>
-
-        <section flex layout="column" layout-gt-sm="row">
-          <aside flex flex-gt-sm="20">
-            Menu<br />
-            flex flex-gt-sm="20"
-          </aside>
-          <main flex>
-            Main<br />flex
-          </main>
-        </section>
-
-        <footer>
-          Footer
-        </footer>
-      </div>
-    </demo-file>
-  </docs-demo>
-  <p>
-    In this layout, the header and footer are both using their normal height, while the main
-    content area is flexing, or stretching, to fill the remaining area.
-    <br/><gr/>
-    The app container is a vertical layout, while the main area is a responsive row/column
-    layout, depending upon the screen size. 
-    The aside menu is above on mobile, and to the left on larger devices.
-  </p>
-  -->
-</div>
-
 </div>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -47,7 +47,9 @@
 
           <ul ng-if="section.children" class="menu-nested-list">
             <li ng-repeat="child in section.children" ng-class="{'childActive' : isSectionSelected(child)}">
-              <menu-toggle section="child"></menu-toggle>
+              <menu-link section="child" ng-if="child.type === 'link'"></menu-link>
+
+              <menu-toggle section="child" ng-if="child.type === 'toggle'"></menu-toggle>
             </li>
           </ul>
         </li>
@@ -62,17 +64,17 @@
         <button class="docs-menu-icon" hide-gt-sm aria-label="Toggle Menu">
           <md-icon md-svg-src="img/icons/ic_menu_24px.svg"></md-icon>
         </button>
-
         <div layout="row" flex class="fill-height">
-          <div class="md-toolbar-item md-breadcrumb">
+          <h2 class="md-toolbar-item md-breadcrumb">
             <span ng-if="menu.currentPage.name !== menu.currentSection.name">
               <span hide-sm hide-md>{{menu.currentSection.name}}</span>
               <span class="docs-menu-separator-icon" style="" hide-sm hide-md>
+                <span class="visually-hidden">-</span>
                 <img src="img/docArrow.png" alt="" aria-hidden="true">
               </span>
             </span>
             <span class="md-breadcrumb-page">{{(menu.currentPage | humanizeDoc) || 'Angular Material' }}</span>
-          </div>
+          </h2>
 
           <span flex></span> <!-- use up the empty space -->
           <div class="md-toolbar-item md-tools docs-tools" layout="column" layout-gt-md="row">

--- a/docs/content/CSS/typography.md
+++ b/docs/content/CSS/typography.md
@@ -1,0 +1,128 @@
+@ngdoc content
+@name Typography
+@description
+
+Angular Material provides typography CSS classes you can use to create visual
+consistency across your application.
+
+Base font size is `10px` for easy rem units (1.2rem = 12px). Body font size is `16px`. sp = scaleable pixels.
+
+[Reference the Material Design specification for Typography.](http://www.google.com/design/spec/style/typography.html)
+
+<section class="demo-container">
+  <md-toolbar class="demo-toolbar">
+    <div class="md-toolbar-tools">
+      <h3>Headings</h3>
+    </div>
+  </md-toolbar>
+  <div class="md-whiteframe-z1 docs-list">
+    <p style="margin-top: 0;">Use classes with `h1`-`h6` tags to style headings while keeping a <a href="http://webaim.org/techniques/semanticstructure/">semantic structure</a>.</p>
+    <div layout="row" class="docs-descriptions">
+      <h4 class="md-body-1" flex="25" id="headings-selectors">Selectors</h4>
+      <h4 class="md-body-1" id="headings-output">Output</h4>
+    </div>
+    <md-divider></md-divider>
+    <ul>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors"><code>
+          .md-display-4</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-display-4">Light 11.2sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors"><code>
+          .md-display-3</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-display-3">Regular 5.6sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors">
+          <code>.md-display-2</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-display-2">Regular 4.5sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors">
+          <code>.md-display-1</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-display-1">Regular 3.4sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors">
+          <code>.md-headline</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-headline">Regular 2.4sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors">
+          <code>.md-title</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-title">Medium 2.0sp</h5>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="headings-selectors">
+          <code>.md-subhead</code>
+        </span>
+        <h5 aria-describedby="headings-output" class="md-subhead">Regular 1.6sp</h5>
+      </li>
+    </ul>
+    <h4 class="md-title">Example</h4>
+    <hljs lang="html">
+      <h1 class="md-display-3">Headline</h1>
+      <h2 class="md-display-1">Headline</h2>
+      <h3 class="md-headline">Headline</h3>
+    </hljs>
+  </div>
+</section>
+
+<section class="demo-container">
+  <md-toolbar class="demo-toolbar">
+    <div class="md-toolbar-tools">
+      <h3>Body Copy</h3>
+    </div>
+  </md-toolbar>
+  <div class="md-whiteframe-z1 docs-list">
+    <div layout="row" class="docs-descriptions">
+      <h4 class="md-body-1" flex="25" id="body-selectors">Selectors</h4>
+      <h4 class="md-body-1" id="body-output">Output</h4>
+    </div>
+    <md-divider></md-divider>
+    <ul>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="body-selectors">
+          <code>.md-body-1</code><br>
+        </span>
+        <p aria-describedby="body-output">Regular 1.4sp</p>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="body-selectors"><code>
+          .md-body-2</code>
+        </span>
+        <p class="md-body-2" aria-describedby="body-output">Medium 1.4sp</p>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="body-selectors">
+          <code>.md-caption</code><br>
+        </span>
+        <div aria-describedby="body-output">
+          <small class="md-caption">Regular 1.2sp</small>
+        </div>
+      </li>
+      <li layout="row" layout-align="start center">
+        <span flex="25" aria-describedby="body-selectors">
+          <code>.md-button</code>
+        </span>
+        <div aria-describedby="body-output">
+          <md-button>Medium 1.4sp</md-button>
+        </div>
+      </li>
+    </ul>
+    <h4 class="md-title">Examples</h4>
+    <hljs lang="html">
+      <p class="md-body-2">Body copy with medium weight.</p>
+      <md-button>Button</md-button>
+      <p class="md-body-1">Regular body copy <small class="md-caption">with small text</small>.</p>
+      <span class="md-caption">Caption</span>
+    </hljs>
+  </div>
+</section>

--- a/src/components/bottomSheet/bottomSheet.scss
+++ b/src/components/bottomSheet/bottomSheet.scss
@@ -4,7 +4,7 @@ $bottom-sheet-icon-after-margin: 4 * $baseline-grid !default;
 $bottom-sheet-list-item-height: 6 * $baseline-grid !default;
 $bottom-sheet-hidden-bottom-padding: 80px !default;
 $bottom-sheet-header-height: 7 * $baseline-grid !default;
-$bottom-sheet-grid-font-weight: 300 !default;
+$bottom-sheet-grid-font-weight: 400 !default;
 
 md-bottom-sheet {
   position: absolute;
@@ -160,7 +160,7 @@ md-bottom-sheet {
         margin: 0 0;
       }
 
-      p.md-grid-text {
+      .md-grid-text {
         font-weight: $bottom-sheet-grid-font-weight;
         line-height: 2 * $baseline-grid;
         font-size: 2 * $baseline-grid - 3;
@@ -168,6 +168,7 @@ md-bottom-sheet {
         white-space: nowrap;
         width: 8 * $baseline-grid;
         text-align: center;
+        text-transform: none;
         padding-top: 1 * $baseline-grid;
       }
     }

--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
@@ -6,7 +6,7 @@
         <div class="md-icon-container">
           <md-inline-grid-icon icon="{{item.icon}}"></md-inline-grid-icon>
         </div>
-        <p class="md-grid-text"> {{ item.name }} </p>
+        <div class="md-grid-text"> {{ item.name }} </div>
       </md-button>
 
     </md-item>

--- a/src/components/bottomSheet/demoBasicUsage/index.html
+++ b/src/components/bottomSheet/demoBasicUsage/index.html
@@ -1,5 +1,5 @@
 <div ng-controller="BottomSheetExample">
-  <p style="padding-left: 20px;">
+  <p style="padding-left: 20px;" class="md-body-1">
     Bottom sheet can be dismissed with the service or a swipe down.
   </p>
   <div class="bottom-sheet-demo inset" layout="column" layout-sm="row" layout-align="center">

--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -24,7 +24,7 @@ section .md-button {
   position: absolute;
   bottom: 5px;
   left: 7px;
-  color: #ccc;
   font-size: 14px;
+  opacity: 0.54;
 }
 

--- a/src/components/card/demoBasicUsage/index.html
+++ b/src/components/card/demoBasicUsage/index.html
@@ -6,7 +6,7 @@
     <md-card>
       <img src="img/washedout.png" alt="Washed Out">
       <md-card-content>
-        <h2>Paracosm</h2>
+        <h2 class="md-title">Paracosm</h2>
         <p>
           The titles of Washed Out's breakthrough song and the first single from Paracosm share the
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
@@ -17,7 +17,7 @@
     <md-card>
       <img src="img/washedout.png" alt="Washed Out">
       <md-card-content>
-        <h2>Paracosm</h2>
+        <h2 class="md-title">Paracosm</h2>
         <p>
           The titles of Washed Out's breakthrough song and the first single from Paracosm share the
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
@@ -28,7 +28,7 @@
     <md-card>
       <img src="img/washedout.png" alt="Washed Out">
       <md-card-content>
-        <h2>Paracosm</h2>
+        <h2 class="md-title">Paracosm</h2>
         <p>
           The titles of Washed Out's breakthrough song and the first single from Paracosm share the
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...

--- a/src/components/content/demoBasicUsage/index.html
+++ b/src/components/content/demoBasicUsage/index.html
@@ -2,7 +2,7 @@
 <div ng-controller="AppCtrl" layout="column" style="padding-bottom: 15px;">
   <md-toolbar class="md-warn">
     <div class="md-toolbar-tools">
-      <span class="md-flex">Toolbar: md-warn</span>
+      <h2 class="md-flex">Toolbar: md-warn</h2>
     </div>
   </md-toolbar>
 

--- a/src/components/content/demoBasicUsage/index.html
+++ b/src/components/content/demoBasicUsage/index.html
@@ -7,7 +7,7 @@
   </md-toolbar>
 
   <md-content class="md-padding" style="height: 600px;padding: 24px;">
-    Lorem ipsum dolor sit amet, ne quod novum mei. Sea omnium invenire mediocrem at, in lobortis conclusionemque nam. Ne deleniti appetere reprimique pro, inani labitur disputationi te sed. At vix sale omnesque, id pro labitur reformidans accommodare, cum labores honestatis eu. Nec quem lucilius in, eam praesent reformidans no. Sed laudem aliquam ne.
+    <p>Lorem ipsum dolor sit amet, ne quod novum mei. Sea omnium invenire mediocrem at, in lobortis conclusionemque nam. Ne deleniti appetere reprimique pro, inani labitur disputationi te sed. At vix sale omnesque, id pro labitur reformidans accommodare, cum labores honestatis eu. Nec quem lucilius in, eam praesent reformidans no. Sed laudem aliquam ne.</p>
 
     <p>
 Facete delenit argumentum cum at. Pro rebum nostrum contentiones ad. Mel exerci tritani maiorum at, mea te audire phaedrum, mel et nibh aliquam. Malis causae equidem vel eu. Noster melius vis ea, duis alterum oporteat ea sea. Per cu vide munere fierent.

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -354,7 +354,7 @@ function MdDialogProvider($$interimElementProvider) {
       template: [
         '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}">',
           '<md-content role="document" tabIndex="0">',
-            '<h2>{{ dialog.title }}</h2>',
+            '<h2 class="md-title">{{ dialog.title }}</h2>',
             '<p>{{ dialog.content }}</p>',
           '</md-content>',
           '<div class="md-actions">',

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -284,7 +284,7 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *   - `hasBackdrop` - `{boolean=}`: Whether there should be an opaque backdrop behind the dialog.
  *     Default true.
  *   - `clickOutsideToClose` - `{boolean=}`: Whether the user can click outside the dialog to
- *     close it. Default true.
+ *     close it. Default false.
  *   - `escapeToClose` - `{boolean=}`: Whether the user can press escape to close the dialog.
  *     Default true.
  *   - `focusOnOpen` - `{boolean=}`: An option to override focus behavior on open. Only disable if

--- a/src/components/divider/demoBasicUsage/index.html
+++ b/src/components/divider/demoBasicUsage/index.html
@@ -1,9 +1,9 @@
 <div ng-controller="AppCtrl">
 
   <md-toolbar class="md-theme-light">
-    <h1 class="md-toolbar-tools">
+    <h2 class="md-toolbar-tools">
       <span>Full Bleed</span>
-    </h1>
+    </h2>
   </md-toolbar>
 
   <md-content>
@@ -24,9 +24,9 @@
   </md-content>
 
   <md-toolbar class="md-theme-light">
-    <h1 class="md-toolbar-tools">
+    <h2 class="md-toolbar-tools">
       <span>Inset</span>
-    </h1>
+    </h2>
   </md-toolbar>
 
   <md-content>

--- a/src/components/icon/demoUsingTemplateCache/style.css
+++ b/src/components/icon/demoUsingTemplateCache/style.css
@@ -19,7 +19,7 @@ md-icon {
 }
 
 .note {
-    font-size: .8em;
+    font-size: 1.2rem;
     display: block;
     margin-top: -2px;
     padding-left: 25px;

--- a/src/components/input/demoBasicUsage/index.html
+++ b/src/components/input/demoBasicUsage/index.html
@@ -1,6 +1,6 @@
 <div ng-app="inputBasicDemo" ng-controller="DemoCtrl" layout="column">
 
-  <md-content md-theme="docs-dark" class="md-padding" layout="row" layout-sm="column" style="font-size:1.2em">
+  <md-content md-theme="docs-dark" class="md-padding" layout="row" layout-sm="column">
     <md-input-container>
       <label>Title</label>
       <input ng-model="user.title">

--- a/src/components/select/demoBasicUsage/style.css
+++ b/src/components/select/demoBasicUsage/style.css
@@ -3,8 +3,7 @@ p {
   text-align: center;
 }
 
-p.result {
-  font-size: 0.8em;
+p.md-caption {
   color: #777;
 }
 

--- a/src/components/select/demoOptionGroups/index.html
+++ b/src/components/select/demoOptionGroups/index.html
@@ -9,6 +9,6 @@
         <md-option ng-value="topping.name" ng-repeat="topping in toppings | filter: {category: 'veg' }">{{topping.name}}</md-option>
       </md-optgroup>
     </md-select>
-    <p class="result">{{ favoriteTopping ? 'Your favorite topping is ' + favoriteTopping : 'Please select a topping'}}</p>
+    <p class="md-caption">{{ favoriteTopping ? 'Your favorite topping is ' + favoriteTopping : 'Please select a topping'}}</p>
   </div>
 </div>

--- a/src/components/select/demoOptionGroups/style.css
+++ b/src/components/select/demoOptionGroups/style.css
@@ -3,8 +3,7 @@ p {
   text-align: center;
 }
 
-p.result {
-  font-size: 0.8em;
+p.md-caption {
   color: #777;
 }
 

--- a/src/components/select/demoOptionsWithAsyncSearch/index.html
+++ b/src/components/select/demoOptionsWithAsyncSearch/index.html
@@ -5,6 +5,6 @@
       <md-select-label>{{ user ? user.name : 'Assign to user' }}</md-select-label>
       <md-option ng-value="user" ng-repeat="user in users">{{user.name}}</md-option>
     </md-select>
-    <p class="result">You have assigned the task to: {{ user ? user.name : 'No one yet' }}</p>
+    <p class="md-caption">You have assigned the task to: {{ user ? user.name : 'No one yet' }}</p>
   </div>
 </div>

--- a/src/components/select/demoOptionsWithAsyncSearch/style.css
+++ b/src/components/select/demoOptionsWithAsyncSearch/style.css
@@ -3,11 +3,9 @@ p {
   text-align: center;
 }
 
-p.result {
-  font-size: 0.8em;
+p.md-caption {
   color: #777;
 }
-
 
 .demo-content  {
     min-height: 348px;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -81,7 +81,7 @@ md-select {
   padding-top: $baseline-grid + 1;
   padding-bottom: $baseline-grid;
   border-bottom: 1px solid;
-  font-size: 1em;
+  font-size: 1.6rem;
   line-height: 0.8em;
   position: relative;
   box-sizing: border-box;
@@ -154,7 +154,7 @@ md-option {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    font-size: 1em;
+    font-size: 1.6rem;
   }
   padding: 0 $select-option-padding 0 $select-option-padding;
   height: $select-option-height;
@@ -164,7 +164,7 @@ md-optgroup {
   display: block;
   label {
     display: block;
-    font-size: 1em;
+    font-size: 1.6rem;
     text-transform: uppercase;
     padding: $baseline-grid * 2 $baseline-grid;
   }

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -1,7 +1,7 @@
 $subheader-line-height: 1em !default;
-$subheader-font-size: 0.9em !default;
+$subheader-font-size: 1.4rem !default;
 $subheader-padding: ($baseline-grid * 2) 0px ($baseline-grid * 2) ($baseline-grid * 2) !default;
-$subheader-font-weight: 400 !default;
+$subheader-font-weight: 500 !default;
 $subheader-margin: 0 0 0 0 !default;
 $subheader-margin-right: 16px !default;
 $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;

--- a/src/components/textField/textField.scss
+++ b/src/components/textField/textField.scss
@@ -1,4 +1,4 @@
-$tff-font-size: 0.75em !default;
+$tff-font-size: 1.2rem !default;
 $tff-line-height:26px !default;
 $tff-transition: all 0.15s $swift-ease-in-out-timing-function !default;
 // - `label` element (aka hint)
@@ -100,7 +100,7 @@ md-input-group,
   display:  block;
 
   label {
-    font-size: 1em;
+    font-size: 1.6rem;
     z-index: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -13,7 +13,7 @@ md-toolbar {
   position: relative;
   z-index: 2;
 
-  font-size: 1.3em;
+  font-size: 2.0rem;
   min-height: $baseline-grid * 8;
   width: 100%;
 
@@ -60,6 +60,12 @@ md-toolbar {
   max-height: $toolbar-tools-height;
   padding: 0 $toolbar-padding;
   margin: 0;
+
+  h2, h3 {
+    font-size: inherit;
+    font-weight: inherit;
+    margin: inherit;
+  }
 
   a {
     color: inherit;

--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -1,7 +1,7 @@
 <div ng-controller="AppCtrl">
 
   <md-toolbar class="md-accent">
-    <h1 class="md-toolbar-tools">
+    <h2 class="md-toolbar-tools">
       <span flex>Awesome Md App</span>
       <md-button class="md-fab md-accent" aria-label="refresh">
         <md-tooltip>
@@ -10,7 +10,7 @@
         <md-icon icon="/img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;">
         </md-icon>
       </md-button>
-    </h1>
+    </h2>
   </md-toolbar>
   <md-content class="md-padding">
 

--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -31,14 +31,11 @@
       </md-tooltip>
     </md-button>
 
-    <br/><br/><br/><br/><br/><br/>
 
-    <p>
-      <div>
-        Additionally, the Tooltip's `md-visible` attribute can use data-binding to programmatically
-        show/hide itself. Toggle the checkbox below...
-      </div>
-    </p>
+    <div style="margin-top: 15rem;">
+      <p>Additionally, the Tooltip's `md-visible` attribute can use data-binding to programmatically show/hide itself. Toggle the checkbox below...</p>
+    </div>
+
 
     <md-checkbox ng-model="demo.showTooltip">
       Insert Drive

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -8,8 +8,8 @@ html, body {
 body {
   margin: 0;
   padding: 0;
-  outline: none;
 }
+
 [tabindex='-1']:focus {
   outline: none;
 }

--- a/src/core/style/typography.scss
+++ b/src/core/style/typography.scss
@@ -1,13 +1,15 @@
+html {
+  font-size: 62.5%;
+  line-height: 1.4;
+}
+body {
+  font-size: 1.6rem;
+}
 html, body {
-  font-size: 16px;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   -webkit-touch-callout: none;
   -webkit-text-size-adjust: 100%;
   -webkit-font-smoothing: antialiased;
-
-  p {
-    line-height: 1.846;
-  }
 }
 
 md-select, md-card, md-list, md-toolbar,
@@ -18,30 +20,32 @@ ul, ol, p, h1, h2, h3, h4, h5, h6 {
 /************
  * Headings
  ************/
-.md-display-1 {
-  font-size: $display-1-font-size-base;
-  font-weight: 400;
-
-  line-height: 2.5rem;
-}
-.md-display-2 {
-  font-size: $display-2-font-size-base;
-  font-weight: 400;
-  line-height: 3rem;
+.md-display-4 {
+  font-size: $display-4-font-size-base;
+  font-weight: 300;
+  letter-spacing: -0.010em;
+  line-height: $display-4-font-size-base;
 }
 .md-display-3 {
   font-size: $display-3-font-size-base;
   font-weight: 400;
   letter-spacing: -0.005em;
+  line-height: $display-3-font-size-base;
 }
-.md-display-4 {
-  font-size: $display-4-font-size-base;
-  font-weight: 300;
-  letter-spacing: -0.010em;
+.md-display-2 {
+  font-size: $display-2-font-size-base;
+  font-weight: 400;
+  line-height: 6.4rem;
+}
+.md-display-1 {
+  font-size: $display-1-font-size-base;
+  font-weight: 400;
+  line-height: 4rem;
 }
 .md-headline {
   font-size: $headline-font-size-base;
   font-weight: 400;
+  line-height: 3.2rem;
 }
 .md-title {
   font-size: $title-font-size-base;
@@ -52,7 +56,7 @@ ul, ol, p, h1, h2, h3, h4, h5, h6 {
   font-size: $subhead-font-size-base;
   font-weight: 400;
   letter-spacing: 0.010em;
-  line-height: 1.5rem;
+  line-height: 2.4rem;
 }
 /************
  * Body Copy
@@ -61,13 +65,13 @@ ul, ol, p, h1, h2, h3, h4, h5, h6 {
   font-size: $body-font-size-base;
   font-weight: 400;
   letter-spacing: 0.010em;
-  line-height: 1.25rem;
+  line-height: 2rem;
 }
 .md-body-2 {
   font-size: $body-font-size-base;
   font-weight: 500;
   letter-spacing: 0.010em;
-  line-height: 1.5rem;
+  line-height: 2.4rem;
 }
 .md-caption {
   font-size: $caption-font-size-base;
@@ -80,30 +84,6 @@ ul, ol, p, h1, h2, h3, h4, h5, h6 {
 /************
  * Defaults
  ************/
-
-h1 {
-  @extend .md-display-1;
-  font-weight: 400;
-  margin: $h1-margin-base;
-}
-h2 {
-  @extend .md-headline;
-  margin: $h2-margin-base;
-}
-h3 {
-  @extend .md-title;
-  margin: $h3-margin-base;
-}
-h4 {
-  @extend .md-subhead;
-  margin: $h4-margin-base;
-}
-h5 {
-  margin: $h5-margin-base;
-}
-h6 {
-  margin: $h6-margin-base;
-}
 
 button,
 select,
@@ -118,12 +98,4 @@ button,
 textarea,
 input {
   font-size: 100%;
-}
-
-a {
-  color: #3f51b5;
-  text-decoration: none;
-}
-a:hover, a:focus {
-  text-decoration: underline;
 }

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -2,22 +2,16 @@
 // ------------------------------
 $font-family: RobotoDraft, Roboto, 'Helvetica Neue', sans-serif !default;
 
-$display-4-font-size-base: 7rem !default;
-$display-3-font-size-base: 3.5rem !default;
-$display-2-font-size-base: 2.813rem !default;
-$display-1-font-size-base: 2.125rem !default;
-$headline-font-size-base:  1.500rem !default;
-$title-font-size-base:     1.250rem !default;
-$subhead-font-size-base:   1rem !default;
-$body-font-size-base:      0.875rem !default;
-$caption-font-size-base:   0.750rem !default;
+$display-4-font-size-base: 11.20rem !default;
+$display-3-font-size-base: 5.600rem !default;
+$display-2-font-size-base: 4.500rem !default;
+$display-1-font-size-base: 3.400rem !default;
+$headline-font-size-base:  2.400rem !default;
+$title-font-size-base:     2.000rem !default;
+$subhead-font-size-base:   1.600rem !default;
 
-$h1-margin-base:           0.67em 0 !default;
-$h2-margin-base:           0.83em 0 !default;
-$h3-margin-base:           1em 0 !default;
-$h4-margin-base:           1.33em 0 !default;
-$h5-margin-base:           1.67em 0 !default;
-$h6-margin-base:           2.33em 0 !default;
+$body-font-size-base:      1.400rem !default;
+$caption-font-size-base:   1.200rem !default;
 
 // Layout
 // ------------------------------


### PR DESCRIPTION
To finish up the work done in #1985, this PR includes some code cleanup along with a new Typography documentation page showing how style classes can be used. In addition:

 * Default styles for headings, links and paragraphs are isolated to the docs' `style.css` to minimize conflicts for people consuming components.
 * Font sizes are now in `rem` units with a base font size of `10`.
 * Component demos updated to use `rem` where `em` was used, but `px` units were left alone.
 * Fixes incorrectly-sized Angular icon on docs site.

Typography page top:

![Page top: headings](https://cloud.githubusercontent.com/assets/1045233/6859311/c05ccc1e-d3d4-11e4-832a-72b431f41a95.png)


Bottom:

![Page bottom: body copy](https://cloud.githubusercontent.com/assets/1045233/6859200/7ed4a61e-d3d3-11e4-8be8-6c1fe042fd07.png)