### PR TITLE
fix(runHandlers): check if handler returned is not undefined

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -48,7 +48,7 @@ function runHandlers(handlerEvent, event) {
   var handler;
   for (var handlerName in HANDLERS) {
     handler = HANDLERS[handlerName];
-    if(handler) {
+    if(typeof handler === "GestureHandler") {
       if (handlerEvent === 'start') {
         // Run cancel to reset any handlers' state
         handler.cancel();

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -48,11 +48,13 @@ function runHandlers(handlerEvent, event) {
   var handler;
   for (var handlerName in HANDLERS) {
     handler = HANDLERS[handlerName];
-    if (handlerEvent === 'start') {
-      // Run cancel to reset any handlers' state
-      handler.cancel();
+    if(handler) {
+      if (handlerEvent === 'start') {
+        // Run cancel to reset any handlers' state
+        handler.cancel();
+      }
+      handler[handlerEvent](event, pointer);
     }
-    handler[handlerEvent](event, pointer);
   }
 }
 


### PR DESCRIPTION
    runHandlers performs a for in loop to retrieve all properties, but does not check
    it HANDLERS contains a handler with that key - which breaks if user code extends
    Object.

   fixes https://github.com/angular/material/issues/2072