### PR TITLE
Fix for hiding the autocomplete results if the input doesnt have focus

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -167,9 +167,10 @@
     }
 
     function shouldHide () {
-      return self.matches.length === 1
+      var hasFocus = (elements && elements.input === document.activeElement && (!document.hasFocus || document.hasFocus())) || false;
+      return !hasFocus || (self.matches.length === 1
           && $scope.searchText === getDisplayValue(self.matches[0])
-          && $scope.selectedItem === self.matches[0];
+          && $scope.selectedItem === self.matches[0]);
     }
 
     function getCurrentDisplayValue () {


### PR DESCRIPTION
Hi,

This is a simple tweak to detect if the autocomplete input has focus before showing the resulting match data dropdown.

I ran into this issue on page load when the autocomplete directives are first bound to the model and the results are automatically rendered without taking into consideration the focus of the mouse/input.

Hope that helps. Please let me know if I can fix up and formatting or supply any supporting documentation.

Thanks,
Charlie