### PR TITLE
feat(radioButton): allow theming on radio group

### DIFF
--- a/src/components/radioButton/demoBasicUsage/index.html
+++ b/src/components/radioButton/demoBasicUsage/index.html
@@ -5,7 +5,7 @@
 
     <md-radio-group ng-model="data.group1">
 
-      <md-radio-button value="Apple">Apple</md-radio-button>
+      <md-radio-button value="Apple" class="md-primary">Apple</md-radio-button>
       <md-radio-button value="Banana"> Banana </md-radio-button>
       <md-radio-button value="Mango">Mango</md-radio-button>
 
@@ -15,7 +15,7 @@
 
     <p>Selected Value: <span class="radioValue">{{ data.group2 }}</span></p>
 
-    <md-radio-group ng-model="data.group2">
+    <md-radio-group ng-model="data.group2" class="md-primary">
 
         <md-radio-button ng-repeat="d in radioData"
                          ng-value="d.value"
@@ -26,8 +26,8 @@
     </md-radio-group>
 
     <p>
-      <md-button ng-click="addItem()" type="button">Add</md-button>
-      <md-button ng-click="removeItem()" type="button">Remove</md-button>
+      <md-button class="md-raised" ng-click="addItem()" type="button">Add</md-button>
+      <md-button class="md-raised" ng-click="removeItem()" type="button">Remove</md-button>
     </p>
 
     <hr />

--- a/src/components/radioButton/radio-button-theme.scss
+++ b/src/components/radioButton/radio-button-theme.scss
@@ -16,33 +16,50 @@ md-radio-button.md-THEME_NAME-theme {
   .md-container .md-ripple {
     color: '{{accent-600}}';
   }
+}
+
+md-radio-group.md-THEME_NAME-theme,
+md-radio-button.md-THEME_NAME-theme {
 
   &:not([disabled]) {
-
+    .md-primary,
     &.md-primary {
       .md-on {
         background-color: '{{primary-color-0.87}}';
       }
-      &.md-checked .md-off {
-        border-color: '{{primary-color-0.87}}';
+      .md-checked,
+      &.md-checked {
+        .md-off {
+          border-color: '{{primary-color-0.87}}';
+        }
       }
-      &.md-checked .md-ink-ripple {
-        color: '{{primary-color-0.87}}';
+      .md-checked,
+      &.md-checked {
+        .md-ink-ripple {
+          color: '{{primary-color-0.87}}';
+        }
       }
       .md-container .md-ripple {
         color: '{{primary-600}}';
       }
     }
 
+    .md-warn,
     &.md-warn {
       .md-on {
         background-color: '{{warn-color-0.87}}';
       }
-      &.md-checked .md-off {
-        border-color: '{{warn-color-0.87}}';
+      .md-checked,
+      &.md-checked {
+        .md-off {
+          border-color: '{{warn-color-0.87}}';
+        }
       }
-      &.md-checked .md-ink-ripple {
-        color: '{{warn-color-0.87}}';
+      .md-checked,
+      &.md-checked {
+        .md-ink-ripple {
+          color: '{{warn-color-0.87}}';
+        }
       }
       .md-container .md-ripple {
         color: '{{warn-600}}';


### PR DESCRIPTION
I didn't see an obvious way to avoid the gross CSS now in `radio-button-theme.scss`. To support both the radio group and radio button selectors, they had to be grouped together, creating a bit of duplication. I'm open to refactoring it if this can be avoided.

I have also updated the radio button demo to show how theming can be applied to a single button or to the group.

Closes #1746