### PR TITLE
chore(): upgrade ngAria, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ when using online tools such as [CodePen](http://codepen.io/), [Plunkr](http://p
   <body>
 
     <!-- Angular Material Dependencies -->
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-animate.min.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-aria.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
 
 
     <!-- Angular Material Javascript now available via Google CDN; version 0.8 used here -->
@@ -150,9 +150,9 @@ pull directly from the distribution GitHub
   <body>
 
     <!-- Angular Material Dependencies -->
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-animate.js"></script>
-    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.6/angular-aria.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.js"></script>
 
     <!-- Angular Material Javascript using RawGit to load directly from `bower-material/master` -->
     <script src="https://rawgit.com/angular/bower-material/master/angular-material.js"></script>

--- a/bower.json
+++ b/bower.json
@@ -9,12 +9,12 @@
   "dependencies": {
     "angular": "^1.3.0",
     "angular-animate": "^1.3.0",
-    "angular-aria": "^1.3.0"
+    "angular-aria": "^1.3.15"
   },
   "devDependencies": {
     "angular": "^1.3.0",
     "angular-animate": "^1.3.0",
-    "angular-aria": "^1.3.0",
+    "angular-aria": "^1.3.15",
     "angular-route": "^1.3.0",
     "angular-mocks": "^1.3.0",
     "angular-messages": "^1.3.0",


### PR DESCRIPTION
This PR upgrades `bower.json` to `angular-aria` version `^1.3.15`. This ensures Angular Material users will have the [bug-free version](https://github.com/angular/angular.js/blob/master/CHANGELOG.md#1315-locality-filtration-2015-03-17) of ngAria that addressed multiple `ng-click` events firing on buttons.

Also updated the README to recommend using newer Angular resources, but I left them alone in `bower.json` in order to minimize conflicts and noise on the command line.