### PR TITLE
Fix for flexgrid position in safari

### DIFF
--- a/src/components/gridList/gridList.js
+++ b/src/components/gridList/gridList.js
@@ -204,7 +204,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
     // The horizontal or vertical position of a tile, e.g., the 'top' or 'left' property value.
     // The position comes the size of a 1x1 tile plus gutter for each previous tile in the
     // row/column (offset).
-    var POSITION  = $interpolate('calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} );-webkit-calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} ));
+    var POSITION  = $interpolate('calc((({{unit}}) + {{gutter}}) * {{offset}})');
 
     // The actual size of a tile, e.g., width or height, taking rowSpan or colSpan into account.
     // This is computed by multiplying the base unit by the rowSpan/colSpan, and then adding back

--- a/src/components/gridList/gridList.js
+++ b/src/components/gridList/gridList.js
@@ -204,13 +204,13 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
     // The horizontal or vertical position of a tile, e.g., the 'top' or 'left' property value.
     // The position comes the size of a 1x1 tile plus gutter for each previous tile in the
     // row/column (offset).
-    var POSITION  = $interpolate('calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} ');
+    var POSITION  = $interpolate('calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} );-webkit-calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} ));
 
     // The actual size of a tile, e.g., width or height, taking rowSpan or colSpan into account.
     // This is computed by multiplying the base unit by the rowSpan/colSpan, and then adding back
     // in the space that the gutter would normally have used (which was already accounted for in
     // the base unit calculation).
-    var DIMENSION = $interpolate('calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}})');
+    var DIMENSION = $interpolate('calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}});-webkit-calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}})');
 
     // TODO(shyndman): Replace args with a ctx object.
 

--- a/src/components/gridList/gridList.js
+++ b/src/components/gridList/gridList.js
@@ -210,7 +210,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
     // This is computed by multiplying the base unit by the rowSpan/colSpan, and then adding back
     // in the space that the gutter would normally have used (which was already accounted for in
     // the base unit calculation).
-    var DIMENSION = $interpolate('calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}});-webkit-calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}})');
+    var DIMENSION = $interpolate('calc(({{unit}}) * {{span}} + ({{span}} - 1) * {{gutter}})');
 
     // TODO(shyndman): Replace args with a ctx object.
 


### PR DESCRIPTION
Native calc isn't supported in safari, it requires the -webkit-calc attribute