### PR TITLE
Fix for flexgrid position in safari

### DIFF
--- a/src/components/gridList/gridList.js
+++ b/src/components/gridList/gridList.js
@@ -204,7 +204,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
     // The horizontal or vertical position of a tile, e.g., the 'top' or 'left' property value.
     // The position comes the size of a 1x1 tile plus gutter for each previous tile in the
     // row/column (offset).
-    var POSITION  = $interpolate('calc( ( ({{unit}}) + {{gutter}} ) * {{offset}} ');
+    var POSITION  = $interpolate('calc((({{unit}}) + {{gutter}}) * {{offset}})');
 
     // The actual size of a tile, e.g., width or height, taking rowSpan or colSpan into account.
     // This is computed by multiplying the base unit by the rowSpan/colSpan, and then adding back


### PR DESCRIPTION
unbalanced brackets and space between brackets means safari wont apply the CSS