### PR TITLE
fix(bower): fixes bower warning

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "dist/angular-material.js",
     "dist/angular-material.css"
   ],
+  "ignore": [],
   "dependencies": {
     "angular": "^1.3.0",
     "angular-animate": "^1.3.0",


### PR DESCRIPTION
Currently, if you use bower to install Angular Material you get the following warning:
```
 invalid-meta angular-material is missing "ignore" entry in bower.json
```
Adding an entry named "ignore" with an empty array fixes the issue.