### PR TITLE
updates(docs): visual tweaks for site docs

### DIFF
--- a/docs/app/css/highlightjs-material.css
+++ b/docs/app/css/highlightjs-material.css
@@ -1,78 +1,69 @@
 .hljs, hljs {
   display: block;
   overflow-x: auto;
-  padding: 0.5em;
-  background: #f5f5f5;
-  color: #333;
+  padding: 48px 0.5em 0.5em;
+  background: #263238;
+  color: white;
   font-family: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
   line-height: 1.45;
   tab-size: 2;
   -webkit-font-smoothing: auto;
   -webkit-text-size-adjust: none;
+  position: relative;
+}
+.hljs:before, hljs:before {
+  content: attr(lang);
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: block;
+  line-height: 48px;
+  text-indent: 16px;
+  background: #e91e63;
 }
 
 hljs pre > code.highlight {
-  background: #f5f5f5;
+  background: transparent;
 }
 
 .hljs-comment,
-.hljs-title {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
+.hljs-title,
 .hljs-variable,
-.hljs-attribute,
-.hljs-tag,
 .hljs-regexp,
-.ruby .constant,
 .xml .tag .title,
 .xml .pi,
 .xml .doctype,
-.html .doctype {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
-.css .value {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
+.html .doctype,
+.css .value,
 .css .value .function,
-.css .value .string {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
-.css .value .number {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
+.css .value .string,
+.css .value .number,
 .css .id,
 .css .class,
 .css-pseudo,
 .css .selector,
-.css .tag {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
+.css .tag,
 .hljs-number,
 .hljs-preprocessor,
 .hljs-built_in,
 .hljs-literal,
 .hljs-params,
-.hljs-constant {
-  color: #E91E63;
-  color: #3F51B5;
+.hljs-constant,
+.ruby .class .title,
+.css .rules .attribute,
+.css .hexcolor,
+.function,
+.javascript .title {
+  color: #e91e63;
 }
 
-.ruby .class .title,
-.css .rules .attribute {
-  color: #E91E63;
-  color: #3F51B5;
+.hljs-attribute {
+  color: #f06292;
+}
+
+.hljs-tag {
+  color: #e91e63;
 }
 
 .hljs-string,
@@ -80,32 +71,10 @@ hljs pre > code.highlight {
 .hljs-inheritance,
 .hljs-header,
 .ruby .symbol,
-.xml .cdata {
-  color: #3F51B5;
-  color: #E91E63;
-}
-
-.css .hexcolor {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
-.function,
-.python .decorator,
-.python .title,
-.ruby .function .title,
-.ruby .title .keyword,
-.perl .sub,
-.javascript .title,
-.coffeescript .title {
-  color: #E91E63;
-  color: #3F51B5;
-}
-
+.xml .cdata,
 .hljs-keyword,
 .javascript .function {
-  color: #3F51B5;
-  color: #E91E63;
+  color: #9FA8DA;
 }
 
 .coffeescript .javascript,

--- a/docs/app/css/highlightjs-monokai.css
+++ b/docs/app/css/highlightjs-monokai.css
@@ -1,0 +1,149 @@
+/*
+Monokai style - ported by Luigi Maselli - http://grigio.org
+*/
+
+hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0;
+  background: #263238;
+  color: white;
+  font-family: Menlo, Monaco, "Andale Mono", "lucida console", "Courier New", monospace;
+  line-height: 1.45;
+  tab-size: 2;
+  -webkit-font-smoothing: auto;
+  -webkit-text-size-adjust: none;
+  position: relative;
+  border-radius: 2px;
+  margin: 0 0 1em;
+}
+
+hljs:before {
+  content: attr(lang);
+  display: block;
+  background: #3949ab;
+  line-height: 48px;
+  padding: 0 16px;
+  border-radius: 2px 2px 0 0;
+}
+
+hljs.no-header:before {
+  display: none;
+}
+
+.hljs-tag,
+.hljs-tag .hljs-title,
+.hljs-keyword,
+.hljs-literal,
+.hljs-strong,
+.hljs-change,
+.hljs-winutils,
+.hljs-flow,
+.nginx .hljs-title,
+.tex .hljs-special {
+  color: #e91e63;
+}
+
+hljs {
+  color: #ddd;
+}
+
+hljs .hljs-constant,
+.asciidoc .hljs-code,
+.markdown .hljs-code {
+	color: #66d9ef;
+}
+
+.hljs-code,
+.hljs-class .hljs-title,
+.hljs-header {
+	color: white;
+}
+
+.hljs-link_label,
+.hljs-attribute,
+.hljs-symbol,
+.hljs-symbol .hljs-string,
+.hljs-value,
+.hljs-regexp {
+  color: #9fa8da;
+}
+
+.hljs-link_url,
+.hljs-tag .hljs-value,
+.hljs-string,
+.hljs-bullet,
+.hljs-subst,
+.hljs-title,
+.hljs-emphasis,
+.hljs-type,
+.hljs-preprocessor,
+.hljs-pragma,
+.ruby .hljs-class .hljs-parent,
+.hljs-built_in,
+.django .hljs-template_tag,
+.django .hljs-variable,
+.smalltalk .hljs-class,
+.hljs-javadoc,
+.django .hljs-filter .hljs-argument,
+.smalltalk .hljs-localvars,
+.smalltalk .hljs-array,
+.hljs-attr_selector,
+.hljs-pseudo,
+.hljs-addition,
+.hljs-stream,
+.hljs-envvar,
+.apache .hljs-tag,
+.apache .hljs-cbracket,
+.tex .hljs-command,
+.hljs-prompt,
+.hljs-name {
+  color: #9ccc65;
+}
+
+.hljs-comment,
+.hljs-annotation,
+.smartquote,
+.hljs-blockquote,
+.hljs-horizontal_rule,
+.hljs-decorator,
+.hljs-pi,
+.hljs-doctype,
+.hljs-deletion,
+.hljs-shebang,
+.apache .hljs-sqbracket,
+.tex .hljs-formula {
+  color: #75715e;
+}
+
+.hljs-keyword,
+.hljs-literal,
+.css .hljs-id,
+.hljs-phpdoc,
+.hljs-dartdoc,
+.hljs-title,
+.hljs-header,
+.hljs-type,
+.vbscript .hljs-built_in,
+.rsl .hljs-built_in,
+.smalltalk .hljs-class,
+.diff .hljs-header,
+.hljs-chunk,
+.hljs-winutils,
+.bash .hljs-variable,
+.apache .hljs-tag,
+.tex .hljs-special,
+.hljs-request,
+.hljs-status {
+  font-weight: bold;
+}
+
+.coffeescript .javascript,
+.javascript .xml,
+.tex .hljs-formula,
+.xml .javascript,
+.xml .vbscript,
+.xml .css,
+.xml .hljs-cdata {
+  opacity: 0.5;
+}

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -137,7 +137,7 @@ pre {
 }
 
 pre > code.highlight {
-  padding: 10px;
+  padding: 16px;
   font-weight: 400;
   -webkit-user-select: initial;
   -moz-user-select: initial;
@@ -156,7 +156,7 @@ pre, code {
 pre > code.highlight {
   background-color: transparent;
   font-weight: 400;
-  padding: 10px;
+  padding: 16px;
 }
 
 code {
@@ -307,8 +307,7 @@ code:not(.highlight) {
 .layout-content,
 .doc-content {
   max-width: 864px;
-  margin: auto;
-  padding: 0 16px;
+  padding: 16px;
 }
 docs-demo {
   display: block;
@@ -360,7 +359,6 @@ md-tabs.demo-source-tabs .active md-tab-label {
 .demo-content {
   position: relative;
   overflow:hidden;
-  min-height: 448px;
   display: -webkit-box;
   display: -webkit-flex;
   display: -moz-box;
@@ -566,11 +564,13 @@ md-content.demo-source-container {
   background-color: transparent;
   border: none;
 }
+.demo-container > md-tabs {
+  border-radius: 0;
+}
+md-content.demo-source-container > hljs,
+md-content.demo-source-container > hljs > pre,
 md-content.demo-source-container > hljs > pre > code.highlight {
-  position : absolute;
-  top : 0px;
-  left: 0px;
-  right: 0px;
+  min-height: 100%;
 }
 
 .dashed-bottom {
@@ -607,6 +607,17 @@ md-content.demo-source-container > hljs > pre > code.highlight {
 ul.no-style {
   padding: 0;
   list-style: none;
+}
+
+ul.methods {
+  padding: 0;
+  list-style: none;
+}
+ul.methods > li {
+  margin: 0;
+}
+ul.methods > li:first-child > *:first-child {
+  padding-top: 0;
 }
 
 /* Styles for Windows High Contrast mode */

--- a/docs/app/partials/docs-demo.tmpl.html
+++ b/docs/app/partials/docs-demo.tmpl.html
@@ -29,7 +29,7 @@
       <md-tabs class="demo-source-tabs" ng-show="demoCtrl.$showSource" md-border-bottom>
         <md-tab ng-repeat="file in demoCtrl.orderedFiles" label="{{file.name}}">
           <md-content md-scroll-y class="demo-source-container">
-            <hljs code="file.contentsPromise" lang="{{file.fileType}}" should-interpolate="demoCtrl.interpolateCode">
+            <hljs class="no-header" code="file.contentsPromise" lang="{{file.fileType}}" should-interpolate="demoCtrl.interpolateCode">
             </hljs>
           </md-c>
         </md-tab>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -67,7 +67,7 @@
           <h2 class="md-toolbar-item md-breadcrumb">
             <span ng-if="menu.currentPage.name !== menu.currentSection.name">
               <span hide-sm hide-md>{{menu.currentSection.name}}</span>
-              <span class="docs-menu-separator-icon" style="" hide-sm hide-md>
+              <span class="docs-menu-separator-icon" hide-sm hide-md style="transform: translate3d(0, 1px, 0)">
                 <span class="visually-hidden">-</span>
                 <img src="img/docArrow.png" alt="" aria-hidden="true">
               </span>
@@ -98,7 +98,7 @@
                   height: 36px;
                   position: absolute;
                   left: 0px;
-                  top: -3px;
+                  top: -1px;
                   margin-top: 0;"></md-icon>
               <span>View Demo</span>
             </md-button>
@@ -111,7 +111,6 @@
                   height: 36px;
                   position: absolute;
                   left: 0px;
-                  top: -3px;
                   margin-top: 0;"></md-icon>
               <span>View on Github</span>
             </md-button>

--- a/docs/config/template/ngdoc/api/api.template.html
+++ b/docs/config/template/ngdoc/api/api.template.html
@@ -4,7 +4,7 @@
 
 {% block header %}
 <header class="api-profile-header">
-  <h1 class="md-display-1" style="text-transform: uppercase;">{{menu.currentPage|humanizeDoc}}</h1>
+  <h2 class="md-display-1" style="margin: 0;">{{menu.currentPage|humanizeDoc}}</h2>
   {% block related_components %}{% endblock %}
 </header>
 
@@ -21,10 +21,10 @@
 <div>
   {% block dependencies %}
   {%- if doc.requires %}
-  <h2 id="dependencies">Dependencies</h2>
-  <ul>
-    {% for require in doc.requires %}<li>{$ require | link $}</li>{% endfor %}
-  </ul>
+  <section class="api-section">
+    <h2 id="dependencies">Dependencies</h2>
+    <ul>{% for require in doc.requires %}<li>{$ require | link $}</li>{% endfor %}</ul>
+  </section>
   {% endif -%}
   {% endblock %}
 
@@ -33,10 +33,12 @@
 
   {% block examples %}
   {%- if doc.examples %}
-  <h2 id="example">Example</h2>
-  {%- for example in doc.examples -%}
+  <section class="api-section">
+    <h2 id="example">Example</h2>
+    {%- for example in doc.examples -%}
     {$ example | marked $}
-  {%- endfor -%}
+    {%- endfor -%}
+  </section>
   {% endif -%}
   {% endblock %}
 </div>

--- a/docs/config/template/ngdoc/api/object.template.html
+++ b/docs/config/template/ngdoc/api/object.template.html
@@ -1,19 +1,23 @@
 {% include "lib/macros.html" %}
 {% extends "api/api.template.html" %}
 
-{% block additional %}  
+{% block additional %}
 
-  <h2 id="Usage">Usage</h2>
-  {% if doc.usage %}
-    {$ doc.usage | marked $}
-  {% else %}
-    <code>{$ functionSyntax(doc) $}</code>
-  {% endif %}
+  <section class="api-section">
+    <h2 id="Usage">Usage</h2>
+    {% if doc.usage %}
+      {$ doc.usage | marked $}
+    {% else %}
+      <code>{$ functionSyntax(doc) $}</code>
+    {% endif %}
+  </section>
 
   {% if doc.params or doc.returns or doc.this or doc.kind == 'function' -%}
-    {% include "lib/params.template.html" %}
-    {% include "lib/this.template.html" %}
-    {% include "lib/returns.template.html" %}
+    <section class="api-section">
+      {% include "lib/params.template.html" %}
+      {% include "lib/this.template.html" %}
+      {% include "lib/returns.template.html" %}
+    </section>
   {%- endif %}
 
   {% include "lib/methods.template.html" %}

--- a/docs/config/template/ngdoc/lib/events.template.html
+++ b/docs/config/template/ngdoc/lib/events.template.html
@@ -1,25 +1,27 @@
 {%- if doc.events %}
-<h2>Events</h2>
-<ul class="events">
-  {%- for event in doc.events %}
-  <li id="{$ event.name $}">
-    <h3>{$ event.name $}</h3>
-    <div>{$ event.description | marked $}</div>
-    {%- if event.eventType == 'listen' %}
-    <div class="inline">
-      <h4>Listen on: {$ event.eventTarget $}</h4>
-    </div>
-    {%- else %}
-    <div class="inline">
-      <h4>Type:</h4>
-      <div class="type">{$ event.eventType $}</div>
-    </div>
-    <div class="inline">
-      <h4>Target:</h4>
-      <div class="target">{$ event.eventTarget $}</div>
-    </div>
-    {% endif -%}
-  </li>
-  {% endfor -%}
-</ul>
+<section class="api-section">
+  <h2>Events</h2>
+  <ul class="events">
+    {%- for event in doc.events %}
+    <li id="{$ event.name $}">
+      <h3>{$ event.name $}</h3>
+      <div>{$ event.description | marked $}</div>
+      {%- if event.eventType == 'listen' %}
+      <div class="inline">
+        <h4>Listen on: {$ event.eventTarget $}</h4>
+      </div>
+      {%- else %}
+      <div class="inline">
+        <h4>Type:</h4>
+        <div class="type">{$ event.eventType $}</div>
+      </div>
+      <div class="inline">
+        <h4>Target:</h4>
+        <div class="target">{$ event.eventTarget $}</div>
+      </div>
+      {% endif -%}
+    </li>
+    {% endfor -%}
+  </ul>
+</section>
 {% endif -%}

--- a/docs/config/template/ngdoc/lib/macros.html
+++ b/docs/config/template/ngdoc/lib/macros.html
@@ -82,26 +82,18 @@
 {% endmacro -%}
 
 {%- macro returnTable(fn) -%}
-<ul class="no-style">
-  <li>
-    <div layout="row" class="dashed-top">
-      <div class="api-params-label api-params-title" layout layout-align="center center" flex="20" flex-sm="20">
-        Returns
-      </div>
-      <div class="api-params-content api-params-title" flex layout="row" layout-align="left center" flex  style="padding-top:15px">
-        Description
-      </div>
-    </div>
-  </li>
-  <li>
-    <div layout="row">
-      <div class="api-params-label" flex="20" flex-sm="20">
-        {$ typeList(fn.typeList) $}
-      </div>
-      <div class="api-params-content" flex>
-        {$ fn.description | marked $}
-      </div>
-    </div>
-  </li>
-</ul>
+<table class="no-style">
+  <thead>
+  <tr>
+    <th>Returns</th>
+    <th>Description</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+    <td>{$ typeList(fn.typeList) $}</td>
+    <td class="description">{$ fn.description | marked $}</td>
+  </tr>
+  </tbody>
+</table>
 {%- endmacro -%}

--- a/docs/config/template/ngdoc/lib/methods.template.html
+++ b/docs/config/template/ngdoc/lib/methods.template.html
@@ -1,25 +1,27 @@
 {%- if doc.methods %}
-<h2>Methods</h2>
-<ul class="methods">
-  {%- for method in doc.methods %}
-  <li id="{$ method.name $}">
-    <h3 class="method-function-syntax"><code class="method-function-syntax">{$ doc.name $}.{$ functionSyntax(method) $}</code></h3>
-    <div>{$ method.description | marked $}</div>
+<section class="api-section">
+  <h2>Methods</h2>
+  <ul class="methods">
+    {%- for method in doc.methods %}
+    <li id="{$ method.name $}">
+      <h3 class="method-function-syntax"><code class="method-function-syntax">{$ doc.name $}.{$ functionSyntax(method) $}</code></h3>
+      <div>{$ method.description | marked $}</div>
 
-    {% if method.params %}
-    {$ paramTable(method.params) $}
-    {% endif %}
+      {% if method.params %}
+      {$ paramTable(method.params) $}
+      {% endif %}
 
-    {% if method.this %}
-    <h4>Method's {% code %}this{% endcode %}</h4>
-    {$ method.this | marked $}
-    {% endif %}
-    
-    {% if method.returns %}
-    {$ returnTable(method.returns) $}
-    {% endif %}
+      {% if method.this %}
+      <h4>Method's {% code %}this{% endcode %}</h4>
+      {$ method.this | marked $}
+      {% endif %}
 
-  </li>
-  {% endfor -%}
-</ul>
+      {% if method.returns %}
+      {$ returnTable(method.returns) $}
+      {% endif %}
+
+    </li>
+    {% endfor -%}
+  </ul>
+</section>
 {%- endif -%}

--- a/docs/config/template/ngdoc/lib/params.template.html
+++ b/docs/config/template/ngdoc/lib/params.template.html
@@ -1,5 +1,4 @@
 {%- if doc.params %}
-<section class="api-section">
   <h2>
     {% if doc.paramType %}
       {$ doc.paramType $}
@@ -9,6 +8,5 @@
       Arguments
     {% endif %}
   </h2>
-{$ paramTable(doc.params) $}
-</section>
+  {$ paramTable(doc.params) $}
 {%- endif -%}

--- a/docs/config/template/ngdoc/lib/properties.template.html
+++ b/docs/config/template/ngdoc/lib/properties.template.html
@@ -1,11 +1,13 @@
 {%- if doc.properties %}
-<h2>Properties</h2>
-<ul class="properties">
-  {%- for property in doc.properties %}
-  <li id="{$ property.name $}">
-    <h3>{$ property.name | code $}</h3>
-    TYPE INFO FOR {$ property | json $}
-  </li>
-  {% endfor -%}
-</ul>
+<section class="api-section">
+  <h2>Properties</h2>
+  <ul class="properties">
+    {%- for property in doc.properties %}
+    <li id="{$ property.name $}">
+      <h3>{$ property.name | code $}</h3>
+      TYPE INFO FOR {$ property | json $}
+    </li>
+    {% endfor -%}
+  </ul>
+</section>
 {%- endif -%}

--- a/docs/config/template/ngdoc/lib/this.template.html
+++ b/docs/config/template/ngdoc/lib/this.template.html
@@ -1,4 +1,7 @@
-{% if doc.this %}
-<h3>Method's {% code %}this{% endcode %}</h3>
-{$ doc.this | marked $}
-{% endif %}
+<section class="api-section">
+  {% if doc.this %}
+  <h3>Method's {% code %}this{% endcode %}</h3>
+  {$ doc.this | marked $}
+  {% endif %}
+</section>
+

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -122,7 +122,7 @@ module.exports = function(gulp, IS_RELEASE_BUILD) {
     return gulp.src([
       'dist/angular-material.css',
       'dist/themes/*.css',
-      'docs/app/css/highlightjs-codepen.css',
+      'docs/app/css/highlightjs-monokai.css',
       'docs/app/css/layout-demo.css',
       'docs/app/css/style.css'
     ])

--- a/src/components/autocomplete/demoBasicUsage/style.css
+++ b/src/components/autocomplete/demoBasicUsage/style.css
@@ -1,3 +1,0 @@
-md-content {
-  min-height: 500px;
-}

--- a/src/components/autocomplete/demoFloatingLabel/index.html
+++ b/src/components/autocomplete/demoFloatingLabel/index.html
@@ -1,5 +1,5 @@
 <div ng-app="autocompleteFloatingLabelDemo" ng-controller="DemoCtrl as ctrl" layout="column">
-  <md-content class="md-padding" layout="column">
+  <md-content class="md-padding" layout="column" style="min-height: 367px">
     <form ng-submit="$event.preventDefault()">
       <p>The following example demonstrates floating labels being used as a normal form element.</p>
       <div layout-gt-sm="row">
@@ -18,6 +18,7 @@
           <span md-highlight-text="ctrl.searchText">{{item.display}}</span>
         </md-autocomplete>
       </div>
+      <md-checkbox ng-model="ctrl.isDisabled">Disable the input?</md-checkbox>
     </form>
   </md-content>
 

--- a/src/components/autocomplete/demoFloatingLabel/style.css
+++ b/src/components/autocomplete/demoFloatingLabel/style.css
@@ -1,3 +1,0 @@
-md-content {
-  min-height: 500px;
-}

--- a/src/components/bottomSheet/demoBasicUsage/index.html
+++ b/src/components/bottomSheet/demoBasicUsage/index.html
@@ -1,4 +1,4 @@
-<div ng-controller="BottomSheetExample">
+<div ng-controller="BottomSheetExample" style="min-height: 367px;">
   <p style="padding-left: 20px;" class="md-body-1">
     Bottom sheet can be dismissed with the service or a swipe down.
   </p>

--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -14,6 +14,9 @@ $button-fab-border-radius: 50% !default;
     border-radius: $button-fab-border-radius;
     background-color: '{{accent-color}}';
     color: '{{accent-contrast}}';
+    md-icon {
+      color: '{{accent-contrast}}';
+    }
     &:not([disabled]) {
       &:focus {
         background-color: '{{accent-A700}}';
@@ -27,6 +30,9 @@ $button-fab-border-radius: 50% !default;
     &.md-fab {
       color: '{{primary-contrast}}';
       background-color: '{{primary-color}}';
+      md-icon {
+        color: '{{primary-contrast}}';
+      }
       &:not([disabled]) {
         &:focus {
           background-color: '{{primary-600}}';
@@ -52,6 +58,9 @@ $button-fab-border-radius: 50% !default;
     &.md-fab {
       color: '{{warn-contrast}}';
       background-color: '{{warn-color}}';
+      md-icon {
+        color: '{{warn-contrast}}';
+      }
       &:not([disabled]) {
         &:focus {
           background-color: '{{warn-700}}';
@@ -62,11 +71,13 @@ $button-fab-border-radius: 50% !default;
 
   &.md-accent {
     color: '{{accent-color}}';
-
     &.md-raised,
     &.md-fab {
       color: '{{accent-contrast}}';
       background-color: '{{accent-color}}';
+      md-icon {
+        color: '{{accent-contrast}}';
+      }
       &:not([disabled]) {
         &:focus {
           background-color: '{{accent-700}}';

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -51,8 +51,6 @@ function MdDialogDirective($$rAF, $mdTheming) {
  * - Default max-width is 80% of the `rootElement` or `parent`.
  *
  * @usage
- * ### HTML
- *
  * <hljs lang="html">
  * <div  ng-app="demoApp" ng-controller="EmployeeController">
  *   <md-button ng-click="showAlert()" class="md-raised md-warn">


### PR DESCRIPTION
- Code theme switched to a modified version of Monokai
- Minimum height removed from demo containers (unless necessary for the demo)
- File type header added to code blocks (except for when viewing source on demo pages)
- Icons in header aligned to match vertical alignment
- Uppercase heading removed from API pages
- Color styles added for icons within buttons