### PR TITLE
For an invalid input field, only make the label red when it's floating

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -59,7 +59,7 @@ md-input-container.md-THEME_NAME-theme {
     .md-input {
       border-color: '{{warn-500}}';
     }
-    label {
+    &.md-input-focused label {
       color: '{{warn-500}}';
     }
     ng-message, data-ng-message, x-ng-message,


### PR DESCRIPTION
Fixes issue #1928. (See that issue for details).