### PR TITLE
fix(list): focus covers whole row, IE11 layout fix

### DIFF
--- a/src/components/list/demoBasicUsage/style.css
+++ b/src/components/list/demoBasicUsage/style.css
@@ -1,7 +1,0 @@
-
-.face {
-  border-radius: 30px;
-  border: 1px solid #ddd;
-  width: 48px;
-  margin: 16px;
-}

--- a/src/components/list/demoListControls/index.html
+++ b/src/components/list/demoListControls/index.html
@@ -8,7 +8,7 @@
   <md-list-item ng-click="navigateTo(setting.extraScreen)" ng-repeat="setting in settings">
     <md-icon md-svg-icon="{{setting.icon}}"></md-icon>
     <p> {{ setting.name }} </p>
-    <md-switch class="md-secondary" ng-model="setting.enabled">
+    <md-switch class="md-secondary" ng-model="setting.enabled"></md-switch>
   </md-list-item>
   <md-list-item ng-click="navigateTo('data usage')">
     <md-icon md-svg-icon="cached"></md-icon>

--- a/src/components/list/demoListControls/style.css
+++ b/src/components/list/demoListControls/style.css
@@ -1,3 +1,0 @@
-md-icon-placeholder {
-  height: 24px;
-}

--- a/src/components/list/list-theme.scss
+++ b/src/components/list/list-theme.scss
@@ -24,4 +24,7 @@ md-list.md-THEME_NAME-theme {
       }
     }
   }
+  md-list-item button {
+    background-color: '{{background-color}}';
+  }
 }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -48,7 +48,7 @@ md-list-item {
     }
   }
   &.md-with-secondary {
-    padding-right: $list-item-padding-horizontal;
+    position: relative;
   }
   &.md-clickable:hover {
     cursor: pointer;
@@ -126,16 +126,15 @@ md-list-item, md-list-item .md-list-item-inner {
     box-sizing: content-box;
   }
 
-  md-checkbox.md-secondary {
-    margin-right: 0px;
-  }
+  md-checkbox.md-secondary,
   md-switch.md-secondary {
-    margin: 0;
-    position: relative;
-    right: -9px;
+    margin-right: 0px;
   }
   .md-secondary {
     margin-left: $list-item-secondary-left-margin;
+    position: absolute;
+    right: $list-item-padding-horizontal;
+    top: 0;
   }
 
   & > p, & > .md-list-item-inner > p {


### PR DESCRIPTION
This PR updates list controls with secondary actions so the primary focus highlight covers the whole row. It also fixes a layout bug in IE caused by an unclosed `<md-switch>` tag (visible on the docs site). 

Closes #2222