### PR TITLE
fix(gestures): fixes issue with non-clickable links

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -319,13 +319,18 @@
 
     /*
      * Dispatch an event with jQuery
-     * TODO: Make sure this sends bubbling events
+     * TODO: Make sure this sends $md.* bubbling events
      *
      * @param srcEvent the original DOM touch event that started this.
      * @param eventType the name of the custom event to send (eg 'click' or '$md.drag')
      * @param eventPointer the pointer object that matches this event.
      */
     function jQueryDispatchEvent(srcEvent, eventType, eventPointer) {
+      if (eventType === 'click') {
+        nativeDispatchEvent(srcEvent, eventType, eventPointer);
+        return;
+      }
+
       eventPointer = eventPointer || pointer;
       var eventObj = new angular.element.Event(eventType);
 


### PR DESCRIPTION
@ajoslin @ThomasBurleson 

This is a possible fix for #1792.
Broken demo in #1792: http://codepen.io/ThomasBurleson/pen/MYRvwy?editors=100
Fixed demo in #1792: http://codepen.io/kennethcachia/pen/azgwWg

**Current status**
Demo: http://codepen.io/kennethcachia/pen/PwrjGp?editors=100
````
// callback is executed
$('#id').on('click', function() { .. });

// callback is executed
$('#id').on('$md.pressdown', function() { .. }); 

// callback is executed
document.querySelector('#id').on('click', function() { .. }); 

// callback is not executed
document.querySelector('#id').on('$md.pressdown', function() { .. });
````

It's not a complete fix but might be enough for this and similar issues in 0.9.0. Makes sense?