### PR TITLE
fix(gestures): attach event listeners once when multiple ng-apps are running.

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -9,6 +9,9 @@
    */
   var pointer, lastPointer;
 
+  // Used to attach event listeners once when multiple ng-apps are running.
+  var isInitialized = false;
+
   angular
     .module('material.core.gestures', [ ])
     .factory('$mdGesture', MdGesture)
@@ -390,7 +393,7 @@
       return document.body.contains(node);
     });
 
-    if ( $mdGesture.isHijackingClicks ) {
+    if (!isInitialized && $mdGesture.isHijackingClicks) {
       /*
        * If hijack clicks is true, we preventDefault any click that wasn't
        * sent by ngMaterial. This is because on older Android & iOS, a false, or 'ghost',
@@ -408,6 +411,8 @@
           ev.stopPropagation();
         }
       }, true);
+      
+      isInitialized = true;
     }
 
     // Listen to all events to cover all platforms.


### PR DESCRIPTION
Closes #2173.