### PR TITLE
fix(checkbox): disable checkboxes with tabindex=-1

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -72,7 +72,7 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
   function compile (tElement, tAttrs) {
 
     tAttrs.type = 'checkbox';
-    tAttrs.tabIndex = 0;
+    tAttrs.tabindex = tAttrs.tabindex || '0';
     tElement.attr('role', tAttrs.type);
 
     return function postLink(scope, element, attr, ngModelCtrl) {
@@ -85,7 +85,10 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
             ngModelCtrl.$setViewValue.bind(ngModelCtrl)
         );
       }
-
+      $$watchExpr('ngDisabled', 'tabindex', {
+        true: '-1',
+        false: attr.tabindex
+      });
       $mdAria.expectWithText(element, 'aria-label');
 
       // Reuse the original input[type=checkbox] directive from Angular core.
@@ -112,6 +115,16 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
         .on('blur', function() { element.removeClass('md-focused'); });
 
       ngModelCtrl.$render = render;
+
+      function $$watchExpr(expr, htmlAttr, valueOpts) {
+        if (attr[expr]) {
+          scope.$watch(attr[expr], function(val) {
+            if (valueOpts[val]) {
+              element.attr(htmlAttr, valueOpts[val]);
+            }
+          });
+        }
+      }
 
       function keypressHandler(ev) {
         var keyCode = ev.which || ev.keyCode;

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -49,7 +49,7 @@ describe('mdCheckbox', function() {
     expect(cbElements.eq(0).attr('role')).toEqual('checkbox');
   }));
 
-  it('should be disabled with disabled attr', inject(function($compile, $rootScope) {
+  it('should be disabled with ngDisabled attr', inject(function($compile, $rootScope) {
     var element = $compile('<div>' +
                              '<md-checkbox ng-disabled="isDisabled" ng-model="blue">' +
                              '</md-checkbox>' +
@@ -67,6 +67,31 @@ describe('mdCheckbox', function() {
 
     checkbox.triggerHandler('click');
     expect($rootScope.blue).toBe(true);
+  }));
+
+  it('should preserve existing tabindex', inject(function($compile, $rootScope) {
+    var element = $compile('<div>' +
+                             '<md-checkbox ng-model="blue" tabindex="2">' +
+                             '</md-checkbox>' +
+                           '</div>')($rootScope);
+
+    var checkbox = element.find('md-checkbox');
+    expect(checkbox.attr('tabindex')).toBe('2');
+  }));
+
+  it('should disable with tabindex=-1', inject(function($compile, $rootScope) {
+    var element = $compile('<div>' +
+                             '<md-checkbox ng-disabled="isDisabled" ng-model="blue">' +
+                             '</md-checkbox>' +
+                           '</div>')($rootScope);
+
+    var checkbox = element.find('md-checkbox');
+
+    $rootScope.$apply('isDisabled = true');
+    expect(checkbox.attr('tabindex')).toBe('-1');
+
+    $rootScope.$apply('isDisabled = false');
+    expect(checkbox.attr('tabindex')).toBe('0');
   }));
 
   it('should not set focus state on mousedown', inject(function($compile, $rootScope) {


### PR DESCRIPTION
ngAria adds `tabindex=0` to elements with `ng-model` on them, but doesn't update it to `-1` when ngDisabled is truthy...preventing mdCheckbox from being fully disabled. This PR adds the correct tabindex for disabled checkboxes, preserving existing tabindex values if present.

Closes #2087