### PR TITLE
fix(build): only uglify js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -250,7 +250,8 @@ function buildModule(module, isRelease) {
 
   function buildMin() {
     return lazypipe()
-      .pipe(gulpif, /.css$/, minifyCss(), uglify({ preserveComments: 'some' }))
+      .pipe(gulpif, /.css$/, minifyCss())
+      .pipe(gulpif, /.js$/, uglify({ preserveComments: 'some' }))
       .pipe(rename, function(path) {
         path.extname = path.extname
           .replace(/.js$/, '.min.js')


### PR DESCRIPTION
https://github.com/angular/material/commit/0e916bfccbd2abd05508c6bde61eb513530c3331 add images to  src/components/list folder, which was assumed (by gulpfile) only contains .js and .css files. So the gulp task was attempt to uglify .jpeg files and throw error.