### PR TITLE
docs: upgrade gulp-uglify, improve error handling

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -250,7 +250,14 @@ function buildModule(module, isRelease) {
 
   function buildMin() {
     return lazypipe()
-      .pipe(gulpif, /.css$/, minifyCss(), uglify({ preserveComments: 'some' }))
+      .pipe(gulpif, /.css$/, minifyCss(),
+        uglify({ preserveComments: 'some' })
+          .on('error', function(e) {
+            console.log('\x07',e.message);
+            return this.end();
+          }
+        )
+      )
       .pipe(rename, function(path) {
         path.extname = path.extname
           .replace(/.js$/, '.min.js')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-sass": "^1.3.3",
-    "gulp-uglify": "^0.3.0",
+    "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.8.3",
     "jasmine-core": "^2.2.0",


### PR DESCRIPTION
I lost an hour to a build error that could have been prevented with better error handling. This change upgrades gulp-uglify to a newer version and adds an error message to pinpoint causes for minified builds.