### PR TITLE
fix(mdUtil): change wrapper width for disableScrollAround

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -82,7 +82,7 @@ angular.module('material.core')
       wrapperEl.css({
         overflow: 'hidden',
         position: 'fixed',
-        width: '100%',
+        width: wrapperEl[0].getBoundingClientRect().width + 'px',
         'padding-top': computedStyle.paddingTop,
         top: (-1 * heightOffset) + 'px'
       });


### PR DESCRIPTION
This commit remove problems with mdSelect component in dialogs
for focus state