### PR TITLE
Fix Select

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -870,8 +870,8 @@ function SelectProvider($$interimElementProvider) {
 
       return $mdUtil.transitionEndPromise(element, { timeout: 350 }).then(function() {
         element.removeClass('md-active');
-        opts.parent[0].removeChild(element[0]); // use browser to avoid $destroy event
         opts.backdrop && opts.backdrop.remove();
+        opts.parent[0].removeChild(element[0]); // use browser to avoid $destroy event
         if (opts.restoreFocus) opts.target.focus();
         if (opts.disableParentScroll) {
           opts.restoreScroll();
@@ -1034,4 +1034,3 @@ function nodesToArray(nodes) {
   return results;
 }
 })();
-


### PR DESCRIPTION
When select is open and you choose an option wich will do
a route change, it is unable to find parent to delete.

This causes an exception and the backdrop generated never closes

EDIT: Backtrace: http://dpaste.com/3P3XWGG

The solution is destroy first the backdrop and then try to find the
parent and delete it.