### PR TITLE
docs(style.css): update sidenav width to be in accordance with material ...

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -186,9 +186,9 @@ code:not(.highlight) {
 .site-sidenav,
 .site-sidenav.md-locked-open-add-active,
 .site-sidenav.md-locked-open {
-  width: 254px;
-  min-width: 254px;
-  max-width: 254px;
+  width: 256px;
+  min-width: 256px;
+  max-width: 256px;
 }
 .site-sidenav > * {
   min-width: 218px;


### PR DESCRIPTION
Creating a PR as @ThomasBurleson suggested here:
https://github.com/angular/material/commit/0318ca44ca1d256d50cd1de675c92c8bf4b2bcb1

I believe 256px sidenav component width would be better accordance with material spec. (incrementing keylines - 64dp x 4 = 256dp) and this way sidenav component would fit perfectly to 8dp square baseline grid.

Spec detail: http://www.google.com/design/spec/layout/metrics-keylines.html#metrics-keylines-ratio-keylines