### PR TITLE
fix(list): add ripple, inherit from .md-button

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -12,6 +12,9 @@ a.md-button.md-THEME_NAME-theme,
     &.md-focused {
       background-color: '{{background-500-0.2}}';
     }
+    &.md-icon-button:hover {
+      background-color: transparent;
+    }
   }
 
   &.md-fab {

--- a/src/components/list/list-theme.scss
+++ b/src/components/list/list-theme.scss
@@ -8,8 +8,7 @@ md-list.md-THEME_NAME-theme {
       color: '{{foreground-2}}';
     }
   }
-  .md-proxy-focus.md-focused div.md-no-style,
-  .md-no-style:focus {
+  .md-proxy-focus.md-focused div.md-no-style {
     background-color: '{{background-100}}';
   }
 
@@ -25,5 +24,9 @@ md-list.md-THEME_NAME-theme {
   }
   md-list-item button {
     background-color: '{{background-color}}';
+
+    &.md-button:not([disabled]):hover {
+      background-color: '{{background-color}}';
+    }
   }
 }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -20,6 +20,7 @@ $list-item-primary-width: $baseline-grid * 7 !default;
 $list-item-primary-avatar-width: $baseline-grid * 5 !default;
 $list-item-primary-icon-width: $baseline-grid * 3 !default;
 $list-item-secondary-left-margin: $baseline-grid * 2 !default;
+$list-item-secondary-button-width: $baseline-grid * 6 !default;
 $list-item-text-padding-top: $baseline-grid * 2 !default;
 $list-item-text-padding-bottom: $baseline-grid * 2.5 !default;
 $list-item-inset-divider-offset: 12 * $baseline-grid !default;
@@ -40,6 +41,14 @@ md-list-item {
     position: relative;
     padding: $list-item-padding-vertical $list-item-padding-horizontal;
     flex: 1;
+    transition: background-color 0.15s linear;
+
+    &.md-button {
+      height: inherit;
+      text-align: left;
+      text-transform: none;
+      width: 100%;
+    }
     &:focus {
       outline: none
     }
@@ -130,11 +139,10 @@ md-list-item, md-list-item .md-list-item-inner {
   }
 
   button.md-button.md-secondary-container {
-    width: $list-item-primary-icon-width;
+    background-color: transparent;
     align-self: center;
-    margin-right: 0px;
-    box-sizing: content-box;
     border-radius: 50%;
+    margin: 0px;
     min-width: 0px;
     .md-ripple,
     .md-ripple-container {

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -25,7 +25,7 @@ describe('mdListItem directive', function() {
   it('creates buttons when used with ng-click', function() {
     var listItem = setup('<md-list-item ng-click="sayHello()"><p>Hello world</p></md-list-item>');
     var firstChild = listItem.children()[0];
-    expect(firstChild.nodeName).toBe('BUTTON');
+    expect(firstChild.nodeName).toBe('MD-BUTTON');
     expect(firstChild.childNodes[0].nodeName).toBe('DIV');
     expect(firstChild.childNodes[0].childNodes[0].nodeName).toBe('P');
   });
@@ -33,7 +33,7 @@ describe('mdListItem directive', function() {
   it('moves md-secondary items outside of the button', function() {
     var listItem = setup('<md-list-item ng-click="sayHello()"><p>Hello World</p><md-icon class="md-secondary" ng-click="goWild()"></md-icon></md-list-item>');
     var firstChild = listItem.children()[0];
-    expect(firstChild.nodeName).toBe('BUTTON');
+    expect(firstChild.nodeName).toBe('MD-BUTTON');
     expect(firstChild.childNodes.length).toBe(1);
     var secondChild = listItem.children()[1];
     expect(secondChild.nodeName).toBe('MD-BUTTON');

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -27,6 +27,7 @@ function InkRippleService($window, $timeout) {
     attachButtonBehavior: attachButtonBehavior,
     attachCheckboxBehavior: attachCheckboxBehavior,
     attachTabBehavior: attachTabBehavior,
+    attachListControlBehavior: attachListControlBehavior,
     attach: attach
   };
 
@@ -48,6 +49,15 @@ function InkRippleService($window, $timeout) {
   }
 
   function attachTabBehavior(scope, element, options) {
+    return attach(scope, element, angular.extend({
+      center: false,
+      dimBackground: true,
+      outline: false,
+      rippleSize: 'full'
+    }, options));
+  }
+
+  function attachListControlBehavior(scope, element, options) {
     return attach(scope, element, angular.extend({
       center: false,
       dimBackground: true,


### PR DESCRIPTION
Updates interaction styles of list controls to attach ripple on click of list items with proxy controls, and makes child primary & secondary icon buttons into `md-button` elements. This allows for correct icon button dimensions and mouse/focus behavior to be extended to list controls.