### PR TITLE
fix(card): action bar spacing, remove order attrs

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -12,16 +12,21 @@ md-card {
 
   > img,
   > :not(md-card-content) img {
-    order: 0;
     width: 100%;
   }
 
   md-card-content {
-    order: 1;
     padding: $card-padding;
   }
+  md-action-bar {
+    margin: 0;
+
+    .md-button {
+      margin-bottom: $card-margin;
+      margin-top: $card-margin;
+    }
+  }
   md-card-footer {
-    order: 2;
     padding: $card-padding;
   }
 }

--- a/src/components/card/demoBasicUsage/index.html
+++ b/src/components/card/demoBasicUsage/index.html
@@ -12,6 +12,10 @@
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
         </p>
       </md-card-content>
+      <md-action-bar layout="row" layout-align="end center">
+        <md-button>Action 1</md-button>
+        <md-button>Action 2</md-button>
+      </md-action-bar>
     </md-card>
 
     <md-card>


### PR DESCRIPTION
Card sections now use DOM source order rather than flex order. This makes it so that an action bar with buttons can go in between content and the footer, and have any number of combinations. Relevant spec section: http://www.google.com/design/spec/components/cards.html#cards-actions

Note: the action bar gets its `8px` spacing from `md-button`.

Closes #2403