### PR TITLE
Apply md-dialog styles only to direct child md-content element

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -33,7 +33,7 @@ md-dialog {
   display: flex;
   flex-direction: column;
 
-  md-content {
+  > md-content {
     order: 1;
     padding: $baseline-grid * 3;
     overflow: auto;


### PR DESCRIPTION
This prevents the style being applied to other md-content elements.