### PR TITLE
feature(button): change md-icon-button to use round ripple effect

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -1,5 +1,6 @@
 $button-border-radius: 3px !default;
 $button-fab-border-radius: 50% !default;
+$button-icon-border-radius: $button-fab-border-radius;
 
 a.md-button.md-THEME_NAME-theme,
 .md-button.md-THEME_NAME-theme {
@@ -32,6 +33,10 @@ a.md-button.md-THEME_NAME-theme,
         background-color: '{{accent-A700}}';
       }
     }
+  }
+
+  &.md-icon-button {
+    border-radius: $button-icon-border-radius;
   }
 
   &.md-primary {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -57,7 +57,7 @@ angular
  *  </md-button>
  * </hljs>
  */
-function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria, $timeout) {
+function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
 
   return {
     restrict: 'EA',
@@ -70,7 +70,7 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria, $timeout) {
   function isAnchor(attr) {
     return angular.isDefined(attr.href) || angular.isDefined(attr.ngHref) || angular.isDefined(attr.ngLink) || angular.isDefined(attr.uiSref);
   }
-  
+
   function getTemplate(element, attr) {
     return isAnchor(attr) ?
            '<a class="md-button" ng-transclude></a>' :
@@ -80,14 +80,14 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria, $timeout) {
   function postLink(scope, element, attr) {
     var node = element[0];
     $mdTheming(element);
-    $mdInkRipple.attachButtonBehavior(scope, element);
+    $mdButtonInkRipple.attach(scope, element);
 
     var elementHasText = node.textContent.trim();
     if (!elementHasText) {
       $mdAria.expect(element, 'aria-label');
     }
 
-    // For anchor elements, we have to set tabindex manually when the 
+    // For anchor elements, we have to set tabindex manually when the
     // element is disabled
     if (isAnchor(attr) && angular.isDefined(attr.ngDisabled) ) {
       scope.$watch(attr.ngDisabled, function(isDisabled) {

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -144,4 +144,15 @@ describe('md-button', function() {
 
   });
 
+  describe('ripple effects for button', function() {
+
+    it('attaches button ripple effects', inject(function($mdButtonInkRipple, $compile, $rootScope) {
+      spyOn($mdButtonInkRipple, 'attach');
+
+      var button = $compile("<md-button class='md-fab'><md-icon><md-icon></md-button>")($rootScope);
+      $rootScope.$apply();
+
+      expect($mdButtonInkRipple.attach).toHaveBeenCalledWith($rootScope, button);
+    }));
+  });
 });

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -246,12 +246,12 @@ function mdListItemDirective($mdAria, $mdConstant, $timeout) {
  * @module material.components.list
  *
  */
-function MdListController($scope, $element, $mdInkRipple) {
+function MdListController($scope, $element, $mdListInkRipple) {
   var ctrl = this;
   ctrl.attachRipple = attachRipple;
 
   function attachRipple (scope, element) {
     var options = {};
-    $mdInkRipple.attachListControlBehavior(scope, element, options);
+    $mdListInkRipple.attach(scope, element, options);
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -558,7 +558,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
 }
 
-function OptionDirective($mdInkRipple, $mdUtil) {
+function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   return {
     restrict: 'E',
@@ -603,7 +603,7 @@ function OptionDirective($mdInkRipple, $mdUtil) {
       });
     });
 
-    $mdInkRipple.attachButtonBehavior(scope, element);
+    $mdButtonInkRipple.attach(scope, element);
     configureAria();
 
     function setOptionValue(newValue, oldValue) {

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -360,6 +360,6 @@ function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $md
 
   function attachRipple (scope, element) {
     var options = { colorElement: angular.element(elements.inkBar) };
-    $mdInkRipple.attachTabBehavior(scope, element, options);
+    $mdTabInkRipple.attach(scope, element, options);
   }
 }

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -5,7 +5,7 @@ angular
 /**
  * @ngInject
  */
-function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $mdInkRipple,
+function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $mdTabInkRipple,
                            $mdUtil, $animate) {
   var ctrl     = this,
       locked   = false,

--- a/src/core/services/ripple/button_ripple.js
+++ b/src/core/services/ripple/button_ripple.js
@@ -1,0 +1,45 @@
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc service
+   * @name $mdButtonInkRipple
+   * @module material.core
+   *
+   * @description
+   * Provides ripple effects for md-button.  See $mdInkRipple service for all possible configuration options.
+   *
+   * @param {object=} scope Scope within the current context
+   * @param {object=} element The element the ripple effect should be applied to
+   * @param {object=} options (Optional) Configuration options to override the defaultripple configuration
+   */
+
+  angular.module('material.core')
+    .factory('$mdButtonInkRipple', MdButtonInkRipple);
+
+  function MdButtonInkRipple($mdInkRipple) {
+    return {
+      attach: attach
+    };
+
+    function attach(scope, element, options) {
+      var elementOptions = optionsForElement(element);
+      return $mdInkRipple.attach(scope, element, angular.extend(elementOptions, options));
+    };
+
+    function optionsForElement(element) {
+      if (element.hasClass('md-icon-button')) {
+        return {
+          isMenuItem: element.hasClass('md-menu-item'),
+          fitRipple: true,
+          center: true
+        };
+      } else {
+        return {
+          isMenuItem: element.hasClass('md-menu-item'),
+          dimBackground: true
+        }
+      }
+    };
+  };
+})();

--- a/src/core/services/ripple/button_ripple.spec.js
+++ b/src/core/services/ripple/button_ripple.spec.js
@@ -1,0 +1,63 @@
+describe('MdButtonInkRipple', function() {
+
+  beforeEach(module('material.core'));
+
+  var $element, $rootScope, $mdButtonInkRipple, $mdInkRipple;
+  beforeEach(inject(function(_$rootScope_, _$mdButtonInkRipple_, _$mdInkRipple_) {
+    $rootScope = _$rootScope_;
+    $mdButtonInkRipple = _$mdButtonInkRipple_;
+    $mdInkRipple = _$mdInkRipple_;
+
+    $element = angular.element('<button></button>');
+    spyOn($mdInkRipple, 'attach');
+  }));
+
+  it('applies the correct ripple configuration for a md-icon-button', function() {
+    $element.addClass('md-icon-button');
+
+    $mdButtonInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      isMenuItem: false,
+      fitRipple: true,
+      center: true
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('applies the correct ripple configuration for all other buttons', function() {
+    $mdButtonInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      isMenuItem: false,
+      dimBackground: true
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('configures the button as a menu item when it is a md-menu-item', function() {
+    $element.addClass('md-menu-item');
+
+    $mdButtonInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      isMenuItem: true,
+      dimBackground: true
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('allows ripple configuration to be overridden', function() {
+    $mdButtonInkRipple.attach($rootScope, $element, { dimBackground: false });
+
+    var expected = {
+      isMenuItem: false,
+      dimBackground: false
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+});

--- a/src/core/services/ripple/checkbox_ripple.js
+++ b/src/core/services/ripple/checkbox_ripple.js
@@ -1,0 +1,33 @@
+(function() {
+  'use strict';
+
+    /**
+   * @ngdoc service
+   * @name $mdCheckboxInkRipple
+   * @module material.core
+   *
+   * @description
+   * Provides ripple effects for md-checkbox.  See $mdInkRipple service for all possible configuration options.
+   *
+   * @param {object=} scope Scope within the current context
+   * @param {object=} element The element the ripple effect should be applied to
+   * @param {object=} options (Optional) Configuration options to override the defaultripple configuration
+   */
+
+  angular.module('material.core')
+    .factory('$mdCheckboxInkRipple', MdCheckboxInkRipple);
+
+  function MdCheckboxInkRipple($mdInkRipple) {
+    return {
+      attach: attach
+    };
+
+    function attach(scope, element, options) {
+      return $mdInkRipple.attach(scope, element, angular.extend({
+        center: true,
+        dimBackground: false,
+        fitRipple: true
+      }, options));
+    };
+  };
+})();

--- a/src/core/services/ripple/checkbox_ripple.spec.js
+++ b/src/core/services/ripple/checkbox_ripple.spec.js
@@ -1,0 +1,38 @@
+describe('MdCheckboxInkRipple', function() {
+
+  beforeEach(module('material.core'));
+
+  var $element, $rootScope, $mdCheckboxInkRipple, $mdInkRipple;
+  beforeEach(inject(function(_$rootScope_, _$mdCheckboxInkRipple_, _$mdInkRipple_) {
+    $rootScope = _$rootScope_;
+    $mdCheckboxInkRipple = _$mdCheckboxInkRipple_;
+    $mdInkRipple = _$mdInkRipple_;
+
+    $element = jasmine.createSpy('element');
+    spyOn($mdInkRipple, 'attach');
+  }));
+
+  it('applies the correct ripple configuration', function() {
+    $mdCheckboxInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      center: true,
+      dimBackground: false,
+      fitRipple: true
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('allows ripple configuration to be overridden', function() {
+    $mdCheckboxInkRipple.attach($rootScope, $element, { center: false, fitRipple: false });
+
+    var expected = {
+      center: false,
+      dimBackground: false,
+      fitRipple: false
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+});

--- a/src/core/services/ripple/list_ripple.js
+++ b/src/core/services/ripple/list_ripple.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc service
+   * @name $mdListInkRipple
+   * @module material.core
+   *
+   * @description
+   * Provides ripple effects for md-list.  See $mdInkRipple service for all possible configuration options.
+   *
+   * @param {object=} scope Scope within the current context
+   * @param {object=} element The element the ripple effect should be applied to
+   * @param {object=} options (Optional) Configuration options to override the defaultripple configuration
+   */
+
+  angular.module('material.core')
+    .factory('$mdListInkRipple', MdListInkRipple);
+
+  function MdListInkRipple($mdInkRipple) {
+    return {
+      attach: attach
+    };
+
+    function attach(scope, element, options) {
+      return $mdInkRipple.attach(scope, element, angular.extend({
+        center: false,
+        dimBackground: true,
+        outline: false,
+        rippleSize: 'full'
+      }, options));
+    };
+  };
+})();

--- a/src/core/services/ripple/list_ripple.spec.js
+++ b/src/core/services/ripple/list_ripple.spec.js
@@ -1,0 +1,40 @@
+describe('MdListInkRipple', function() {
+
+  beforeEach(module('material.core'));
+
+  var $element, $rootScope, $mdListInkRipple, $mdInkRipple;
+  beforeEach(inject(function(_$rootScope_, _$mdListInkRipple_, _$mdInkRipple_) {
+    $rootScope = _$rootScope_;
+    $mdListInkRipple = _$mdListInkRipple_;
+    $mdInkRipple = _$mdInkRipple_;
+
+    $element = jasmine.createSpy('element');
+    spyOn($mdInkRipple, 'attach');
+  }));
+
+  it('applies the correct ripple configuration', function() {
+    $mdListInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      center: false,
+      dimBackground: true,
+      outline: false,
+      rippleSize: 'full'
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('allows ripple configuration to be overridden', function() {
+    $mdListInkRipple.attach($rootScope, $element, { center: true, outline: true });
+
+    var expected = {
+      center: true,
+      dimBackground: true,
+      outline: true,
+      rippleSize: 'full'
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+});

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -5,14 +5,14 @@ angular.module('material.core')
   .directive('mdNoBar', attrNoDirective())
   .directive('mdNoStretch', attrNoDirective());
 
-function InkRippleDirective($mdInkRipple) {
+function InkRippleDirective($mdButtonInkRipple, $mdCheckboxInkRipple) {
   return {
     controller: angular.noop,
     link: function (scope, element, attr) {
       if (attr.hasOwnProperty('mdInkRippleCheckbox')) {
-        $mdInkRipple.attachCheckboxBehavior(scope, element);
+        $mdCheckboxInkRipple.attach(scope, element);
       } else {
-        $mdInkRipple.attachButtonBehavior(scope, element);
+        $mdButtonInkRipple.attach(scope, element);
       }
     }
   };
@@ -21,47 +21,8 @@ function InkRippleDirective($mdInkRipple) {
 function InkRippleService($window, $timeout) {
 
   return {
-    attachButtonBehavior: attachButtonBehavior,
-    attachCheckboxBehavior: attachCheckboxBehavior,
-    attachTabBehavior: attachTabBehavior,
-    attachListControlBehavior: attachListControlBehavior,
     attach: attach
   };
-
-  function attachButtonBehavior(scope, element, options) {
-    return attach(scope, element, angular.extend({
-      fullRipple: true,
-      isMenuItem: element.hasClass('md-menu-item'),
-      center: false,
-      dimBackground: true
-    }, options));
-  }
-
-  function attachCheckboxBehavior(scope, element, options) {
-    return attach(scope, element, angular.extend({
-      center: true,
-      dimBackground: false,
-      fitRipple: true
-    }, options));
-  }
-
-  function attachTabBehavior(scope, element, options) {
-    return attach(scope, element, angular.extend({
-      center: false,
-      dimBackground: true,
-      outline: false,
-      rippleSize: 'full'
-    }, options));
-  }
-
-  function attachListControlBehavior(scope, element, options) {
-    return attach(scope, element, angular.extend({
-      center: false,
-      dimBackground: true,
-      outline: false,
-      rippleSize: 'full'
-    }, options));
-  }
 
   function attach(scope, element, options) {
     if (element.controller('mdNoInk')) return angular.noop;

--- a/src/core/services/ripple/tab_ripple.js
+++ b/src/core/services/ripple/tab_ripple.js
@@ -1,0 +1,34 @@
+(function() {
+  'use strict';
+
+    /**
+   * @ngdoc service
+   * @name $mdTabInkRipple
+   * @module material.core
+   *
+   * @description
+   * Provides ripple effects for md-tabs.  See $mdInkRipple service for all possible configuration options.
+   *
+   * @param {object=} scope Scope within the current context
+   * @param {object=} element The element the ripple effect should be applied to
+   * @param {object=} options (Optional) Configuration options to override the defaultripple configuration
+   */
+
+  angular.module('material.core')
+    .factory('$mdTabInkRipple', MdTabInkRipple);
+
+  function MdTabInkRipple($mdInkRipple) {
+    return {
+      attach: attach
+    };
+
+    function attach(scope, element, options) {
+      return $mdInkRipple.attach(scope, element, angular.extend({
+        center: false,
+        dimBackground: true,
+        outline: false,
+        rippleSize: 'full'
+      }, options));
+    };
+  };
+})();

--- a/src/core/services/ripple/tab_ripple.spec.js
+++ b/src/core/services/ripple/tab_ripple.spec.js
@@ -1,0 +1,40 @@
+describe('MdTabInkRipple', function() {
+
+  beforeEach(module('material.core'));
+
+  var $element, $rootScope, $mdTabInkRipple, $mdInkRipple;
+  beforeEach(inject(function(_$rootScope_, _$mdTabInkRipple_, _$mdInkRipple_) {
+    $rootScope = _$rootScope_;
+    $mdTabInkRipple = _$mdTabInkRipple_;
+    $mdInkRipple = _$mdInkRipple_;
+
+    $element = jasmine.createSpy('element');
+    spyOn($mdInkRipple, 'attach');
+  }));
+
+  it('applies the correct ripple configuration', function() {
+    $mdTabInkRipple.attach($rootScope, $element);
+
+    var expected = {
+      center: false,
+      dimBackground: true,
+      outline: false,
+      rippleSize: 'full'
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+
+  it('allows ripple configuration to be overridden', function() {
+    $mdTabInkRipple.attach($rootScope, $element, { center: true, outline: true });
+
+    var expected = {
+      center: true,
+      dimBackground: true,
+      outline: true,
+      rippleSize: 'full'
+    };
+
+    expect($mdInkRipple.attach).toHaveBeenCalledWith($rootScope, $element, expected);
+  });
+});


### PR DESCRIPTION
Addresses issue -> https://github.com/angular/material/issues/2373.

A breaking change was introduced in https://github.com/angular/material/commit/0300c3af1bcb29ea8de5e9550a96775614de9df3.  The breaking change removes attach{insert component name}Behavior from $mdInkRipple to seperate the concern of configuring ripple effects for specific component types and the core ripple effect behavior.

This PR could be broken up into 1) implement feature 2) refactor inkRipple if this change is too extreme to bring into the project ATM.