### PR TITLE
demo(): fix breadcrumb when using back button

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -273,6 +273,12 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
   function onLocationChange() {
     var path = $location.path();
 
+    if (path == '/') {
+      self.selectSection(null);
+      self.selectPage(null, null);
+      return;
+    }
+
     var matchPage = function(section, page) {
       if (path === page.url) {
         self.selectSection(section);


### PR DESCRIPTION
Fixes issue -> https://github.com/angular/material/issues/2285.

menu.currentSection and menu.currentPage were not updated when location changed.  This occurs because '/' will never match a registered section in the menu, causing the currentSection and currentPage to remain the same.