### PR TITLE
fix(dialog): spacing issue

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -61,6 +61,7 @@ md-dialog {
     > * {
       margin-left: $baseline-grid / 2;
       margin-right: 0;
+      margin-bottom: 0;
     }
   }
   &.md-content-overflow .md-actions {


### PR DESCRIPTION
Remove bottom margin from an md-dialog's actions. The bottom margin was causing extra space that isn't in the Material spec.

Closes #2472