### PR TITLE
fix(specs): failing specs now exit with non zero

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -153,27 +153,38 @@ gulp.task('karma', function(done) {
     browsers : argv.browsers ? argv.browsers.trim().split(',') : ['Chrome'],
     configFile: __dirname + '/config/karma.conf.js'
   };
+  var errorCount = 0;
+  function captureError(next) {
+    return function(exitCode) {
+      if (exitCode != 0) {
+        gutil.log(gutil.colors.red("Karma exited with the following exit code: " + exitCode));
+        errorCount++;
+      }
+      next();
+    };
+  };
 
   gutil.log('Running unit tests on unminified source.');
   buildJs(true);
-  karma.start(karmaConfig, testMinified);
+  karma.start(karmaConfig, captureError(testMinified));
 
   function testMinified() {
     gutil.log('Running unit tests on minified source.');
     process.env.KARMA_TEST_COMPRESSED = true;
-    karma.start(karmaConfig, testMinifiedJquery);
+    karma.start(karmaConfig, captureError(testMinifiedJquery));
   }
 
   function testMinifiedJquery() {
     gutil.log('Running unit tests on minified source w/ jquery.');
     process.env.KARMA_TEST_COMPRESSED = true;
     process.env.KARMA_TEST_JQUERY = true;
-    karma.start(karmaConfig, clearEnv);
+    karma.start(karmaConfig, captureError(clearEnv));
   }
 
   function clearEnv() {
     process.env.KARMA_TEST_COMPRESSED = undefined;
     process.env.KARMA_TEST_JQUERY = undefined;
+    if (errorCount > 0) { process.exit(errorCount); }
     done();
   }
 });


### PR DESCRIPTION
Running karma on ci was not exiting with non zero code, giving the impression the specs passed.

Here is an example of a failing PR without this logic:
https://travis-ci.org/angular/material/builds/59751055

Here is an example using code from this PR:
https://travis-ci.org/matthewrfindley/material/builds/59786743

With this pull request, I am making an assumption that `gulp karma` should run all three versions of the specs (unminified, minified and minified with jQuery).  Given this was the existing behavior, all specs will run in each context and report with a non zero exit code when they are all done.



