### PR TITLE
fix(gridList): reorder tiles when ngRepeat array changes

### DIFF
--- a/src/components/gridList/demoRearrangingTiles/index.html
+++ b/src/components/gridList/demoRearrangingTiles/index.html
@@ -1,5 +1,5 @@
 <div ng-app="gridListDemo" ng-controller="gridListDemoCtrl as vm" flex>
-  <md-select ng-model="vm.order" ng-change="vm.sortTiles()">
+  <md-select ng-model="vm.order" ng-change="vm.sortTiles()" placeholder="Order tiles">
     <md-option ng-value="0">Ascending</md-option>
     <md-option ng-value="1">Descending</md-option>
   </md-select>
@@ -10,7 +10,7 @@
         md-gutter="8px" md-gutter-gt-sm="4px" >
 
     <md-grid-tile ng-repeat="tile in vm.getTiles()" md-colspan-sm="1" >
-      <md-grid-tile-content><h3>{{tile.name}}</h3></md-grid-tile-content>
+      <md-grid-tile-content><h3>{{tile.val}}</h3></md-grid-tile-content>
     </md-grid-tile>
   </md-grid-list>
 </div>

--- a/src/components/gridList/demoRearrangingTiles/index.html
+++ b/src/components/gridList/demoRearrangingTiles/index.html
@@ -1,0 +1,16 @@
+<div ng-app="gridListDemo" ng-controller="gridListDemoCtrl as vm" flex>
+  <md-select ng-model="vm.order" ng-change="vm.sortTiles()">
+    <md-option ng-value="0">Ascending</md-option>
+    <md-option ng-value="1">Descending</md-option>
+  </md-select>
+
+  <md-grid-list
+        md-cols-sm="1" md-cols-md="2" md-cols-gt-md="6"
+        md-row-height-gt-md="1:1" md-row-height="4:3"
+        md-gutter="8px" md-gutter-gt-sm="4px" >
+
+    <md-grid-tile ng-repeat="tile in vm.getTiles()" md-colspan-sm="1" >
+      <md-grid-tile-content><h3>{{tile.name}}</h3></md-grid-tile-content>
+    </md-grid-tile>
+  </md-grid-list>
+</div>

--- a/src/components/gridList/demoRearrangingTiles/script.js
+++ b/src/components/gridList/demoRearrangingTiles/script.js
@@ -3,29 +3,29 @@ angular
   .module('gridListDemoApp', ['ngMaterial'])
   .controller('gridListDemoCtrl', function($scope) {
 
-    this.order = 0;
+    this.order = undefined;
 
     this.tiles = buildGridModel();
     this.sortTiles = sortTiles;
-    this.getTiles = function() {
+    this.getTiles = getTiles;
+
+
+    function getTiles() {
       return this.tiles;
-    }.bind(this);
-
-    function sortTiles() {
-      console.log(this.order);
-      this.tiles.sort(function(a, b) {
-        return b.name - a.name;
-      });
-
-      if (this.order != 0) {
-        this.tiles.reverse();
-      }
-
-      console.log(this.tiles);
     };
 
-    function buildGridModel(){
-      var tiles = [{name: 1},{ name:2},{ name:3},{ name:4},{ name:5},{ name:6},{ name:7}];
+    function sortTiles() {
+      this.tiles.sort(function(a, b) {
+        return a.val - b.val;
+      });
+
+      if (this.order !== 0) {
+        this.tiles.reverse();
+      }
+    };
+
+    function buildGridModel() {
+      var tiles = [{val: 1},{ val:4},{ val:3},{ val:7},{ val:5},{ val:2},{ val:6}];
 
       return tiles;
     }

--- a/src/components/gridList/demoRearrangingTiles/script.js
+++ b/src/components/gridList/demoRearrangingTiles/script.js
@@ -1,0 +1,35 @@
+
+angular
+  .module('gridListDemoApp', ['ngMaterial'])
+  .controller('gridListDemoCtrl', function($scope) {
+
+    this.order = 0;
+
+    this.tiles = buildGridModel();
+    this.sortTiles = sortTiles;
+    this.getTiles = function() {
+      return this.tiles;
+    }.bind(this);
+
+    function sortTiles() {
+      console.log(this.order);
+      this.tiles.sort(function(a, b) {
+        return b.name - a.name;
+      });
+
+      if (this.order != 0) {
+        this.tiles.reverse();
+      }
+
+      console.log(this.tiles);
+    };
+
+    function buildGridModel(){
+      var tiles = [{name: 1},{ name:2},{ name:3},{ name:4},{ name:5},{ name:6},{ name:7}];
+
+      return tiles;
+    }
+  })
+  .config( function( $mdIconProvider ){
+    $mdIconProvider.iconSet("avatar", './icons/avatar-icons.svg', 128);
+  });

--- a/src/components/gridList/demoRearrangingTiles/style.scss
+++ b/src/components/gridList/demoRearrangingTiles/style.scss
@@ -1,0 +1,78 @@
+md-icon {
+    width:50%;height:50%
+}
+
+md-icon svg {
+  -webkit-border-radius: 50%;
+    -moz-border-radius: 50%;
+    border-radius: 50%;
+}
+
+.s64 {
+  font-size:64px;
+}
+
+.s32 {
+  
+  font-size:48px;
+
+}
+
+md-icon.fa {
+  display:block;
+  padding-left: 0;
+}
+
+md-icon.s32 span {
+  padding-left:8px;
+}
+
+md-grid-list {
+  margin: 8px; }
+.gray {
+  background: #f5f5f5; }
+.green {
+  background: #b9f6ca; }
+.yellow {
+  background: #ffff8d; }
+.blue {
+  background: #84ffff; }
+.darkBlue {
+  background: #80d8ff; }
+.deepBlue {
+  background: #448aff; }
+.purple {
+  background: #b388ff; }
+.lightPurple {
+  background: #8c9eff; }
+.red {
+  background: #ff8a80; }
+.pink {
+  background: #ff80ab; }
+
+
+md-grid-tile {
+  transition: all 300ms ease-out 50ms;
+}
+
+
+md-grid-tile md-icon {
+  padding-bottom: 32px;
+}
+
+md-grid-tile md-grid-tile-footer {
+  background:  rgba(0,0,0,.68);
+  height: 36px;
+  
+}
+
+md-grid-tile-footer figcaption  {
+  width:100%;
+}
+
+md-grid-tile-footer figcaption h3 {
+  margin: 0;
+  font-weight:700;
+  width:100%;
+  text-align:center;
+}


### PR DESCRIPTION
when I tried sorting an array bound to md-grid-list ngRepeat we found that items that didn't change place were displayed incorrectly - this here fixes it (created a demo to prove it - before fix the 4th item would be displayed on 2nd from beginning or end of the md-grid-list after sorting the underlying array)