### PR TITLE
style(): fix some style inconsistencies and indentation

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -13,7 +13,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
       templateUrl: 'partials/home.tmpl.html'
     })
     .when('/layout/:tmpl', {
-      templateUrl: function(params){
+      templateUrl: function(params) {
         return 'partials/layout-' + params.tmpl + '.tmpl.html';
       }
     })
@@ -289,9 +289,9 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope) {
     sections.forEach(function(section) {
       if(section.children) {
         // matches nested section toggles, such as API or Customization
-        section.children.forEach(function(childSection){
-          if(childSection.pages){
-            childSection.pages.forEach(function(page){
+        section.children.forEach(function(childSection) {
+          if(childSection.pages) {
+            childSection.pages.forEach(function(page) {
               matchPage(childSection, page);
             });
           }
@@ -428,7 +428,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
     // prevent skip link from redirecting
     if ($event) { $event.preventDefault(); }
 
-    $timeout(function(){
+    $timeout(function() {
       mainContentArea.focus();
     },90);
 
@@ -441,12 +441,12 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   function isSectionSelected(section) {
     var selected = false;
     var openedSection = menu.openedSection;
-    if(openedSection === section){
+    if(openedSection === section) {
       selected = true;
     }
     else if(section.children) {
       section.children.forEach(function(childSection) {
-        if(childSection === openedSection){
+        if(childSection === openedSection) {
           selected = true;
         }
       });
@@ -479,7 +479,7 @@ function($scope, $rootScope, $http) {
   var versionFile = "version.json" + "?ts=" + now;
 
   $http.get("version.json")
-    .then(function(response){
+    .then(function(response) {
       var sha = response.data.sha || "";
       var url = response.data.url;
 

--- a/docs/config/processors/buildConfig.js
+++ b/docs/config/processors/buildConfig.js
@@ -18,7 +18,7 @@ module.exports = function buildConfigProcessor(log) {
     });
 
     return q.all([ getSHA(), getCommitDate() ])
-            .then( function(){
+            .then(function() {
               return docs;
           });
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -223,7 +223,7 @@ gulp.task('build-all-modules', function() {
 });
 
 function buildModule(module, isRelease) {
-  if ( module.indexOf(".") < 0) {
+  if (module.indexOf(".") < 0) {
     module = "material.components." + module;
   }
 
@@ -240,7 +240,6 @@ function buildModule(module, isRelease) {
     .pipe(insert.prepend(config.banner))
     .pipe(gulpif(isRelease, buildMin()))
     .pipe(gulp.dest(BUILD_MODE.outputDir + name));
-
 
   function buildMin() {
     return lazypipe()
@@ -261,33 +260,32 @@ function buildModule(module, isRelease) {
       ();
   }
 
-function buildModuleJs(name) {
-  return lazypipe()
-    .pipe(plumber)
-    .pipe(ngAnnotate)
-    .pipe(concat, name + '.js')
-    ();
-}
+  function buildModuleJs(name) {
+    return lazypipe()
+      .pipe(plumber)
+      .pipe(ngAnnotate)
+      .pipe(concat, name + '.js')
+      ();
+  }
 
-function buildModuleStyles(name) {
-  var files = [];
-  config.themeBaseFiles.forEach(function(fileGlob) {
-    files = files.concat(glob(fileGlob, { cwd: __dirname }));
-  });
-  var baseStyles = files.map(function(fileName) {
-    return fs.readFileSync(fileName, 'utf8').toString();
-  }).join('\n');
+  function buildModuleStyles(name) {
+    var files = [];
+    config.themeBaseFiles.forEach(function(fileGlob) {
+      files = files.concat(glob(fileGlob, { cwd: __dirname }));
+    });
+    var baseStyles = files.map(function(fileName) {
+      return fs.readFileSync(fileName, 'utf8').toString();
+    }).join('\n');
 
-  return lazypipe()
-    .pipe(insert.prepend, baseStyles)
-    .pipe(gulpif, /theme.scss/,
-      rename(name + '-default-theme.scss'), concat(name + '.scss')
-    )
-    .pipe(sass)
-    .pipe(autoprefix)
-    (); // invoke the returning fn to create our pipe
-}
-
+    return lazypipe()
+      .pipe(insert.prepend, baseStyles)
+      .pipe(gulpif, /theme.scss/,
+        rename(name + '-default-theme.scss'), concat(name + '.scss')
+      )
+      .pipe(sass)
+      .pipe(autoprefix)
+      (); // invoke the returning fn to create our pipe
+  }
 }
 
 /** *****************************************
@@ -319,7 +317,7 @@ gulp.task('watch-demo', ['build-demo'], function() {
   return gulp.watch('src/**/*', ['build-demo']);
 });
 
-gulp.task('site', function () {
+gulp.task('site', function() {
   return gulp.src('dist/docs')
       .pipe(webserver({
         host: '0.0.0.0',
@@ -442,7 +440,6 @@ gulp.task('build-module-demo', function() {
     );
     next();
   }));
-
 });
 
 
@@ -492,10 +489,10 @@ gulp.task('build-scss', function() {
     );
   }
   return series(streams);
-  function getPaths () {
+  function getPaths() {
     var paths = config.scssBaseFiles.slice();
     if (modules) {
-      paths.push.apply(paths, modules.split(',').map(function (module) {
+      paths.push.apply(paths, modules.split(',').map(function(module) {
         return 'src/components/' + module + '/*.scss';
       }));
     } else {

--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -22,9 +22,9 @@ exports.humanizeCamelCase = function(str) {
  */
 exports.copyDemoAssets = function(component, srcDir, distDir) {
   gulp.src(srcDir + component + '/demo*/')
-      .pipe(through2.obj( copyAssetsFor ));
+      .pipe(through2.obj(copyAssetsFor));
 
-  function copyAssetsFor( demo, enc, next){
+  function copyAssetsFor(demo, enc, next) {
     var demoID = component + "/" + path.basename(demo.path);
     var demoDir = demo.path + "/**/*";
 

--- a/src/components/autocomplete/demoBasicUsage/script.js
+++ b/src/components/autocomplete/demoBasicUsage/script.js
@@ -4,7 +4,7 @@
       .module('autocompleteDemo', ['ngMaterial'])
       .controller('DemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($timeout, $q, $log) {
+  function DemoCtrl($timeout, $q, $log) {
     var self = this;
 
     self.simulateQuery = false;
@@ -24,7 +24,7 @@
      * Search for states... use $timeout to simulate
      * remote dataservice call.
      */
-    function querySearch (query) {
+    function querySearch(query) {
       var results = query ? self.states.filter( createFilterFor(query) ) : self.states,
           deferred;
       if (self.simulateQuery) {

--- a/src/components/autocomplete/demoFloatingLabel/script.js
+++ b/src/components/autocomplete/demoFloatingLabel/script.js
@@ -4,7 +4,7 @@
       .module('autocompleteFloatingLabelDemo', ['ngMaterial'])
       .controller('DemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($timeout, $q) {
+  function DemoCtrl($timeout, $q) {
     var self = this;
 
     // list of `state` value/display objects
@@ -21,7 +21,7 @@
      * Search for states... use $timeout to simulate
      * remote dataservice call.
      */
-    function querySearch (query) {
+    function querySearch(query) {
       var results = query ? self.states.filter( createFilterFor(query) ) : [];
       return results;
     }

--- a/src/components/bottomSheet/demoBasicUsage/script.js
+++ b/src/components/bottomSheet/demoBasicUsage/script.js
@@ -44,7 +44,7 @@ angular.module('bottomSheetDemo1', ['ngMaterial'])
     { name: 'Share', icon: 'share-arrow' },
     { name: 'Upload', icon: 'upload' },
     { name: 'Copy', icon: 'copy' },
-    { name: 'Print this page', icon: 'print' },
+    { name: 'Print this page', icon: 'print' }
   ];
 
   $scope.listItemClick = function($index) {
@@ -59,7 +59,7 @@ angular.module('bottomSheetDemo1', ['ngMaterial'])
     { name: 'Message', icon: 'message' },
     { name: 'Copy', icon: 'copy2' },
     { name: 'Facebook', icon: 'facebook' },
-    { name: 'Twitter', icon: 'twitter' },
+    { name: 'Twitter', icon: 'twitter' }
   ];
 
   $scope.listItemClick = function($index) {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -96,7 +96,7 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria, $timeout) {
     }
 
     // disabling click event when disabled is true
-    element.on('click', function(e){
+    element.on('click', function(e) {
       if (attr.disabled === true) {
         e.preventDefault();
         e.stopImmediatePropagation();
@@ -107,7 +107,7 @@ function MdButtonDirective($mdInkRipple, $mdTheming, $mdAria, $timeout) {
     scope.mouseActive = false;
     element.on('mousedown', function() {
         scope.mouseActive = true;
-        $timeout(function(){
+        $timeout(function() {
           scope.mouseActive = false;
         }, 100);
       })

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -34,14 +34,14 @@ describe('md-button', function() {
     expect(button.hasClass('md-button')).toBe(true);
   }));
 
-  it('should not set focus state on mousedown', inject(function ($compile, $rootScope){
+  it('should not set focus state on mousedown', inject(function ($compile, $rootScope) {
     var button = $compile('<md-button>')($rootScope.$new());
     $rootScope.$apply();
     button.triggerHandler('mousedown');
     expect(button[0]).not.toHaveClass('md-focused');
   }));
 
-  it('should set focus state on focus and remove on blur', inject(function ($compile, $rootScope){
+  it('should set focus state on focus and remove on blur', inject(function ($compile, $rootScope) {
     var button = $compile('<md-button>')($rootScope.$new());
     $rootScope.$apply();
     button.triggerHandler('focus');
@@ -102,7 +102,7 @@ describe('md-button', function() {
       $rootScope.$apply();
       expect(button.attr('tabindex')).toBe("-1");
 
-      $rootScope.$apply(function(){
+      $rootScope.$apply(function() {
         scope.isDisabled = false;
       });
       expect(button.attr('tabindex')).toBe("0");
@@ -119,7 +119,7 @@ describe('md-button', function() {
 
     it('should not trigger click on button when disabled', inject(function ($compile, $rootScope) {
       var clicked = false;
-      var onClick = function(){ clicked = true;};
+      var onClick = function() { clicked = true;};
       var scope   = angular.extend( $rootScope.$new(), { isDisabled : true, onClick : onClick} );
 
       var element = $compile('<md-button ng-disabled="isDisabled" ng-click="onClick()">button</md-button>')(scope);
@@ -131,7 +131,7 @@ describe('md-button', function() {
 
     it('should not trigger click on anchor when disabled', inject(function ($compile, $rootScope) {
       var clicked = false;
-      var onClick = function(){ clicked = true;};
+      var onClick = function() { clicked = true;};
       var scope   = angular.extend( $rootScope.$new(), { isDisabled : true, onClick : onClick} );
 
       var element = $compile('<md-button ng-disabled="isDisabled" ng-href="#" ng-click="onClick()">button</md-button>')(scope);

--- a/src/components/button/demoBasicUsage/script.js
+++ b/src/components/button/demoBasicUsage/script.js
@@ -1,4 +1,3 @@
-
 angular.module('buttonsDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope) {
@@ -7,5 +6,4 @@ angular.module('buttonsDemo1', ['ngMaterial'])
   $scope.isDisabled = true;
 
   $scope.googleUrl = 'http://google.com';
-
 });

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -66,7 +66,7 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
   // Private Methods
   // **********************************************************
 
-  function compile (tElement, tAttrs) {
+  function compile(tElement, tAttrs) {
 
     tAttrs.type = 'checkbox';
     tAttrs.tabindex = tAttrs.tabindex || '0';
@@ -101,7 +101,7 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
         .on('keypress', keypressHandler)
         .on('mousedown', function() {
           scope.mouseActive = true;
-          $timeout(function(){
+          $timeout(function() {
             scope.mouseActive = false;
           }, 100);
         })
@@ -143,7 +143,7 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
       }
 
       function render() {
-        if(ngModelCtrl.$viewValue) {
+        if (ngModelCtrl.$viewValue) {
           element.addClass(CHECKED_CSS);
         } else {
           element.removeClass(CHECKED_CSS);

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -5,7 +5,7 @@ describe('mdCheckbox', function() {
   beforeEach(module('material.components.checkbox'));
   beforeEach(module('ngAria'));
 
-  it('should warn developers they need a label', inject(function($compile, $rootScope, $log){
+  it('should warn developers they need a label', inject(function($compile, $rootScope, $log) {
     spyOn($log, "warn");
 
     var element = $compile('<div>' +
@@ -16,7 +16,7 @@ describe('mdCheckbox', function() {
     expect($log.warn).toHaveBeenCalled();
   }));
 
-  it('should copy text content to aria-label', inject(function($compile, $rootScope){
+  it('should copy text content to aria-label', inject(function($compile, $rootScope) {
     var element = $compile('<div>' +
                              '<md-checkbox ng-model="blue">' +
                              'Some text' +
@@ -35,7 +35,7 @@ describe('mdCheckbox', function() {
                              '</md-checkbox>' +
                            '</div>')($rootScope);
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.blue = false;
       $rootScope.green = true;
     });

--- a/src/components/checkbox/demoSyncing/script.js
+++ b/src/components/checkbox/demoSyncing/script.js
@@ -1,18 +1,16 @@
-
 angular.module('checkboxDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope) {
+  $scope.items = [1,2,3,4,5];
+  $scope.selected = [];
 
-    $scope.items = [1,2,3,4,5];
-      $scope.selected = [];
+  $scope.toggle = function(item, list) {
+    var idx = list.indexOf(item);
+    if (idx > -1) list.splice(idx, 1);
+    else list.push(item);
+  };
 
-      $scope.toggle = function (item, list) {
-        var idx = list.indexOf(item);
-        if (idx > -1) list.splice(idx, 1);
-        else list.push(item);
-      };
-
-      $scope.exists = function (item, list) {
-        return list.indexOf(item) > -1;
-      };
+  $scope.exists = function(item, list) {
+    return list.indexOf(item) > -1;
+  };
 });

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -75,7 +75,7 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *
  * ### JavaScript: object syntax
  * <hljs lang="js">
- * (function(angular, undefined){
+ * (function(angular, undefined) {
  *   "use strict";
  *
  *   angular
@@ -141,7 +141,7 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *
  * ### JavaScript: promise API syntax, custom dialog template
  * <hljs lang="js">
- * (function(angular, undefined){
+ * (function(angular, undefined) {
  *   "use strict";
  *
  *   angular
@@ -546,7 +546,7 @@ function MdDialogProvider($$interimElementProvider) {
       });
 
       var dialogContent = element.find('md-dialog-content');
-      if (dialogContent.length === 0){
+      if (dialogContent.length === 0) {
         dialogContent = element;
       }
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -502,7 +502,7 @@ describe('$mdDialog', function() {
       expect(dialog.attr('aria-label')).toEqual(dialog.text());
     }));
 
-    it('should not modify an existing ARIA label', inject(function($mdDialog, $rootScope){
+    it('should not modify an existing ARIA label', inject(function($mdDialog, $rootScope) {
       var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
       var parent = angular.element('<div>');
 
@@ -518,7 +518,7 @@ describe('$mdDialog', function() {
       expect(dialog.attr('aria-label')).toEqual('Some Other Thing');
     }));
 
-    it('should add an ARIA label if supplied through chaining', inject(function($mdDialog, $rootScope, $animate){
+    it('should add an ARIA label if supplied through chaining', inject(function($mdDialog, $rootScope, $animate) {
       var parent = angular.element('<div>');
 
       $mdDialog.show(

--- a/src/components/gridList/demoDynamicTiles/script.js
+++ b/src/components/gridList/demoDynamicTiles/script.js
@@ -9,7 +9,7 @@ angular
             background: ""
           });
 
-    function buildGridModel(tileTmpl){
+    function buildGridModel(tileTmpl) {
       var it, results = [ ];
 
       for (var j=0; j<11; j++) {
@@ -50,6 +50,6 @@ angular
       return results;
     }
   })
-  .config( function( $mdIconProvider ){
+  .config(function($mdIconProvider) {
     $mdIconProvider.iconSet("avatar", './icons/avatar-icons.svg', 128);
   });

--- a/src/components/icon/demoFontIcons/script.js
+++ b/src/components/icon/demoFontIcons/script.js
@@ -2,30 +2,27 @@
 angular
   .module('appDemoFontIcons', ['ngMaterial'])
   .controller('DemoCtrl', function( $scope ) {
-      // Create list of font-icon names with color overrides
-      var iconData = [
-            {name: 'icon-home'        , color: "#777" },
-            {name: 'icon-user-plus'   , color: "rgb(89, 226, 168)" },
-            {name: 'icon-google-plus2', color: "#A00" },
-            {name: 'icon-youtube4'    , color:"#00A" },
-             // Use theming to color the font-icon
-            {name: 'icon-settings'    , color:"#A00", theme:"md-warn md-hue-5"}
-          ];
+    // Create list of font-icon names with color overrides
+    var iconData = [
+          {name: 'icon-home'        , color: "#777" },
+          {name: 'icon-user-plus'   , color: "rgb(89, 226, 168)" },
+          {name: 'icon-google-plus2', color: "#A00" },
+          {name: 'icon-youtube4'    , color:"#00A" },
+           // Use theming to color the font-icon
+          {name: 'icon-settings'    , color:"#A00", theme:"md-warn md-hue-5"}
+        ];
 
-      // Create a set of sizes...
-      $scope.sizes = [
-        {size:12,padding:0},
-        {size:21,padding:2},
-        {size:36,padding:6},
-        {size:48,padding:10}
-      ];
+    // Create a set of sizes...
+    $scope.sizes = [
+      {size:12,padding:0},
+      {size:21,padding:2},
+      {size:36,padding:6},
+      {size:48,padding:10}
+    ];
 
-      $scope.fonts = [].concat(iconData);
-
-
-
+    $scope.fonts = [].concat(iconData);
   })
-  .config(function($mdThemingProvider){
+  .config(function($mdThemingProvider) {
     // Update the theme colors to use themes on font-icons
     $mdThemingProvider.theme('default')
           .primaryPalette("red")

--- a/src/components/icon/iconDirective.spec.js
+++ b/src/components/icon/iconDirective.spec.js
@@ -21,7 +21,7 @@ describe('mdIcon directive', function() {
 
     deferred.resolve(getIcon(id));
     return deferred.promise;
-  }
+  };
 
   function make(html) {
     var el;
@@ -35,7 +35,7 @@ describe('mdIcon directive', function() {
       $provide.value('$mdIcon', mockIconSvc);
     });
 
-    inject(function($rootScope, _$compile_, _$q_){
+    inject(function($rootScope, _$compile_, _$q_) {
       $scope = $rootScope;
       $compile = _$compile_;
       $q = _$q_;
@@ -46,7 +46,7 @@ describe('mdIcon directive', function() {
   describe('using md-font-icon=""', function() {
 
     it('should render correct HTML with md-font-icon value as class', function() {
-      el = make( '<md-icon md-font-icon="android"></md-icon>');
+      el = make('<md-icon md-font-icon="android"></md-icon>');
       expect(el.html()).toEqual('<span class="md-font android" ng-class="fontIcon"></span>');
     });
 

--- a/src/components/icon/iconService.js
+++ b/src/components/icon/iconService.js
@@ -40,7 +40,7 @@
     *     $mdIconProvider.defaultIconSet('my/app/icons.svg')
     *
     *   })
-    *   .run(function($http, $templateCache){
+    *   .run(function($http, $templateCache) {
     *
     *     // Pre-fetch icons sources by URL and cache in the $templateCache...
     *     // subsequent $http calls will look there first.
@@ -239,7 +239,7 @@
        }
      ];
 
-     svgRegistry.forEach(function(asset){
+     svgRegistry.forEach(function(asset) {
        iconProvider.icon(asset.id,  asset.url);
        $templateCache.put(asset.url, asset.svg);
      });
@@ -327,7 +327,7 @@
    /**
     * Prepare and cache the loaded icon for the specified `id`
     */
-   function cacheIcon( id ) {
+   function cacheIcon(id) {
 
      return function updateCache( icon ) {
        iconCache[id] = isIcon(icon) ? icon : new Icon(icon, config[id]);
@@ -455,7 +455,7 @@
    /**
     * Clone the Icon DOM element.
     */
-   function cloneSVG(){
+   function cloneSVG() {
      return this.element.cloneNode(true);
    }
 

--- a/src/components/icon/iconService.spec.js
+++ b/src/components/icon/iconService.spec.js
@@ -5,7 +5,7 @@ describe('mdIcon service', function() {
   var $scope;
 
   beforeEach(module('material.core'));
-  beforeEach(module('material.components.icon',function($mdIconProvider){
+  beforeEach(module('material.components.icon', function($mdIconProvider) {
     $mdIconProvider
       .icon('android',   'android.svg')
       .icon('c2',        'c2.svg')
@@ -14,7 +14,7 @@ describe('mdIcon service', function() {
       .defaultIconSet('core.svg');
   }));
 
-  beforeEach(inject(function($templateCache, _$httpBackend_, _$mdIcon_, $rootScope){
+  beforeEach(inject(function($templateCache, _$httpBackend_, _$mdIcon_, $rootScope) {
     $mdIcon = _$mdIcon_;
     $httpBackend = _$httpBackend_;
     $scope = $rootScope;
@@ -33,7 +33,7 @@ describe('mdIcon service', function() {
       var expected = updateDefaults('<svg><g id="android"></g></svg>');
       $mdIcon('android').then(function(el) {
         expect(el.outerHTML).toEqual(expected);
-      })
+      });
       $scope.$digest();
     });
 
@@ -41,7 +41,7 @@ describe('mdIcon service', function() {
       var expected = updateDefaults('<svg xmlns="http://www.w3.org/2000/svg"><g id="s1"></g></g></svg>');
       $mdIcon('social:s1').then(function(el) {
         expect(el.outerHTML).toEqual(expected);
-      })
+      });
       $scope.$digest();
     });
 
@@ -49,14 +49,14 @@ describe('mdIcon service', function() {
       var expected = updateDefaults('<svg xmlns="http://www.w3.org/2000/svg"><g id="c1"></g></g></svg>');
       $mdIcon('c1').then(function(el) {
         expect(el.outerHTML).toEqual(expected);
-      })
+      });
       $scope.$digest();
     });
 
     it('should allow single icon defs to override those defined in groups', function() {
       $mdIcon('c2').then(function(el) {
         expect(el.querySelector('g').classList.contains('override')).toBe(true);
-      })
+      });
       $scope.$digest();
     });
 
@@ -67,7 +67,7 @@ describe('mdIcon service', function() {
     it('should return correct SVG markup', function() {
       $mdIcon('android.svg').then(function(el) {
         expect(el.outerHTML).toEqual( updateDefaults('<svg><g id="android"></g></svg>') );
-      })
+      });
       $scope.$digest();
     });
 
@@ -78,7 +78,7 @@ describe('mdIcon service', function() {
       var msg;
       try {
         $mdIcon('notconfigured')
-          .catch(function(error){
+          .catch(function(error) {
             msg = error;
           });
 
@@ -94,7 +94,7 @@ describe('mdIcon service', function() {
       var msg;
       try {
         $mdIcon('notfound:someIcon')
-          .catch(function(error){
+          .catch(function(error) {
             msg = error;
           });
 

--- a/src/components/input/demoBasicUsage/script.js
+++ b/src/components/input/demoBasicUsage/script.js
@@ -14,7 +14,7 @@ angular
       postalCode : '94043'
     };
   })
-  .config( function($mdThemingProvider){
+  .config(function($mdThemingProvider) {
 
     // Configure a dark theme with primary foreground yellow
 

--- a/src/components/list/demoBasicUsage/script.js
+++ b/src/components/list/demoBasicUsage/script.js
@@ -1,47 +1,46 @@
-
 angular.module('listDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope) {
-    $scope.phones = [
-      { type: 'Home', number: '(555) 251-1234' },
-      { type: 'Cell', number: '(555) 786-9841' },
-    ];
-    $scope.todos = [
-      {
-        face : '/img/list/60.jpeg',
-        what: 'Brunch this weekend?',
-        who: 'Min Li Chan',
-        when: '3:08PM',
-        notes: " I'll be in your neighborhood doing errands"
-      },
-      {
-        face : '/img/list/60.jpeg',
-        what: 'Brunch this weekend?',
-        who: 'Min Li Chan',
-        when: '3:08PM',
-        notes: " I'll be in your neighborhood doing errands"
-      },
-      {
-        face : '/img/list/60.jpeg',
-        what: 'Brunch this weekend?',
-        who: 'Min Li Chan',
-        when: '3:08PM',
-        notes: " I'll be in your neighborhood doing errands"
-      },
-      {
-        face : '/img/list/60.jpeg',
-        what: 'Brunch this weekend?',
-        who: 'Min Li Chan',
-        when: '3:08PM',
-        notes: " I'll be in your neighborhood doing errands"
-      },
-      {
-        face : '/img/list/60.jpeg',
-        what: 'Brunch this weekend?',
-        who: 'Min Li Chan',
-        when: '3:08PM',
-        notes: " I'll be in your neighborhood doing errands"
-      },
-    ];
+  $scope.phones = [
+    { type: 'Home', number: '(555) 251-1234' },
+    { type: 'Cell', number: '(555) 786-9841' }
+  ];
+  $scope.todos = [
+    {
+      face : '/img/list/60.jpeg',
+      what: 'Brunch this weekend?',
+      who: 'Min Li Chan',
+      when: '3:08PM',
+      notes: " I'll be in your neighborhood doing errands"
+    },
+    {
+      face : '/img/list/60.jpeg',
+      what: 'Brunch this weekend?',
+      who: 'Min Li Chan',
+      when: '3:08PM',
+      notes: " I'll be in your neighborhood doing errands"
+    },
+    {
+      face : '/img/list/60.jpeg',
+      what: 'Brunch this weekend?',
+      who: 'Min Li Chan',
+      when: '3:08PM',
+      notes: " I'll be in your neighborhood doing errands"
+    },
+    {
+      face : '/img/list/60.jpeg',
+      what: 'Brunch this weekend?',
+      who: 'Min Li Chan',
+      when: '3:08PM',
+      notes: " I'll be in your neighborhood doing errands"
+    },
+    {
+      face : '/img/list/60.jpeg',
+      what: 'Brunch this weekend?',
+      who: 'Min Li Chan',
+      when: '3:08PM',
+      notes: " I'll be in your neighborhood doing errands"
+    }
+  ];
 });
 

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -169,7 +169,7 @@ function mdListItemDirective($mdAria, $mdConstant, $timeout) {
             $scope.mouseActive = false;
             proxy.on('mousedown', function() {
               $scope.mouseActive = true;
-              $timeout(function(){
+              $timeout(function() {
                 $scope.mouseActive = false;
               }, 100);
             })

--- a/src/components/progressLinear/progressLinear.js
+++ b/src/components/progressLinear/progressLinear.js
@@ -101,13 +101,13 @@ function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
 // **********************************************************
 var transforms = (function() {
   var values = new Array(101);
-  for(var i = 0; i < 101; i++){
+  for(var i = 0; i < 101; i++) {
     values[i] = makeTransform(i);
   }
 
   return values;
 
-  function makeTransform(value){
+  function makeTransform(value) {
     var scale = value/100;
     var translateX = (value-100)/2;
     return 'translateX(' + translateX.toString() + '%) scale(' + scale.toString() + ', 1)';

--- a/src/components/radioButton/radioButton.js
+++ b/src/components/radioButton/radioButton.js
@@ -276,7 +276,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
     /**
      * Inject ARIA-specific attributes appropriate for each radio button
      */
-    function configureAria( element, scope ){
+    function configureAria(element, scope) {
       scope.ariaId = buildAriaID();
 
       element.attr({

--- a/src/components/radioButton/radioButton.spec.js
+++ b/src/components/radioButton/radioButton.spec.js
@@ -9,7 +9,7 @@ describe('radioButton', function() {
                             '<md-radio-button value="green"></md-radio-button>' +
                           '</md-radio-group>')($rootScope);
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.color = 'green';
     });
 
@@ -25,7 +25,7 @@ describe('radioButton', function() {
                             '<md-radio-button value="2"></md-radio-button>' +
                           '</md-radio-group>')($rootScope);
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.value = 1;
     });
 
@@ -51,7 +51,7 @@ describe('radioButton', function() {
                             '<md-radio-button value="green"></md-radio-button>' +
                           '</md-radio-group>')($rootScope);
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.color = 'green';
     });
 
@@ -64,7 +64,7 @@ describe('radioButton', function() {
     expect(element.attr('aria-activedescendant')).not.toEqual(rbElements.eq(0).attr('id'));
   }));
 
-  it('should warn developers they need a label', inject(function($compile, $rootScope, $log){
+  it('should warn developers they need a label', inject(function($compile, $rootScope, $log) {
     spyOn($log, "warn");
     var element = $compile('<md-radio-group ng-model="color">' +
                             '<md-radio-button value="blue"></md-radio-button>' +
@@ -99,7 +99,7 @@ describe('radioButton', function() {
                             '<md-radio-button value="blue"></md-radio-button>' +
                             '<md-radio-button value="green"></md-radio-button>' +
                           '</md-radio-group>')($rootScope);
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.color = 'blue';
     });
 
@@ -154,8 +154,8 @@ describe('radioButton', function() {
       var el;
       expect(function() {
         el = $compile('<md-radio-group>' +
-                              '<md-radio-button value="white">' +
-                              '</md-radio-group>')($rootScope);
+                      '<md-radio-button value="white">' +
+                      '</md-radio-group>')($rootScope);
       }).not.toThrow();
       var rbElements = el.find('md-radio-button');
 
@@ -192,7 +192,7 @@ describe('radioButton', function() {
     it('should trigger a submit', inject(function($compile, $rootScope, $mdConstant) {
 
       $rootScope.testValue = false;
-      $rootScope.submitFn = function(){
+      $rootScope.submitFn = function() {
         $rootScope.testValue = true;
       };
       var element = $compile('<div><form ng-submit="submitFn()">' +

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -917,7 +917,7 @@ function SelectProvider($$interimElementProvider) {
       } else if (optgroupNodes.length) {
         centeredNode = optgroupNodes[0];
       // Otherwise, center around the first optionNode
-      } else if (optionNodes.length){
+      } else if (optionNodes.length) {
         centeredNode = optionNodes[0];
       // In case there are no options, center on whatever's in there... (eg progress indicator)
       } else {

--- a/src/components/sidenav/demoBasicUsage/script.js
+++ b/src/components/sidenav/demoBasicUsage/script.js
@@ -1,6 +1,6 @@
 angular
   .module('sidenavDemo1', ['ngMaterial'])
-  .controller('AppCtrl', function ($scope, $timeout, $mdSidenav, $mdUtil, $log) {
+  .controller('AppCtrl', function($scope, $timeout, $mdSidenav, $mdUtil, $log) {
 
     $scope.toggleLeft = buildToggler('left');
     $scope.toggleRight = buildToggler('right');
@@ -10,7 +10,7 @@ angular
      * report completion in console
      */
     function buildToggler(navID) {
-      var debounceFn =  $mdUtil.debounce(function(){
+      var debounceFn = $mdUtil.debounce(function() {
             $mdSidenav(navID)
               .toggle()
               .then(function () {
@@ -22,8 +22,8 @@ angular
     }
 
   })
-  .controller('LeftCtrl', function ($scope, $timeout, $mdSidenav, $log) {
-    $scope.close = function () {
+  .controller('LeftCtrl', function($scope, $timeout, $mdSidenav, $log) {
+    $scope.close = function() {
       $mdSidenav('left').close()
         .then(function () {
           $log.debug("close LEFT is done");
@@ -31,8 +31,8 @@ angular
 
     };
   })
-  .controller('RightCtrl', function ($scope, $timeout, $mdSidenav, $log) {
-    $scope.close = function () {
+  .controller('RightCtrl', function($scope, $timeout, $mdSidenav, $log) {
+    $scope.close = function() {
       $mdSidenav('right').close()
         .then(function () {
           $log.debug("close RIGHT is done");

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -35,19 +35,19 @@ angular.module('material.components.sidenav', [
  * // when instance is known ready and lazy lookup is not needed.
  * $mdSidenav(componentId)
  *    .toggle()
- *    .then(function(){
+ *    .then(function() {
  *      $log.debug('toggled');
  *    });
  * // Async open the given sidenav
  * $mdSidenav(componentId)
  *    .open()
- *    .then(function(){
+ *    .then(function() {
  *      $log.debug('opened');
  *    });
  * // Async close the given sidenav
  * $mdSidenav(componentId)
  *    .close()
- *    .then(function(){
+ *    .then(function() {
  *      $log.debug('closed');
  *    });
  * // Sync check to see if the specified sidenav is set to be open
@@ -103,7 +103,7 @@ function SidenavService($mdComponentRegistry, $q) {
     function waitForInstance() {
       return $mdComponentRegistry
                 .when(handle)
-                .then(function( it ){
+                .then(function( it ) {
                   instance = it;
                   return it;
                 });

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -139,7 +139,7 @@ describe('md-slider', function() {
     expect($log.warn).not.toHaveBeenCalled();
   }));
 
-  it('should add aria attributes', inject(function($compile, $rootScope, $timeout, $mdConstant){
+  it('should add aria attributes', inject(function($compile, $rootScope, $timeout, $mdConstant) {
     var slider = setup('min="100" max="104" step="2" ng-model="model"');
 
     $rootScope.$apply('model = 102');

--- a/src/components/switch/switch.spec.js
+++ b/src/components/switch/switch.spec.js
@@ -11,7 +11,7 @@ describe('<md-switch>', function() {
                              '</md-switch>' +
                            '</div>')($rootScope);
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.blue = false;
       $rootScope.green = true;
     });
@@ -24,7 +24,7 @@ describe('<md-switch>', function() {
     expect(switches.eq(1).attr('aria-checked')).toEqual('true');
     expect(switches.eq(0).attr('role')).toEqual('checkbox');
 
-    $rootScope.$apply(function(){
+    $rootScope.$apply(function() {
       $rootScope.blue = true;
       $rootScope.green = false;
     });

--- a/src/components/tabs/demoDynamicTabs/script.js
+++ b/src/components/tabs/demoDynamicTabs/script.js
@@ -21,7 +21,7 @@
         previous = null;
     $scope.tabs = tabs;
     $scope.selectedIndex = 2;
-    $scope.$watch('selectedIndex', function(current, old){
+    $scope.$watch('selectedIndex', function(current, old) {
       previous = selected;
       selected = tabs[current];
       if ( old && (old != current)) $log.debug('Goodbye ' + previous.title + '!');

--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -67,10 +67,10 @@ function AriaService($$rAF, $log, $window) {
 
     if(hasChildren) {
       var children = node.childNodes;
-      for(var i=0; i<children.length; i++){
+      for(var i=0; i<children.length; i++) {
         var child = children[i];
         if(child.nodeType === 1 && child.hasAttribute(attrName)) {
-          if(!isHidden(child)){
+          if(!isHidden(child)) {
             hasAttr = true;
           }
         }

--- a/src/core/services/aria/aria.spec.js
+++ b/src/core/services/aria/aria.spec.js
@@ -1,7 +1,7 @@
 describe('$mdAria service', function() {
   beforeEach(module('material.core'));
 
-  describe('expecting attributes', function(){
+  describe('expecting attributes', function() {
     it('should warn if element is missing attribute', inject(function($compile, $rootScope, $log, $mdAria) {
       spyOn($log, 'warn');
       var button = $compile('<button><md-icon></md-icon></button>')($rootScope);

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -381,7 +381,7 @@ function InterimElementProvider() {
               if (options.themable) $mdTheming(element);
               var ret = options.onShow(options.scope, element, options);
               return $q.when(ret)
-                .then(function(){
+                .then(function() {
                   // Issue onComplete callback when the `show()` finishes
                   (options.onComplete || angular.noop)(options.scope, element, options);
                   startHideTimeout();

--- a/src/core/services/registry/componentRegistry.js
+++ b/src/core/services/registry/componentRegistry.js
@@ -115,7 +115,7 @@
 
     };
 
-    function isValidID(handle){
+    function isValidID(handle) {
       return handle && (handle !== "");
     }
 

--- a/src/core/services/registry/componentRegistry.spec.js
+++ b/src/core/services/registry/componentRegistry.spec.js
@@ -66,7 +66,7 @@ describe('$mdComponentRegistry Service', function() {
       var instance = $mdComponentRegistry.get('left');
       var resolved = false;
 
-      promise.then(function(inst){   resolved = inst;  });
+      promise.then(function(inst) { resolved = inst; });
       $timeout.flush();
 
       expect(instance).toBe(resolved);
@@ -78,14 +78,14 @@ describe('$mdComponentRegistry Service', function() {
       var promise = $mdComponentRegistry.when('left');
       var el = setup('md-component-id="left"');
 
-      promise.then(function(inst){ count += 1; });
+      promise.then(function(inst) { count += 1; });
       $timeout.flush();
 
       el.triggerHandler('$destroy');
 
       el = setup('md-component-id="left"');
       promise = $mdComponentRegistry.when('left');
-      promise.then(function(inst){
+      promise.then(function(inst) {
         resolved = inst;
         count += 1;
       });
@@ -102,7 +102,7 @@ describe('$mdComponentRegistry Service', function() {
   describe('component ids', function() {
     var $mdComponentRegistry, $timeout;
 
-    beforeEach( inject(function(_$mdComponentRegistry_, _$timeout_) {
+    beforeEach(inject(function(_$mdComponentRegistry_, _$timeout_) {
       $mdComponentRegistry = _$mdComponentRegistry_;
       $timeout = _$timeout_;
     }));
@@ -115,7 +115,7 @@ describe('$mdComponentRegistry Service', function() {
       var promise = $mdComponentRegistry.when('left');
       var instance = $mdComponentRegistry.get('left');
 
-      promise.then(function(inst){ resolved = inst; count += 1; });
+      promise.then(function(inst) { resolved = inst; count += 1; });
       $timeout.flush();
 
       expect(count).toBe(0);

--- a/src/core/util/iterator.js
+++ b/src/core/util/iterator.js
@@ -1,9 +1,9 @@
-(function(){
+(function() {
 
   angular
     .module('material.core')
-    .config( function($provide){
-       $provide.decorator('$mdUtil', ['$delegate', function ($delegate){
+    .config(function($provide) {
+       $provide.decorator('$mdUtil', ['$delegate', function($delegate) {
            /**
             * Inject the iterator facade to easily support iteration and accessors
             * @see iterator below
@@ -150,7 +150,7 @@
      * @param item
      */
     function remove(item) {
-      if ( contains(item) ){
+      if ( contains(item) ) {
         _items.splice(indexOf(item), 1);
       }
     }

--- a/src/core/util/media.js
+++ b/src/core/util/media.js
@@ -1,4 +1,4 @@
-(function(){
+(function() {
 
 angular.module('material.core')
 .factory('$mdMedia', mdMediaFactory);

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -385,7 +385,7 @@ angular.module('material.core')
      */
     extractElementByName: function (element, nodeName) {
       for (var i = 0, len = element.length; i < len; i++) {
-        if (element[i].nodeName.toLowerCase() === nodeName){
+        if (element[i].nodeName.toLowerCase() === nodeName) {
           return angular.element(element[i]);
         }
       }


### PR DESCRIPTION
Partially fix styling and indentation.

Discovered this via documentation https://material.angularjs.org/#/demo/material.components.checkbox : the JS source for the Syncing example is not properly indented and it feels confusing.

Suggestion: go further and apply stricter code styling like `if( foo )` vs `if (foo)`, `function ( foo ){` vs `function(foo) {`, 2 spaces indentation... so it is easier to contribute.