### PR TITLE
chore(): simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,5 @@
 *.log
-*.sw*
-.DS_STORE
-.sass-cache/
-bower_components
+.DS_Store
 node_modules
 dist
-/src/themes/_default-theme.scss
-
 /.idea/
-/components
-/vendor
-/material-font
-
-.polymer-qp


### PR DESCRIPTION
- `.*.sw*` => ?
- .DS_STORE => should be written .DS_Store
- .sass-cache/ => gulp current tasks don't generate a cache directory
- bower_components => obsolete: Bower is not used anymore
- /src/themes/_default-theme.scss => does not exist anymore
- /.idea/ => WebStorm
- /components => some like to rename bower_components or node_components to simply components, not the case here
- /vendor => no vendor directory
- /material-font => no material-font directory, also referenced inside [gulpfile.js](https://github.com/angular/material/blob/v0.9.0-rc2/gulpfile.js#L203)
- .polymer-qp => ?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2566)
<!-- Reviewable:end -->
