### PR TITLE
chore(): fix the banner inside angular-material.*.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -367,12 +367,12 @@ function buildJs(isRelease) {
   )
     .pipe(filterNonCodeFiles())
     .pipe(utils.buildNgMaterialDefinition())
-    .pipe(insert.prepend(config.banner))
     .pipe(plumber())
     .pipe(ngAnnotate());
 
   return series(jsBuildStream, themeBuildStream())
     .pipe(concat('angular-material.js'))
+    .pipe(insert.prepend(config.banner))
     .pipe(gulp.dest(config.outputDir))
     .pipe(gulpif(isRelease, lazypipe()
       .pipe(uglify, { preserveComments: 'some' })


### PR DESCRIPTION
The banner is present multiple times inside `dist/angular-material.js` and `dist/angular-material.min.js`, examples:

- [angular-material.js#L1](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.js#L1)
- [angular-material.js#L8](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.js#L8)
- [angular-material.js#L71](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.js#L71)
- [angular-material.min.js#L1](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.min.js#L1)
- [angular-material.min.js#L10](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.min.js#L10)
- [angular-material.min.js#L16](https://github.com/angular/bower-material/blob/v0.9.0-rc2-master-fdcceb5/angular-material.min.js#L16)
