### PR TITLE
fix(mdUtil): move comment nodes as well when disabling scroll

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -76,7 +76,7 @@ angular.module('material.core')
       var disableStyle = $window.getComputedStyle(disableTarget[0]);
       var wrapperEl = angular.element('<div class="md-virtual-scroll-container"><div class="md-virtual-scroller"></div></div>');
       var virtualScroller = wrapperEl.children().eq(0);
-      virtualScroller.append(disableTarget.children());
+      virtualScroller.append(disableTarget[0].childNodes);
       disableTarget.append(wrapperEl);
       var originalScrollBarShow = originalWidth < scrollEl.clientWidth;
 


### PR DESCRIPTION
As comment nodes were not moved by `disableScrollAround()`, Angular could
misplace a few elements because of a forgotten comment node that points
to a directive.

Fixes #2456