### PR TITLE
Fixed confusing reversed wording

### DIFF
--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -7,7 +7,7 @@
     <p>Only one word is required for the attribute. For example, <code>layout="row" layout-align="center"</code> would make the elements center horizontally and use the default behavior vertically.</p>
 
     <p><code>layout="column" layout-align="center end"</code> would make
-    children align along the center horizontally and along the end (right) vertically.</p>
+    children align along the center horizontally and along the end vertically.</p>
   <table>
     <tr>
       <td>layout-align</td>

--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -7,7 +7,7 @@
     <p>Only one word is required for the attribute. For example, <code>layout="row" layout-align="center"</code> would make the elements center horizontally and use the default behavior vertically.</p>
 
     <p><code>layout="column" layout-align="center end"</code> would make
-    children align along the center vertically and along the end (right) horizontally.</p>
+    children align along the center horizontally and along the end (right) vertically.</p>
   <table>
     <tr>
       <td>layout-align</td>


### PR DESCRIPTION
The first word in layout-align is for horizontal positioning and the second is for vertical positioning. This document had that reversed.