### PR TITLE
fix(mdUtil): move comment nodes as well when reenabling scroll

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -159,7 +159,7 @@ angular.module('material.core')
       }
 
       return function restoreScroll() {
-        disableTarget.append(virtualScroller.children());
+        disableTarget.append(virtualScroller[0].childNodes);
         wrapperEl.remove();
         angular.element($window).off('resize', computeSize);
         disableTarget.attr('style', restoreStyle || false);


### PR DESCRIPTION
The comment nodes were being moved to the virtual scroll container,
but they were not moved back to the disabled target when the scroll
was reenabled.

Ref: #2456 and 160df4cf436ff22b487e4691dfb3b8034cc0da19