### PR TITLE
fixed md-autocomplete loading indicator bug

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -322,9 +322,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $timeout, $
     }
     function handleResults (matches) {
       cache[term] = matches;
+      self.loading = false;
       if (searchText !== $scope.searchText) return; //-- just cache the results if old request
       promise = null;
-      self.loading = false;
       self.matches = matches;
       self.hidden = shouldHide();
       updateMessages();


### PR DESCRIPTION
When selecting an item with noCache turned on, a loading indicator persists on the bottom of the control. To reproduce:

1. Go to https://material.angularjs.org/#/demo/material.components.autocomplete
2. Make sure the **Simulate query for results?** and **Disable caching of queries?** options are checked.
3. Select an autocompleted result from the list
4. Observe the loading indicator still present at the bottom of the control

