### PR TITLE
fix(select): fix cycle option focus after keyboard search

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -858,6 +858,7 @@ function SelectProvider($$interimElementProvider) {
       element.addClass('md-leave')
         .removeClass('md-clickable');
       opts.target.attr('aria-expanded', 'false');
+      opts.selectEl.off('keydown');
 
 
       angular.element($window).off('resize', opts.resizeFn);

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -806,6 +806,7 @@ function SelectProvider($$interimElementProvider) {
             default:
               if (ev.keyCode >= 31 && ev.keyCode <= 90) {
                 var optNode = opts.selectEl.controller('mdSelectMenu').optNodeForKeyboardSearch(ev);
+                opts.focusedNode = optNode || opts.focusedNode;
                 optNode && optNode.focus();
               }
           }


### PR DESCRIPTION
After keyboard search option focus cycling would start from previously focused element

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2616)
<!-- Reviewable:end -->
