### PR TITLE
feat(checkbox): handle 'checked' property + emit 'change' event

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -83,6 +83,21 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
             ngModelCtrl.$setViewValue.bind(ngModelCtrl)
         );
       }
+
+      // Initial state
+      // Like standard HTML checkbox, 'checked' property should be false by default
+      element[0].checked = false;
+
+      // Watch external changes made to 'checked' property
+      scope.$watch(
+        function() {
+          return element[0].checked;
+        },
+        function(newValue, oldValue) {
+          ngModelCtrl.$setViewValue(newValue);
+        }
+      );
+
       $$watchExpr('ngDisabled', 'tabindex', {
         true: '-1',
         false: attr.tabindex
@@ -141,10 +156,15 @@ function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant,
           ngModelCtrl.$setViewValue( viewValue, ev && ev.type);
           ngModelCtrl.$render();
         });
+
+        // Emit 'change' event
+        element.triggerHandler('change');
       }
 
       function render() {
-        if(ngModelCtrl.$viewValue) {
+        element[0].checked = ngModelCtrl.$viewValue;
+
+        if (element[0].checked) {
           element.addClass(CHECKED_CSS);
         } else {
           element.removeClass(CHECKED_CSS);

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -56,10 +56,14 @@ describe('mdCheckbox', function() {
     var cbElements = element.find('md-checkbox');
 
     expect(cbElements.eq(0).hasClass(CHECKED_CSS)).toEqual(false);
-    expect(cbElements.eq(1).hasClass(CHECKED_CSS)).toEqual(true);
+    expect(cbElements.eq(0).prop('checked')).toEqual(false);
     expect(cbElements.eq(0).attr('aria-checked')).toEqual('false');
-    expect(cbElements.eq(1).attr('aria-checked')).toEqual('true');
     expect(cbElements.eq(0).attr('role')).toEqual('checkbox');
+
+    expect(cbElements.eq(1).hasClass(CHECKED_CSS)).toEqual(true);
+    expect(cbElements.eq(1).prop('checked')).toEqual(true);
+    expect(cbElements.eq(1).attr('aria-checked')).toEqual('true');
+    expect(cbElements.eq(1).attr('role')).toEqual('checkbox');
   }));
 
   it('should be disabled with ngDisabled attr', inject(function($compile, $rootScope) {
@@ -134,10 +138,72 @@ describe('mdCheckbox', function() {
     expect(checkbox[0]).toHaveClass('md-focused');
   }));
 
+  it("should trigger 'change' event when user interacts with the checkbox", inject(function($mdConstant) {
+    var checkbox = buildInstance('<md-checkbox></md-checkbox>');
+
+    var nbChangeEvents = 0;
+    var changeEventTriggered = false;
+    checkbox.on('change', function() {
+      changeEventTriggered = true;
+      nbChangeEvents++;
+    });
+
+    changeEventTriggered = false;
+    checkbox.triggerHandler('click');
+    expect(changeEventTriggered).toBe(true);
+
+    changeEventTriggered = false;
+    checkbox.triggerHandler({
+      type: 'keypress',
+      keyCode: $mdConstant.KEY_CODE.SPACE
+    });
+    expect(changeEventTriggered).toBe(true);
+
+    expect(nbChangeEvents).toEqual(2);
+  }));
+
+  it("should not trigger 'change' event when 'checked' property is changed programmatically", function() {
+    var checkbox = buildInstance('<md-checkbox></md-checkbox>');
+
+    var nbChangeEvents = 0;
+    var changeEventTriggered = false;
+    checkbox.on('change', function() {
+      changeEventTriggered = true;
+      nbChangeEvents++;
+    });
+
+    changeEventTriggered = false;
+    checkbox.prop('checked', true);
+    expect(changeEventTriggered).toBe(false);
+
+    changeEventTriggered = false;
+    checkbox.prop('checked', false);
+    expect(changeEventTriggered).toBe(false);
+
+    expect(nbChangeEvents).toEqual(0);
+  });
+
+  it("should watch 'checked' property", function() {
+    var checkbox = buildInstance('<md-checkbox></md-checkbox>');
+
+    // Initial state
+    // Like standard HTML checkbox, 'checked' property should be false by default
+    expect(checkbox.prop('checked')).toBe(false);
+    expect(checkbox.hasClass(CHECKED_CSS)).toEqual(false);
+
+    checkbox.prop('checked', true);
+    $rootScope.$digest();
+    expect(checkbox.hasClass(CHECKED_CSS)).toEqual(true);
+
+    checkbox.prop('checked', false);
+    $rootScope.$digest();
+    expect(checkbox.hasClass(CHECKED_CSS)).toEqual(false);
+  });
+
   describe('ng core checkbox tests', function() {
 
     function isChecked(cbEl) {
-      return cbEl.hasClass(CHECKED_CSS);
+      return cbEl.hasClass(CHECKED_CSS) && cbEl.prop('checked');
     }
 
     it('should format booleans', function() {


### PR DESCRIPTION
A checkbox is not a checkbox until:
- it emits the 'change' event each time a user interacts with it
- it exposes its state via the 'checked' property (true or false - never undefined) + listen to any programmatic change of 'checked'.

This is what [the regular HTML checkbox](http://www.w3.org/TR/html-markup/input.checkbox.html) (`<input type="checkbox">`) does.

This PR is somewhat related to #535 and #1550.

How others manage this?
- [Twitter Bootstrap](http://getbootstrap.com/css/#forms-example) uses directly the regular HTML checkbox: `<input type="checkbox">` => no problem: all W3C spec is therefore implemented
- [Materialize](http://materializecss.com/forms.html#checkbox) creates a new beautiful checkbox and binds it to the regular HTML checkbox which is hidden (with `position: absolute; left: -9999px`) => no problem: all W3C spec already implemented
- [React material ui](http://material-ui.com/#/components/switches) works the same way as Materialize: binds to and hides (`opacity: 0`) the regular HTML checkbox
- [awesome-bootstrap-checkbox](http://flatlogic.github.io/awesome-bootstrap-checkbox/demo/) again binds to and hides (`opacity: 0`) the regular HTML checkbox
- [Polymer](https://github.com/PolymerElements/paper-checkbox/blob/v0.8.3/paper-checkbox.html#L111) does not reuse the regular HTML checkbox and reimplements it => much like Angular Material. And they do handle the 'checked' property and fire the 'change' event (very clear implementation btw).

The way Angular Material does things is probably cleaner than hidding the regular checkbox input, but then it has the responsibility to implement the W3C specifications. This is also true whenever Angular Material reimplements a standard HTML element: md-radio-button (code factorization is probably possible). For md-button this does not apply since it wraps a regular `<button>`.

Also I've noticed that you [verify](https://github.com/angular/material/blob/v0.9.0-rc3/src/components/checkbox/checkbox.js#L139) the `checked` "attribute":
`var viewValue = attr.ngChecked ? attr.checked : !ngModelCtrl.$viewValue;`
`checked` should be a DOM node object property and thus you don't always see it in the HTML.

You also verify the `ngChecked` attribute: this is wrong. This is intended for the user not for the directive implementation. The purpose of `ng-checked` is to set `checked`.

Here a demo: http://plnkr.co/edit/yXJ7nn?p=preview

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2619)
<!-- Reviewable:end -->
