### PR TITLE
fix(mdCompiler): prevent `resolve` and `locals` overwrite

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -71,8 +71,8 @@ function mdCompilerService($q, $http, $injector, $compile, $controller, $templat
     var template = options.template || '';
     var controller = options.controller;
     var controllerAs = options.controllerAs;
-    var resolve = options.resolve || {};
-    var locals = options.locals || {};
+    var resolve = angular.copy(options.resolve || {});
+    var locals = angular.copy(options.locals || {});
     var transformTemplate = options.transformTemplate || angular.identity;
     var bindToController = options.bindToController;
 

--- a/src/core/services/compiler/compiler.spec.js
+++ b/src/core/services/compiler/compiler.spec.js
@@ -54,27 +54,41 @@ describe('$mdCompiler service', function() {
       expect(data.element.html()).toBe('hello world');
     });
 
-    it('resolve and locals should work', function() {
-      module(function($provide) {
-        $provide.constant('StrawberryColor', 'red');
+    describe('with resolve and locals options', function() {
+      var options;
+
+      beforeEach(function() {
+        module(function($provide) {
+          $provide.constant('StrawberryColor', 'red');
+        });
+
+        options = {
+          resolve: {
+            //Resolve a factory inline
+            fruit: function($q) {
+              return $q.when('apple');
+            },
+            //Resolve a DI token's value
+            color: 'StrawberryColor'
+          },
+          locals: {
+            vegetable: 'carrot'
+          }
+        };
       });
 
-      var data = compile({
-        resolve: {
-          //Resolve a factory inline
-          fruit: function($q) {
-            return $q.when('apple');
-          },
-          //Resolve a DI token's value
-          color: 'StrawberryColor'
-        },
-        locals: {
-          vegetable: 'carrot'
-        }
+      it('should work', function() {
+        var data = compile(options);
+        expect(data.locals.fruit).toBe('apple');
+        expect(data.locals.vegetable).toBe('carrot');
+        expect(data.locals.color).toBe('red');
       });
-      expect(data.locals.fruit).toBe('apple');
-      expect(data.locals.vegetable).toBe('carrot');
-      expect(data.locals.color).toBe('red');
+
+      it('should not overwrite the original values', function() {
+        var clone = angular.copy(options);
+        compile(options);
+        expect(options).toEqual(clone);
+      });
     });
 
     describe('after link()', function() {


### PR DESCRIPTION
  Objects passed to a function should be considered immutable   to avoid unexpected side-effects

Closes #2614

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2676)
<!-- Reviewable:end -->
