### PR TITLE
fix a typo in documentation of contactChipsDirective

### DIFF
--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -38,7 +38,7 @@ angular
  *       md-contact-name="name"
  *       md-contact-image="image"
  *       md-contact-email="email"
- *       md-filter-selected="ctrl.filterSelected"
+ *       filter-selected="ctrl.filterSelected"
  *       placeholder="To">
  *   </md-contact-chips>
  * </hljs>


### PR DESCRIPTION
In the sample code of [this page](https://material.angularjs.org/#/api/material.components.chips/directive/mdContactChips),  
attributes should correspond to the directive's definition. So md-filter-selected here is a typo, it should be filter-selected.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2690)
<!-- Reviewable:end -->
