### PR TITLE
feat(autocomplete): Add promise support to md-item-text

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -58,6 +58,8 @@ describe('<md-autocomplete>', function() {
       ctrl.keydown({ keyCode: $mdConstant.KEY_CODE.DOWN_ARROW, preventDefault: angular.noop });
       ctrl.keydown({ keyCode: $mdConstant.KEY_CODE.ENTER, preventDefault: angular.noop });
       scope.$apply();
+      $timeout.flush();
+
       expect(scope.searchText).toBe('foo');
       expect(scope.selectedItem).toBe(scope.match(scope.searchText)[0]);
     }));
@@ -96,6 +98,8 @@ describe('<md-autocomplete>', function() {
       ctrl.keydown({ keyCode: $mdConstant.KEY_CODE.DOWN_ARROW, preventDefault: angular.noop });
       ctrl.keydown({ keyCode: $mdConstant.KEY_CODE.ENTER, preventDefault: angular.noop });
       scope.$apply();
+      $timeout.flush();
+
       expect(scope.searchText).toBe('foo');
       expect(scope.selectedItem).toBe(scope.match(scope.searchText)[0]);
     }));
@@ -153,6 +157,7 @@ describe('<md-autocomplete>', function() {
 
       ctrl.select(0);
       element.scope().$apply();
+      $timeout.flush();
 
       expect(scope.searchText).toBe('foo');
       expect(scope.selectedItem).not.toBeNull();
@@ -196,6 +201,7 @@ describe('<md-autocomplete>', function() {
 
       ctrl.select(0);
       element.scope().$apply();
+      $timeout.flush();
 
       expect(scope.itemChanged).toHaveBeenCalled();
       expect(scope.itemChanged.calls.mostRecent().args[0].display).toBe('foo');

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -158,7 +158,7 @@ function MdAutocomplete ($mdTheming, $mdUtil) {
             class="md-visually-hidden"\
             role="status"\
             aria-live="assertive">\
-          <p ng-repeat="message in $mdAutocompleteCtrl.messages" ng-if="message">{{message}}</p>\
+          <p ng-repeat="message in $mdAutocompleteCtrl.messages track by $index" ng-if="message">{{message}}</p>\
         </aria-status>';
 
       function getItemTemplate() {

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -159,7 +159,8 @@ describe('<md-chips>', function() {
         element.scope().$apply(function() {
           autocompleteCtrl.select(0);
         });
-
+        $timeout.flush();
+        
         expect(scope.items.length).toBe(4);
         expect(scope.items[3]).toBe('Kiwi');
       }));


### PR DESCRIPTION
This adds promise support for autocompletes `md-item-text` option. It makes use of `$q.when()` in `getDisplayValue()` to convert all functions to promises. Because of this I had to change several things around to make the rest of the autocomplete controller work with promises when it used `getDisplayValue()`.

I tried running the karma tests and got a few errors related to `md-autocomplete` but I also got errors when I ran it on the just released `0.9.0`. I checked several things on the docs auto complete demo locally with this build and also in my app and it functions the same as the official docs so I don't think I broke anything.

This should close #2462 If you want to see a use case see that issue I explained how it's needed for the google places api. But in general this is needed anytime you need to fill in extra data after you select something.

@ThomasBurleson Can you take a look at this please?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2710)
<!-- Reviewable:end -->
