### PR TITLE
fix(tests): update the mdToast hide test

### DIFF
--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -150,12 +150,13 @@ describe('$mdToast service', function() {
 
       it('should hide after duration', inject(function($timeout, $animate, $rootElement) {
         var parent = angular.element('<div>');
+        var hideDelay = 1234;
         setup({
           template: '<md-toast />',
-          hideTimeout: 1234
+          hideDelay: hideDelay
         });
         expect($rootElement.find('md-toast').length).toBe(1);
-        $timeout.flush();
+        $timeout.flush(hideDelay);
         expect($rootElement.find('md-toast').length).toBe(0);
       }));
 


### PR DESCRIPTION
In the `should hide after duration` unit test, an option value is provided to the parameter
`hideTimeout`. This option is not valid and should be `hideDelay`. The test passes
because the toast will default to hide after 3000 anyway.

https://github.com/angular/material/issues/2728

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2729)
<!-- Reviewable:end -->
