### PR TITLE
feature: mdToast uses `$interval` for hiding after delay

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -209,7 +209,7 @@ function MdToastProvider($$interimElementProvider) {
     return $mdToast;
 
   /* @ngInject */
-  function toastDefaultOptions($timeout, $animate, $mdToast, $mdUtil) {
+  function toastDefaultOptions($interval, $animate, $mdToast, $mdUtil) {
     return {
       onShow: onShow,
       onRemove: onRemove,
@@ -231,7 +231,7 @@ function MdToastProvider($$interimElementProvider) {
       options.onSwipe = function(ev, gesture) {
         //Add swipeleft/swiperight class to element so it can animate correctly
         element.addClass('md-' + ev.type.replace('$md.',''));
-        $timeout($mdToast.cancel);
+        $interval($mdToast.cancel,1);
       };
       element.on('$md.swipeleft $md.swiperight', options.onSwipe);
       return $animate.enter(element, options.parent);

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -15,8 +15,9 @@ describe('$mdToast service', function() {
   describe('simple()', function() {
     hasConfigMethods(['content', 'action', 'capsule', 'highlightAction', 'theme']);
 
-    it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $animate) {
+    it('supports a basic toast', inject(function($mdToast, $rootScope, $interval, $animate) {
       var rejected = false;
+      var hideDelayDefault = 3000;
       var parent = angular.element('<div>');
       $mdToast.show(
         $mdToast.simple({
@@ -33,7 +34,7 @@ describe('$mdToast service', function() {
       expect(parent.find('md-toast')).toHaveClass('md-capsule');
       expect(parent.find('md-toast').attr('md-theme')).toBe('some-theme');
       $animate.triggerCallbacks();
-      $timeout.flush();
+      $interval.flush(hideDelayDefault);
       $animate.triggerCallbacks();
       expect(rejected).toBe(true);
     }));
@@ -148,29 +149,29 @@ describe('$mdToast service', function() {
         expect($rootElement[0].querySelector('md-toast.three')).toBeTruthy();
       }));
 
-      it('should hide after duration', inject(function($timeout, $animate, $rootElement) {
+      it('should hide after duration', inject(function($interval, $animate, $rootElement) {
         var parent = angular.element('<div>');
+        var timeout = 1234;
         setup({
           template: '<md-toast />',
-          hideTimeout: 1234
+          hideDelay: timeout
         });
         expect($rootElement.find('md-toast').length).toBe(1);
-        $timeout.flush();
+        $interval.flush(timeout);
         expect($rootElement.find('md-toast').length).toBe(0);
       }));
 
-      it('should have template', inject(function($timeout, $rootScope, $rootElement) {
+      it('should have template', inject(function($interval, $rootScope, $rootElement) {
         var parent = angular.element('<div>');
         setup({
           template: '<md-toast>{{1}}234</md-toast>',
           appendTo: parent
         });
         var toast = $rootElement.find('md-toast');
-        $timeout.flush();
         expect(toast.text()).toBe('1234');
       }));
 
-      it('should have templateUrl', inject(function($timeout, $rootScope, $templateCache, $rootElement) {
+      it('should have templateUrl', inject(function($interval, $rootScope, $templateCache, $rootElement) {
         $templateCache.put('template.html', '<md-toast>hello, {{1}}</md-toast>');
         setup({
           templateUrl: 'template.html',
@@ -179,13 +180,12 @@ describe('$mdToast service', function() {
         expect(toast.text()).toBe('hello, 1');
       }));
 
-      it('should add position class to tast', inject(function($rootElement, $timeout) {
+      it('should add position class to tast', inject(function($rootElement, $interval) {
         setup({
           template: '<md-toast>',
           position: 'top left'
         });
         var toast = $rootElement.find('md-toast');
-        $timeout.flush();
         expect(toast.hasClass('md-top')).toBe(true);
         expect(toast.hasClass('md-left')).toBe(true);
       }));

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -220,7 +220,7 @@ function InterimElementProvider() {
   }
 
   /* @ngInject */
-  function InterimElementFactory($document, $q, $rootScope, $timeout, $rootElement, $animate,
+  function InterimElementFactory($document, $q, $rootScope, $interval, $rootElement, $animate,
                                  $interpolate, $mdCompiler, $mdTheming ) {
     var startSymbol = $interpolate.startSymbol(),
         endSymbol = $interpolate.endSymbol(),
@@ -389,14 +389,14 @@ function InterimElementProvider() {
 
               function startHideTimeout() {
                 if (options.hideDelay) {
-                  hideTimeout = $timeout(service.cancel, options.hideDelay) ;
+                  hideTimeout = $interval(service.cancel, options.hideDelay, 1) ;
                 }
               }
             }, function(reason) { showDone = true; self.deferred.reject(reason); });
           },
           cancelTimeout: function() {
             if (hideTimeout) {
-              $timeout.cancel(hideTimeout);
+              $interval.cancel(hideTimeout);
               hideTimeout = undefined;
             }
           },

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -314,12 +314,13 @@ describe('$$interimElement service', function() {
         expect($themingSpy).toHaveBeenCalled();
       }));
 
-      it('calls hide after hideDelay', inject(function($animate, $timeout, $rootScope) {
+      it('calls hide after hideDelay', inject(function($animate, $interval, $rootScope) {
         var hideSpy = spyOn(Service, 'cancel').and.callThrough();
-        Service.show({hideDelay: 1000});
+        var hideDelay = 1000;
+        Service.show({hideDelay: hideDelay});
         $rootScope.$digest();
         $animate.triggerCallbacks();
-        $timeout.flush();
+        $interval.flush(hideDelay);
         expect(hideSpy).toHaveBeenCalled();
       }));
 


### PR DESCRIPTION
In order to be better compatiable with Protractor, the hide delays on mdToast are
switched from `$timeout` to `$interval`.

https://github.com/angular/material/issues/2704

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2731)
<!-- Reviewable:end -->
