### PR TITLE
fix(dialog): set css `position: fixed` to `.md-dialog-container`

### DIFF
--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -15,7 +15,7 @@ md-backdrop {
 
   background-color: rgba(0,0,0,0);
 
-  position: absolute;
+  position: fixed;
   height: 100%;
   left: 0;
   right: 0;

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -5,7 +5,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Closes #1967. [Example 1](http://codepen.io/anon/pen/LVVbay) (comment the first css line to see the problem)

Also, it fixes another issue with the sidenav toggle where the backdrop element caused the body to overflow. [Example 2](http://codepen.io/anon/pen/waaoyX) (comment the second css line to see the problem).

(Same as #2631 - corrected commit messages and reopened)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2754)
<!-- Reviewable:end -->
