### PR TITLE
fix(subheader): themes are applied to sticky subheader

### DIFF
--- a/src/components/subheader/demoBasicUsage/index.html
+++ b/src/components/subheader/demoBasicUsage/index.html
@@ -1,6 +1,6 @@
 
 <div ng-controller="SubheaderAppCtrl" layout="column" flex layout-fill>
-  <md-content style="height: 600px;">
+  <md-content style="height: 600px;" md-theme="altTheme">
     <section>
       <md-subheader class="md-primary">Unread Messages</md-subheader>
       <md-list layout-padding>

--- a/src/components/subheader/demoBasicUsage/script.js
+++ b/src/components/subheader/demoBasicUsage/script.js
@@ -1,6 +1,9 @@
 
 angular.module('subheaderBasicDemo', ['ngMaterial'])
-
+.config(function($mdThemingProvider) {
+  $mdThemingProvider.theme('altTheme')
+    .primaryPalette('purple');
+})
 .controller('SubheaderAppCtrl', function($scope) {
     var imagePath = 'https://material.angularjs.org/img/list/60.jpeg';
     $scope.messages = [

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -52,9 +52,10 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming) {
         '</div>' +
       '</h2>',
     compile: function(element, attr, transclude) {
-      var outerHTML = element[0].outerHTML;
       return function postLink(scope, element, attr) {
         $mdTheming(element);
+        var outerHTML = element[0].outerHTML;
+
         function getContent(el) {
           return angular.element(el[0].querySelector('.md-subheader-content'));
         }
@@ -70,7 +71,6 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming) {
         if (!element.hasClass('md-no-sticky')) {
           transclude(scope, function(clone) {
             var stickyClone = $compile(angular.element(outerHTML))(scope);
-            $mdTheming(stickyClone);
             getContent(stickyClone).append(clone);
             $mdSticky(scope, element, stickyClone);
           });

--- a/src/components/subheader/subheader.spec.js
+++ b/src/components/subheader/subheader.spec.js
@@ -25,4 +25,12 @@ describe('mdSubheader', function() {
     expect($mdStickyMock.args[0]).toBe(scope);
   }));
 
+  it('should apply the theme to the header and clone', inject(function($compile, $rootScope) {
+    var scope = $rootScope.$new();
+    $compile('<div md-theme="somethingElse">' + basicHtml + '</div>')(scope);
+    var element = $mdStickyMock.args[1];
+    var clone = $mdStickyMock.args[2];
+    expect(element.hasClass('md-somethingElse-theme')).toBe(true);
+    expect(clone.hasClass('md-somethingElse-theme')).toBe(true);
+  }));
 });


### PR DESCRIPTION
Fixes https://github.com/angular/material/issues/2093.

The demo has been updated to prove themes can be applied to the sticky header.