### PR TITLE
fix(checkbox): only add margin to the first span

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -121,7 +121,7 @@ md-checkbox {
     content: '';
   }
 
-  .md-label {
+  > .md-label {
     position: relative;
     display: inline-block;
     vertical-align: middle;
@@ -129,7 +129,7 @@ md-checkbox {
     pointer-events: none;
     user-select: text;
 
-    span {
+    > span:first-child {
       margin-left: $checkbox-text-margin;
     }
   }


### PR DESCRIPTION
If there are multiple spans inside a checkbox, all of them will have a left margin. That can be undesirable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2786)
<!-- Reviewable:end -->
