### PR TITLE
style(checkbox): fix spacing between component and value when value wraps

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -128,13 +128,10 @@ md-checkbox {
   .md-label {
     position: relative;
     display: inline-block;
+    margin-left: 10px;
+    margin-right: 10px;
     vertical-align: middle;
     white-space: normal;
     user-select: text;
-
-    span {
-      @include rtl(margin-left, $checkbox-text-margin, 0);
-      @include rtl(margin-right, 0, $checkbox-text-margin);
-    }
   }
 }


### PR DESCRIPTION
followed the same styling that the radio group components have which didn't seem to have this problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2812)
<!-- Reviewable:end -->
