### PR TITLE
fix(demo,swipe): add missing demo for swipe

### DIFF
--- a/src/components/swipe/demoBasicUsage/index.html
+++ b/src/components/swipe/demoBasicUsage/index.html
@@ -1,0 +1,9 @@
+<div ng-controller="demoSwipeCtrl">
+  <div class="demo-swipe" md-swipe-left="onSwipeLeft()">
+    Swipe me to the left
+  </div>
+  <md-divider></md-divider>
+  <div class="demo-swipe" md-swipe-right="onSwipeRight()">
+    Swipe me to the right
+  </div>
+</div>

--- a/src/components/swipe/demoBasicUsage/readme.html
+++ b/src/components/swipe/demoBasicUsage/readme.html
@@ -1,0 +1,4 @@
+<p md-warn>This UX pattern is intended for mobile devices only, and
+may not make sense to use on responsive sites.  To initiate a swipe
+gesture on a desktop, you must click, hold and drag either right or
+left</p>

--- a/src/components/swipe/demoBasicUsage/script.js
+++ b/src/components/swipe/demoBasicUsage/script.js
@@ -1,0 +1,10 @@
+angular.module('demoSwipe', ['ngMaterial'])
+  .controller('demoSwipeCtrl', function($scope) {
+    $scope.onSwipeLeft = function(ev) {
+      alert('You swiped left!!');
+    };
+
+    $scope.onSwipeRight = function(ev) {
+      alert('You swiped right!!');
+    };
+  });

--- a/src/components/swipe/demoBasicUsage/style.css
+++ b/src/components/swipe/demoBasicUsage/style.css
@@ -1,0 +1,3 @@
+.demo-swipe {
+  padding: 20px 10px;
+}


### PR DESCRIPTION
Closes: https://github.com/angular/material/issues/1911

Fixes an issue where the link on the toolbar redirects to '/' since no
demo exists.  

One solution was to hide the link, but the process to determine if an ngDoc has a demo would be more complicated.  The code already handles showing the button based on if the doc hasDemo is true.  The sticky part is given a doc, it is difficult to determine the associated examples without knowledge of the example files convention

Additional demos can be added in the future to show more advanced usage.

Currently this is the only directive without a demo.