### PR TITLE
docs(tooltip): Fix src attribute in "Refresh" button's <md-icon> in t…

### DIFF
--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -7,7 +7,7 @@
         <md-tooltip>
           Refresh
         </md-tooltip>
-        <md-icon icon="/img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;">
+        <md-icon md-svg-src="img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;">
         </md-icon>
       </md-button>
     </h2>


### PR DESCRIPTION
…ooltip demo

Change src attribute from "icon" to "md-svg-src" and remove leading slash from url. As is, the refresh button does not appear in the demo.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2815)
<!-- Reviewable:end -->
