### PR TITLE
fix(codepen): escape ampersand in &nbsp;

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -142,6 +142,7 @@
     function htmlEscapeAmpersand(html) {
       return html
         .replace(/&gt;/g, "&amp;gt;")
+        .replace(/&nbsp;/g, "&amp;nbsp;")
         .replace(/&lt;/g, "&amp;lt;");
     }
 

--- a/docs/spec/codepen.spec.js
+++ b/docs/spec/codepen.spec.js
@@ -118,6 +118,15 @@ describe('CodepenDataAdapter', function() {
 
     });
 
+    describe('when the html example includes &nbsp;', function() {
+
+      it('escapes the ampersand, so that the codepen does not translate to an invalid character', function() {
+        demo.files.index.contents = '<div>&nbsp;&nbsp;</div>';
+        data = codepenDataAdapter.translate(demo, externalScripts);
+        expect(angular.element(data.html).html()).toBe('&amp;nbsp;&amp;nbsp;');
+      });
+    });
+
     describe('when the module definition in the js file is formatted in different ways', function() {
 
       it('handles second argument on a new line', function() {


### PR DESCRIPTION
Closes -> https://github.com/angular/material/issues/2826

Without escaping the ampersand the &nbsp; is translated into the
incorrect character.

Before fix:
![screen shot 2015-05-12 at 10 01 43 am](https://cloud.githubusercontent.com/assets/483058/7593335/4735db44-f88e-11e4-971e-8dde255ed5b1.png)

After fix:

![screen shot 2015-05-12 at 10 04 01 am](https://cloud.githubusercontent.com/assets/483058/7593333/3fc51eba-f88e-11e4-9a11-ae0c51848873.png)