### PR TITLE
fix(codepen): fix demos with special characters

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -39,8 +39,8 @@
     // See http://blog.codepen.io/documentation/api/prefill
     function escapeJsonQuotes(json) {
       return JSON.stringify(json)
-        .replace(/"/g, "&quot;")
-        .replace(/"/g, "&apos;");
+        .replace(/'/g, "&amp;apos;")
+        .replace(/"/g, "&amp;quot;");
     }
   }
 

--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -141,6 +141,7 @@
     // uses the correct escaped characters
     function htmlEscapeAmpersand(html) {
       return html
+        .replace(/&mdash;/g, "&amp;mdash;")
         .replace(/&gt;/g, "&amp;gt;")
         .replace(/&nbsp;/g, "&amp;nbsp;")
         .replace(/&lt;/g, "&amp;lt;");

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -42,7 +42,7 @@
         'Anita Gros',
         'Megan Smith',
         'Tsvetko Metzger',
-        'Hector Šimek',
+        'Hector Simek',
         'Some-guy withalongalastaname'
       ];
 

--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -10,7 +10,7 @@
       <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="https://material.angularjs.org/img/mangues.jpg">
 
       <p>
-        The highest concentration of Mangifera genus is in the western part of Malesia (Sumatra, Java and Borneo) and in Burma and India. While other Mangifera species (e.g. horse mango, M. foetida) are also grown on a more localized basis, Mangifera indica—the "common mango" or "Indian mango"—is the only mango tree commonly cultivated in many tropical and subtropical regions.
+        The highest concentration of Mangifera genus is in the western part of Malesia (Sumatra, Java and Borneo) and in Burma and India. While other Mangifera species (e.g. horse mango, M. foetida) are also grown on a more localized basis, Mangifera indica&mdash;the "common mango" or "Indian mango"&mdash;is the only mango tree commonly cultivated in many tropical and subtropical regions.
       </p>
       <p>
         It originated in Indian subcontinent (present day India and Pakistan) and Burma. It is the national fruit of India, Pakistan, and the Philippines, and the national tree of Bangladesh. In several cultures, its fruit and leaves are ritually used as floral decorations at weddings, public celebrations, and religious ceremonies.

--- a/src/components/progressCircular/demoBasicUsage/index.html
+++ b/src/components/progressCircular/demoBasicUsage/index.html
@@ -7,7 +7,7 @@
     </div>
 
     <h4>Indeterminate</h4>
-    <p>For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
+    <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
     <div layout="row" layout-sm="column" layout-align="space-around">
       <md-progress-circular md-mode="indeterminate"></md-progress-circular>
     </div>


### PR DESCRIPTION
Closes -> https://github.com/angular/material/issues/2822

An undocumented change occured during the 05/12/2015 release of codepen that caused some of our demos to break.

A more robust solution could be put in place to solve this, but the edge cases make the effort rather large for what seems to be a small feature.  At this point I am unclear if the changes to the API are intended and will continue to be the standard moving forward.  I am in favor of the simpler solution until the Codepen API is stable.