### PR TITLE
feat(docs): Use $scope instead of scope

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -128,14 +128,14 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *          },
  *          controller: DialogController
  *       });
- *       function DialogController(scope, $mdDialog, items) {
- *         scope.items = items;
- *         scope.closeDialog = function() {
+ *       function DialogController($scope, $mdDialog, items) {
+ *         $scope.items = items;
+ *         $scope.closeDialog = function() {
  *           $mdDialog.hide();
  *         }
  *       }
  *     }
- *
+ *   }
  * })(angular);
  * </hljs>
  *


### PR DESCRIPTION
To avoid confusion it would be good to keep the examples consistent.
While `scope` in `DialogController` will be the same as `$scope` it brings confusion to a reader.
I can only guess that `scope` here working is by accident - caused by https://github.com/angular/material/blob/786b0ed3652b7460c2c802efa1aa79972bd96f5d/src/core/services/interimElement/interimElement.js#L353.

The fix also includes missing `}` mentioned here:   #2788

Here's a working pen: http://codepen.io/anon/pen/ZGWOpZ.