### PR TITLE
feat(build): snapshot docs site on successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_script:
 script:
   - gulp karma --browsers=Firefox
   - ./scripts/travis-build-init.sh --sha=$TRAVIS_COMMIT
+  - ./scripts/snapshot-docs-site.sh --sha=$TRAVIS_COMMIT
 
 notifications:
   flowdock: ca58afe1354053b15fe75a763138829d

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_script:
 script:
   - gulp karma --browsers=Firefox
   - ./scripts/travis-build-init.sh --sha=$TRAVIS_COMMIT
-  - ./scripts/snapshot-docs-site.sh --sha=$TRAVIS_COMMIT
 
 notifications:
   flowdock: ca58afe1354053b15fe75a763138829d

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+ARG_DEFS=(
+  "--sha=(.*)"
+)
+
+function run {
+  cd ../
+
+  echo "-- Building docs site release..."
+  rm -rf dist
+  gulp docs --release
+
+  echo "-- Cloning code.material.angularjs.org..."
+  rm -rf code.material.angularjs.org
+  git clone https://github.com/angular/code.material.angularjs.org.git --depth=1
+
+  echo "-- Remove previous snapshot..."
+  rm -rf code.material.angularjs.org/snapshot
+
+  echo "-- Copying docs site to snapshot..."
+  cp -Rf dist/docs code.material.angularjs.org/snapshot
+
+  cd code.material.angularjs.org
+
+  echo "-- Commiting snapshot..."
+  git add -A
+  git commit -m "snapshot: $SHA"
+
+  echo "-- Pushing snapshot..."
+  git push -q origin master
+
+  cd ../
+
+  echo "-- Cleanup..."
+  rm -rf code.material.angularjs.org
+
+  echo "-- Successfully pushed the snapshot to angular/code.material.angularjs.org!!"
+}
+
+source $(dirname $0)/utils.inc

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -13,7 +13,7 @@ function run {
 
   echo "-- Cloning code.material.angularjs.org..."
   rm -rf code.material.angularjs.org
-  git clone https://github.com/angular/code.material.angularjs.org.git --depth=1
+  git clone https://angular:$GF_TOKEN@github.com/angular/code.material.angularjs.org.git --depth=1
 
   echo "-- Remove previous snapshot..."
   rm -rf code.material.angularjs.org/snapshot

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -13,7 +13,7 @@ function run {
 
   echo "-- Cloning code.material.angularjs.org..."
   rm -rf code.material.angularjs.org
-  git clone https://angular:$GF_TOKEN@github.com/angular/code.material.angularjs.org.git --depth=1
+  git clone https://angular:$GH_TOKEN@github.com/angular/code.material.angularjs.org.git --depth=1
 
   echo "-- Remove previous snapshot..."
   rm -rf code.material.angularjs.org/snapshot

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ARG_DEFS=(
-  "--sha=(.*)"
+  "--version=(.*)"
 )
 
 function run {
@@ -25,7 +25,7 @@ function run {
 
   echo "-- Commiting snapshot..."
   git add -A
-  git commit -m "snapshot: $SHA"
+  git commit -m "snapshot: $VERSION"
 
   echo "-- Pushing snapshot..."
   git push -q origin master

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -16,10 +16,10 @@ function run {
   git clone https://angular:$GH_TOKEN@github.com/angular/code.material.angularjs.org.git --depth=1
 
   echo "-- Remove previous snapshot..."
-  rm -rf code.material.angularjs.org/snapshot
+  rm -rf code.material.angularjs.org/HEAD
 
   echo "-- Copying docs site to snapshot..."
-  cp -Rf dist/docs code.material.angularjs.org/snapshot
+  cp -Rf dist/docs code.material.angularjs.org/HEAD
 
   cd code.material.angularjs.org
 

--- a/scripts/travis-build-init.sh
+++ b/scripts/travis-build-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/bash
 
 ARG_DEFS=(
   "--sha=(.*)"
@@ -22,6 +22,7 @@ function run {
   NEW_VERSION="$(readJsonProp "package.json" "version")-master-$(echo $SHA | head -c 7)"
 
   ./scripts/bower-material-release.sh --version=$NEW_VERSION
+  ./scripts/snapshot-docs-site.sh --version=$NEW_VERSION
 }
 
 source $(dirname $0)/utils.inc


### PR DESCRIPTION
Pre-requisite for allowing users to select a version.

In order to serve older versions, we needed to update how the site is served.  We are following a similar pattern to how angularjs is being served using a seperate repo to store the snapshots and pre-built older versions (https://github.com/angular/code.material.angularjs.org).

This is only part of the larger puzzle, but I don't see any reason not to start capturing the snapshots now.  

The remaining pieces include, but not limited to, taking a snapshot of a release, serving the site using the new structure and implementing version selection.