### PR TITLE
bugfix: Vertical scrollbar always shown

### DIFF
--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -1,5 +1,5 @@
 html, body {
-  height: 100%;
+  min-height: 100%;
   color: rgba(0,0,0,0.87);
   background: white;
   position: relative;


### PR DESCRIPTION
The page is always breaking the height. Changing the height attribute to min-height resolves the problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2874)
<!-- Reviewable:end -->
