### PR TITLE
feat (mdTabs): Allow mdTab to not be direct child of mdTabs

### DIFF
--- a/src/components/tabs/js/tabDirective.js
+++ b/src/components/tabs/js/tabDirective.js
@@ -71,8 +71,7 @@ function MdTab () {
 
   function postLink (scope, element, attr, ctrl) {
     if (!ctrl) return;
-    var tabs = element.parent()[0].getElementsByTagName('md-tab'),
-        index = Array.prototype.indexOf.call(tabs, element[0]),
+    var index = ctrl.getTabElementIndex(element),
         data = ctrl.insertTab({
           scope:    scope,
           parent:   scope.$parent,
@@ -88,7 +87,7 @@ function MdTab () {
     scope.$watch('disabled', function () { ctrl.refreshIndex(); });
     scope.$watch(
         function () {
-          return Array.prototype.indexOf.call(tabs, element[0]);
+          return ctrl.getTabElementIndex(element);
         },
         function (newIndex) {
           data.index = newIndex;

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -37,6 +37,7 @@ function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $md
   ctrl.incrementSelectedIndex = incrementSelectedIndex;
   ctrl.updateInkBarStyles = updateInkBarStyles;
   ctrl.updateTabOrder = $mdUtil.debounce(updateTabOrder, 100);
+  ctrl.getTabElementIndex = getTabElementIndex;
 
   init();
 
@@ -70,6 +71,11 @@ function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $md
     elements.contents = elements.contentsWrapper.getElementsByTagName('md-tab-content');
 
     return elements;
+  }
+
+  function getTabElementIndex(tabEl){
+    var tabs = $element[0].getElementsByTagName('md-tab');
+    return Array.prototype.indexOf.call(tabs, tabEl[0]);
   }
 
   function keydown (event) {


### PR DESCRIPTION
Hey,

Right now the mdTabs/mdTab component assumes that if there is an mdTabs component above the mdTab, it will be it's direct parent. However, my use case is not like that. I have a component in between that shows/hides tabs based on the current user's rights. The calculation of the index fails in that case, making the tab order seemingly random.

This is a small patch that allows the mdTab components to not be direct children of the mdTabs component.

Simon

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2890)
<!-- Reviewable:end -->
