### PR TITLE
remove annotation as it fails closure compiler

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -48,7 +48,6 @@
 
     /**
      * $get is used to build an instance of $mdGesture
-     * @ngInject
      */
     $get : function($$MdGestureHandler, $$rAF, $timeout) {
          return new MdGesture($$MdGestureHandler, $$rAF, $timeout);

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -34,7 +34,7 @@
      *
      *   });
      * </hljs>
-     *
+     * @ngInject
      */
   function MdGestureProvider() { }
 


### PR DESCRIPTION
This fails my closure.

    ERROR - @ngInject can only be used when defining a function or assigning a function expression.
        $get : function($$MdGestureHandler, $$rAF, $timeout) {
        ^
