### PR TITLE
fix(docs): use correct link to file on github

### DIFF
--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -29,7 +29,8 @@ module.exports = new Package('angular-md', [
 .config(function(readFilesProcessor, writeFilesProcessor) {
   readFilesProcessor.basePath = projectPath;
   readFilesProcessor.sourceFiles = [
-    { include: 'dist/angular-material.js', basePath: 'dist' },
+    { include: 'src/components/**/*.js', basePath: '.' },
+    { include: 'src/core/**/*.js', basePath: '.' },
     { include: 'docs/content/**/*.md', basePath: 'docs/content', fileReader: 'ngdocFileReader' }
   ];
 

--- a/docs/config/processors/componentsData.js
+++ b/docs/config/processors/componentsData.js
@@ -4,35 +4,34 @@ var buildConfig = require('../../../config/build.config.js');
 // We don't need to publish all of a doc's data to the app, that will
 // add many kilobytes of loading overhead.
 function publicDocData(doc, extraData) {
-  var githubBaseUrl = buildConfig.repository + '/blob/master/src/components/';
-  doc = doc || {};
-  var jsName = doc.module.split('material.components.').pop();
-  return _.assign({
-    name: doc.name,
-    type: doc.docType,
-    outputPath: doc.outputPath,
-    url: doc.path,
-    label: doc.label || doc.name,
-    hasDemo: (doc.docType === 'directive'),
-    module: doc.module,
-    githubUrl: githubBaseUrl + jsName + '/' + jsName + '.js'
-  }, extraData || {});
+  var options = _.assign(extraData || {}, { hasDemo: (doc.docType === 'directive') });
+  return buildDocData(doc, options, 'components');
 }
 
 function coreServiceData(doc, extraData) {
-  var githubBaseUrl = buildConfig.repository + '/blob/master/src/core/services/';
-  doc = doc || {};
-  var jsName = doc.module.split('material.core.').pop();
+  var options = _.assign(extraData || {}, { hasDemo: false });
+  return buildDocData(doc, options, 'core');
+}
+
+function buildDocData(doc, extraData, descriptor) {
+  var module = 'material.' + descriptor;
+  var githubBaseUrl = buildConfig.repository + '/blob/master/src/' + descriptor + '/';
+  var jsName = doc.module.split(module + '.').pop();
+
+  var basePathFromProjectRoot = 'src/' + descriptor + '/';
+  var filePath = doc.fileInfo.filePath;
+  var indexOfBasePath = filePath.indexOf(basePathFromProjectRoot);
+  var path = filePath.substr(indexOfBasePath + basePathFromProjectRoot.length, filePath.length);
+
   return _.assign({
     name: doc.name,
     type: doc.docType,
     outputPath: doc.outputPath,
     url: doc.path,
     label: doc.label || doc.name,
-    hasDemo: false,
-    module: 'material.core',
-    githubUrl: githubBaseUrl + '/' + jsName + '.js'
-  }, extraData || {});
+    module: module,
+    githubUrl: githubBaseUrl + path
+  }, extraData);
 }
 
 module.exports = function componentsGenerateProcessor(log, moduleMap) {
@@ -74,6 +73,7 @@ module.exports = function componentsGenerateProcessor(log, moduleMap) {
       .value();
 
     var EXPOSED_CORE_SERVICES = '$mdMedia';
+
     var services = _(docs).filter(function(doc) {
       return doc.docType == 'service' &&
         doc.module == 'material.core' &&
@@ -95,4 +95,3 @@ module.exports = function componentsGenerateProcessor(log, moduleMap) {
     });
   }
 };
-


### PR DESCRIPTION
Closes: https://github.com/angular/material/issues/2005

Previously the github url was generated using a convention that most, if not all, components/core services were not adhering to.

Instead of using the consolidated js files in angular-material.js, using the source provides ngDoc with the correct location of the file being documented.