### PR TITLE
chore(karma): fix invalid logLevel config value

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -45,7 +45,7 @@ module.exports = function(config) {
     frameworks: ['jasmine'],
     files: dependencies.concat(testSrc),
 
-    logLevel:'warn',
+    logLevel: config.LOG_WARN,
     port: 9876,
     reporters: ['progress'],
     colors: true,


### PR DESCRIPTION
This invalid value made the karma runner in WebStorm fail.