### PR TITLE
feat(docs): version selection

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -218,6 +218,10 @@ code:not(.highlight) {
 .docs-menu > li {
   border-top: 1px solid rgba(0, 0, 0, 0.12);
 }
+.docs-menu > li:nth-child(-n+2) {
+  border-top: none;
+}
+
 .docs-menu .md-button {
   border-radius: 0;
   color: inherit;
@@ -233,6 +237,29 @@ code:not(.highlight) {
   white-space: normal;
   width: 100%;
 }
+
+.docs-menu md-select {
+
+ /* Override md-select margins.  With margins the menu will look incorrect and causes mobile list
+    to not be scrollable.
+  */
+  margin: 0;
+  width: 100%;
+}
+
+.docs-menu md-select md-select-label {
+  justify-content: flex-end;
+}
+
+.docs-menu md-select md-select-label span {
+  margin-right: auto;
+  padding-left: 16px;
+}
+
+.docs-menu md-select .md-select-icon {
+  margin-right: 28px;
+}
+
 .docs-menu button.md-button::-moz-focus-inner {
   padding: 0;
 }
@@ -287,6 +314,7 @@ code:not(.highlight) {
   transform: rotate(0deg);
   -webkit-transform: rotate(0deg);
 }
+
 /* End Docs Menu */
 
 .docs-logo:focus {

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -249,11 +249,12 @@ code:not(.highlight) {
 
 .docs-menu md-select md-select-label {
   justify-content: flex-end;
+  padding-top: 10px;
 }
 
 .docs-menu md-select md-select-label span {
   margin-right: auto;
-  padding-left: 16px;
+  padding-left: 13px;
 }
 
 .docs-menu md-select .md-select-icon {
@@ -268,11 +269,12 @@ code:not(.highlight) {
 }
 .menu-heading {
   display: block;
-  line-height: 40px;
+  line-height: 32px;
   margin: 0;
-  padding: 0px 16px;
+  padding: 8px 16px 0;
   text-align: left;
   width: 100%;
+  color: rgba(0,0,0, 0.54)
 }
 .docs-menu li.parentActive,
 .docs-menu li.parentActive .menu-toggle-list {

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -468,6 +468,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   '$window',
   '$http',
   function($scope, $window, $http) {
+    var versionFromPath = $window.location.pathname.match(/^\/([^\/]+)/);
 
     $scope.versions = [];
     $scope.showVersionSelection = true;
@@ -480,15 +481,14 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
         });
 
         $scope.versions = commonVersions.concat(knownVersions);
+        if (versionFromPath) {
+          var version = versionFromPath[1];
+          $scope.version = version == 'latest' ? response.latest : version;
+        }
       })
       .error(function() {
         $scope.showVersionSelection = false;
       });
-
-    var versionFromPath = $window.location.pathname.match(/^\/([^\/]+)/);
-    if (versionFromPath) {
-      $scope.version = versionFromPath[1];
-    }
 
     $scope.redirectToVersion = function(version) {
       window.location = '/' + version;

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -470,7 +470,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   function($scope, $window, $http) {
 
     $scope.versions = [];
-    $scope.showVersionSelection = false;
+    $scope.showVersionSelection = true;
 
     $http.get("/docs.json")
       .success(function(response) {
@@ -480,7 +480,9 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
         });
 
         $scope.versions = commonVersions.concat(knownVersions);
-        $scope.showVersionSelection = true;
+      })
+      .error(function() {
+        $scope.showVersionSelection = false;
       });
 
     var versionFromPath = $window.location.pathname.match(/^\/([^\/]+)/);

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -472,7 +472,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
     $scope.versions = [];
     $scope.showVersionSelection = true;
 
-    $http.get("/docs.json")
+    $http.get("https://cdn.rawgit.com/angular/code.material.angularjs.org/master/docs.json")
       .success(function(response) {
         var commonVersions = [{ version: 'HEAD', label: 'HEAD'}];
         var knownVersions = response.versions.map(function(version) {

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -473,7 +473,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
     $scope.versions = [];
     $scope.showVersionSelection = true;
 
-    $http.get("https://cdn.rawgit.com/angular/code.material.angularjs.org/master/docs.json")
+    $http.get("/docs.json")
       .success(function(response) {
         var commonVersions = [{ version: 'HEAD', label: 'HEAD'}];
         var knownVersions = response.versions.map(function(version) {

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -463,6 +463,36 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   }
 }])
 
+.controller('DocsVersionsCtrl', [
+  '$scope',
+  '$window',
+  '$http',
+  function($scope, $window, $http) {
+
+    $scope.versions = [];
+    $scope.showVersionSelection = false;
+
+    $http.get("/docs.json")
+      .success(function(response) {
+        var commonVersions = [{ version: 'HEAD', label: 'HEAD'}];
+        var knownVersions = response.versions.map(function(version) {
+          return { version: version, label: 'v' + version };
+        });
+
+        $scope.versions = commonVersions.concat(knownVersions);
+        $scope.showVersionSelection = true;
+      });
+
+    var versionFromPath = $window.location.pathname.match(/^\/([^\/]+)/);
+    if (versionFromPath) {
+      $scope.version = versionFromPath[1];
+    }
+
+    $scope.redirectToVersion = function(version) {
+      window.location = '/' + version;
+    };
+  }])
+
 .controller('HomeCtrl', [
   '$scope',
   '$rootScope',

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -496,30 +496,8 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
 .controller('HomeCtrl', [
   '$scope',
   '$rootScope',
-  '$http',
-function($scope, $rootScope, $http) {
+function($scope, $rootScope) {
   $rootScope.currentComponent = $rootScope.currentDoc = null;
-
-  $scope.version = "";
-  $scope.versionURL = "";
-
-  // Load build version information; to be
-  // used in the header bar area
-  var now = Math.round(new Date().getTime()/1000);
-  var versionFile = "version.json" + "?ts=" + now;
-
-  $http.get("version.json")
-    .then(function(response){
-      var sha = response.data.sha || "";
-      var url = response.data.url;
-
-      if (sha) {
-        $scope.versionURL = url + sha;
-        $scope.version = sha.substr(0,6);
-      }
-    });
-
-
 }])
 
 

--- a/docs/app/version.json
+++ b/docs/app/version.json
@@ -1,5 +1,0 @@
-{
-  "sha":"",
-  "url":"https://github.com/angular/material/tree/",
-  "_comment": "see gulp task 'docs-version' for usage"
-}

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -3,7 +3,6 @@
 <head>
 <title ng-bind="(menu.currentSection.name || 'Material Design') + (menu.currentPage ? (' > ' + (menu.currentPage | humanizeDoc)) : '')">Material Design</title>
 <meta name="viewport" content="initial-scale=1" />
-
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
 <link rel="stylesheet" href="angular-material.min.css">
 <link rel="stylesheet" href="docs.css">
@@ -31,6 +30,11 @@
 
     <md-content flex role="navigation">
       <ul class="docs-menu">
+        <li class="parent-list-item" ng-show="showVersionSelection" ng-controller="DocsVersionsCtrl">
+          <md-select ng-model="version" placeholder="Version">
+            <md-option ng-value="v.version" ng-click="redirectToVersion(v.version)" ng-repeat="v in versions">{{v.label}}</md-option>
+          </md-select>
+        </li>
         <li ng-repeat="section in menu.sections" class="parent-list-item" ng-class="{'parentActive' : isSectionSelected(section)}">
           <h2 class="menu-heading md-subhead" ng-if="section.type === 'heading'" id="heading_{{ section.name | nospace }}">
             {{section.name}}

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -30,7 +30,9 @@
 
     <md-content flex role="navigation">
       <ul class="docs-menu">
-        <li class="parent-list-item" ng-show="showVersionSelection" ng-controller="DocsVersionsCtrl">
+        <li class="parent-list-item" ng-show="showVersionSelection"
+            ng-controller="DocsVersionsCtrl">
+          <h2 class="menu-heading md-subhead" id="version">Version</h2>
           <md-select ng-model="version" placeholder="Version">
             <md-option ng-value="v.version" ng-click="redirectToVersion(v.version)" ng-repeat="v in versions">{{v.label}}</md-option>
           </md-select>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -2,6 +2,7 @@
 <html ng-app="docsApp" ng-controller="DocsCtrl" lang="en" ng-strict-di>
 <head>
 <title ng-bind="(menu.currentSection.name || 'Material Design') + (menu.currentPage ? (' > ' + (menu.currentPage | humanizeDoc)) : '')">Material Design</title>
+<link rel="icon" type="image/x-icon" href="favicon.ico" />
 <meta name="viewport" content="initial-scale=1" />
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
 <link rel="stylesheet" href="angular-material.min.css">

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -33,7 +33,8 @@
       <ul class="docs-menu">
         <li class="parent-list-item" ng-show="showVersionSelection"
             ng-controller="DocsVersionsCtrl">
-          <h2 class="menu-heading md-subhead" id="version">Version</h2>
+          <h2 class="menu-heading md-subhead" id="version">Current API
+          Version</h2>
           <md-select ng-model="version" placeholder="Version">
             <md-option ng-value="v.version" ng-click="redirectToVersion(v.version)" ng-repeat="v in versions">{{v.label}}</md-option>
           </md-select>

--- a/src/components/tooltip/demoBasicUsage/index.html
+++ b/src/components/tooltip/demoBasicUsage/index.html
@@ -7,7 +7,7 @@
         <md-tooltip>
           Refresh
         </md-tooltip>
-        <md-icon md-svg-src="/img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;">
+        <md-icon md-svg-src="img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;">
         </md-icon>
       </md-button>
     </h2>


### PR DESCRIPTION
closes: https://github.com/angular/material/issues/918

Version selection is hidden when no docs.json is present.  Developing locally will not show the version selector.

This PR is dependant on the new hosting solution proposed by work @robertmesserle has been working on.  This can be merged prior to the new hosting solution.  The version selection will be hidden until the host can provide the docs.json required to define the versions in the selector.