### PR TITLE
feat(autocomplete): adds support for preSelectedItemChange

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -83,7 +83,7 @@ describe('<md-autocomplete>', function() {
       element.scope().$apply();
       $timeout.flush();
 
-      ctrl.select(0);
+      ctrl.preSelect(0);
       element.scope().$apply();
 
       expect(scope.searchText).toBe('foo');
@@ -126,7 +126,7 @@ describe('<md-autocomplete>', function() {
       element.scope().$apply();
       $timeout.flush();
 
-      ctrl.select(0);
+      ctrl.preSelect(0);
       element.scope().$apply();
 
       expect(scope.itemChanged).toHaveBeenCalled();
@@ -147,6 +147,73 @@ describe('<md-autocomplete>', function() {
       expect(scope.itemChanged.calls.count()).toBe(2);
       expect(scope.itemChanged.calls.mostRecent().args[0]).toBeUndefined();
       expect(scope.selectedItem).toBe(null);
+    }));
+
+    it('should notify selected item watchers when md-pre-selected-item-change returns true', inject(function($timeout, $mdConstant) {
+      var scope = createScope();
+      scope.itemChanged = jasmine.createSpy('itemChanged');
+
+      scope.preSelectedItemChange = function(item){
+        return item.display !== 'foo';
+      };
+      spyOn(scope, 'preSelectedItemChange').and.callThrough();
+
+      var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-selected-item-change="itemChanged(item)"\
+              md-pre-selected-item-change="preSelectedItemChange(item)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl    = element.controller('mdAutocomplete');
+
+      element.scope().searchText = 'fo';
+      ctrl.keydown({});
+      element.scope().$apply();
+      $timeout.flush();
+
+      ctrl.preSelect(0);
+      element.scope().$apply();
+
+      expect(scope.preSelectedItemChange).toHaveBeenCalled();
+      expect(scope.preSelectedItemChange.calls.mostRecent().args[0].display).toBe('foo');
+      expect(scope.itemChanged.calls.count()).toBe(0);
+
+      expect(scope.selectedItem).toBeNull();
+
+      ctrl.clear();
+      element.scope().$apply();
+
+      expect(scope.itemChanged.calls.count()).toBe(0);
+      expect(scope.selectedItem).toBeNull();
+
+      element.scope().searchText = 'ba';
+      ctrl.keydown({});
+      element.scope().$apply();
+      $timeout.flush();
+
+      ctrl.preSelect(0);
+      element.scope().$apply();
+
+      expect(scope.preSelectedItemChange).toHaveBeenCalled();
+      expect(scope.preSelectedItemChange.calls.mostRecent().args[0].display).toBe('bar');
+      expect(scope.itemChanged.calls.count()).toBe(1);
+
+      expect(scope.selectedItem.display).toBe('bar');
+
+      ctrl.clear();
+      element.scope().$apply();
+
+      expect(scope.itemChanged.calls.count()).toBe(2);
+      expect(scope.itemChanged.calls.mostRecent().args[0]).toBeUndefined();
+      expect(scope.selectedItem).toBeNull();
+
+
     }));
   });
 

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -78,6 +78,7 @@ function MdAutocomplete ($mdTheming, $mdUtil) {
       itemText:      '&mdItemText',
       placeholder:   '@placeholder',
       noCache:       '=?mdNoCache',
+      preItemChange: '&?mdPreSelectedItemChange',
       itemChange:    '&?mdSelectedItemChange',
       textChange:    '&?mdSearchTextChange',
       minLength:     '=?mdMinLength',
@@ -111,7 +112,7 @@ function MdAutocomplete ($mdTheming, $mdUtil) {
             <li ng-repeat="(index, item) in $mdAutocompleteCtrl.matches"\
                 ng-class="{ selected: index === $mdAutocompleteCtrl.index }"\
                 ng-hide="$mdAutocompleteCtrl.hidden"\
-                ng-click="$mdAutocompleteCtrl.select(index)"\
+                ng-click="$mdAutocompleteCtrl.preSelect(index)"\
                 md-autocomplete-list-item="$mdAutocompleteCtrl.itemName">\
                 ' + getItemTemplate() + '\
             </li>\

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -157,7 +157,7 @@ describe('<md-chips>', function() {
         });
 
         element.scope().$apply(function() {
-          autocompleteCtrl.select(0);
+          autocompleteCtrl.preSelect(0);
         });
 
         expect(scope.items.length).toBe(4);


### PR DESCRIPTION
Add md-pre-selected-item-change to md-autocomplete which is fired before the select(index) function is called with support for promises. The function you define can return a boolean or a promise. Return false or rejecting the promise will result in the autocomplete box NOT changing.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2917)
<!-- Reviewable:end -->
