### PR TITLE
fix(textarea): Start at a height of one line

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -235,6 +235,7 @@ function inputTextareaDirective($mdUtil, $window) {
       element.on('keydown input', onChangeTextarea);
       element.on('scroll', onScroll);
       angular.element($window).on('resize', onChangeTextarea);
+      element.attr('rows', '1');
 
       scope.$on('$destroy', function() {
         angular.element($window).off('resize', onChangeTextarea);

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -58,7 +58,7 @@ md-input-container {
   }
 
   textarea.md-input {
-    min-height: 2 * $input-line-height + $input-border-width-focused + $input-padding-top;
+    min-height: $input-line-height;
     -ms-flex-preferred-size: auto; //IE fix
   }
 


### PR DESCRIPTION
Change min-height for textarea to one line height (and remove extra
padding space), and set rows=“1”, since it defaults to 2. Fixes #2154

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/2953)
<!-- Reviewable:end -->
