### PR TITLE
fix(md-icon): change icon size back to 24px

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -1,4 +1,4 @@
-$icon-size: rem(2.8);
+$icon-size: rem(2.4);
 
 md-icon {
   margin: auto;


### PR DESCRIPTION
Use `$icon-size: rem(2.4);` instead of `$icon-size: rem(2.8);`.

Fixes: #2992