### PR TITLE
Make it clearer that ngMessages is needed for this

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -118,7 +118,8 @@ function labelDirective() {
  *   <input type="text" ng-model="color" required md-maxlength="10">
  * </md-input-container>
  * </hljs>
- * <h3>With Errors (uses [ngMessages](https://docs.angularjs.org/api/ngMessages))</h3>
+ * <h3>With Errors</h3>
+ *
  * <hljs lang="html">
  * <form name="userForm">
  *   <md-input-container>
@@ -147,6 +148,7 @@ function labelDirective() {
  * </form>
  * </hljs>
  *
+ * Requires [ngMessages](https://docs.angularjs.org/api/ngMessages).
  * Behaves like the [AngularJS input directive](https://docs.angularjs.org/api/ng/directive/input).
  *
  */


### PR DESCRIPTION
The information that ngMessages is needed for errors is easily overlooked when it's part of the heading. It took me a while to figure this out.

So put this in an extra sentence below the example.