### PR TITLE
feat(autocomplete): add required attr to input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="0.9.6"></a>
+### 0.9.6  (2015-05-28)
+
+
+#### Bug Fixes
+
+* **build:** fixes bug where versions in 0.9.5 comments were wrong. ([7a1ad41f](https://github.com/angular/material/commit/7a1ad41f3c1df6cb1dfa750cb817f166f02097ee))
+* **closure:** fixes issue in core.js where multiple `goog.provide` lines were included
+
+
 <a name="0.9.5"></a>
 ### 0.9.5  (2015-05-28)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-material-source",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "repository": {
     "url": "git://github.com/angular/material.git"
   },


### PR DESCRIPTION
The autocomplete don't validate required field.
I have some modify: 
- add ng-required="true" inner autocomplete tag
- add ng-required="isRequire" on function getInputElement()
- add attr.$observe('required', function (value) { scope.isRequire = value; }) on function link (scope, element, attr)
The attr work the same with ng-disabled.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3023)
<!-- Reviewable:end -->
