### PR TITLE
fix(calendar): Make calendar directive IDs unique

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -176,6 +176,7 @@ $icon-button-margin: rem(0.600) !default;
     }
   }
 }
+
 .md-toast-open-bottom {
   .md-button.md-fab-bottom-left,
   .md-button.md-fab-bottom-right {
@@ -194,6 +195,7 @@ $icon-button-margin: rem(0.600) !default;
   flex: 1;
   width: 100%;
 }
+
 .md-button-group > .md-button {
   flex: 1;
 

--- a/src/components/calendar/calendar-theme.scss
+++ b/src/components/calendar/calendar-theme.scss
@@ -1,0 +1,28 @@
+// Theme styles for mdCalendar.
+
+.md-calendar-day-header {
+  background-color: #eeeeee; // grey-200
+  color: #616161; // need spec; currently grey-700
+}
+
+.md-calendar-date.md-calendar-date-today {
+  color: #2196f3; // blue-500
+}
+
+.md-calendar-date:focus {
+  .md-calendar-date-selection-indicator {
+    background-color: #e0e0e0; // grey-300
+  }
+}
+
+.md-calendar-date-selection-indicator:hover {
+  background-color: #e0e0e0; // grey-300
+}
+
+// Selected style goes after hover and focus so that it takes priority.
+.md-calendar-date.md-calendar-selected-date {
+  .md-calendar-date-selection-indicator {
+    background-color: #2196f3; // blue-500
+    color: white; // ?
+  }
+}

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -9,13 +9,10 @@
   angular.module('material.components.calendar', ['material.core'])
       .directive('mdCalendar', calendarDirective);
 
-  // TODO(jelbourn): i18n [month names, day names, days of month, date formatting]
   // TODO(jelbourn): Date cell IDs need to be unique per-calendar.
-
-  // TODO(jelbourn): a11y (announcements and labels)
+  // TODO(jelbourn): internationalize a11y announcements.
 
   // TODO(jelbourn): Update the selected date on [click, tap, enter]
-
   // TODO(jelbourn): Shown month transition on [swipe, scroll, keyboard, ngModel change]
   // TODO(jelbourn): Introduce free scrolling that works w/ mobile momemtum scrolling (+snapping)
 
@@ -26,11 +23,9 @@
   // TODO(jelbourn): Minimum and maximum date
   // TODO(jelbourn): Make sure the *time* on the written date makes sense (probably midnight).
   // TODO(jelbourn): Refactor "sections" into separate files.
-  // TODO(jelbourn): Highlight today.
   // TODO(jelbourn): Horizontal line between months (pending spec finalization)
   // TODO(jelbourn): Alt+down in date input to open calendar
   // TODO(jelbourn): Animations should use `.finally()` instead of `.then()`
-  // TODO(jelbourn): Make sure $locale in dateLocaleProvider does nto error if module not loaded.
   // TODO(jelbourn): improve default date parser in locale provider.
 
   function calendarDirective() {

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -30,20 +30,14 @@
   // TODO(jelbourn): Horizontal line between months (pending spec finalization)
   // TODO(jelbourn): Alt+down in date input to open calendar
   // TODO(jelbourn): Animations should use `.finally()` instead of `.then()`
-
-  var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-
-  var fullMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
-      'September', 'October', 'November', 'December'];
-  var fullDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  // TODO(jelbourn): Make sure $locale in dateLocaleProvider does nto error if module not loaded.
+  // TODO(jelbourn): improve default date parser in locale provider.
 
   function calendarDirective() {
     return {
       template:
         '<div>' +
-          '<table class="md-calendar-day-header"><thead><tr>' +
-            '<th>S</th><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th>' +
-          '</tr></thead></table>' +
+          '<table class="md-calendar-day-header"><thead></thead></table>' +
           '<div class="md-calendar-container">' +
             '<table class="md-calendar"></table>' +
           '</div>' +
@@ -74,20 +68,6 @@
     DISTANT_PAST: 4
   };
 
-  // TODO(jelbourn): Refactor this to core and share with other components.
-  /** @enum {number} */
-  var Keys = {
-    ENTER: 13,
-    PAGE_UP: 33,
-    PAGE_DOWN: 34,
-    END: 35,
-    HOME: 36,
-    LEFT: 37,
-    UP: 38,
-    RIGHT: 39,
-    DOWN: 40
-  };
-
   /** Class applied to the selected date cell/. */
   var SELECTED_DATE_CLASS = 'md-calendar-selected-date';
 
@@ -108,7 +88,9 @@
    * Controller for the mdCalendar component.
    * @ngInject @constructor
    */
-  function CalendarCtrl($element, $scope, $animate, $q, $$mdDateUtil, $$mdDateLocale, $mdInkRipple, $mdUtil) {
+  function CalendarCtrl($element, $scope, $animate, $q, $mdConstant,
+      $$mdDateUtil, $$mdDateLocale, $mdInkRipple, $mdUtil) {
+
     /** @final {!angular.$animate} */
     this.$animate = $animate;
 
@@ -122,7 +104,13 @@
     this.$mdUtil = $mdUtil;
 
     /** @final */
+    this.keyCode = $mdConstant.KEY_CODE;
+
+    /** @final */
     this.dateUtil = $$mdDateUtil;
+
+    /** @final */
+    this.dateLocale = $$mdDateLocale;
 
     /** @final {!angular.JQLite} */
     this.$element = $element;
@@ -209,6 +197,8 @@
    * Initialization should occur after the ngModel value is known.
    */
   CalendarCtrl.prototype.buildInitialCalendarDisplay = function() {
+    this.buildWeekHeader();
+
     this.displayDate = this.selectedDate || new Date();
     var nextMonth = this.dateUtil.getDateInNextMonth(this.displayDate);
     this.calendarElement.appendChild(this.buildCalendarForMonth(this.displayDate));
@@ -250,7 +240,7 @@
     this.$scope.$apply(function() {
       // Handled key events fall into two categories: selection and navigation.
       // Start by checking if this is a selection event.
-      if (event.which === Keys.ENTER) {
+      if (event.which === self.keyCode.ENTER) {
         self.ngModelCtrl.$setViewValue(self.displayDate);
         self.ngModelCtrl.$render();
         event.preventDefault();
@@ -280,16 +270,17 @@
    */
   CalendarCtrl.prototype.getFocusDateFromKeyEvent = function(event) {
     var dateUtil = this.dateUtil;
+    var keyCode = this.keyCode;
 
     switch (event.which) {
-      case Keys.RIGHT: return dateUtil.incrementDays(this.displayDate, 1);
-      case Keys.LEFT: return dateUtil.incrementDays(this.displayDate, -1);
-      case Keys.DOWN: return dateUtil.incrementDays(this.displayDate, 7);
-      case Keys.UP: return dateUtil.incrementDays(this.displayDate, -7);
-      case Keys.PAGE_DOWN: return dateUtil.incrementMonths(this.displayDate, 1);
-      case Keys.PAGE_UP: return dateUtil.incrementMonths(this.displayDate, -1);
-      case Keys.HOME: return dateUtil.getFirstDateOfMonth(this.displayDate);
-      case Keys.END: return dateUtil.getLastDateOfMonth(this.displayDate);
+      case keyCode.RIGHT_ARROW: return dateUtil.incrementDays(this.displayDate, 1);
+      case keyCode.LEFT_ARROW: return dateUtil.incrementDays(this.displayDate, -1);
+      case keyCode.DOWN_ARROW: return dateUtil.incrementDays(this.displayDate, 7);
+      case keyCode.UP_ARROW: return dateUtil.incrementDays(this.displayDate, -7);
+      case keyCode.PAGE_DOWN: return dateUtil.incrementMonths(this.displayDate, 1);
+      case keyCode.PAGE_UP: return dateUtil.incrementMonths(this.displayDate, -1);
+      case keyCode.HOME: return dateUtil.getFirstDateOfMonth(this.displayDate);
+      case keyCode.END: return dateUtil.getLastDateOfMonth(this.displayDate);
       default: return this.displayDate;
     }
   };
@@ -572,11 +563,13 @@
     var annoucement = '';
 
     if (!previousDate || !this.dateUtil.isSameMonthAndYear(previousDate, currentDate)) {
-      annoucement += currentDate.getFullYear() + '. ' + fullMonths[currentDate.getMonth()] + '. ';
+      annoucement += currentDate.getFullYear() +
+          '. ' +
+          this.dateLocale.months[currentDate.getMonth()] + '. ';
     }
 
     if (previousDate.getDate() !== currentDate.getDate()) {
-      annoucement += fullDays[currentDate.getDay()] + '. ' + currentDate.getDate() ;
+      annoucement += this.dateLocale.days[currentDate.getDay()] + '. ' + currentDate.getDate() ;
     }
 
     this.ariaLiveElement.textContent = annoucement;
@@ -584,6 +577,21 @@
 
 
   /*** Constructing the calendar table ***/
+
+  /**
+   * Builds and appends a day-of-the-week header to the calendar.
+   * This should only need to be called once during initialization.
+   */
+  CalendarCtrl.prototype.buildWeekHeader = function() {
+    var row = document.createElement('tr');
+    for (var i = 0; i < 7; i++) {
+      var th = document.createElement('th');
+      th.textContent = this.dateLocale.shortDays[i];
+      row.appendChild(th);
+    }
+
+    this.$element.find('thead').append(row);
+  };
 
   /**
    * Creates a single cell to contain a date in the calendar with all appropriate
@@ -601,7 +609,7 @@
       var selectionIndicator = document.createElement('span');
       cell.appendChild(selectionIndicator);
       selectionIndicator.classList.add('md-calendar-date-selection-indicator');
-      selectionIndicator.textContent = opt_date.getDate();
+      selectionIndicator.textContent = this.dateLocale.dates[opt_date.getDate()];
       //selectionIndicator.setAttribute('aria-label', '');
 
       cell.setAttribute('tabindex', '-1');
@@ -629,7 +637,7 @@
     // Store rows for the month in a document fragment so that we can append them all at once.
     var monthBody = document.createElement('tbody');
     monthBody.classList.add('md-calendar-month');
-    monthBody.setAttribute('aria-hidden', 'true')
+    monthBody.setAttribute('aria-hidden', 'true');
 
     var row = document.createElement('tr');
     monthBody.appendChild(row);
@@ -642,7 +650,7 @@
     monthLabelCell.classList.add('md-calendar-month-label');
     if (firstDayOfTheWeek <= 1) {
       monthLabelCell.setAttribute('colspan', '7');
-      monthLabelCell.textContent = months[date.getMonth()];
+      monthLabelCell.textContent = this.dateLocale.shortMonths[date.getMonth()];
 
       var monthLabelRow = document.createElement('tr');
       monthLabelRow.appendChild(monthLabelCell);
@@ -650,7 +658,7 @@
     } else {
       blankCellOffset = 2;
       monthLabelCell.setAttribute('colspan', '2');
-      monthLabelCell.textContent = months[date.getMonth()];
+      monthLabelCell.textContent = this.dateLocale.shortMonths[date.getMonth()];
 
       row.appendChild(monthLabelCell);
     }

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -1,0 +1,686 @@
+(function() {
+  'use strict';
+
+  /**
+   * @ngdoc module
+   * @name material.components.calendar
+   * @description Calendar
+   */
+  angular.module('material.components.calendar', ['material.core'])
+      .directive('mdCalendar', calendarDirective);
+
+  // TODO(jelbourn): i18n [month names, day names, days of month, date formatting]
+  // TODO(jelbourn): Date cell IDs need to be unique per-calendar.
+
+  // TODO(jelbourn): a11y (announcements and labels)
+
+  // TODO(jelbourn): Update the selected date on [click, tap, enter]
+
+  // TODO(jelbourn): Shown month transition on [swipe, scroll, keyboard, ngModel change]
+  // TODO(jelbourn): Introduce free scrolling that works w/ mobile momemtum scrolling (+snapping)
+
+  // TODO(jelbourn): Responsive
+  // TODO(jelbourn): Themes
+  // TODO(jelbourn); inkRipple (need UX input)
+
+  // TODO(jelbourn): Minimum and maximum date
+  // TODO(jelbourn): Make sure the *time* on the written date makes sense (probably midnight).
+  // TODO(jelbourn): Refactor "sections" into separate files.
+  // TODO(jelbourn): Highlight today.
+  // TODO(jelbourn): Horizontal line between months (pending spec finalization)
+  // TODO(jelbourn): Alt+down in date input to open calendar
+  // TODO(jelbourn): Animations should use `.finally()` instead of `.then()`
+
+  var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+  var fullMonths = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August',
+      'September', 'October', 'November', 'December'];
+  var fullDays = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+  function calendarDirective() {
+    return {
+      template:
+        '<div>' +
+          '<table class="md-calendar-day-header"><thead><tr>' +
+            '<th>S</th><th>M</th><th>T</th><th>W</th><th>T</th><th>F</th><th>S</th>' +
+          '</tr></thead></table>' +
+          '<div class="md-calendar-container">' +
+            '<table class="md-calendar"></table>' +
+          '</div>' +
+          '<div aria-live="polite"></div>' +
+        '</div>',
+      restrict: 'E',
+      require: ['ngModel', 'mdCalendar'],
+      controller: CalendarCtrl,
+      controllerAs: 'ctrl',
+      bindToController: true,
+      link: function(scope, element, attrs, controllers) {
+        var ngModelCtrl = controllers[0];
+        var mdCalendarCtrl = controllers[1];
+        mdCalendarCtrl.configureNgModel(ngModelCtrl);
+      }
+    };
+  }
+
+  /**
+   * Catigorization of type of date changes that can occur.
+   * @enum {number}
+   */
+  var DateChangeType = {
+    SAME_MONTH: 0,
+    NEXT_MONTH: 1,
+    PREVIOUS_MONTH: 2,
+    DISTANT_FUTURE: 3,
+    DISTANT_PAST: 4
+  };
+
+  // TODO(jelbourn): Refactor this to core and share with other components.
+  /** @enum {number} */
+  var Keys = {
+    ENTER: 13,
+    PAGE_UP: 33,
+    PAGE_DOWN: 34,
+    END: 35,
+    HOME: 36,
+    LEFT: 37,
+    UP: 38,
+    RIGHT: 39,
+    DOWN: 40
+  };
+
+  /** Class applied to the selected date cell/. */
+  var SELECTED_DATE_CLASS = 'md-calendar-selected-date';
+
+  /** Class applied to the cell for today. */
+  var TODAY_CLASS = 'md-calendar-date-today';
+
+
+  /**
+   * Gets a unique identifier for a date for internal purposes. Not to be displayed.
+   * @param {Date} date
+   * @returns {string}
+   */
+  function getDateId(date) {
+    return 'md-' + date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
+  }
+
+  /**
+   * Controller for the mdCalendar component.
+   * @ngInject @constructor
+   */
+  function CalendarCtrl($element, $scope, $animate, $q, $$mdDateUtil, $$mdDateLocale, $mdInkRipple, $mdUtil) {
+    /** @final {!angular.$animate} */
+    this.$animate = $animate;
+
+    /** @final {!angular.$q} */
+    this.$q = $q;
+
+    /** @final */
+    this.$mdInkRipple = $mdInkRipple;
+
+    /** @final */
+    this.$mdUtil = $mdUtil;
+
+    /** @final */
+    this.dateUtil = $$mdDateUtil;
+
+    /** @final {!angular.JQLite} */
+    this.$element = $element;
+
+    /** @final {!angular.Scope} */
+    this.$scope = $scope;
+
+    /** @final {HTMLElement} */
+    this.calendarElement = $element[0].querySelector('.md-calendar');
+
+    /** @final {HTMLElement} */
+    this.ariaLiveElement = $element[0].querySelector('[aria-live]');
+
+    /** @final {Date} */
+    this.today = new Date();
+
+    /** @type {!angular.NgModelController} */
+    this.ngModelCtrl = null;
+
+    /**
+     * The selected date. Keep track of this separately from the ng-model value so that we
+     * can know, when the ng-model value changes, what the previous value was before its updated
+     * in the component's UI.
+     *
+     * @type {Date}
+     */
+    this.selectedDate = null;
+
+    /**
+     * The date that is currently focused or showing in the calendar. This will initially be set
+     * to the ng-model value if set, otherwise to today. It will be updated as the user navigates
+     * to other months. The cell corresponding to the displayDate does not necesarily always have
+     * focus in the document (such as for cases when the user is scrolling the calendar).
+     * @type {Date}
+     */
+    this.displayDate = null;
+
+    /** @type {boolean} */
+    this.isInitialized = false;
+
+    /** @type {boolean} */
+    this.isMonthTransitionInProgress = false;
+
+    var self = this;
+
+    /**
+     * Handles a click event on a date cell.
+     * Created here so that every cell can use the same function instance.
+     * @this {HTMLTableCellElement} The cell that was clicked.
+     */
+    this.cellClickHandler = function() {
+      if (this.dataset.timestamp) {
+        $scope.$apply(function() {
+          self.ngModelCtrl.$setViewValue(new Date(Number(this.dataset.timestamp)));
+          self.ngModelCtrl.$render();
+        }.bind(this));
+      }
+    };
+
+    this.attachCalendarEventListeners();
+
+    // DEBUG
+    window.ctrl = this;
+  }
+
+
+  /*** Initialization ***/
+
+  /**
+   * Sets up the controller's reference to ngModelController.
+   * @param {!angular.NgModelController} ngModelCtrl
+   */
+  CalendarCtrl.prototype.configureNgModel = function(ngModelCtrl) {
+    this.ngModelCtrl = ngModelCtrl;
+
+    var self = this;
+    ngModelCtrl.$render = function() {
+      self.changeSelectedDate(self.ngModelCtrl.$viewValue);
+    };
+  };
+
+  /**
+   * Initialize the calendar by building the months that are initially visible.
+   * Initialization should occur after the ngModel value is known.
+   */
+  CalendarCtrl.prototype.buildInitialCalendarDisplay = function() {
+    this.displayDate = this.selectedDate || new Date();
+    var nextMonth = this.dateUtil.getDateInNextMonth(this.displayDate);
+    this.calendarElement.appendChild(this.buildCalendarForMonth(this.displayDate));
+    this.calendarElement.appendChild(this.buildCalendarForMonth(nextMonth));
+
+    this.isInitialized = true;
+  };
+
+  /**
+   * Attach event listeners for the calendar.
+   */
+  CalendarCtrl.prototype.attachCalendarEventListeners = function() {
+    var self = this;
+
+    // Keyboard interaction.
+    this.calendarElement.addEventListener('keydown', this.handleKeyEvent.bind(this));
+
+    // EXPERIMENT: does this weel event work on all browsers?
+    this.calendarElement.addEventListener('wheel', function(event) {
+      event.preventDefault();
+      self.$scope.$apply(self.$mdUtil.debounce(function() {
+        var transitionToDate = event.deltaY > 0 ?
+            self.dateUtil.getDateInNextMonth(self.displayDate) :
+            self.dateUtil.getDateInPreviousMonth(self.displayDate);
+        self.changeDisplayDate(transitionToDate);
+      }, 100));
+    });
+  };
+  
+  /*** User input handling ***/
+
+  /**
+   * Handles a key event in the calendar with the appropriate action. The action will either
+   * be to select the focused date or to navigate to focus a new date.
+   * @param {KeyboardEvent} event
+   */
+  CalendarCtrl.prototype.handleKeyEvent = function(event) {
+    var self = this;
+    this.$scope.$apply(function() {
+      // Handled key events fall into two categories: selection and navigation.
+      // Start by checking if this is a selection event.
+      if (event.which === Keys.ENTER) {
+        self.ngModelCtrl.$setViewValue(self.displayDate);
+        self.ngModelCtrl.$render();
+        event.preventDefault();
+        return;
+      }
+
+      // Selection isn't occuring, so the key event is either navigation or nothing.
+      var date = self.getFocusDateFromKeyEvent(event);
+
+      // Prevent the default on the key event only if it triggered a date navigation.
+      if (!self.dateUtil.isSameDay(date, self.displayDate)) {
+        event.preventDefault();
+      }
+
+      // Since this is a keyboard interaction, actually give the newly focused date keyboard
+      // focus after the been brought into view.
+      self.changeDisplayDate(date).then(function() {
+        self.focusDateElement(date);
+      });
+    })
+  };
+
+  /**
+   * Gets the date to focus as the result of a key event.
+   * @param {KeyboardEvent} event
+   * @returns {Date}
+   */
+  CalendarCtrl.prototype.getFocusDateFromKeyEvent = function(event) {
+    var dateUtil = this.dateUtil;
+
+    switch (event.which) {
+      case Keys.RIGHT: return dateUtil.incrementDays(this.displayDate, 1);
+      case Keys.LEFT: return dateUtil.incrementDays(this.displayDate, -1);
+      case Keys.DOWN: return dateUtil.incrementDays(this.displayDate, 7);
+      case Keys.UP: return dateUtil.incrementDays(this.displayDate, -7);
+      case Keys.PAGE_DOWN: return dateUtil.incrementMonths(this.displayDate, 1);
+      case Keys.PAGE_UP: return dateUtil.incrementMonths(this.displayDate, -1);
+      case Keys.HOME: return dateUtil.getFirstDateOfMonth(this.displayDate);
+      case Keys.END: return dateUtil.getLastDateOfMonth(this.displayDate);
+      default: return this.displayDate;
+    }
+  };
+
+  /**
+   * Focus the cell corresponding to the given date.
+   * @param {Date} date
+   */
+  CalendarCtrl.prototype.focusDateElement = function(date) {
+    var cellId = getDateId(date);
+    var cell = this.calendarElement.querySelector('#' + cellId);
+    cell.focus();
+  };
+  
+
+  /*** Animation ***/
+
+  /**
+   * Animates the calendar to the next month.
+   * @param date
+   * @returns {angular.$q.Promise} The animation promise.
+   */
+  CalendarCtrl.prototype.animateToNextMonth = function(date) {
+    var currentMonth = this.calendarElement.querySelector('tbody');
+    var amountToMove = -(currentMonth.clientHeight) + 'px'; // todo: Why is this 2px off (Chrome)?
+
+    var newMonthToShow = this.buildCalendarForMonth(this.dateUtil.getDateInNextMonth(date));
+    this.calendarElement.appendChild(newMonthToShow);
+
+    var animatePromise = this.$animate.animate(angular.element(this.calendarElement),
+        {transform: 'translateY(0)'},
+        {transform: 'translateY(' + amountToMove + ')'});
+
+    var self = this;
+    return animatePromise.then(function() {
+      self.calendarElement.removeChild(currentMonth);
+      self.calendarElement.style.transform = '';
+    });
+  };
+
+
+  /**
+   * Animates the calendar to the previous month.
+   * @param date
+   * @returns {angular.$q.Promise} The animation promise.
+   */
+  CalendarCtrl.prototype.animateToPreviousMonth = function(date) {
+    var displayedMonths = this.calendarElement.querySelectorAll('tbody');
+    var currentMonth = displayedMonths[0];
+    var nextMonth = displayedMonths[1];
+
+    var newMonthToShow = this.buildCalendarForMonth(date);
+    this.calendarElement.insertBefore(newMonthToShow, currentMonth);
+    var amountToMove = newMonthToShow.clientHeight + 'px';
+
+    var animatePromise = this.$animate.animate(angular.element(this.calendarElement),
+          {transform: 'translateY(-' + amountToMove + ')'},
+          {transform: 'translateY(0)'});
+
+    var self = this;
+    return animatePromise.then(function() {
+      self.calendarElement.removeChild(nextMonth);
+      self.calendarElement.style.transform = '';
+    });
+  };
+
+
+  /**
+   * Animates the calendar to a date further than one month in the future.
+   * @param date
+   * @returns {angular.$q.Promise} The animation promise.
+   */
+  CalendarCtrl.prototype.animateToDistantFuture = function(date) {
+    var displayedMonths = this.calendarElement.querySelectorAll('tbody');
+    var currentMonth = displayedMonths[0];
+    var nextMonth = displayedMonths[1];
+
+    var midpointDate = this.dateUtil.getDateMidpoint(this.displayDate, date);
+    var midpointMonth = this.buildCalendarForMonth(midpointDate);
+    this.calendarElement.appendChild(midpointMonth);
+
+    var amountToMove = -(currentMonth.clientHeight +
+        nextMonth.clientHeight + midpointMonth.clientHeight) + 'px';
+
+    var targetMonth = this.buildCalendarForMonth(date);
+    this.calendarElement.appendChild(targetMonth);
+
+    var monthAfterTargetMonth = this.buildCalendarForMonth(this.dateUtil.getDateInNextMonth(date));
+    this.calendarElement.appendChild(monthAfterTargetMonth);
+
+    var animatePromise = this.$animate.animate(angular.element(this.calendarElement),
+        {transform: 'translateY(0)'},
+        {transform: 'translateY(' + amountToMove + ')'});
+
+    var self = this;
+    return animatePromise.then(function() {
+      self.calendarElement.removeChild(currentMonth);
+      self.calendarElement.removeChild(nextMonth);
+      self.calendarElement.removeChild(midpointMonth);
+      self.calendarElement.style.transform = '';
+    });
+  };
+
+
+  /**
+   * Animates the calendar to a date further than one month in the past.
+   * @param date
+   * @returns {angular.$q.Promise} The animation promise.
+   */
+  CalendarCtrl.prototype.animateToDistantPast = function(date) {
+    var displayedMonths = this.calendarElement.querySelectorAll('tbody');
+    var currentMonth = displayedMonths[0];
+    var nextMonth = displayedMonths[1];
+
+    var midpointDate = this.dateUtil.getDateMidpoint(this.displayDate, date);
+    var midpointMonth = this.buildCalendarForMonth(midpointDate);
+    this.calendarElement.insertBefore(midpointMonth, currentMonth);
+
+    var monthAfterTargetMonth = this.buildCalendarForMonth(this.dateUtil.getDateInNextMonth(date));
+    this.calendarElement.insertBefore(monthAfterTargetMonth, midpointMonth);
+
+    var targetMonth = this.buildCalendarForMonth(date);
+    this.calendarElement.insertBefore(targetMonth, monthAfterTargetMonth);
+
+    var amountToMove = -(targetMonth.clientHeight + midpointMonth.clientHeight +
+        monthAfterTargetMonth.clientHeight) + 'px';
+
+    var animatePromise = this.$animate.animate(angular.element(this.calendarElement),
+          {transform: 'translateY(' + amountToMove + ')'},
+          {transform: 'translateY(0)'});
+
+    var self = this;
+    return animatePromise.then(function() {
+      self.calendarElement.removeChild(nextMonth);
+      self.calendarElement.removeChild(currentMonth);
+      self.calendarElement.removeChild(midpointMonth);
+      self.calendarElement.style.transform = '';
+    });
+  };
+
+
+  /**
+   * Animates the transition from the calendar's current month to the given month.
+   * @param date
+   * @returns {angular.$q.Promise} The animation promise.
+   */
+  CalendarCtrl.prototype.animateDateChange = function(date) {
+    var dateChangeType = this.getDateChangeType(date);
+    switch (dateChangeType) {
+      case DateChangeType.NEXT_MONTH: return this.animateToNextMonth(date);
+      case DateChangeType.PREVIOUS_MONTH: return this.animateToPreviousMonth(date);
+      case DateChangeType.DISTANT_FUTURE: return this.animateToDistantFuture(date);
+      case DateChangeType.DISTANT_PAST: return this.animateToDistantPast(date);
+      default: return this.$q.when();
+    }
+  };
+
+  /**
+   * Given a date, determines the type of transition that will occur from the currently shown date.
+   * @param {Date} date
+   * @returns {DateChangeType}
+   */
+  CalendarCtrl.prototype.getDateChangeType = function(date) {
+    if (date && this.displayDate && !this.dateUtil.isSameMonthAndYear(date, this.displayDate)) {
+      if (this.dateUtil.isInNextMonth(this.displayDate, date)) {
+        return DateChangeType.NEXT_MONTH;
+      }
+
+      if (this.dateUtil.isInPreviousMonth(this.displayDate, date)) {
+        return DateChangeType.PREVIOUS_MONTH;
+      }
+
+      if (date > this.displayDate) {
+        return DateChangeType.DISTANT_FUTURE;
+      }
+
+      return DateChangeType.DISTANT_PAST;
+    }
+
+    return DateChangeType.SAME_MONTH;
+  };
+
+
+  /*** Updating the displayed / selected date ***/
+
+  /**
+   * Change the selected date in the calendar (ngModel value has already been changed).
+   * @param {Date} date
+   */
+  CalendarCtrl.prototype.changeSelectedDate = function(date) {
+    var self = this;
+    this.changeDisplayDate(date).then(function() {
+
+      // Remove the selected class from the previously selected date, if any.
+      if (self.selectedDate) {
+        var prevDateCell = self.calendarElement.querySelector('#' + getDateId(self.selectedDate));
+        if (prevDateCell) {
+          prevDateCell.classList.remove(SELECTED_DATE_CLASS);
+        }
+      }
+
+      // Apply the select class to the new selected date if it is set.
+      if (date) {
+        var dateCell = self.calendarElement.querySelector('#' + getDateId(date));
+        if (dateCell) {
+          dateCell.classList.add(SELECTED_DATE_CLASS);
+        }
+      }
+
+      self.selectedDate = date;
+    });
+  };
+
+
+  /**
+   * Change the date that is being shown in the calendar. If the given date is in a different
+   * month, the displayed month will be transitioned.
+   * @param {Date} date
+   */
+  CalendarCtrl.prototype.changeDisplayDate = function(date) {
+    // Initialization is deferred until this function is called because we want to reflect
+    // the starting value of ngModel.
+    if (!this.isInitialized) {
+      this.buildInitialCalendarDisplay();
+      return this.$q.when();
+    }
+
+    // If trying to show a null or undefined date, do nothing.
+    if (!date) {
+      return this.$q.when();
+    }
+
+
+    // WORK IN PROGRESS: do nothing if animation is in progress.
+    if (this.isMonthTransitionInProgress) {
+      //return this.$q.when();
+    }
+
+    this.isMonthTransitionInProgress = true;
+    var animationPromise = this.animateDateChange(date);
+
+    this.announceDisplayDateChange(this.displayDate, date);
+    this.displayDate = date;
+
+    var self = this;
+    animationPromise.then(function() {
+      self.highlightToday();
+      self.isMonthTransitionInProgress = false;
+    });
+
+    return animationPromise;
+  };
+
+
+  /**
+   * Highlight the cell corresponding to today if it is on the screen.
+   */
+  CalendarCtrl.prototype.highlightToday = function() {
+    var todayCell = this.calendarElement.querySelector('#' + getDateId(this.today));
+    if (todayCell) {
+      todayCell.classList.add(TODAY_CLASS);
+    }
+  };
+
+
+  /**
+   * Announces a change in date to the calendar's aria-live region.
+   * @param {Date} previousDate
+   * @param {Date} currentDate
+   */
+  CalendarCtrl.prototype.announceDisplayDateChange = function(previousDate, currentDate) {
+    // PROOF OF CONCEPT: this obviously needs to be internationalized, but we can see if the idea
+    // works.
+
+    // If the date has not changed at all, do nothing.
+    if (previousDate && this.dateUtil.isSameDay(previousDate, currentDate)) {
+      return;
+    }
+
+    var annoucement = '';
+
+    if (!previousDate || !this.dateUtil.isSameMonthAndYear(previousDate, currentDate)) {
+      annoucement += currentDate.getFullYear() + '. ' + fullMonths[currentDate.getMonth()] + '. ';
+    }
+
+    if (previousDate.getDate() !== currentDate.getDate()) {
+      annoucement += fullDays[currentDate.getDay()] + '. ' + currentDate.getDate() ;
+    }
+
+    this.ariaLiveElement.textContent = annoucement;
+  };
+
+
+  /*** Constructing the calendar table ***/
+
+  /**
+   * Creates a single cell to contain a date in the calendar with all appropriate
+   * attributes and classes added. If a date is given, the cell content will be set
+   * based on the date.
+   * @param {Date=} opt_date
+   * @returns {HTMLElement}
+   */
+  CalendarCtrl.prototype.buildDateCell = function(opt_date) {
+    var cell = document.createElement('td');
+    cell.classList.add('md-calendar-date');
+
+    if (opt_date) {
+      // Add a indicator for select, hover, and focus states.
+      var selectionIndicator = document.createElement('span');
+      cell.appendChild(selectionIndicator);
+      selectionIndicator.classList.add('md-calendar-date-selection-indicator');
+      selectionIndicator.textContent = opt_date.getDate();
+      //selectionIndicator.setAttribute('aria-label', '');
+
+      cell.setAttribute('tabindex', '-1');
+      cell.id = getDateId(opt_date);
+      cell.dataset.timestamp = opt_date.getTime();
+      cell.addEventListener('click', this.cellClickHandler);
+    }
+
+    return cell;
+  };
+
+
+  /**
+   * Builds a <tbody> element for the given date's month.
+   * @param {Date=} opt_dateInMonth
+   * @returns {HTMLTableSectionElement} A <tbody> containing the <tr> elements.
+   */
+  CalendarCtrl.prototype.buildCalendarForMonth = function(opt_dateInMonth) {
+    var date = opt_dateInMonth || new Date();
+
+    var firstDayOfMonth = this.dateUtil.getFirstDateOfMonth(date);
+    var firstDayOfTheWeek = firstDayOfMonth.getDay();
+    var numberOfDaysInMonth = this.dateUtil.getNumberOfDaysInMonth(date);
+
+    // Store rows for the month in a document fragment so that we can append them all at once.
+    var monthBody = document.createElement('tbody');
+    monthBody.classList.add('md-calendar-month');
+    monthBody.setAttribute('aria-hidden', 'true')
+
+    var row = document.createElement('tr');
+    monthBody.appendChild(row);
+
+    // Add a label for the month. If the month starts on a Sunday or a Monday, the month label
+    // goes on a row above the first of the month. Otherwise, the month label takes up the first
+    // two cells of the first row.
+    var blankCellOffset = 0;
+    var monthLabelCell = document.createElement('td');
+    monthLabelCell.classList.add('md-calendar-month-label');
+    if (firstDayOfTheWeek <= 1) {
+      monthLabelCell.setAttribute('colspan', '7');
+      monthLabelCell.textContent = months[date.getMonth()];
+
+      var monthLabelRow = document.createElement('tr');
+      monthLabelRow.appendChild(monthLabelCell);
+      monthBody.insertBefore(monthLabelRow, row);
+    } else {
+      blankCellOffset = 2;
+      monthLabelCell.setAttribute('colspan', '2');
+      monthLabelCell.textContent = months[date.getMonth()];
+
+      row.appendChild(monthLabelCell);
+    }
+
+    // Add a blank cell for each day of the week that occurs before the first of the month.
+    // For example, if the first day of the month is a Tuesday, add blank cells for Sun and Mon.
+    // The blankCellOffset is needed in cases where the first N cells are used by the month label.
+    for (var i = blankCellOffset; i < firstDayOfTheWeek; i++) {
+      row.appendChild(this.buildDateCell());
+    }
+
+    // Add a cell for each day of the month, keeping track of the day of the week so that
+    // we know when to start a new row.
+    var dayOfWeek = firstDayOfTheWeek;
+    var iterationDate = firstDayOfMonth;
+    for (var d = 1; d <= numberOfDaysInMonth; d++) {
+      // If we've reached the end of the week, start a new row.
+      if (dayOfWeek === 7) {
+        dayOfWeek = 0;
+        row = document.createElement('tr');
+        monthBody.appendChild(row);
+      }
+
+      iterationDate.setDate(d);
+      var cell = this.buildDateCell(iterationDate);
+      row.appendChild(cell);
+
+      dayOfWeek++;
+    }
+
+    return monthBody;
+  };
+})();

--- a/src/components/calendar/calendar.js
+++ b/src/components/calendar/calendar.js
@@ -9,7 +9,6 @@
   angular.module('material.components.calendar', ['material.core'])
       .directive('mdCalendar', calendarDirective);
 
-  // TODO(jelbourn): Date cell IDs need to be unique per-calendar.
   // TODO(jelbourn): internationalize a11y announcements.
 
   // TODO(jelbourn): Update the selected date on [click, tap, enter]
@@ -29,6 +28,9 @@
   // TODO(jelbourn): improve default date parser in locale provider.
 
   function calendarDirective() {
+    // Generate a unique ID for each instance of the directive.
+    var directiveId = 0;
+
     return {
       template:
         '<div>' +
@@ -46,6 +48,7 @@
       link: function(scope, element, attrs, controllers) {
         var ngModelCtrl = controllers[0];
         var mdCalendarCtrl = controllers[1];
+        mdCalendarCtrl.directiveId = directiveId++;
         mdCalendarCtrl.configureNgModel(ngModelCtrl);
       }
     };
@@ -68,16 +71,6 @@
 
   /** Class applied to the cell for today. */
   var TODAY_CLASS = 'md-calendar-date-today';
-
-
-  /**
-   * Gets a unique identifier for a date for internal purposes. Not to be displayed.
-   * @param {Date} date
-   * @returns {string}
-   */
-  function getDateId(date) {
-    return 'md-' + date.getFullYear() + '-' + date.getMonth() + '-' + date.getDate();
-  }
 
   /**
    * Controller for the mdCalendar component.
@@ -255,7 +248,7 @@
       self.changeDisplayDate(date).then(function() {
         self.focusDateElement(date);
       });
-    })
+    });
   };
 
   /**
@@ -285,7 +278,7 @@
    * @param {Date} date
    */
   CalendarCtrl.prototype.focusDateElement = function(date) {
-    var cellId = getDateId(date);
+    var cellId = this.getDateId_(date);
     var cell = this.calendarElement.querySelector('#' + cellId);
     cell.focus();
   };
@@ -471,7 +464,7 @@
 
       // Remove the selected class from the previously selected date, if any.
       if (self.selectedDate) {
-        var prevDateCell = self.calendarElement.querySelector('#' + getDateId(self.selectedDate));
+        var prevDateCell = self.calendarElement.querySelector('#' + self.getDateId_(self.selectedDate));
         if (prevDateCell) {
           prevDateCell.classList.remove(SELECTED_DATE_CLASS);
         }
@@ -479,7 +472,7 @@
 
       // Apply the select class to the new selected date if it is set.
       if (date) {
-        var dateCell = self.calendarElement.querySelector('#' + getDateId(date));
+        var dateCell = self.calendarElement.querySelector('#' + self.getDateId_(date));
         if (dateCell) {
           dateCell.classList.add(SELECTED_DATE_CLASS);
         }
@@ -534,7 +527,7 @@
    * Highlight the cell corresponding to today if it is on the screen.
    */
   CalendarCtrl.prototype.highlightToday = function() {
-    var todayCell = this.calendarElement.querySelector('#' + getDateId(this.today));
+    var todayCell = this.calendarElement.querySelector('#' + this.getDateId_(this.today));
     if (todayCell) {
       todayCell.classList.add(TODAY_CLASS);
     }
@@ -608,7 +601,7 @@
       //selectionIndicator.setAttribute('aria-label', '');
 
       cell.setAttribute('tabindex', '-1');
-      cell.id = getDateId(opt_date);
+      cell.id = this.getDateId_(opt_date);
       cell.dataset.timestamp = opt_date.getTime();
       cell.addEventListener('click', this.cellClickHandler);
     }
@@ -685,5 +678,23 @@
     }
 
     return monthBody;
+  };
+
+
+  /**
+   * Gets an identifier for a date unique to the calendar instance for internal
+   * purposes. Not to be displayed.
+   * @param {Date} date
+   * @returns {string}
+   * @private
+   */
+  CalendarCtrl.prototype.getDateId_ = function (date) {
+    return [
+      'md',
+      this.directiveId,
+      date.getFullYear(), 
+      date.getMonth(), 
+      date.getDate()
+    ].join('-');
   };
 })();

--- a/src/components/calendar/calendar.scss
+++ b/src/components/calendar/calendar.scss
@@ -1,0 +1,58 @@
+// Styles for mdCalendar.
+$date-cell-size: 44px !default;
+$date-cell-emphasis-size: 40px !default;
+$calendar-number-of-weeks: 7 !default;
+
+// Style applied to date cells, including day-of-the-week header cells.
+@mixin calendar-date-cell() {
+  height: $date-cell-size;
+  width: $date-cell-size;
+  text-align: center;
+}
+
+md-calendar {
+  font-size: 12px;
+}
+
+.md-calendar-container {
+  position: relative;
+  max-height: $calendar-number-of-weeks * $date-cell-size;
+  overflow: hidden;
+}
+
+.md-calendar-date {
+  @include calendar-date-cell();
+}
+
+.md-calendar-date-selection-indicator {
+  transition-property: background-color, color;
+  transition-duration: $swift-ease-out-duration;
+  transition-timing-function: $swift-ease-out-timing-function;
+
+  border-radius: 50%;
+  display: inline-block;
+
+  cursor: pointer;
+
+  width: $date-cell-emphasis-size;
+  height: $date-cell-emphasis-size;
+  line-height: $date-cell-emphasis-size;
+}
+
+.md-calendar-month-label {
+  height: $date-cell-size;
+}
+
+.md-calendar-day-header th {
+  @include calendar-date-cell();
+  font-weight: normal;
+}
+
+.md-calendar {
+  // DEBUGGING: add border to container
+  border: 1px dotted lightgray;
+}
+
+.md-calendar.ng-animate {
+  transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
+}

--- a/src/components/calendar/calendar.spec.js
+++ b/src/components/calendar/calendar.spec.js
@@ -1,0 +1,63 @@
+
+describe('md-checkbox', function() {
+  var ngElement, element, scope, pageScope, controller, $animate;
+
+  /**
+   * To apply a change in the date, a scope $apply() AND a manual triggering of animation
+   * callbacks is necessary.
+   */
+  function applyDateChange() {
+    pageScope.$apply();
+    $animate.triggerCallbacks();
+  }
+
+  beforeEach(module('material.components.calendar', 'ngAnimateMock'));
+
+  beforeEach(inject(function($compile, $rootScope, _$animate_) {
+    $animate = _$animate_;
+
+    var template = '<md-calendar ng-model="myDate"></md-calendar>';
+    pageScope = $rootScope.$new();
+    pageScope.myDate = null;
+
+    ngElement = $compile(template)(pageScope);
+    element = ngElement[0];
+    scope = ngElement.scope();
+    controller = ngElement.controller('mdCalendar');
+
+    pageScope.$apply();
+  }));
+
+  describe('ngModel binding', function() {
+
+    it('should update the calendar based on ngModel change', function() {
+      pageScope.myDate = new Date(2014, 4, 30);
+      applyDateChange();
+
+      var displayedMonth = element.querySelector('.md-calendar-month-label');
+      var selectedDate = element.querySelector('.md-calendar-selected-date');
+
+      expect(displayedMonth.textContent).toBe('May');
+      expect(selectedDate.textContent).toBe('30')
+    });
+
+  });
+
+  describe('calendar construction', function() {
+
+  });
+
+  describe('keyboard events', function() {
+
+  });
+
+  describe('focus behavior', function() {
+
+  });
+
+  describe('a11y announcements', function() {
+  });
+
+  describe('i18n', function() {
+  });
+});

--- a/src/components/calendar/dateLocale.spec.js
+++ b/src/components/calendar/dateLocale.spec.js
@@ -1,0 +1,88 @@
+
+describe('$$mdDateLocale', function() {
+  var dateLocale, dateUtil;
+
+  // Fake $locale with made-up days and months.
+  var $localeFake = {
+    DATETIME_FORMATS: {
+      DAY: ['Sundog', 'Mondog', 'Tuesdog', 'Wednesdog', 'Thursdog', 'Fridog', 'Saturdog'],
+      MONTH: ['JanZ', 'FebZ', 'MarZ', 'AprZ', 'MayZ', 'JunZ', 'JulZ', 'AugZ', 'SeptZ',
+          'OctZ', 'NovZ', 'DecZ'],
+      SHORTMONTH: ['JZ', 'FZ', 'MZ', 'AZ', 'MZ', 'JZ', 'JZ', 'AZ', 'SZ', 'OZ', 'NZ', 'DZ']
+    }
+  };
+
+  beforeEach(module('material.components.calendar'));
+
+  describe('with default values', function() {
+    beforeEach(module(function($provide) {
+      $provide.value('$locale', $localeFake);
+    }));
+
+    beforeEach(inject(function($$mdDateLocale, $$mdDateUtil) {
+      dateLocale = $$mdDateLocale;
+      dateUtil = $$mdDateUtil;
+    }));
+
+    it('should expose default days, months, and dates', function() {
+      expect(dateLocale.months).toEqual($localeFake.DATETIME_FORMATS.MONTH);
+      expect(dateLocale.shortMonths).toEqual($localeFake.DATETIME_FORMATS.SHORTMONTH);
+      expect(dateLocale.days).toEqual($localeFake.DATETIME_FORMATS.DAY);
+      expect(dateLocale.shortDays).toEqual(['S', 'M', 'T', 'W', 'T', 'F', 'S']);
+      expect(dateLocale.dates).toEqual([undefined, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+          15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+    });
+
+    it('should have a default date formatter', function() {
+      var date = new Date(2014, 2, 25);
+      var dateStr = dateLocale.formatDate(date);
+      expect(dateStr).toEqual(jasmine.any(String));
+      expect(dateStr).toBeTruthy();
+    });
+
+    it('should have a default date parser', function() {
+      var dateStr = '2014-03-25';
+      expect(dateLocale.parseDate(dateStr)).toEqual(jasmine.any(Date));
+    });
+  });
+
+  describe('with custom values', function() {
+    var fakeMonths = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'];
+    var fakeshortMonths = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'j', 'l'];
+    var fakeDays = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7'];
+    var fakeShortDays = ['1', '2', '3', '4', '5', '6', '7'];
+    var fakeDates = [undefined, 'X1', 'X2', 'X3', 'X4', 'X5', 'X6', 'X7', 'X8', 'X9', 'X10', 'X11',
+        'X12', 'X13', 'X14', 'X15', 'X16', 'X17', 'X18', 'X19', 'X20', 'X21', 'X22', 'X23', 'X24',
+        'X25', 'X26', 'X27', 'X28', 'X29', 'X30', 'X31'];
+
+    beforeEach(module(function($$mdDateLocaleProvider) {
+      $$mdDateLocaleProvider.months = fakeMonths;
+      $$mdDateLocaleProvider.shortMonths = fakeshortMonths;
+      $$mdDateLocaleProvider.days = fakeDays;
+      $$mdDateLocaleProvider.shortDays = fakeShortDays;
+      $$mdDateLocaleProvider.dates = fakeDates;
+      $$mdDateLocaleProvider.formatDate = function() {
+        return 'Your birthday!'
+      };
+      $$mdDateLocaleProvider.parseDate = function() {
+        return new Date(1969, 6, 16);
+      };
+    }));
+
+
+    beforeEach(inject(function($$mdDateLocale, $$mdDateUtil) {
+      dateLocale = $$mdDateLocale;
+      dateUtil = $$mdDateUtil;
+    }));
+
+    it('should expose custom settings', function() {
+      expect(dateLocale.months).toEqual(fakeMonths);
+      expect(dateLocale.shortMonths).toEqual(fakeshortMonths);
+      expect(dateLocale.days).toEqual(fakeDays);
+      expect(dateLocale.shortDays).toEqual(fakeShortDays);
+      expect(dateLocale.dates).toEqual(fakeDates);
+      expect(dateLocale.formatDate(new Date())).toEqual('Your birthday!');
+      expect(dateLocale.parseDate('2020-01-20')).toEqual(new Date(1969, 6, 16));
+    });
+  });
+});

--- a/src/components/calendar/dateLocaleProvider.js
+++ b/src/components/calendar/dateLocaleProvider.js
@@ -44,7 +44,7 @@
      * @param $locale
      * @returns {DateLocale}
      */
-    DateLocaleProvider.prototype.$get = function($locale, $filter) {
+    DateLocaleProvider.prototype.$get = function($locale) {
       /**
        * Default date-to-string formatting function.
        * @param {Date} date
@@ -63,21 +63,28 @@
         return new Date(dateString);
       }
 
-      // The default "short" day strings are the first character of each day.
+      // The default "short" day strings are the first character of each day,
+      // e.g., "Monday" => "M".
       var defaultShortDays = $locale.DATETIME_FORMATS.DAY.map(function(day) {
         return day[0];
       });
 
-      window.$locale = $locale;
-      window.$filter = $filter;
+      // The default dates are simply the numbers 1 through 31.
+      var defaultDates = Array(32);
+      for (var i = 1; i <= 31; i++) {
+        defaultDates[i] = i;
+      }
 
-      var dateLocale = {
+      window.$locale = $locale;
+
+      return {
         months: this.months || $locale.DATETIME_FORMATS.MONTH,
         shortMonths: this.shortMonths || $locale.DATETIME_FORMATS.SHORTMONTH,
         days: this.days || $locale.DATETIME_FORMATS.DAY,
         shortDays: this.shortDays || defaultShortDays,
-        formatDate: defaultFormatDate,
-        parseDate: defaultParseDate
+        dates: this.dates || defaultDates,
+        formatDate: this.formatDate || defaultFormatDate,
+        parseDate: this.parseDate || defaultParseDate
       };
     };
 

--- a/src/components/calendar/dateLocaleProvider.js
+++ b/src/components/calendar/dateLocaleProvider.js
@@ -1,0 +1,86 @@
+(function() {
+  'use strict';
+
+  /**
+   * Provider that allows the user to specify messages, formatters, and parsers for date
+   * internationalization.
+   */
+  angular.module('material.components.calendar').config(function($provide) {
+    // TODO(jelbourn): Assert provided values are correctly formatted. Need assertions.
+
+    /** @constructor */
+    function DateLocaleProvider() {
+      /** Array of full month names. E.g., ['January', 'Febuary', ...] */
+      this.months = null;
+
+      /** Array of abbreviated month names. E.g., ['Jan', 'Feb', ...] */
+      this.shortMonths = null;
+
+      /** Array of full day of the week names. E.g., ['Monday', 'Tuesday', ...] */
+      this.days = null;
+
+      /** Array of abbreviated dat of the week names. E.g., ['M', 'T', ...] */
+      this.shortDays = null;
+
+      /** Array of dates of a month (1 - 31). Characters might be different in some locales. */
+      this.dates = null;
+
+      /**
+       * Function that converts the date portion of a Date to a string.
+       * @type {function(Date): string)}
+       */
+      this.formatDate = null;
+
+      /**
+       * Function that converts a date string to a Date object (the date portion)
+       * @type {function(string): Date}
+       */
+      this.parseDate = null;
+    }
+
+    /**
+     * Factory function that returns an instance of the dateLocale service.
+     * @ngInject
+     * @param $locale
+     * @returns {DateLocale}
+     */
+    DateLocaleProvider.prototype.$get = function($locale, $filter) {
+      /**
+       * Default date-to-string formatting function.
+       * @param {Date} date
+       * @returns {string}
+       */
+      function defaultFormatDate(date) {
+        return date.toLocaleDateString();
+      }
+
+      /**
+       * Default string-to-date parsing function.
+       * @param {string} dateString
+       * @returns {Date}
+       */
+      function defaultParseDate(dateString) {
+        return new Date(dateString);
+      }
+
+      // The default "short" day strings are the first character of each day.
+      var defaultShortDays = $locale.DATETIME_FORMATS.DAY.map(function(day) {
+        return day[0];
+      });
+
+      window.$locale = $locale;
+      window.$filter = $filter;
+
+      var dateLocale = {
+        months: this.months || $locale.DATETIME_FORMATS.MONTH,
+        shortMonths: this.shortMonths || $locale.DATETIME_FORMATS.SHORTMONTH,
+        days: this.days || $locale.DATETIME_FORMATS.DAY,
+        shortDays: this.shortDays || defaultShortDays,
+        formatDate: defaultFormatDate,
+        parseDate: defaultParseDate
+      };
+    };
+
+    $provide.provider('$$mdDateLocale', new DateLocaleProvider());
+  });
+})();

--- a/src/components/calendar/dateUtil.js
+++ b/src/components/calendar/dateUtil.js
@@ -1,0 +1,166 @@
+(function() {
+  'use strict';
+
+  /**
+   * Utility for performing date calculations to facilitate operation of the calendar and
+   * datepicker.
+   */
+  angular.module('material.components.calendar').factory('$$mdDateUtil', function() {
+    return {
+      getFirstDateOfMonth: getFirstDateOfMonth,
+      getNumberOfDaysInMonth: getNumberOfDaysInMonth,
+      getDateInNextMonth: getDateInNextMonth,
+      getDateInPreviousMonth: getDateInPreviousMonth,
+      isInNextMonth: isInNextMonth,
+      isInPreviousMonth: isInPreviousMonth,
+      getDateMidpoint: getDateMidpoint,
+      isSameMonthAndYear: isSameMonthAndYear,
+      getWeekOfMonth: getWeekOfMonth,
+      incrementDays: incrementDays,
+      incrementMonths: incrementMonths,
+      getLastDateOfMonth: getLastDateOfMonth,
+      isSameDay: isSameDay
+    };
+
+    /**
+     * Gets the first day of the month for the given date's month.
+     * @param {Date} date
+     * @returns {Date}
+     */
+    function getFirstDateOfMonth(date) {
+      return new Date(date.getFullYear(), date.getMonth(), 1);
+    }
+
+    /**
+     * Gets the number of days in the month for the given date's month.
+     * @param date
+     * @returns {number}
+     */
+    function getNumberOfDaysInMonth(date) {
+      return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();
+    }
+
+    /**
+     * Get an arbitrary date in the month after the given date's month.
+     * @param date
+     * @returns {Date}
+     */
+    function getDateInNextMonth(date) {
+      return new Date(date.getFullYear(), date.getMonth() + 1, 1);
+    }
+
+    /**
+     * Get an arbitrary date in the month before the given date's month.
+     * @param date
+     * @returns {Date}
+     */
+    function getDateInPreviousMonth(date) {
+      return new Date(date.getFullYear(), date.getMonth() - 1, 1);
+    }
+
+    /**
+     * Gets whether two dates have the same month and year.
+     * @param {Date} d1
+     * @param {Date} d2
+     * @returns {boolean}
+     */
+    function isSameMonthAndYear(d1, d2) {
+      return d1.getFullYear() === d2.getFullYear() && d1.getMonth() === d2.getMonth();
+    }
+
+    /**
+     * Gets whether two dates are the same day (not not necesarily the same time).
+     * @param {Date} d1
+     * @param {Date} d2
+     * @returns {boolean}
+     */
+    function isSameDay(d1, d2) {
+      return d1.getDate() == d2.getDate() && isSameMonthAndYear(d1, d2);
+    }
+
+    /**
+     * Gets whether a date is in the month immediately after some date.
+     * @param {Date} startDate The date from which to compare.
+     * @param {Date} endDate The date to check.
+     * @returns {boolean}
+     */
+    function isInNextMonth(startDate, endDate) {
+      var nextMonth = getDateInNextMonth(startDate);
+      return isSameMonthAndYear(nextMonth, endDate);
+    }
+
+    /**
+     * Gets whether a date is in the month immediately before some date.
+     * @param {Date} startDate The date from which to compare.
+     * @param {Date} endDate The date to check.
+     * @returns {boolean}
+     */
+    function isInPreviousMonth(startDate, endDate) {
+      var previousMonth = getDateInPreviousMonth(startDate);
+      return isSameMonthAndYear(endDate, previousMonth);
+    }
+
+    /**
+     * Gets the midpoint between two dates.
+     * @param {Date} d1
+     * @param {Date} d2
+     * @returns {Date}
+     */
+    function getDateMidpoint(d1, d2) {
+      return new Date((d1.getTime() + d2.getTime()) / 2);
+    }
+
+    /**
+     * Gets the week of the month that a given date occurs in.
+     * @param {Date} date
+     * @returns {number} Index of the week of the month (zero-based).
+     */
+    function getWeekOfMonth(date) {
+      var firstDayOfMonth = getFirstDateOfMonth(date);
+      return Math.floor((firstDayOfMonth.getDay() + date.getDate() - 1) / 7);
+    }
+
+    /**
+     * Gets a new date incremented by the given number of days. Number of days can be negative.
+     * @param {Date} date
+     * @param {number} numberOfDays
+     * @returns {Date}
+     */
+    function incrementDays(date, numberOfDays) {
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate() + numberOfDays);
+    }
+
+    /**
+     * Gets a new date incremented by the given number of months. Number of months can be negative.
+     * If the date of the given month does not match the target month, the date will be set to the
+     * last day of the month.
+     * @param {Date} date
+     * @param {number} numberOfMonths
+     * @returns {Date}
+     */
+    function incrementMonths(date, numberOfMonths) {
+      // If the same date in the target month does not actually exist, the Date object will
+      // automatically advance *another* month by the number of missing days.
+      // For example, if you try to go from Jan. 30 to Feb. 30, you'll end up on March 2.
+      // So, we check if the month overflowed and go to the last day of the target month instead.
+      var dateInTargetMonth = new Date(date.getFullYear(), date.getMonth() + numberOfMonths, 1);
+      var numberOfDaysInMonth = getNumberOfDaysInMonth(dateInTargetMonth);
+      if (numberOfDaysInMonth < date.getDate()) {
+        dateInTargetMonth.setDate(numberOfDaysInMonth);
+      } else {
+        dateInTargetMonth.setDate(date.getDate());
+      }
+
+      return dateInTargetMonth;
+    }
+
+    /**
+     * Gets the last day of the month for the given date.
+     * @param {Date} date
+     * @returns {Date}
+     */
+    function getLastDateOfMonth(date) {
+      return new Date(date.getFullYear(), date.getMonth(), getNumberOfDaysInMonth(date));
+    }
+  });
+})();

--- a/src/components/calendar/dateUtil.spec.js
+++ b/src/components/calendar/dateUtil.spec.js
@@ -1,0 +1,197 @@
+
+describe('$$mdDateUtil', function() {
+  var dateUtil;
+
+  beforeEach(module('material.components.calendar'));
+
+  beforeEach(inject(function($$mdDateUtil) {
+    dateUtil = $$mdDateUtil;
+  }));
+
+  it('should get the first day of a month', function() {
+    var first = dateUtil.getFirstDateOfMonth(new Date(1985, 9, 26));
+
+    expect(first.getFullYear()).toBe(1985);
+    expect(first.getMonth()).toBe(9);
+    expect(first.getDate()).toBe(1);
+  });
+
+  it('should get the first day of the month from the first day of the month', function() {
+    var first = dateUtil.getFirstDateOfMonth(new Date(1985, 9, 1));
+
+    expect(first.getFullYear()).toBe(1985);
+    expect(first.getMonth()).toBe(9);
+    expect(first.getDate()).toBe(1);
+  });
+
+  it('should get the number of days in a month', function() {
+    // Month with 31 days.
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 0, 1))).toBe(31);
+
+    // Month with 30 days.
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 3, 1))).toBe(30);
+
+    // Month with 28 days
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 1, 1))).toBe(28);
+
+    // Month with 29 days.
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2012, 1, 1))).toBe(29);
+  });
+
+  it('should get an arbitrary day in the next month', function() {
+    // Next month in the same year.
+    var next = dateUtil.getDateInNextMonth(new Date(2015, 0, 1));
+    expect(next.getMonth()).toBe(1);
+    expect(next.getFullYear()).toBe(2015);
+
+    // Next month in the following year.
+    next = dateUtil.getDateInNextMonth(new Date(2015, 11, 1));
+    expect(next.getMonth()).toBe(0);
+    expect(next.getFullYear()).toBe(2016);
+  });
+
+  it('should get an arbitrary day in the previous month', function() {
+    // Previous month in the same year.
+    var next = dateUtil.getDateInPreviousMonth(new Date(2015, 6, 1));
+    expect(next.getMonth()).toBe(5);
+    expect(next.getFullYear()).toBe(2015);
+
+    // Previous month in the past year.
+    next = dateUtil.getDateInPreviousMonth(new Date(2015, 0, 1));
+    expect(next.getMonth()).toBe(11);
+    expect(next.getFullYear()).toBe(2014);
+  });
+
+  it('should check whether two dates are in the same month and year', function() {
+    // Same month and year.
+    var first = new Date(2015, 3, 30);
+    var second = new Date(2015, 3, 1);
+    expect(dateUtil.isSameMonthAndYear(first, second)).toBe(true);
+
+    // Same exact day.
+    first = new Date(2015, 3, 1);
+    second = new Date(2015, 3, 1);
+    expect(dateUtil.isSameMonthAndYear(first, second)).toBe(true);
+
+    // Same month, different year.
+    first = new Date(2015, 3, 30);
+    second = new Date(2005, 3, 1);
+    expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
+
+    // Same year, different month.
+    first = new Date(2015, 3, 30);
+    second = new Date(2015, 6, 1);
+    expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
+
+    // Different month and year.
+    first = new Date(2012, 3, 30);
+    second = new Date(2015, 6, 1);
+    expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
+  });
+
+  it('should check whether two dates are the same day', function() {
+    // Same exact day and time.
+    var first = new Date(2015, 3, 1);
+    var second = new Date(2015, 3, 1);
+    expect(dateUtil.isSameDay(first, second)).toBe(true);
+
+    // Same day, different time.
+    first = new Date(2015, 3, 30, 3);
+    second = new Date(2015, 3, 30, 4);
+    expect(dateUtil.isSameDay(first, second)).toBe(true);
+
+    // Same month and year, different day.
+    first = new Date(2015, 3, 30);
+    second = new Date(2015, 3, 1);
+    expect(dateUtil.isSameDay(first, second)).toBe(false);
+
+    // Same month, different year.
+    first = new Date(2015, 3, 30);
+    second = new Date(2005, 3, 30);
+    expect(dateUtil.isSameDay(first, second)).toBe(false);
+
+    // Same year, different month.
+    first = new Date(2015, 3, 30);
+    second = new Date(2015, 6, 30);
+    expect(dateUtil.isSameDay(first, second)).toBe(false);
+
+    // Different month and year.
+    first = new Date(2012, 3, 30);
+    second = new Date(2015, 6, 30);
+    expect(dateUtil.isSameDay(first, second)).toBe(false);
+  });
+
+  it('should check whether a date is in the next month', function() {
+    // Next month within the same year.
+    var first = new Date(2015, 6, 15);
+    var second = new Date(2015, 7, 25);
+    expect(dateUtil.isInNextMonth(first, second)).toBe(true);
+
+    // Next month across years.
+    first = new Date(2015, 11, 15);
+    second = new Date(2016, 0, 25);
+    expect(dateUtil.isInNextMonth(first, second)).toBe(true);
+
+    // Not in the next month (past, same year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2015, 3, 25);
+    expect(dateUtil.isInNextMonth(first, second)).toBe(false);
+
+    // Not in the next month (future, same year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2015, 7, 25);
+    expect(dateUtil.isInNextMonth(first, second)).toBe(false);
+
+    // Not in the next month (month + 1 in different year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2016, 6, 25);
+    expect(dateUtil.isInNextMonth(first, second)).toBe(false);
+  });
+
+  it('should check whether a date is in the previous month', function() {
+    // Previous month within the same year.
+    var first = new Date(2015, 7, 15);
+    var second = new Date(2015, 6, 25);
+    expect(dateUtil.isInPreviousMonth(first, second)).toBe(true);
+
+    // Previous month across years.
+    first = new Date(2015, 0, 15);
+    second = new Date(2014, 11, 25);
+    expect(dateUtil.isInPreviousMonth(first, second)).toBe(true);
+
+    // Not in the previous month (past, same year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2015, 3, 25);
+    expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
+
+    // Not in the previous month (future, same year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2015, 7, 25);
+    expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
+
+    // Not in the previous month (month - 1 in different year).
+    first = new Date(2015, 5, 15);
+    second = new Date(2016, 4, 25);
+    expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
+  });
+
+  it('should get the midpoint between two dates', function() {
+    var start = new Date(2010, 2, 10);
+    var end = new Date(2010, 2, 20);
+    var midpoint = dateUtil.getDateMidpoint(start, end);
+
+    expect(dateUtil.isSameDay(midpoint, new Date(2010, 2, 15))).toBe(true);
+  });
+
+  it('should get the week of the month in which a given date appears', function() {
+  });
+
+  it('should increment a date by a number of days', function() {
+  });
+
+  it('should increment a date by a number of months', function() {
+  });
+
+  it('should get the last date of a month', function() {
+  });
+});

--- a/src/components/calendar/dateUtil.spec.js
+++ b/src/components/calendar/dateUtil.spec.js
@@ -1,5 +1,10 @@
 
 describe('$$mdDateUtil', function() {
+  // When constructing a Date, the month is zero-based. This can be confusing, since people are
+  // used to seeing them one-based. So we create these aliases to make reading the tests easier.
+  var JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9,
+      NOV = 10, DEC = 11;
+
   var dateUtil;
 
   beforeEach(module('material.components.calendar'));
@@ -9,7 +14,7 @@ describe('$$mdDateUtil', function() {
   }));
 
   it('should get the first day of a month', function() {
-    var first = dateUtil.getFirstDateOfMonth(new Date(1985, 9, 26));
+    var first = dateUtil.getFirstDateOfMonth(new Date(1985, OCT, 26));
 
     expect(first.getFullYear()).toBe(1985);
     expect(first.getMonth()).toBe(9);
@@ -17,7 +22,7 @@ describe('$$mdDateUtil', function() {
   });
 
   it('should get the first day of the month from the first day of the month', function() {
-    var first = dateUtil.getFirstDateOfMonth(new Date(1985, 9, 1));
+    var first = dateUtil.getFirstDateOfMonth(new Date(1985, OCT, 1));
 
     expect(first.getFullYear()).toBe(1985);
     expect(first.getMonth()).toBe(9);
@@ -26,172 +31,256 @@ describe('$$mdDateUtil', function() {
 
   it('should get the number of days in a month', function() {
     // Month with 31 days.
-    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 0, 1))).toBe(31);
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, JAN, 1))).toBe(31);
 
     // Month with 30 days.
-    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 3, 1))).toBe(30);
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, APR, 1))).toBe(30);
 
     // Month with 28 days
-    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, 1, 1))).toBe(28);
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2015, FEB, 1))).toBe(28);
 
     // Month with 29 days.
-    expect(dateUtil.getNumberOfDaysInMonth(new Date(2012, 1, 1))).toBe(29);
+    expect(dateUtil.getNumberOfDaysInMonth(new Date(2012, FEB, 1))).toBe(29);
   });
 
   it('should get an arbitrary day in the next month', function() {
     // Next month in the same year.
-    var next = dateUtil.getDateInNextMonth(new Date(2015, 0, 1));
+    var next = dateUtil.getDateInNextMonth(new Date(2015, JAN, 1));
     expect(next.getMonth()).toBe(1);
     expect(next.getFullYear()).toBe(2015);
 
     // Next month in the following year.
-    next = dateUtil.getDateInNextMonth(new Date(2015, 11, 1));
+    next = dateUtil.getDateInNextMonth(new Date(2015, DEC, 1));
     expect(next.getMonth()).toBe(0);
     expect(next.getFullYear()).toBe(2016);
   });
 
   it('should get an arbitrary day in the previous month', function() {
     // Previous month in the same year.
-    var next = dateUtil.getDateInPreviousMonth(new Date(2015, 6, 1));
+    var next = dateUtil.getDateInPreviousMonth(new Date(2015, JUL, 1));
     expect(next.getMonth()).toBe(5);
     expect(next.getFullYear()).toBe(2015);
 
     // Previous month in the past year.
-    next = dateUtil.getDateInPreviousMonth(new Date(2015, 0, 1));
+    next = dateUtil.getDateInPreviousMonth(new Date(2015, JAN, 1));
     expect(next.getMonth()).toBe(11);
     expect(next.getFullYear()).toBe(2014);
   });
 
   it('should check whether two dates are in the same month and year', function() {
     // Same month and year.
-    var first = new Date(2015, 3, 30);
-    var second = new Date(2015, 3, 1);
+    var first = new Date(2015, APR, 30);
+    var second = new Date(2015, APR, 1);
     expect(dateUtil.isSameMonthAndYear(first, second)).toBe(true);
 
     // Same exact day.
-    first = new Date(2015, 3, 1);
-    second = new Date(2015, 3, 1);
+    first = new Date(2015, APR, 1);
+    second = new Date(2015, APR, 1);
     expect(dateUtil.isSameMonthAndYear(first, second)).toBe(true);
 
     // Same month, different year.
-    first = new Date(2015, 3, 30);
-    second = new Date(2005, 3, 1);
+    first = new Date(2015, APR, 30);
+    second = new Date(2005, APR, 1);
     expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
 
     // Same year, different month.
-    first = new Date(2015, 3, 30);
-    second = new Date(2015, 6, 1);
+    first = new Date(2015, APR, 30);
+    second = new Date(2015, JUL, 1);
     expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
 
     // Different month and year.
-    first = new Date(2012, 3, 30);
-    second = new Date(2015, 6, 1);
+    first = new Date(2012, APR, 30);
+    second = new Date(2015, JUL, 1);
     expect(dateUtil.isSameMonthAndYear(first, second)).toBe(false);
   });
 
   it('should check whether two dates are the same day', function() {
     // Same exact day and time.
-    var first = new Date(2015, 3, 1);
-    var second = new Date(2015, 3, 1);
+    var first = new Date(2015, APR, 1);
+    var second = new Date(2015, APR, 1);
     expect(dateUtil.isSameDay(first, second)).toBe(true);
 
     // Same day, different time.
-    first = new Date(2015, 3, 30, 3);
-    second = new Date(2015, 3, 30, 4);
+    first = new Date(2015, APR, 30, 3);
+    second = new Date(2015, APR, 30, 4);
     expect(dateUtil.isSameDay(first, second)).toBe(true);
 
     // Same month and year, different day.
-    first = new Date(2015, 3, 30);
-    second = new Date(2015, 3, 1);
+    first = new Date(2015, APR, 30);
+    second = new Date(2015, APR, 1);
     expect(dateUtil.isSameDay(first, second)).toBe(false);
 
     // Same month, different year.
-    first = new Date(2015, 3, 30);
-    second = new Date(2005, 3, 30);
+    first = new Date(2015, APR, 30);
+    second = new Date(2005, APR, 30);
     expect(dateUtil.isSameDay(first, second)).toBe(false);
 
     // Same year, different month.
-    first = new Date(2015, 3, 30);
-    second = new Date(2015, 6, 30);
+    first = new Date(2015, APR, 30);
+    second = new Date(2015, JUL, 30);
     expect(dateUtil.isSameDay(first, second)).toBe(false);
 
     // Different month and year.
-    first = new Date(2012, 3, 30);
-    second = new Date(2015, 6, 30);
+    first = new Date(2012, APR, 30);
+    second = new Date(2015, JUL, 30);
     expect(dateUtil.isSameDay(first, second)).toBe(false);
   });
 
   it('should check whether a date is in the next month', function() {
     // Next month within the same year.
-    var first = new Date(2015, 6, 15);
-    var second = new Date(2015, 7, 25);
+    var first = new Date(2015, JUL, 15);
+    var second = new Date(2015, AUG, 25);
     expect(dateUtil.isInNextMonth(first, second)).toBe(true);
 
     // Next month across years.
-    first = new Date(2015, 11, 15);
-    second = new Date(2016, 0, 25);
+    first = new Date(2015, DEC, 15);
+    second = new Date(2016, JAN, 25);
     expect(dateUtil.isInNextMonth(first, second)).toBe(true);
 
     // Not in the next month (past, same year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2015, 3, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2015, APR, 25);
     expect(dateUtil.isInNextMonth(first, second)).toBe(false);
 
     // Not in the next month (future, same year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2015, 7, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2015, AUG, 25);
     expect(dateUtil.isInNextMonth(first, second)).toBe(false);
 
     // Not in the next month (month + 1 in different year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2016, 6, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2016, JUL, 25);
     expect(dateUtil.isInNextMonth(first, second)).toBe(false);
   });
 
   it('should check whether a date is in the previous month', function() {
     // Previous month within the same year.
-    var first = new Date(2015, 7, 15);
-    var second = new Date(2015, 6, 25);
+    var first = new Date(2015, AUG, 15);
+    var second = new Date(2015, JUL, 25);
     expect(dateUtil.isInPreviousMonth(first, second)).toBe(true);
 
     // Previous month across years.
-    first = new Date(2015, 0, 15);
-    second = new Date(2014, 11, 25);
+    first = new Date(2015, JAN, 15);
+    second = new Date(2014, DEC, 25);
     expect(dateUtil.isInPreviousMonth(first, second)).toBe(true);
 
     // Not in the previous month (past, same year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2015, 3, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2015, APR, 25);
     expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
 
     // Not in the previous month (future, same year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2015, 7, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2015, AUG, 25);
     expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
 
     // Not in the previous month (month - 1 in different year).
-    first = new Date(2015, 5, 15);
-    second = new Date(2016, 4, 25);
+    first = new Date(2015, JUN, 15);
+    second = new Date(2016, MAY, 25);
     expect(dateUtil.isInPreviousMonth(first, second)).toBe(false);
   });
 
   it('should get the midpoint between two dates', function() {
-    var start = new Date(2010, 2, 10);
-    var end = new Date(2010, 2, 20);
+    var start = new Date(2010, MAR, 10);
+    var end = new Date(2010, MAR, 20);
     var midpoint = dateUtil.getDateMidpoint(start, end);
 
-    expect(dateUtil.isSameDay(midpoint, new Date(2010, 2, 15))).toBe(true);
+    expect(dateUtil.isSameDay(midpoint, new Date(2010, MAR, 15))).toBe(true);
   });
 
   it('should get the week of the month in which a given date appears', function() {
+    // May 2015 spans 6 weeks.
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 1))).toBe(0);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 8))).toBe(1);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 15))).toBe(2);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 22))).toBe(3);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 29))).toBe(4);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, MAY, 31))).toBe(5);
+
+    // Feb 2015 spans 4 weeks. Check both the first and last day of each week.
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 1))).toBe(0);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 7))).toBe(0);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 8))).toBe(1);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 14))).toBe(1);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 15))).toBe(2);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 21))).toBe(2);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 22))).toBe(3);
+    expect(dateUtil.getWeekOfMonth(new Date(2015, FEB, 28))).toBe(3);
   });
 
   it('should increment a date by a number of days', function() {
+    // Increment by one.
+    var start = new Date(2015, MAY, 15);
+    var end = new Date(2015, MAY, 16);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, 1), end)).toBe(true);
+
+    // Negative by negative one.
+    start = new Date(2015, MAY, 15);
+    end = new Date(2015, MAY, 14);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, -1), end)).toBe(true);
+
+    // Into next month.
+    start = new Date(2015, MAY, 31);
+    end = new Date(2015, JUN, 1);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, 1), end)).toBe(true);
+
+    // Into previous month.
+    start = new Date(2015, MAY, 1);
+    end = new Date(2015, APR, 30);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, -1), end)).toBe(true);
+
+    // Into next year.
+    start = new Date(2015, DEC, 31);
+    end = new Date(2016, JAN, 1);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, 1), end)).toBe(true);
+
+    // Into last year.
+    start = new Date(2015, JAN, 1);
+    end = new Date(2014, DEC, 31);
+    expect(dateUtil.isSameDay(dateUtil.incrementDays(start, -1), end)).toBe(true);
   });
 
   it('should increment a date by a number of months', function() {
+    // Increment by one.
+    var start = new Date(2015, MAY, 15);
+    var end = new Date(2015, JUN, 15);
+    expect(dateUtil.isSameDay(dateUtil.incrementMonths(start, 1), end)).toBe(true);
+
+    // Negative by negative one.
+    start = new Date(2015, MAY, 15);
+    end = new Date(2015, APR, 15);
+    expect(dateUtil.isSameDay(dateUtil.incrementMonths(start, -1), end)).toBe(true);
+
+    // Next month has fewer days.
+    start = new Date(2015, JAN, 30);
+    end = new Date(2015, FEB, 28);
+    expect(dateUtil.isSameDay(dateUtil.incrementMonths(start, 1), end)).toBe(true);
+
+    // Previous month has fewer days.
+    start = new Date(2015, MAY, 31);
+    end = new Date(2015, APR, 30);
+    expect(dateUtil.isSameDay(dateUtil.incrementMonths(start, -1), end)).toBe(true);
   });
 
   it('should get the last date of a month', function() {
+    // Normal February
+    var date = new Date(2015, FEB, 1);
+    var lastOfMonth = new Date(2015, FEB, 28);
+    expect(dateUtil.isSameDay(dateUtil.getLastDateOfMonth(date), lastOfMonth)).toBe(true);
+
+    // Leap year February
+    date = new Date(2012, FEB, 1);
+    lastOfMonth = new Date(2012, FEB, 29);
+    expect(dateUtil.isSameDay(dateUtil.getLastDateOfMonth(date), lastOfMonth)).toBe(true);
+
+    // Month with 31 days.
+    date = new Date(2015, DEC, 12);
+    lastOfMonth = new Date(2015, DEC, 31);
+    expect(dateUtil.isSameDay(dateUtil.getLastDateOfMonth(date), lastOfMonth)).toBe(true);
+
+    // Month with 30 days.
+    date = new Date(2015, APR, 3);
+    lastOfMonth = new Date(2015, APR, 30);
+    expect(dateUtil.isSameDay(dateUtil.getLastDateOfMonth(date), lastOfMonth)).toBe(true);
   });
 });

--- a/src/components/calendar/demoBasicUsage/index.html
+++ b/src/components/calendar/demoBasicUsage/index.html
@@ -1,0 +1,28 @@
+<div ng-controller="AppCtrl" style='padding: 40px;'>
+  <md-content>
+    <h1>{{title}}</h1>
+
+    <hr>
+    <p>
+      <h2>Development tools</h2>
+      <button type="button" ng-click="adjustMonth(+1)">Next month</button>
+      <button type="button" ng-click="adjustMonth(-1)">Prev month</button>
+      <input type="date" ng-model="myDate">
+    </p>
+    <hr>
+
+    <md-calendar ng-model="myDate"></md-calendar>
+
+    <br><br>
+    <br><br>
+    <br><br>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <p>Here is a bunch of stuff after the calendar</p>
+    <input>
+
+  </md-content>
+</div>

--- a/src/components/calendar/demoBasicUsage/script.js
+++ b/src/components/calendar/demoBasicUsage/script.js
@@ -1,0 +1,12 @@
+angular.module('calendarDemo1', ['ngMaterial'])
+    .controller('AppCtrl', function($scope) {
+      $scope.title = 'Calendar demo';
+      $scope.myDate = new Date();
+
+      $scope.adjustMonth = function(delta) {
+        $scope.myDate = new Date(
+            $scope.myDate.getFullYear(),
+            $scope.myDate.getMonth() + delta,
+            $scope.myDate.getDate());
+      };
+    });

--- a/src/components/calendar/demoBasicUsage/style.css
+++ b/src/components/calendar/demoBasicUsage/style.css
@@ -1,0 +1,1 @@
+/** Demo styles for mdCalendar. */

--- a/src/core/util/constant.js
+++ b/src/core/util/constant.js
@@ -1,7 +1,11 @@
 angular.module('material.core')
 .factory('$mdConstant', MdConstantFactory);
 
-function MdConstantFactory($$rAF, $sniffer) {
+/**
+ * Factory function that creates the grab-bag $mdConstant service.
+ * @ngInject
+ */
+function MdConstantFactory($sniffer) {
 
   var webkit = /webkit/i.test($sniffer.vendorPrefix);
   function vendorProperty(name) {
@@ -13,6 +17,10 @@ function MdConstantFactory($$rAF, $sniffer) {
       ENTER: 13,
       ESCAPE: 27,
       SPACE: 32,
+      PAGE_UP: 33,
+      PAGE_DOWN: 34,
+      END: 35,
+      HOME: 36,
       LEFT_ARROW : 37,
       UP_ARROW : 38,
       RIGHT_ARROW : 39,


### PR DESCRIPTION
Prefix all calendar id attributes with the directive scope $id. This
makes it possible to include multiple calendar instances on the same
page.