### PR TITLE
center align remove-chip button - issue #2920

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -89,6 +89,8 @@ $contact-chip-name-width: rem(12) !default;
       box-shadow: none;
       margin: 0;
       position: relative;
+      display: inline-block;
+      vertical-align: middle;
       md-icon {
         height: $chip-delete-icon-size;
         width: $chip-delete-icon-size;


### PR DESCRIPTION
Remove-chip button was improperly rendered in some browsers, such as
Safari 8 and FF Developer Edition. Added inline-level alignment, which
properly centers it.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3043)
<!-- Reviewable:end -->
