### PR TITLE
docs(dialog): add return values to `hide` and `cancel` methods.

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -357,6 +357,8 @@ function MdDialogDirective($$rAF, $mdTheming) {
  * Hide an existing dialog and resolve the promise returned from `$mdDialog.show()`.
  *
  * @param {*=} response An argument for the resolved promise.
+ *
+ * @returns {promise} A promise that is resolved when the dialog has been closed.
  */
 
 /**
@@ -367,6 +369,8 @@ function MdDialogDirective($$rAF, $mdTheming) {
  * Hide an existing dialog and reject the promise returned from `$mdDialog.show()`.
  *
  * @param {*=} response An argument for the rejected promise.
+ *
+ * @returns {promise} A promise that is resolved when the dialog has been closed.
  */
 
 function MdDialogProvider($$interimElementProvider) {


### PR DESCRIPTION
Return values for these methods were missing.