### PR TITLE
fix(tabs): ensure $scope is not being destroyed when removing tab

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -177,9 +177,9 @@ function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $md
     var selectedIndex = $scope.selectedIndex,
         tab = ctrl.tabs.splice(tabData.getIndex(), 1)[0];
     refreshIndex();
-    //-- when removing a tab, if the selected index did not change, we have to manually trigger the
-    //   tab select/deselect events
-    if ($scope.selectedIndex === selectedIndex) {
+    //-- when removing a tab, if the selected index did not change, and the $scope is not destroyed,
+    //   we have to manually trigger the tab select/deselect events
+    if (!$scope.$$destroyed && $scope.selectedIndex === selectedIndex) {
       tab.scope.deselect();
       ctrl.tabs[$scope.selectedIndex] && ctrl.tabs[$scope.selectedIndex].scope.select();
     }


### PR DESCRIPTION
Related to #3096  

Ensure that the $scope is not already destroyed before automatically selecting a new tab after removing one (which was implemented as part of a fix for #2837).

Alternative implementation could include passing a parameter to the `removeTab()` function indicating that the entire tab structure is being removed (not sure if `$scope.$$destroyed` is safe to use)