### PR TITLE
Rename .md-actions to md-dialog-actions/md-card-actions

### DIFF
--- a/docs/app/partials/view-source.tmpl.html
+++ b/docs/app/partials/view-source.tmpl.html
@@ -17,9 +17,9 @@
     </div>
   </md-dialog-content>
 
-  <div class="md-actions" layout="horizontal">
+  <md-dialog-actions layout="horizontal">
     <md-button class="md-primary" ng-click="$hideDialog()">
       Done
     </md-button>
-  </div>
+  </md-dialog-actions>
 </md-dialog>

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -26,7 +26,7 @@ angular.module('material.components.card', [
  * container will wrap text content and provide padding. An `<md-card-footer>` element can be
  * optionally included to put content flush against the bottom edge of the card.
  *
- * Action buttons can be included in an element with the `.md-actions` class, also used in `md-dialog`.
+ * Action buttons can be included in an `<md-card-actions>` element, similar to `<md-dialog-actions>`.
  * You can then position buttons using layout attributes.
  *
  * Cards have constant width and variable heights; where the maximum height is limited to what can
@@ -55,10 +55,10 @@ angular.module('material.components.card', [
  *    <h2>Card headline</h2>
  *    <p>Card content</p>
  *  </md-card-content>
- *  <div class="md-actions" layout="row" layout-align="end center">
+ *  <md-card-actions layout="row" layout-align="end center">
  *    <md-button>Action 1</md-button>
  *    <md-button>Action 2</md-button>
- *  </div>
+ *  </md-card-actions>
  * </md-card>
  * </hljs>
  *

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -17,7 +17,7 @@ md-card {
   md-card-content {
     padding: $card-padding;
   }
-  .md-actions {
+  md-card-actions {
     margin: 0;
 
     .md-button {

--- a/src/components/card/demoBasicUsage/index.html
+++ b/src/components/card/demoBasicUsage/index.html
@@ -12,10 +12,10 @@
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
         </p>
       </md-card-content>
-      <div class="md-actions" layout="row" layout-align="end center">
+      <md-card-actions layout="row" layout-align="end center">
         <md-button>Action 1</md-button>
         <md-button>Action 2</md-button>
-      </div>
+      </md-card-actions>
     </md-card>
     <br/>
 

--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -25,18 +25,17 @@
       </p>
     </div>
   </md-dialog-content>
-
-  <div class="md-actions" layout="row">
-    <md-button href="http://en.wikipedia.org/wiki/Mango" target="_blank" hide show-md>
-      More on Wikipedia
-    </md-button>
-    <span flex></span>
-    <md-button ng-click="answer('not useful')" class="md-primary">
-     Not Useful
-    </md-button>
-    <md-button ng-click="answer('useful')" class="md-primary">
-      Useful
-    </md-button>
-  </div>
+    <md-dialog-actions layout="row">
+      <md-button href="http://en.wikipedia.org/wiki/Mango" target="_blank" hide show-md>
+        More on Wikipedia
+      </md-button>
+      <span flex></span>
+      <md-button ng-click="answer('not useful')" class="md-primary">
+       Not Useful
+      </md-button>
+      <md-button ng-click="answer('useful')" class="md-primary">
+        Useful
+      </md-button>
+    </md-dialog-actions>
   </form>
 </md-dialog>

--- a/src/components/dialog/dialog-theme.scss
+++ b/src/components/dialog/dialog-theme.scss
@@ -4,7 +4,7 @@ md-dialog.md-THEME_NAME-theme {
   border-radius: $dialog-border-radius;
   background-color: '{{background-color}}';
 
-  &.md-content-overflow .md-actions {
+  &.md-content-overflow md-dialog-actions {
     border-top-color: '{{foreground-4}}';
   }
 }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -39,7 +39,7 @@ function MdDialogDirective($$rAF, $mdTheming) {
  * - The dialog is always given an isolate scope.
  * - The dialog's template must have an outer `<md-dialog>` element.
  *   Inside, use an `<md-dialog-content>` element for the dialog's content, and use
- *   an element with class `md-actions` for the dialog's actions.
+ *   an `<md-dialog-actions>` element for the dialog's actions.
  * - Dialogs must cover the entire application to keep interactions inside of them.
  * Use the `parent` option to change where dialogs are appended.
  *
@@ -117,11 +117,11 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *            '      </md-item>'+
  *            '    </md-list>'+
  *            '  </md-dialog-content>' +
- *            '  <div class="md-actions">' +
+ *            '  <md-dialog-actions>' +
  *            '    <md-button ng-click="closeDialog()" class="md-primary">' +
  *            '      Close Dialog' +
  *            '    </md-button>' +
- *            '  </div>' +
+ *            '  </md-dialog-actions>' +
  *            '</md-dialog>',
  *          locals: {
  *            items: $scope.items
@@ -196,11 +196,11 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *
  *             '  <md-dialog-content>Hello {{ employee }}!</md-dialog-content>' +
  *
- *             '  <div class="md-actions">' +
+ *             '  <md-dialog-actions>' +
  *             '    <md-button ng-click="closeDialog()" class="md-primary">' +
  *             '      Close Greeting' +
  *             '    </md-button>' +
- *             '  </div>' +
+ *             '  </md-dialog-actions>' +
  *             '</md-dialog>',
  *           controller: 'GreetingController',
  *           onComplete: afterShowAnimation,
@@ -400,7 +400,7 @@ function MdDialogProvider($$interimElementProvider) {
             '<h2 class="md-title">{{ dialog.title }}</h2>',
             '<p>{{ dialog.content }}</p>',
           '</md-dialog-content>',
-          '<div class="md-actions">',
+          '<md-dialog-actions>',
             '<md-button ng-if="dialog.$type == \'confirm\'"' +
                       ' ng-click="dialog.abort()" class="md-primary">',
               '{{ dialog.cancel }}',
@@ -408,7 +408,7 @@ function MdDialogProvider($$interimElementProvider) {
             '<md-button ng-click="dialog.hide()" class="md-primary">',
               '{{ dialog.ok }}',
             '</md-button>',
-          '</div>',
+          '</md-dialog-actions>',
         '</md-dialog>'
       ].join(''),
       controller: function mdDialogCtrl() {
@@ -426,7 +426,7 @@ function MdDialogProvider($$interimElementProvider) {
   }
 
   /* @ngInject */
-  function dialogDefaultOptions($mdAria, $document, $mdUtil, $mdConstant, $mdTheming, $mdDialog, $timeout, $rootElement, $animate, $$rAF, $q) {
+  function dialogDefaultOptions($mdAria, $document, $mdUtil, $mdConstant, $mdTheming, $mdDialog, $timeout, $rootElement, $animate, $$rAF, $q, $log) {
     return {
       hasBackdrop: true,
       isolateScope: true,
@@ -460,7 +460,7 @@ function MdDialogProvider($$interimElementProvider) {
       options.parent = angular.element(options.parent);
 
       options.popInTarget = angular.element((options.targetEvent || {}).target);
-      var closeButton = findCloseButton();
+      var closeButton = findCloseButtonOrWarn();
 
       if (options.hasBackdrop) {
         // Fix for IE 10
@@ -525,13 +525,17 @@ function MdDialogProvider($$interimElementProvider) {
       });
 
 
-      function findCloseButton() {
+      function findCloseButtonOrWarn() {
         //If no element with class dialog-close, try to find the last
-        //button child in md-actions and assume it is a close button
+        //button child in md-dialog-actions and assume it is a close button.
+        //If no actions at all, log a warning to the console.
         var closeButton = element[0].querySelector('.dialog-close');
         if (!closeButton) {
-          var actionButtons = element[0].querySelectorAll('.md-actions button');
+          var actionButtons = element[0].querySelectorAll('md-dialog-actions .md-button');
           closeButton = actionButtons[ actionButtons.length - 1 ];
+          if (actionButtons.length === 0) {
+            $log.warn('At least one action button is required for <md-dialog-actions>.');
+          }
         }
         return angular.element(closeButton);
       }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -75,7 +75,7 @@ md-dialog {
     }
   }
 
-  .md-actions {
+  md-dialog-actions {
     display: flex;
     order: 2;
     box-sizing: border-box;
@@ -93,7 +93,7 @@ md-dialog {
       margin-top: $baseline-grid;
     }
   }
-  &.md-content-overflow .md-actions {
+  &.md-content-overflow md-dialog-actions {
     border-top-width: 1px;
     border-top-style: solid;
   }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -156,10 +156,10 @@ describe('$mdDialog', function() {
       $mdDialog.show({
         template:
           '<md-dialog>' +
-            '<div class="md-actions">' +
-              '<button class="dialog-close">Close</button>' +
-            '</div>' +
-            '</md-dialog>',
+            '<md-dialog-actions>' +
+              '<button class="md-button dialog-close">Close</button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
         parent: parent
       });
 
@@ -365,10 +365,10 @@ describe('$mdDialog', function() {
         parent: parent,
         template:
           '<md-dialog>' +
-            '<div class="md-actions">' +
-              '<button id="a">A</md-button>' +
-              '<button id="focus-target">B</md-button>' +
-            '</div>' +
+            '<md-dialog-actions>' +
+              '<button class="md-button" id="a">A</md-button>' +
+              '<button class="md-button" id="focus-target">B</md-button>' +
+            '</md-dialog-actions>' +
           '</md-dialog>'
       });
 
@@ -393,10 +393,10 @@ describe('$mdDialog', function() {
         parent: parent,
         template:
           '<md-dialog>' +
-            '<div class="md-actions">' +
+            '<md-dialog-actions>' +
               '<button id="a">A</md-button>' +
               '<button id="focus-target">B</md-button>' +
-            '</div>' +
+            '</md-dialog-actions>' +
           '</md-dialog>',
       });
 
@@ -412,17 +412,17 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(undefined);
     }));
 
-    it('should focus the last `md-button` in md-actions open if no `.dialog-close`', inject(function($mdDialog, $rootScope, $document, $timeout, $mdConstant) {
+    it('should focus the last `md-button` in md-dialog-actions open if no `.dialog-close`', inject(function($mdDialog, $rootScope, $document, $timeout, $mdConstant) {
       jasmine.mockElementFocus(this);
 
       var parent = angular.element('<div>');
       $mdDialog.show({
         template:
           '<md-dialog>' +
-            '<div class="md-actions">' +
-              '<button id="a">A</md-button>' +
-              '<button id="focus-target">B</md-button>' +
-            '</div>' +
+            '<md-dialog-actions>' +
+              '<button class="md-button" id="a">A</md-button>' +
+              '<button class="md-button" id="focus-target">B</md-button>' +
+            '</md-dialog-actions>' +
           '</md-dialog>',
         parent: parent
       });
@@ -437,6 +437,58 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
 
       expect($document.activeElement).toBe(parent[0].querySelector('#focus-target'));
+    }));
+
+    it('should warn if md-dialog-actions does not contain actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+      spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<p>Why is this here</p>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      $rootScope.$apply();
+      $timeout.flush();
+
+      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+
+      container.triggerHandler('transitionend');
+      $rootScope.$apply();
+      parent.find('md-dialog').triggerHandler('transitionend');
+      $rootScope.$apply();
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
+    it('should not warn if md-dialog-actions has actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+      spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button class="md-button">Ok good</button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      $rootScope.$apply();
+      $timeout.flush();
+      container.triggerHandler('transitionend');
+      $rootScope.$apply();
+      parent.find('md-dialog').triggerHandler('transitionend');
+      $rootScope.$apply();
+
+      expect($log.warn).not.toHaveBeenCalled();
     }));
 
     it('should only allow one open at a time', inject(function($mdDialog, $rootScope, $animate) {
@@ -598,7 +650,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
     var content = mdContent.find('p');
-    var mdActions = angular.element(mdDialog[0].querySelector('.md-actions'));
+    var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
     expect(mdDialog.attr('aria-label')).toBe('test alert');
@@ -625,7 +677,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
     var content = mdContent.find('p');
-    var mdActions = angular.element(mdDialog[0].querySelector('.md-actions'));
+    var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
     expect(mdDialog.attr('aria-label')).toBe('test alert');


### PR DESCRIPTION
To be more semantic, this PR includes a change from `<div class="md-actions">` in both cards and dialogs to `<md-card-actions>` and `<md-dialog-actions>`, respectively. Breaking changes noted in the commits.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3112)
<!-- Reviewable:end -->
