### PR TITLE
Improve the documentation of md-autoselect

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -43,7 +43,7 @@ angular
  * @param {number=} md-min-length Specifies the minimum length of text before autocomplete will make suggestions
  * @param {number=} md-delay Specifies the amount of time (in milliseconds) to wait before looking for results
  * @param {boolean=} md-autofocus If true, will immediately focus the input element
- * @param {boolean=} md-autoselect If true, the first item will be selected by default
+ * @param {boolean=} md-autoselect If true, the first item in the dropdown will be highlighted by default
  * @param {string=} md-menu-class This will be applied to the dropdown menu for styling
  * @param {string=} md-floating-label This will add a floating label to autocomplete and wrap it in `md-input-container`
  *


### PR DESCRIPTION
The current documentation might be a little bit misleading. It could be understood, that the first item will be selected by default, i.e the model will have the value of the first item.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3156)
<!-- Reviewable:end -->
