### PR TITLE
Allow chaining on fontSet method

### DIFF
--- a/src/components/icon/iconService.js
+++ b/src/components/icon/iconService.js
@@ -256,6 +256,7 @@
       alias : alias,
       fontSet : className || alias
     });
+    return this;
    },
 
    /**


### PR DESCRIPTION
Codepen: http://codepen.io/shprink/pen/LVLmYm

Open the console.

```
 $mdIconProvider
            .fontSet('fa', 'fontawesome')
            .defaultFontSet('fontawesome');
```

Does not work.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3238)
<!-- Reviewable:end -->
