### PR TITLE
fix(mdChipsController inputKeyDown): change use of property mdRequire…

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -84,7 +84,7 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
   var chipBuffer = this.getChipBuffer();
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.ENTER:
-      if (this.$scope.requireMatch || !chipBuffer) break;
+      if (this.requireMatch || !chipBuffer) break;
       event.preventDefault();
       this.appendChip(chipBuffer);
       this.resetChipBuffer();


### PR DESCRIPTION
…Match on mdChips

the mdRequireMatch is not located on the $scope, due to a bug in the link or compile process.
The property is located on "this". This is a hotfix, and the proper solution is to fix the compile function of the directive

ISSUE: #2982