### PR TITLE
Switched RawGit for GitCDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,15 +136,15 @@ when using online tools such as [CodePen](http://codepen.io/), [Plunkr](http://p
 
 > Note that the above sample references the 0.8.3 CDN release. Your version will change based on the latest stable release version.
 
-Developers seeking the latest, most-current build versions can use [RawGit.com](//rawgit.com) to
+Developers seeking the latest, most-current build versions can use [GitCDN.xyz](//gitcdn.xyz) to
 pull directly from the distribution GitHub
 [Bower-Material](https://github.com/angular/bower-material) repository:
 
 ```html
   <head>
 
-    <!-- Angular Material CSS using RawGit to load directly from `bower-material/master` -->
-    <link rel="stylesheet" href="https://rawgit.com/angular/bower-material/master/angular-material.css">
+    <!-- Angular Material CSS using GitCDN to load directly from `bower-material/master` -->
+    <link rel="stylesheet" href="https://gitcdn.xyz/repo/angular/bower-material/master/angular-material.css">
 
   </head>
   <body>
@@ -154,11 +154,9 @@ pull directly from the distribution GitHub
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.js"></script>
 
-    <!-- Angular Material Javascript using RawGit to load directly from `bower-material/master` -->
-    <script src="https://rawgit.com/angular/bower-material/master/angular-material.js"></script>
+    <!-- Angular Material Javascript using GitCDN to load directly from `bower-material/master` -->
+    <script src="https://gitcdn.xyz/repo/angular/bower-material/master/angular-material.js"></script>
 
   </body>
 ```
 
-> Please note that the above RawGit access is intended **ONLY** for development purposes or sharing
-  low-traffic, temporary examples or demos with small numbers of people.


### PR DESCRIPTION
Due to the damage than can be caused to Ryan (owner of RawGit) if people abuse the dev link, I've switched it to GitCDN, it lets you get the latest master branch, without losing the CDN and without it's service getting harmed.

Full disclosure, I am the maintainer of GitCDN