### PR TITLE
fix(mdChipsController inputKeyDown): Fix use of property mdRequireMatch

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -84,7 +84,7 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
   var chipBuffer = this.getChipBuffer();
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.ENTER:
-      if (this.$scope.requireMatch || !chipBuffer) break;
+      if (this.requireMatch || !chipBuffer) break;
       event.preventDefault();
       this.appendChip(chipBuffer);
       this.resetChipBuffer();


### PR DESCRIPTION
the mdRequireMatch is not located on the $scope, due to a bug in the link or compile process.
The property is located on "this". This is a hotfix, and the proper solution is to fix the compile function of the directive

ISSUE: https://github.com/angular/material/issues/2982

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3270)
<!-- Reviewable:end -->
