### PR TITLE
check tabs length before update tab order

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -442,6 +442,7 @@ function MdTabsController ($scope, $element, $window, $timeout, $mdConstant, $md
    * This is triggered by `tabDirective.js` when the user's tabs have been re-ordered.
    */
   function updateTabOrder () {
+    if (!ctrl.tabs[$scope.selectedIndex]) return;
     var selectedItem = ctrl.tabs[$scope.selectedIndex],
         focusItem = ctrl.tabs[ctrl.focusIndex];
     ctrl.tabs = ctrl.tabs.sort(function (a, b) {


### PR DESCRIPTION
When `tabs` is empty, updating tab order will cause `$scope.selectedIndex` to be `-1`, which could result in exception when we try to access  selected tab.