### PR TITLE
Change md-select label behaviour to match md-input

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -168,7 +168,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 
     if ( !containerCtrl ) return;
     if (containerCtrl.input) {
-      throw new Error("<md-input-container> can only have *one* <input> or <textarea> child element!");
+      throw new Error("<md-input-container> can only have *one* child <input>, <textarea> or <select> element!");
     }
     containerCtrl.input = element;
 
@@ -327,7 +327,6 @@ function mdMaxlengthDirective($animate) {
 }
 
 function placeholderDirective($log) {
-  var blackListElements = ['MD-SELECT'];
   return {
     restrict: 'A',
     require: '^^?mdInputContainer',
@@ -337,7 +336,6 @@ function placeholderDirective($log) {
 
   function postLink(scope, element, attr, inputContainer) {
     if (!inputContainer) return;
-    if (blackListElements.indexOf(element[0].nodeName) != -1) return;
     if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 
     var placeholderText = attr.placeholder;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -80,7 +80,7 @@ md-input-container {
 
 
   label:not(.md-no-float),
-  .md-placeholder:not(.md-select-label) {
+  .md-placeholder {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
@@ -91,7 +91,7 @@ md-input-container {
 
     @include rtl(transform-origin, left top, right top);
   }
-  .md-placeholder:not(.md-select-label) {
+  .md-placeholder {
     position: absolute;
     top: 0;
     opacity: 0;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -113,10 +113,6 @@ md-input-container {
     color: transparent;
   }
 
-
-
-
-
   /*
    * The .md-input class is added to the input/textarea
    */

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -98,6 +98,7 @@ md-input-container {
     transition-property: opacity, transform;
     transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
   }
+
   &.md-input-focused .md-placeholder {
     opacity: 1;
     transform: translate3d(0, $input-placeholder-offset, 0);
@@ -111,6 +112,9 @@ md-input-container {
   &:not( .md-input-has-value ) input:not( :focus ) {
     color: transparent;
   }
+
+
+
 
 
   /*

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -68,7 +68,7 @@ angular.module('material.components.select', [
 function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, $compile, $parse) {
   return {
     restrict: 'E',
-    require: ['mdSelect', 'ngModel', '?^form'],
+    require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
     controller: function() { } // empty placeholder controller to be initialized in link
   };
@@ -143,9 +143,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       var isOpen;
       var isDisabled;
 
-      var mdSelectCtrl = ctrls[0];
-      var ngModel = ctrls[1];
-      var formCtrl = ctrls[2];
+      var containerCtrl = ctrls[0];
+      var mdSelectCtrl = ctrls[1];
+      var ngModel = ctrls[2];
+      var formCtrl = ctrls[3];
 
       var labelEl = element.find('md-select-label');
       var customLabel = labelEl.text().length !== 0;

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -75,7 +75,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
   function compile(element, attr) {
     // The user is allowed to provide a label for the select as md-select-label child
-    var labelEl = element.find('md-select-label').remove();
+    var labelEl = element.parent().find('label').remove();
 
     // If not provided, we automatically make one
     if (!labelEl.length) {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -184,6 +184,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       };
 
       mdSelectCtrl.setIsPlaceholder = function(val) {
+        val ? valueEl.addClass('md-select-placeholder') : valueEl.removeClass('md-select-placeholder');
         val ? containerCtrl.label.addClass('md-placeholder') : containerCtrl.label.removeClass('md-placeholder');
       };
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -11,6 +11,7 @@ $select-max-visible-options: 5;
   top: 0;
   z-index: 99;
   opacity: 0;
+  border: solid 1px;
 
   // Don't let the user select a new choice while it's animating
   &:not(.md-clickable) {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -49,12 +49,11 @@ $select-max-visible-options: 5;
 
 md-input-container > md-select {
   margin: 0;
-//  margin-top: 3px;
 }
 
 md-select {
-//  padding: 24px 2px 26px;
   display: flex;
+  order: 2;
   &:focus {
     outline: none;
   }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -117,6 +117,15 @@ md-select {
     transform: scaleY(0.6) scaleX(1);
   }
 
+  &.md-select-placeholder {
+    display: flex;
+    order: 1;
+    pointer-events: none;
+    -webkit-font-smoothing: antialiased;
+    padding-left: 2px;
+    z-index: 1;
+    color: rgba(0,0,0,0.26);
+  }
 
 }
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -49,11 +49,11 @@ $select-max-visible-options: 5;
 
 md-input-container > md-select {
   margin: 0;
-  margin-top: 3px;
+//  margin-top: 3px;
 }
 
 md-select {
-  padding: 24px 2px 26px;
+//  padding: 24px 2px 26px;
   display: flex;
   &:focus {
     outline: none;
@@ -66,13 +66,13 @@ md-select {
       cursor: pointer
     }
     &.ng-invalid.ng-dirty {
-      .md-select-label {
+      .md-select-value {
         border-bottom: 2px solid;
         padding-bottom: 0;
       }
     }
     &:focus {
-      .md-select-label {
+      .md-select-value {
         border-bottom: 2px solid;
         padding-bottom: 0;
       }
@@ -81,7 +81,7 @@ md-select {
 }
 
 
-.md-select-label {
+.md-select-value {
   display: flex;
   align-items: center;
   padding: 2px 2px 1px;
@@ -116,6 +116,8 @@ md-select {
     speak: none;
     transform: scaleY(0.6) scaleX(1);
   }
+
+
 }
 
 md-select-menu {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,5 +1,6 @@
 describe('<md-select>', function() {
 
+  beforeEach(module('material.components.input'));
   beforeEach(module('material.components.select', 'ngAnimateMock'));
 
   beforeEach(inject(function($mdUtil, $$q) {
@@ -8,10 +9,14 @@ describe('<md-select>', function() {
     };
   }));
 
-  function setupSelect(attrs, options) {
+  function setupSelect(attrs, options, bNoLabel) {
     var el;
     inject(function($compile, $rootScope) {
-      var src = '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select>';
+      var src = '<md-input-container>';
+      if (!bNoLabel) {
+        src += '<label>Label</label>';
+      }
+      src += '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select></md-input-container>';
       var template = angular.element(src);
       el = $compile(template)($rootScope);
       $rootScope.$digest();
@@ -92,24 +97,24 @@ describe('<md-select>', function() {
   }
 
   it('should preserve tabindex', inject(function($document) {
-    var select = setupSelect('tabindex="2", ng-model="val"');
+    var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
     expect(select.attr('tabindex')).toBe('2');
   }));
 
   it('supports non-disabled state', inject(function($document) {
-    var select = setupSelect('ng-model="val"');
+    var select = setupSelect('ng-model="val"' ).find('md-select');
     expect(select.attr('aria-disabled')).toBe('false');
   }));
 
   it('supports disabled state', inject(function($document) {
-    var select = setupSelect('disabled="disabled", ng-model="val"');
+    var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
     openSelect(select);
     expect($document.find('md-select-menu').length).toBe(0);
     expect(select.attr('aria-disabled')).toBe('true');
   }));
 
-  xit('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
-    var select = setupSelect('ng-model="val"');
+  it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
+    var select = setupSelect('ng-model="val"').find('md-select');
 
     openSelect(select);
     expect($document.find('md-select-menu').length).toBe(1);
@@ -121,7 +126,7 @@ describe('<md-select>', function() {
   }));
 
   it('restores focus to select when the menu is closed', inject(function($document) {
-    var select = setupSelect('ng-model="val"');
+    var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);
 
     $document[0].body.appendChild(select[0]);
@@ -134,40 +139,86 @@ describe('<md-select>', function() {
     select.remove();
   }));
 
+  describe('input container', function () {
+    it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
+      $rootScope.model = 0;
+      var el = setupSelect('ng-model="$root.model"', [1,2,3] );
+      var select = el.find('md-select');
+      expect(selectedOptions(select).length).toBe(0);
+
+      el.triggerHandler({
+        type: 'click',
+        target: select.find('md-option')[1]
+      });
+
+      expect(el).toHaveClass('md-input-has-value');
+    }));
+
+    it('should set has-value class on container for ng-model input', inject(function($rootScope) {
+      $rootScope.value = 'test';
+      var el = setupSelect('ng-model="$root.value"');
+      expect(el).toHaveClass('md-input-has-value');
+
+      $rootScope.$apply('value = "3"');
+      expect(el).toHaveClass('md-input-has-value');
+
+      $rootScope.$apply('value = null');
+      expect(el).not.toHaveClass('md-input-has-value');
+    }));
+
+    it('should match label to given input id', inject(function($rootScope) {
+      var el = setupSelect('ng-model="$root.value", id="foo"');
+      expect(el.find('label').attr('for')).toBe('foo');
+      expect(el.find('md-select').attr('id')).toBe('foo');
+    }));
+
+    it('should match label to automatic input id', inject(function($rootScope) {
+      var el = setupSelect('ng-model="$root.value"');
+      expect(el.find('md-select').attr('id')).toBeTruthy();
+      expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
+    }));
+  });
+
   describe('label behavior', function() {
     it('defaults to the placeholder text', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"');
-      var label = select.find('md-select-label');
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+      var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
-      expect(label.hasClass('md-placeholder')).toBe(true);
+      expect(label.hasClass('md-select-placeholder')).toBe(true);
     });
 
     it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
       $rootScope.val = 2;
-      var select = $compile('<md-select ng-model="val" placeholder="Hello World">' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      var label = select.find('md-select-label');
+      var select = $compile('<md-input-container>' +
+                              '<label>Label</label>' +
+                              '<md-select ng-model="val" placeholder="Hello World">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
+      var label = select.find('md-select-value');
       $rootScope.$digest();
 
       expect(label.text()).toBe('Two');
-      expect(label.hasClass('md-placeholder')).toBe(false);
+      expect(label.hasClass('md-select-placeholder')).toBe(false);
     }));
 
     it('supports rendering multiple', inject(function($rootScope, $compile) {
       $rootScope.val = [1, 3];
-      var select = $compile('<md-select multiple ng-model="val" placeholder="Hello World">' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      var label = select.find('md-select-label');
+      var select = $compile('<md-input-container>' +
+                              '<label>Label</label>' +
+                              '<md-select multiple ng-model="val" placeholder="Hello World">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
+      var label = select.find('md-select-value');
       $rootScope.$digest();
 
       expect(label.text()).toBe('One, Three');
-      expect(label.hasClass('md-placeholder')).toBe(false);
+      expect(label.hasClass('md-select-placeholder')).toBe(false);
     }));
   });
 
@@ -196,8 +247,8 @@ describe('<md-select>', function() {
 
   it('watches the collection for changes', inject(function($rootScope) {
     $rootScope.val = 1;
-    var select = setupSelect('ng-model="val"', [1, 2, 3]);
-    var label = select.find('md-select-label')[0];
+    var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
+    var label = select.find('md-select-value')[0];
     expect(label.textContent).toBe('1');
     $rootScope.val = 4;
     $rootScope.$$values = [4, 5, 6];
@@ -309,7 +360,7 @@ describe('<md-select>', function() {
             changeCalled = true;
           };
 
-          var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]);
+          var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3] ).find('md-select');
           openSelect(selectEl);
 
           var menuEl = $document.find('md-select-menu');
@@ -592,34 +643,25 @@ describe('<md-select>', function() {
   describe('aria', function() {
     var el;
     beforeEach(inject(function($q, $document) {
-      el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+      el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
       var selectMenus = $document.find('md-select-menu');
       selectMenus.remove();
     }));
 
     it('adds an aria-label from placeholder', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"');
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     });
 
-    it('adds aria-label from label element', inject(function($rootScope, $compile) {
-      var select = $compile('<md-select ng-model="val">' +
-                              '<md-select-label>{{"Pick"}}</md-select-label>' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      $rootScope.$digest();
-      expect(select.attr('aria-label')).toBe('Pick');
-    }));
-
     it('preserves aria-label on value change', inject(function($rootScope, $compile) {
-      var select = $compile('<md-select ng-model="val">' +
-                              '<md-select-label>Pick</md-select-label>' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
+      var select = $compile('<md-input-container>' +
+                              '<label>Pick</label>' +
+                              '<md-select ng-model="val">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
       $rootScope.$apply('model = 1');
       $rootScope.$digest();
 
@@ -627,18 +669,18 @@ describe('<md-select>', function() {
     }));
 
     it('preserves existing aria-label', inject(function($rootScope) {
-      var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"');
+      var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     }));
 
     it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
       spyOn($log, 'warn');
-      var select = setupSelect('ng-model="someVal"');
+      var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
       $rootScope.$apply();
       expect($log.warn).toHaveBeenCalled();
 
       $log.warn.calls.reset();
-      select = setupSelect('ng-model="someVal", aria-label="Hello world"');
+      select = setupSelect('ng-model="someVal", aria-label="Hello world"').find('md-select');
       $rootScope.$apply();
       expect($log.warn).not.toHaveBeenCalled();
     }));
@@ -681,7 +723,7 @@ describe('<md-select>', function() {
 
     describe('md-select', function() {
       it('can be opened with a space key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 32);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
@@ -689,7 +731,7 @@ describe('<md-select>', function() {
       }));
 
       it('can be opened with an enter key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 13);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
@@ -697,7 +739,7 @@ describe('<md-select>', function() {
       }));
 
       it('can be opened with the up key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 38);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
@@ -705,7 +747,7 @@ describe('<md-select>', function() {
       }));
 
       it('can be opened with the down key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 40);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
@@ -713,7 +755,7 @@ describe('<md-select>', function() {
       }));
 
       it('supports typing an option name', inject(function($document, $rootScope) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 50);
         expect($rootScope.someModel).toBe(2);
       }));
@@ -721,7 +763,7 @@ describe('<md-select>', function() {
 
     describe('md-select-menu', function() {
       it('can be closed with escape', inject(function($document, $rootScope, $animate) {
-        var el = setupSelect('ng-model="someVal"', [1, 2, 3]);
+        var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
         openSelect(el);
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);


### PR DESCRIPTION
Adds required md-input-container to md-select. 
Replaces md-select-label with md-select-value
Adjusts scss to make label transition the same way as with md-input-container/md-input
