### PR TITLE
Make md-select work more like md-input-container/input

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -3,15 +3,15 @@
  * @name material.components.input
  */
 
-angular.module('material.components.input', [
+angular.module('material.components.input',[
   'material.core'
 ])
-  .directive('mdInputContainer', mdInputContainerDirective)
-  .directive('label', labelDirective)
-  .directive('input', inputTextareaDirective)
-  .directive('textarea', inputTextareaDirective)
-  .directive('mdMaxlength', mdMaxlengthDirective)
-  .directive('placeholder', placeholderDirective);
+  .directive('mdInputContainer',mdInputContainerDirective)
+  .directive('label',labelDirective)
+  .directive('input',inputTextareaDirective)
+  .directive('textarea',inputTextareaDirective)
+  .directive('mdMaxlength',mdMaxlengthDirective)
+  .directive('placeholder',placeholderDirective);
 
 /**
  * @ngdoc directive
@@ -44,18 +44,18 @@ angular.module('material.components.input', [
  *
  * </hljs>
  */
-function mdInputContainerDirective($mdTheming, $parse) {
+function mdInputContainerDirective($mdTheming,$parse) {
   return {
     restrict: 'E',
     link: postLink,
     controller: ContainerCtrl
   };
 
-  function postLink(scope, element, attr) {
+  function postLink(scope,element,attr) {
     $mdTheming(element);
   }
 
-  function ContainerCtrl($scope, $element, $attrs) {
+  function ContainerCtrl($scope,$element,$attrs) {
     var self = this;
 
     self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
@@ -65,19 +65,19 @@ function mdInputContainerDirective($mdTheming, $parse) {
     };
     self.element = $element;
     self.setFocused = function(isFocused) {
-      $element.toggleClass('md-input-focused', !!isFocused);
+      $element.toggleClass('md-input-focused',!!isFocused);
     };
     self.setHasValue = function(hasValue) {
-      $element.toggleClass('md-input-has-value', !!hasValue);
+      $element.toggleClass('md-input-has-value',!!hasValue);
     };
     self.setInvalid = function(isInvalid) {
-      $element.toggleClass('md-input-invalid', !!isInvalid);
+      $element.toggleClass('md-input-invalid',!!isInvalid);
     };
     $scope.$watch(function() {
       return self.label && self.input;
-    }, function(hasLabelAndInput) {
+    },function(hasLabelAndInput) {
       if (hasLabelAndInput && !self.label.attr('for')) {
-        self.label.attr('for', self.input.attr('id'));
+        self.label.attr('for',self.input.attr('id'));
       }
     });
   }
@@ -87,11 +87,11 @@ function labelDirective() {
   return {
     restrict: 'E',
     require: '^?mdInputContainer',
-    link: function(scope, element, attr, containerCtrl) {
+    link: function(scope,element,attr,containerCtrl) {
       if (!containerCtrl || attr.mdNoFloat) return;
 
       containerCtrl.label = element;
-      scope.$on('$destroy', function() {
+      scope.$on('$destroy',function() {
         containerCtrl.label = null;
       });
     }
@@ -154,14 +154,14 @@ function labelDirective() {
  *
  */
 
-function inputTextareaDirective($mdUtil, $window, $mdAria) {
+function inputTextareaDirective($mdUtil,$window,$mdAria) {
   return {
     restrict: 'E',
-    require: ['^?mdInputContainer', '?ngModel'],
+    require: ['^?mdInputContainer','?ngModel'],
     link: postLink
   };
 
-  function postLink(scope, element, attr, ctrls) {
+  function postLink(scope,element,attr,ctrls) {
 
     var containerCtrl = ctrls[0];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
@@ -174,12 +174,12 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     containerCtrl.input = element;
 
     if (!containerCtrl.label) {
-      $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+      $mdAria.expect(element,'aria-label',element.attr('placeholder'));
     }
 
     element.addClass('md-input');
     if (!element.attr('id')) {
-      element.attr('id', 'input_' + $mdUtil.nextUid());
+      element.attr('id','input_' + $mdUtil.nextUid());
     }
 
     if (element[0].tagName.toLowerCase() === 'textarea') {
@@ -189,19 +189,19 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
         return ngModelCtrl.$invalid && ngModelCtrl.$touched;
       };
-    scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+    scope.$watch(isErrorGetter,containerCtrl.setInvalid);
 
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
     ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
 
-    element.on('input', inputCheckValue);
+    element.on('input',inputCheckValue);
 
     if (!isReadonly) {
       element
-        .on('focus', function(ev) {
+        .on('focus',function(ev) {
           containerCtrl.setFocused(true);
         })
-        .on('blur', function(ev) {
+        .on('blur',function(ev) {
           containerCtrl.setFocused(false);
           inputCheckValue();
         });
@@ -211,7 +211,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     //ngModelCtrl.$setTouched();
     //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
 
-    scope.$on('$destroy', function() {
+    scope.$on('$destroy',function() {
       containerCtrl.setFocused(false);
       containerCtrl.setHasValue(false);
       containerCtrl.input = null;
@@ -233,7 +233,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 
     function setupTextarea() {
       var node = element[0];
-      var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
+      var onChangeTextarea = $mdUtil.debounce(growTextarea,1);
 
       function pipelineListener(value) {
         onChangeTextarea();
@@ -246,12 +246,12 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       } else {
         onChangeTextarea();
       }
-      element.on('keydown input', onChangeTextarea);
-      element.on('scroll', onScroll);
-      angular.element($window).on('resize', onChangeTextarea);
+      element.on('keydown input',onChangeTextarea);
+      element.on('scroll',onScroll);
+      angular.element($window).on('resize',onChangeTextarea);
 
-      scope.$on('$destroy', function() {
-        angular.element($window).off('resize', onChangeTextarea);
+      scope.$on('$destroy',function() {
+        angular.element($window).off('resize',onChangeTextarea);
       });
 
       function growTextarea() {
@@ -280,11 +280,11 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 function mdMaxlengthDirective($animate) {
   return {
     restrict: 'A',
-    require: ['ngModel', '^mdInputContainer'],
+    require: ['ngModel','^mdInputContainer'],
     link: postLink
   };
 
-  function postLink(scope, element, attr, ctrls) {
+  function postLink(scope,element,attr,ctrls) {
     var maxlength;
     var ngModelCtrl = ctrls[0];
     var containerCtrl = ctrls[1];
@@ -292,20 +292,20 @@ function mdMaxlengthDirective($animate) {
 
     // Stop model from trimming. This makes it so whitespace
     // over the maxlength still counts as invalid.
-    attr.$set('ngTrim', 'false');
+    attr.$set('ngTrim','false');
     containerCtrl.element.append(charCountEl);
 
     ngModelCtrl.$formatters.push(renderCharCount);
     ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-    element.on('input keydown', function() {
+    element.on('input keydown',function() {
       renderCharCount(); //make sure it's called with no args
     });
 
-    scope.$watch(attr.mdMaxlength, function(value) {
+    scope.$watch(attr.mdMaxlength,function(value) {
       maxlength = value;
       if (angular.isNumber(value) && value > 0) {
         if (!charCountEl.parent().length) {
-          $animate.enter(charCountEl, containerCtrl.element,
+          $animate.enter(charCountEl,containerCtrl.element,
             angular.element(containerCtrl.element[0].lastElementChild));
         }
         renderCharCount();
@@ -314,7 +314,7 @@ function mdMaxlengthDirective($animate) {
       }
     });
 
-    ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
+    ngModelCtrl.$validators['md-maxlength'] = function(modelValue,viewValue) {
       if (!angular.isNumber(maxlength) || maxlength < 0) {
         return true;
       }
@@ -336,7 +336,7 @@ function placeholderDirective($log) {
     link: postLink
   };
 
-  function postLink(scope, element, attr, inputContainer) {
+  function postLink(scope,element,attr,inputContainer) {
     if (!inputContainer) return;
     if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -4,14 +4,14 @@
  */
 
 angular.module('material.components.input', [
-    'material.core'
+  'material.core'
 ])
-    .directive('mdInputContainer', mdInputContainerDirective)
-    .directive('label', labelDirective)
-    .directive('input', inputTextareaDirective)
-    .directive('textarea', inputTextareaDirective)
-    .directive('mdMaxlength', mdMaxlengthDirective)
-    .directive('placeholder', placeholderDirective);
+  .directive('mdInputContainer', mdInputContainerDirective)
+  .directive('label', labelDirective)
+  .directive('input', inputTextareaDirective)
+  .directive('textarea', inputTextareaDirective)
+  .directive('mdMaxlength', mdMaxlengthDirective)
+  .directive('placeholder', placeholderDirective);
 
 /**
  * @ngdoc directive
@@ -45,56 +45,57 @@ angular.module('material.components.input', [
  * </hljs>
  */
 function mdInputContainerDirective($mdTheming, $parse) {
-    return {
-        restrict: 'E',
-        link: postLink,
-        controller: ContainerCtrl
+  return {
+    restrict: 'E',
+    link: postLink,
+    controller: ContainerCtrl
+  };
+
+  function postLink(scope, element, attr) {
+    $mdTheming(element);
+  }
+
+  function ContainerCtrl($scope, $element, $attrs) {
+    var self = this;
+
+    self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
+
+    self.delegateClick = function () {
+      self.input.focus();
     };
-
-    function postLink(scope, element, attr) {
-        $mdTheming(element);
-    }
-    function ContainerCtrl($scope, $element, $attrs) {
-        var self = this;
-
-        self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
-
-        self.delegateClick = function() {
-            self.input.focus();
-        };
-        self.element = $element;
-        self.setFocused = function(isFocused) {
-            $element.toggleClass('md-input-focused', !!isFocused);
-        };
-        self.setHasValue = function(hasValue) {
-            $element.toggleClass('md-input-has-value', !!hasValue);
-        };
-        self.setInvalid = function(isInvalid) {
-            $element.toggleClass('md-input-invalid', !!isInvalid);
-        };
-        $scope.$watch(function() {
-            return self.label && self.input;
-        }, function(hasLabelAndInput) {
-            if (hasLabelAndInput && !self.label.attr('for')) {
-                self.label.attr('for', self.input.attr('id'));
-            }
-        });
-    }
+    self.element = $element;
+    self.setFocused = function (isFocused) {
+      $element.toggleClass('md-input-focused', !!isFocused);
+    };
+    self.setHasValue = function (hasValue) {
+      $element.toggleClass('md-input-has-value', !!hasValue);
+    };
+    self.setInvalid = function (isInvalid) {
+      $element.toggleClass('md-input-invalid', !!isInvalid);
+    };
+    $scope.$watch(function () {
+      return self.label && self.input;
+    }, function (hasLabelAndInput) {
+      if (hasLabelAndInput && !self.label.attr('for')) {
+        self.label.attr('for', self.input.attr('id'));
+      }
+    });
+  }
 }
 
 function labelDirective() {
-    return {
-        restrict: 'E',
-        require: '^?mdInputContainer',
-        link: function(scope, element, attr, containerCtrl) {
-            if (!containerCtrl || attr.mdNoFloat) return;
+  return {
+    restrict: 'E',
+    require: '^?mdInputContainer',
+    link: function (scope, element, attr, containerCtrl) {
+      if (!containerCtrl || attr.mdNoFloat) return;
 
-            containerCtrl.label = element;
-            scope.$on('$destroy', function() {
-                containerCtrl.label = null;
-            });
-        }
-    };
+      containerCtrl.label = element;
+      scope.$on('$destroy', function () {
+        containerCtrl.label = null;
+      });
+    }
+  };
 }
 
 /**
@@ -154,201 +155,202 @@ function labelDirective() {
  */
 
 function inputTextareaDirective($mdUtil, $window, $mdAria) {
-    return {
-        restrict: 'E',
-        require: ['^?mdInputContainer', '?ngModel'],
-        link: postLink
-    };
+  return {
+    restrict: 'E',
+    require: ['^?mdInputContainer', '?ngModel'],
+    link: postLink
+  };
 
-    function postLink(scope, element, attr, ctrls) {
+  function postLink(scope, element, attr, ctrls) {
 
-        var containerCtrl = ctrls[0];
-        var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
-        var isReadonly = angular.isDefined(attr.readonly);
+    var containerCtrl = ctrls[0];
+    var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
+    var isReadonly = angular.isDefined(attr.readonly);
 
-        if ( !containerCtrl ) return;
-        if (containerCtrl.input) {
-            throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
-        }
-        containerCtrl.input = element;
+    if (!containerCtrl) return;
+    if (containerCtrl.input) {
+      throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
+    }
+    containerCtrl.input = element;
 
-        if(!containerCtrl.label) {
-            $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
-        }
+    if (!containerCtrl.label) {
+      $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+    }
 
-        element.addClass('md-input');
-        if (!element.attr('id')) {
-            element.attr('id', 'input_' + $mdUtil.nextUid());
-        }
+    element.addClass('md-input');
+    if (!element.attr('id')) {
+      element.attr('id', 'input_' + $mdUtil.nextUid());
+    }
 
-        if (element[0].tagName.toLowerCase() === 'textarea') {
-            setupTextarea();
-        }
+    if (element[0].tagName.toLowerCase() === 'textarea') {
+      setupTextarea();
+    }
 
-        var isErrorGetter = containerCtrl.isErrorGetter || function() {
-                return ngModelCtrl.$invalid && ngModelCtrl.$touched;
-            };
-        scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+    var isErrorGetter = containerCtrl.isErrorGetter || function () {
+        return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+      };
+    scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
-        ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
-        ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
+    ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
+    ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
 
-        element.on('input', inputCheckValue);
+    element.on('input', inputCheckValue);
 
-        if (!isReadonly) {
-            element
-                .on('focus', function(ev) {
-                    containerCtrl.setFocused(true);
-                })
-                .on('blur', function(ev) {
-                    containerCtrl.setFocused(false);
-                    inputCheckValue();
-                });
-
-        }
-
-        //ngModelCtrl.$setTouched();
-        //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
-
-        scope.$on('$destroy', function() {
-            containerCtrl.setFocused(false);
-            containerCtrl.setHasValue(false);
-            containerCtrl.input = null;
+    if (!isReadonly) {
+      element
+        .on('focus', function (ev) {
+          containerCtrl.setFocused(true);
+        })
+        .on('blur', function (ev) {
+          containerCtrl.setFocused(false);
+          inputCheckValue();
         });
 
-        /**
-         *
-         */
-        function ngModelPipelineCheckValue(arg) {
-            containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
-            return arg;
-        }
-        function inputCheckValue() {
-            // An input's value counts if its length > 0,
-            // or if the input's validity state says it has bad input (eg string in a number input)
-            containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity||{}).badInput);
-        }
-
-        function setupTextarea() {
-            var node = element[0];
-            var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
-
-            function pipelineListener(value) {
-                onChangeTextarea();
-                return value;
-            }
-
-            if (ngModelCtrl) {
-                ngModelCtrl.$formatters.push(pipelineListener);
-                ngModelCtrl.$viewChangeListeners.push(pipelineListener);
-            } else {
-                onChangeTextarea();
-            }
-            element.on('keydown input', onChangeTextarea);
-            element.on('scroll', onScroll);
-            angular.element($window).on('resize', onChangeTextarea);
-
-            scope.$on('$destroy', function() {
-                angular.element($window).off('resize', onChangeTextarea);
-            });
-
-            function growTextarea() {
-                node.style.height = "auto";
-                node.scrollTop = 0;
-                var height = getHeight();
-                if (height) node.style.height = height + 'px';
-            }
-
-            function getHeight () {
-                var line = node.scrollHeight - node.offsetHeight;
-                return node.offsetHeight + (line > 0 ? line : 0);
-            }
-
-            function onScroll(e) {
-                node.scrollTop = 0;
-                // for smooth new line adding
-                var line = node.scrollHeight - node.offsetHeight;
-                var height = node.offsetHeight + line;
-                node.style.height = height + 'px';
-            }
-        }
     }
+
+    //ngModelCtrl.$setTouched();
+    //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
+
+    scope.$on('$destroy', function () {
+      containerCtrl.setFocused(false);
+      containerCtrl.setHasValue(false);
+      containerCtrl.input = null;
+    });
+
+    /**
+     *
+     */
+    function ngModelPipelineCheckValue(arg) {
+      containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
+      return arg;
+    }
+
+    function inputCheckValue() {
+      // An input's value counts if its length > 0,
+      // or if the input's validity state says it has bad input (eg string in a number input)
+      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity || {}).badInput);
+    }
+
+    function setupTextarea() {
+      var node = element[0];
+      var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
+
+      function pipelineListener(value) {
+        onChangeTextarea();
+        return value;
+      }
+
+      if (ngModelCtrl) {
+        ngModelCtrl.$formatters.push(pipelineListener);
+        ngModelCtrl.$viewChangeListeners.push(pipelineListener);
+      } else {
+        onChangeTextarea();
+      }
+      element.on('keydown input', onChangeTextarea);
+      element.on('scroll', onScroll);
+      angular.element($window).on('resize', onChangeTextarea);
+
+      scope.$on('$destroy', function () {
+        angular.element($window).off('resize', onChangeTextarea);
+      });
+
+      function growTextarea() {
+        node.style.height = "auto";
+        node.scrollTop = 0;
+        var height = getHeight();
+        if (height) node.style.height = height + 'px';
+      }
+
+      function getHeight() {
+        var line = node.scrollHeight - node.offsetHeight;
+        return node.offsetHeight + (line > 0 ? line : 0);
+      }
+
+      function onScroll(e) {
+        node.scrollTop = 0;
+        // for smooth new line adding
+        var line = node.scrollHeight - node.offsetHeight;
+        var height = node.offsetHeight + line;
+        node.style.height = height + 'px';
+      }
+    }
+  }
 }
 
 function mdMaxlengthDirective($animate) {
-    return {
-        restrict: 'A',
-        require: ['ngModel', '^mdInputContainer'],
-        link: postLink
+  return {
+    restrict: 'A',
+    require: ['ngModel', '^mdInputContainer'],
+    link: postLink
+  };
+
+  function postLink(scope, element, attr, ctrls) {
+    var maxlength;
+    var ngModelCtrl = ctrls[0];
+    var containerCtrl = ctrls[1];
+    var charCountEl = angular.element('<div class="md-char-counter">');
+
+    // Stop model from trimming. This makes it so whitespace
+    // over the maxlength still counts as invalid.
+    attr.$set('ngTrim', 'false');
+    containerCtrl.element.append(charCountEl);
+
+    ngModelCtrl.$formatters.push(renderCharCount);
+    ngModelCtrl.$viewChangeListeners.push(renderCharCount);
+    element.on('input keydown', function () {
+      renderCharCount(); //make sure it's called with no args
+    });
+
+    scope.$watch(attr.mdMaxlength, function (value) {
+      maxlength = value;
+      if (angular.isNumber(value) && value > 0) {
+        if (!charCountEl.parent().length) {
+          $animate.enter(charCountEl, containerCtrl.element,
+            angular.element(containerCtrl.element[0].lastElementChild));
+        }
+        renderCharCount();
+      } else {
+        $animate.leave(charCountEl);
+      }
+    });
+
+    ngModelCtrl.$validators['md-maxlength'] = function (modelValue, viewValue) {
+      if (!angular.isNumber(maxlength) || maxlength < 0) {
+        return true;
+      }
+      return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
     };
 
-    function postLink(scope, element, attr, ctrls) {
-        var maxlength;
-        var ngModelCtrl = ctrls[0];
-        var containerCtrl = ctrls[1];
-        var charCountEl = angular.element('<div class="md-char-counter">');
-
-        // Stop model from trimming. This makes it so whitespace
-        // over the maxlength still counts as invalid.
-        attr.$set('ngTrim', 'false');
-        containerCtrl.element.append(charCountEl);
-
-        ngModelCtrl.$formatters.push(renderCharCount);
-        ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-        element.on('input keydown', function() {
-            renderCharCount(); //make sure it's called with no args
-        });
-
-        scope.$watch(attr.mdMaxlength, function(value) {
-            maxlength = value;
-            if (angular.isNumber(value) && value > 0) {
-                if (!charCountEl.parent().length) {
-                    $animate.enter(charCountEl, containerCtrl.element,
-                        angular.element(containerCtrl.element[0].lastElementChild));
-                }
-                renderCharCount();
-            } else {
-                $animate.leave(charCountEl);
-            }
-        });
-
-        ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
-            if (!angular.isNumber(maxlength) || maxlength < 0) {
-                return true;
-            }
-            return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
-        };
-
-        function renderCharCount(value) {
-            charCountEl.text( ( element.val() || value || '' ).length + '/' + maxlength );
-            return value;
-        }
+    function renderCharCount(value) {
+      charCountEl.text(( element.val() || value || '' ).length + '/' + maxlength);
+      return value;
     }
+  }
 }
 
 function placeholderDirective($log) {
-    return {
-        restrict: 'A',
-        require: '^^?mdInputContainer',
-        priority: 200,
-        link: postLink
-    };
+  return {
+    restrict: 'A',
+    require: '^^?mdInputContainer',
+    priority: 200,
+    link: postLink
+  };
 
-    function postLink(scope, element, attr, inputContainer) {
-        if (!inputContainer) return;
-        if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
+  function postLink(scope, element, attr, inputContainer) {
+    if (!inputContainer) return;
+    if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 
-        var placeholderText = attr.placeholder;
-        element.removeAttr('placeholder');
+    var placeholderText = attr.placeholder;
+    element.removeAttr('placeholder');
 
-        if ( inputContainer.element.find('label').length == 0 ) {
-            var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
+    if (inputContainer.element.find('label').length == 0) {
+      var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
 
-            inputContainer.element.addClass('md-icon-float');
-            inputContainer.element.prepend(placeholder);
-        } else {
-            $log.warn("The placeholder='" + placeholderText + "' will be ignored since this md-input-container has a child label element.");
-        }
-
+      inputContainer.element.addClass('md-icon-float');
+      inputContainer.element.prepend(placeholder);
+    } else {
+      $log.warn("The placeholder='" + placeholderText + "' will be ignored since this md-input-container has a child label element.");
     }
+
+  }
 }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -54,7 +54,6 @@ function mdInputContainerDirective($mdTheming, $parse) {
   function postLink(scope, element, attr) {
     $mdTheming(element);
   }
-
   function ContainerCtrl($scope, $element, $attrs) {
     var self = this;
 
@@ -167,13 +166,13 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
     var isReadonly = angular.isDefined(attr.readonly);
 
-    if (!containerCtrl) return;
+    if ( !containerCtrl ) return;
     if (containerCtrl.input) {
       throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
     }
     containerCtrl.input = element;
 
-    if (!containerCtrl.label) {
+    if(!containerCtrl.label) {
       $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
     }
 
@@ -187,8 +186,8 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-        return ngModelCtrl.$invalid && ngModelCtrl.$touched;
-      };
+      return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+    };
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
@@ -224,11 +223,10 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
       return arg;
     }
-
     function inputCheckValue() {
       // An input's value counts if its length > 0,
       // or if the input's validity state says it has bad input (eg string in a number input)
-      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity || {}).badInput);
+      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity||{}).badInput);
     }
 
     function setupTextarea() {
@@ -261,7 +259,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
         if (height) node.style.height = height + 'px';
       }
 
-      function getHeight() {
+      function getHeight () {
         var line = node.scrollHeight - node.offsetHeight;
         return node.offsetHeight + (line > 0 ? line : 0);
       }
@@ -306,7 +304,7 @@ function mdMaxlengthDirective($animate) {
       if (angular.isNumber(value) && value > 0) {
         if (!charCountEl.parent().length) {
           $animate.enter(charCountEl, containerCtrl.element,
-            angular.element(containerCtrl.element[0].lastElementChild));
+                         angular.element(containerCtrl.element[0].lastElementChild));
         }
         renderCharCount();
       } else {
@@ -322,7 +320,7 @@ function mdMaxlengthDirective($animate) {
     };
 
     function renderCharCount(value) {
-      charCountEl.text(( element.val() || value || '' ).length + '/' + maxlength);
+      charCountEl.text( ( element.val() || value || '' ).length + '/' + maxlength );
       return value;
     }
   }
@@ -343,7 +341,7 @@ function placeholderDirective($log) {
     var placeholderText = attr.placeholder;
     element.removeAttr('placeholder');
 
-    if (inputContainer.element.find('label').length == 0) {
+    if ( inputContainer.element.find('label').length == 0 ) {
       var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
 
       inputContainer.element.addClass('md-icon-float');

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -3,15 +3,15 @@
  * @name material.components.input
  */
 
-angular.module('material.components.input',[
+angular.module('material.components.input', [
   'material.core'
 ])
-  .directive('mdInputContainer',mdInputContainerDirective)
-  .directive('label',labelDirective)
-  .directive('input',inputTextareaDirective)
-  .directive('textarea',inputTextareaDirective)
-  .directive('mdMaxlength',mdMaxlengthDirective)
-  .directive('placeholder',placeholderDirective);
+  .directive('mdInputContainer', mdInputContainerDirective)
+  .directive('label', labelDirective)
+  .directive('input', inputTextareaDirective)
+  .directive('textarea', inputTextareaDirective)
+  .directive('mdMaxlength', mdMaxlengthDirective)
+  .directive('placeholder', placeholderDirective);
 
 /**
  * @ngdoc directive
@@ -44,18 +44,18 @@ angular.module('material.components.input',[
  *
  * </hljs>
  */
-function mdInputContainerDirective($mdTheming,$parse) {
+function mdInputContainerDirective($mdTheming, $parse) {
   return {
     restrict: 'E',
     link: postLink,
     controller: ContainerCtrl
   };
 
-  function postLink(scope,element,attr) {
+  function postLink(scope, element, attr) {
     $mdTheming(element);
   }
 
-  function ContainerCtrl($scope,$element,$attrs) {
+  function ContainerCtrl($scope, $element, $attrs) {
     var self = this;
 
     self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
@@ -65,19 +65,19 @@ function mdInputContainerDirective($mdTheming,$parse) {
     };
     self.element = $element;
     self.setFocused = function(isFocused) {
-      $element.toggleClass('md-input-focused',!!isFocused);
+      $element.toggleClass('md-input-focused', !!isFocused);
     };
     self.setHasValue = function(hasValue) {
-      $element.toggleClass('md-input-has-value',!!hasValue);
+      $element.toggleClass('md-input-has-value', !!hasValue);
     };
     self.setInvalid = function(isInvalid) {
-      $element.toggleClass('md-input-invalid',!!isInvalid);
+      $element.toggleClass('md-input-invalid', !!isInvalid);
     };
     $scope.$watch(function() {
       return self.label && self.input;
-    },function(hasLabelAndInput) {
+    }, function(hasLabelAndInput) {
       if (hasLabelAndInput && !self.label.attr('for')) {
-        self.label.attr('for',self.input.attr('id'));
+        self.label.attr('for', self.input.attr('id'));
       }
     });
   }
@@ -87,11 +87,11 @@ function labelDirective() {
   return {
     restrict: 'E',
     require: '^?mdInputContainer',
-    link: function(scope,element,attr,containerCtrl) {
+    link: function(scope, element, attr, containerCtrl) {
       if (!containerCtrl || attr.mdNoFloat) return;
 
       containerCtrl.label = element;
-      scope.$on('$destroy',function() {
+      scope.$on('$destroy', function() {
         containerCtrl.label = null;
       });
     }
@@ -154,14 +154,14 @@ function labelDirective() {
  *
  */
 
-function inputTextareaDirective($mdUtil,$window,$mdAria) {
+function inputTextareaDirective($mdUtil, $window, $mdAria) {
   return {
     restrict: 'E',
-    require: ['^?mdInputContainer','?ngModel'],
+    require: ['^?mdInputContainer', '?ngModel'],
     link: postLink
   };
 
-  function postLink(scope,element,attr,ctrls) {
+  function postLink(scope, element, attr, ctrls) {
 
     var containerCtrl = ctrls[0];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
@@ -174,12 +174,12 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
     containerCtrl.input = element;
 
     if (!containerCtrl.label) {
-      $mdAria.expect(element,'aria-label',element.attr('placeholder'));
+      $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
     }
 
     element.addClass('md-input');
     if (!element.attr('id')) {
-      element.attr('id','input_' + $mdUtil.nextUid());
+      element.attr('id', 'input_' + $mdUtil.nextUid());
     }
 
     if (element[0].tagName.toLowerCase() === 'textarea') {
@@ -189,19 +189,19 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
         return ngModelCtrl.$invalid && ngModelCtrl.$touched;
       };
-    scope.$watch(isErrorGetter,containerCtrl.setInvalid);
+    scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
     ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
 
-    element.on('input',inputCheckValue);
+    element.on('input', inputCheckValue);
 
     if (!isReadonly) {
       element
-        .on('focus',function(ev) {
+        .on('focus', function(ev) {
           containerCtrl.setFocused(true);
         })
-        .on('blur',function(ev) {
+        .on('blur', function(ev) {
           containerCtrl.setFocused(false);
           inputCheckValue();
         });
@@ -211,7 +211,7 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
     //ngModelCtrl.$setTouched();
     //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
 
-    scope.$on('$destroy',function() {
+    scope.$on('$destroy', function() {
       containerCtrl.setFocused(false);
       containerCtrl.setHasValue(false);
       containerCtrl.input = null;
@@ -233,7 +233,7 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
 
     function setupTextarea() {
       var node = element[0];
-      var onChangeTextarea = $mdUtil.debounce(growTextarea,1);
+      var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
 
       function pipelineListener(value) {
         onChangeTextarea();
@@ -246,12 +246,12 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
       } else {
         onChangeTextarea();
       }
-      element.on('keydown input',onChangeTextarea);
-      element.on('scroll',onScroll);
-      angular.element($window).on('resize',onChangeTextarea);
+      element.on('keydown input', onChangeTextarea);
+      element.on('scroll', onScroll);
+      angular.element($window).on('resize', onChangeTextarea);
 
-      scope.$on('$destroy',function() {
-        angular.element($window).off('resize',onChangeTextarea);
+      scope.$on('$destroy', function() {
+        angular.element($window).off('resize', onChangeTextarea);
       });
 
       function growTextarea() {
@@ -280,11 +280,11 @@ function inputTextareaDirective($mdUtil,$window,$mdAria) {
 function mdMaxlengthDirective($animate) {
   return {
     restrict: 'A',
-    require: ['ngModel','^mdInputContainer'],
+    require: ['ngModel', '^mdInputContainer'],
     link: postLink
   };
 
-  function postLink(scope,element,attr,ctrls) {
+  function postLink(scope, element, attr, ctrls) {
     var maxlength;
     var ngModelCtrl = ctrls[0];
     var containerCtrl = ctrls[1];
@@ -292,20 +292,20 @@ function mdMaxlengthDirective($animate) {
 
     // Stop model from trimming. This makes it so whitespace
     // over the maxlength still counts as invalid.
-    attr.$set('ngTrim','false');
+    attr.$set('ngTrim', 'false');
     containerCtrl.element.append(charCountEl);
 
     ngModelCtrl.$formatters.push(renderCharCount);
     ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-    element.on('input keydown',function() {
+    element.on('input keydown', function() {
       renderCharCount(); //make sure it's called with no args
     });
 
-    scope.$watch(attr.mdMaxlength,function(value) {
+    scope.$watch(attr.mdMaxlength, function(value) {
       maxlength = value;
       if (angular.isNumber(value) && value > 0) {
         if (!charCountEl.parent().length) {
-          $animate.enter(charCountEl,containerCtrl.element,
+          $animate.enter(charCountEl, containerCtrl.element,
             angular.element(containerCtrl.element[0].lastElementChild));
         }
         renderCharCount();
@@ -314,7 +314,7 @@ function mdMaxlengthDirective($animate) {
       }
     });
 
-    ngModelCtrl.$validators['md-maxlength'] = function(modelValue,viewValue) {
+    ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
       if (!angular.isNumber(maxlength) || maxlength < 0) {
         return true;
       }
@@ -336,7 +336,7 @@ function placeholderDirective($log) {
     link: postLink
   };
 
-  function postLink(scope,element,attr,inputContainer) {
+  function postLink(scope, element, attr, inputContainer) {
     if (!inputContainer) return;
     if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -4,14 +4,14 @@
  */
 
 angular.module('material.components.input', [
-  'material.core'
+    'material.core'
 ])
-  .directive('mdInputContainer', mdInputContainerDirective)
-  .directive('label', labelDirective)
-  .directive('input', inputTextareaDirective)
-  .directive('textarea', inputTextareaDirective)
-  .directive('mdMaxlength', mdMaxlengthDirective)
-  .directive('placeholder', placeholderDirective);
+    .directive('mdInputContainer', mdInputContainerDirective)
+    .directive('label', labelDirective)
+    .directive('input', inputTextareaDirective)
+    .directive('textarea', inputTextareaDirective)
+    .directive('mdMaxlength', mdMaxlengthDirective)
+    .directive('placeholder', placeholderDirective);
 
 /**
  * @ngdoc directive
@@ -45,56 +45,56 @@ angular.module('material.components.input', [
  * </hljs>
  */
 function mdInputContainerDirective($mdTheming, $parse) {
-  return {
-    restrict: 'E',
-    link: postLink,
-    controller: ContainerCtrl
-  };
+    return {
+        restrict: 'E',
+        link: postLink,
+        controller: ContainerCtrl
+    };
 
-  function postLink(scope, element, attr) {
-    $mdTheming(element);
-  }
-  function ContainerCtrl($scope, $element, $attrs) {
-    var self = this;
+    function postLink(scope, element, attr) {
+        $mdTheming(element);
+    }
+    function ContainerCtrl($scope, $element, $attrs) {
+        var self = this;
 
-    self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
+        self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
 
-    self.delegateClick = function() {
-      self.input.focus();
-    };
-    self.element = $element;
-    self.setFocused = function(isFocused) {
-      $element.toggleClass('md-input-focused', !!isFocused);
-    };
-    self.setHasValue = function(hasValue) {
-      $element.toggleClass('md-input-has-value', !!hasValue);
-    };
-    self.setInvalid = function(isInvalid) {
-      $element.toggleClass('md-input-invalid', !!isInvalid);
-    };
-    $scope.$watch(function() {
-      return self.label && self.input;
-    }, function(hasLabelAndInput) {
-      if (hasLabelAndInput && !self.label.attr('for')) {
-        self.label.attr('for', self.input.attr('id'));
-      }
-    });
-  }
+        self.delegateClick = function() {
+            self.input.focus();
+        };
+        self.element = $element;
+        self.setFocused = function(isFocused) {
+            $element.toggleClass('md-input-focused', !!isFocused);
+        };
+        self.setHasValue = function(hasValue) {
+            $element.toggleClass('md-input-has-value', !!hasValue);
+        };
+        self.setInvalid = function(isInvalid) {
+            $element.toggleClass('md-input-invalid', !!isInvalid);
+        };
+        $scope.$watch(function() {
+            return self.label && self.input;
+        }, function(hasLabelAndInput) {
+            if (hasLabelAndInput && !self.label.attr('for')) {
+                self.label.attr('for', self.input.attr('id'));
+            }
+        });
+    }
 }
 
 function labelDirective() {
-  return {
-    restrict: 'E',
-    require: '^?mdInputContainer',
-    link: function(scope, element, attr, containerCtrl) {
-      if (!containerCtrl || attr.mdNoFloat) return;
+    return {
+        restrict: 'E',
+        require: '^?mdInputContainer',
+        link: function(scope, element, attr, containerCtrl) {
+            if (!containerCtrl || attr.mdNoFloat) return;
 
-      containerCtrl.label = element;
-      scope.$on('$destroy', function() {
-        containerCtrl.label = null;
-      });
-    }
-  };
+            containerCtrl.label = element;
+            scope.$on('$destroy', function() {
+                containerCtrl.label = null;
+            });
+        }
+    };
 }
 
 /**
@@ -154,203 +154,201 @@ function labelDirective() {
  */
 
 function inputTextareaDirective($mdUtil, $window, $mdAria) {
-  return {
-    restrict: 'E',
-    require: ['^?mdInputContainer', '?ngModel'],
-    link: postLink
-  };
-
-  function postLink(scope, element, attr, ctrls) {
-
-    var containerCtrl = ctrls[0];
-    var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
-    var isReadonly = angular.isDefined(attr.readonly);
-
-    if ( !containerCtrl ) return;
-    if (containerCtrl.input) {
-      throw new Error("<md-input-container> can only have *one* <input> or <textarea> child element!");
-    }
-    containerCtrl.input = element;
-
-    if(!containerCtrl.label) {
-      $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
-    }
-
-    element.addClass('md-input');
-    if (!element.attr('id')) {
-      element.attr('id', 'input_' + $mdUtil.nextUid());
-    }
-
-    if (element[0].tagName.toLowerCase() === 'textarea') {
-      setupTextarea();
-    }
-
-    var isErrorGetter = containerCtrl.isErrorGetter || function() {
-      return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+    return {
+        restrict: 'E',
+        require: ['^?mdInputContainer', '?ngModel'],
+        link: postLink
     };
-    scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
-    ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
-    ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
+    function postLink(scope, element, attr, ctrls) {
 
-    element.on('input', inputCheckValue);
+        var containerCtrl = ctrls[0];
+        var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
+        var isReadonly = angular.isDefined(attr.readonly);
 
-    if (!isReadonly) {
-      element
-        .on('focus', function(ev) {
-          containerCtrl.setFocused(true);
-        })
-        .on('blur', function(ev) {
-          containerCtrl.setFocused(false);
-          inputCheckValue();
+        if ( !containerCtrl ) return;
+        if (containerCtrl.input) {
+            throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
+        }
+        containerCtrl.input = element;
+
+        if(!containerCtrl.label) {
+            $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+        }
+
+        element.addClass('md-input');
+        if (!element.attr('id')) {
+            element.attr('id', 'input_' + $mdUtil.nextUid());
+        }
+
+        if (element[0].tagName.toLowerCase() === 'textarea') {
+            setupTextarea();
+        }
+
+        var isErrorGetter = containerCtrl.isErrorGetter || function() {
+                return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+            };
+        scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+
+        ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
+        ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
+
+        element.on('input', inputCheckValue);
+
+        if (!isReadonly) {
+            element
+                .on('focus', function(ev) {
+                    containerCtrl.setFocused(true);
+                })
+                .on('blur', function(ev) {
+                    containerCtrl.setFocused(false);
+                    inputCheckValue();
+                });
+
+        }
+
+        //ngModelCtrl.$setTouched();
+        //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
+
+        scope.$on('$destroy', function() {
+            containerCtrl.setFocused(false);
+            containerCtrl.setHasValue(false);
+            containerCtrl.input = null;
         });
 
+        /**
+         *
+         */
+        function ngModelPipelineCheckValue(arg) {
+            containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
+            return arg;
+        }
+        function inputCheckValue() {
+            // An input's value counts if its length > 0,
+            // or if the input's validity state says it has bad input (eg string in a number input)
+            containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity||{}).badInput);
+        }
+
+        function setupTextarea() {
+            var node = element[0];
+            var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
+
+            function pipelineListener(value) {
+                onChangeTextarea();
+                return value;
+            }
+
+            if (ngModelCtrl) {
+                ngModelCtrl.$formatters.push(pipelineListener);
+                ngModelCtrl.$viewChangeListeners.push(pipelineListener);
+            } else {
+                onChangeTextarea();
+            }
+            element.on('keydown input', onChangeTextarea);
+            element.on('scroll', onScroll);
+            angular.element($window).on('resize', onChangeTextarea);
+
+            scope.$on('$destroy', function() {
+                angular.element($window).off('resize', onChangeTextarea);
+            });
+
+            function growTextarea() {
+                node.style.height = "auto";
+                node.scrollTop = 0;
+                var height = getHeight();
+                if (height) node.style.height = height + 'px';
+            }
+
+            function getHeight () {
+                var line = node.scrollHeight - node.offsetHeight;
+                return node.offsetHeight + (line > 0 ? line : 0);
+            }
+
+            function onScroll(e) {
+                node.scrollTop = 0;
+                // for smooth new line adding
+                var line = node.scrollHeight - node.offsetHeight;
+                var height = node.offsetHeight + line;
+                node.style.height = height + 'px';
+            }
+        }
     }
-
-    //ngModelCtrl.$setTouched();
-    //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
-
-    scope.$on('$destroy', function() {
-      containerCtrl.setFocused(false);
-      containerCtrl.setHasValue(false);
-      containerCtrl.input = null;
-    });
-
-    /**
-     *
-     */
-    function ngModelPipelineCheckValue(arg) {
-      containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
-      return arg;
-    }
-    function inputCheckValue() {
-      // An input's value counts if its length > 0,
-      // or if the input's validity state says it has bad input (eg string in a number input)
-      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity||{}).badInput);
-    }
-
-    function setupTextarea() {
-      var node = element[0];
-      var onChangeTextarea = $mdUtil.debounce(growTextarea, 1);
-
-      function pipelineListener(value) {
-        onChangeTextarea();
-        return value;
-      }
-
-      if (ngModelCtrl) {
-        ngModelCtrl.$formatters.push(pipelineListener);
-        ngModelCtrl.$viewChangeListeners.push(pipelineListener);
-      } else {
-        onChangeTextarea();
-      }
-      element.on('keydown input', onChangeTextarea);
-      element.on('scroll', onScroll);
-      angular.element($window).on('resize', onChangeTextarea);
-
-      scope.$on('$destroy', function() {
-        angular.element($window).off('resize', onChangeTextarea);
-      });
-
-      function growTextarea() {
-        node.style.height = "auto";
-        node.scrollTop = 0;
-        var height = getHeight();
-        if (height) node.style.height = height + 'px';
-      }
-
-      function getHeight () {
-        var line = node.scrollHeight - node.offsetHeight;
-        return node.offsetHeight + (line > 0 ? line : 0);
-      }
-
-      function onScroll(e) {
-        node.scrollTop = 0;
-        // for smooth new line adding
-        var line = node.scrollHeight - node.offsetHeight;
-        var height = node.offsetHeight + line;
-        node.style.height = height + 'px';
-      }
-    }
-  }
 }
 
 function mdMaxlengthDirective($animate) {
-  return {
-    restrict: 'A',
-    require: ['ngModel', '^mdInputContainer'],
-    link: postLink
-  };
-
-  function postLink(scope, element, attr, ctrls) {
-    var maxlength;
-    var ngModelCtrl = ctrls[0];
-    var containerCtrl = ctrls[1];
-    var charCountEl = angular.element('<div class="md-char-counter">');
-
-    // Stop model from trimming. This makes it so whitespace
-    // over the maxlength still counts as invalid.
-    attr.$set('ngTrim', 'false');
-    containerCtrl.element.append(charCountEl);
-
-    ngModelCtrl.$formatters.push(renderCharCount);
-    ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-    element.on('input keydown', function() {
-      renderCharCount(); //make sure it's called with no args
-    });
-
-    scope.$watch(attr.mdMaxlength, function(value) {
-      maxlength = value;
-      if (angular.isNumber(value) && value > 0) {
-        if (!charCountEl.parent().length) {
-          $animate.enter(charCountEl, containerCtrl.element,
-                         angular.element(containerCtrl.element[0].lastElementChild));
-        }
-        renderCharCount();
-      } else {
-        $animate.leave(charCountEl);
-      }
-    });
-
-    ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
-      if (!angular.isNumber(maxlength) || maxlength < 0) {
-        return true;
-      }
-      return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
+    return {
+        restrict: 'A',
+        require: ['ngModel', '^mdInputContainer'],
+        link: postLink
     };
 
-    function renderCharCount(value) {
-      charCountEl.text( ( element.val() || value || '' ).length + '/' + maxlength );
-      return value;
+    function postLink(scope, element, attr, ctrls) {
+        var maxlength;
+        var ngModelCtrl = ctrls[0];
+        var containerCtrl = ctrls[1];
+        var charCountEl = angular.element('<div class="md-char-counter">');
+
+        // Stop model from trimming. This makes it so whitespace
+        // over the maxlength still counts as invalid.
+        attr.$set('ngTrim', 'false');
+        containerCtrl.element.append(charCountEl);
+
+        ngModelCtrl.$formatters.push(renderCharCount);
+        ngModelCtrl.$viewChangeListeners.push(renderCharCount);
+        element.on('input keydown', function() {
+            renderCharCount(); //make sure it's called with no args
+        });
+
+        scope.$watch(attr.mdMaxlength, function(value) {
+            maxlength = value;
+            if (angular.isNumber(value) && value > 0) {
+                if (!charCountEl.parent().length) {
+                    $animate.enter(charCountEl, containerCtrl.element,
+                        angular.element(containerCtrl.element[0].lastElementChild));
+                }
+                renderCharCount();
+            } else {
+                $animate.leave(charCountEl);
+            }
+        });
+
+        ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
+            if (!angular.isNumber(maxlength) || maxlength < 0) {
+                return true;
+            }
+            return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
+        };
+
+        function renderCharCount(value) {
+            charCountEl.text( ( element.val() || value || '' ).length + '/' + maxlength );
+            return value;
+        }
     }
-  }
 }
 
 function placeholderDirective($log) {
-  var blackListElements = ['MD-SELECT'];
-  return {
-    restrict: 'A',
-    require: '^^?mdInputContainer',
-    priority: 200,
-    link: postLink
-  };
+    return {
+        restrict: 'A',
+        require: '^^?mdInputContainer',
+        priority: 200,
+        link: postLink
+    };
 
-  function postLink(scope, element, attr, inputContainer) {
-    if (!inputContainer) return;
-    if (blackListElements.indexOf(element[0].nodeName) != -1) return;
-    if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
+    function postLink(scope, element, attr, inputContainer) {
+        if (!inputContainer) return;
+        if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 
-    var placeholderText = attr.placeholder;
-    element.removeAttr('placeholder');
+        var placeholderText = attr.placeholder;
+        element.removeAttr('placeholder');
 
-    if ( inputContainer.element.find('label').length == 0 ) {
-      var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
+        if ( inputContainer.element.find('label').length == 0 ) {
+            var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
 
-      inputContainer.element.addClass('md-icon-float');
-      inputContainer.element.prepend(placeholder);
-    } else {
-      $log.warn("The placeholder='" + placeholderText + "' will be ignored since this md-input-container has a child label element.");
+            inputContainer.element.addClass('md-icon-float');
+            inputContainer.element.prepend(placeholder);
+        } else {
+            $log.warn("The placeholder='" + placeholderText + "' will be ignored since this md-input-container has a child label element.");
+        }
+
     }
-
-  }
 }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -60,22 +60,22 @@ function mdInputContainerDirective($mdTheming, $parse) {
 
     self.isErrorGetter = $attrs.mdIsError && $parse($attrs.mdIsError);
 
-    self.delegateClick = function () {
+    self.delegateClick = function() {
       self.input.focus();
     };
     self.element = $element;
-    self.setFocused = function (isFocused) {
+    self.setFocused = function(isFocused) {
       $element.toggleClass('md-input-focused', !!isFocused);
     };
-    self.setHasValue = function (hasValue) {
+    self.setHasValue = function(hasValue) {
       $element.toggleClass('md-input-has-value', !!hasValue);
     };
-    self.setInvalid = function (isInvalid) {
+    self.setInvalid = function(isInvalid) {
       $element.toggleClass('md-input-invalid', !!isInvalid);
     };
-    $scope.$watch(function () {
+    $scope.$watch(function() {
       return self.label && self.input;
-    }, function (hasLabelAndInput) {
+    }, function(hasLabelAndInput) {
       if (hasLabelAndInput && !self.label.attr('for')) {
         self.label.attr('for', self.input.attr('id'));
       }
@@ -87,11 +87,11 @@ function labelDirective() {
   return {
     restrict: 'E',
     require: '^?mdInputContainer',
-    link: function (scope, element, attr, containerCtrl) {
+    link: function(scope, element, attr, containerCtrl) {
       if (!containerCtrl || attr.mdNoFloat) return;
 
       containerCtrl.label = element;
-      scope.$on('$destroy', function () {
+      scope.$on('$destroy', function() {
         containerCtrl.label = null;
       });
     }
@@ -186,7 +186,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       setupTextarea();
     }
 
-    var isErrorGetter = containerCtrl.isErrorGetter || function () {
+    var isErrorGetter = containerCtrl.isErrorGetter || function() {
         return ngModelCtrl.$invalid && ngModelCtrl.$touched;
       };
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
@@ -198,10 +198,10 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 
     if (!isReadonly) {
       element
-        .on('focus', function (ev) {
+        .on('focus', function(ev) {
           containerCtrl.setFocused(true);
         })
-        .on('blur', function (ev) {
+        .on('blur', function(ev) {
           containerCtrl.setFocused(false);
           inputCheckValue();
         });
@@ -211,7 +211,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     //ngModelCtrl.$setTouched();
     //if( ngModelCtrl.$invalid ) containerCtrl.setInvalid();
 
-    scope.$on('$destroy', function () {
+    scope.$on('$destroy', function() {
       containerCtrl.setFocused(false);
       containerCtrl.setHasValue(false);
       containerCtrl.input = null;
@@ -250,7 +250,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       element.on('scroll', onScroll);
       angular.element($window).on('resize', onChangeTextarea);
 
-      scope.$on('$destroy', function () {
+      scope.$on('$destroy', function() {
         angular.element($window).off('resize', onChangeTextarea);
       });
 
@@ -297,11 +297,11 @@ function mdMaxlengthDirective($animate) {
 
     ngModelCtrl.$formatters.push(renderCharCount);
     ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-    element.on('input keydown', function () {
+    element.on('input keydown', function() {
       renderCharCount(); //make sure it's called with no args
     });
 
-    scope.$watch(attr.mdMaxlength, function (value) {
+    scope.$watch(attr.mdMaxlength, function(value) {
       maxlength = value;
       if (angular.isNumber(value) && value > 0) {
         if (!charCountEl.parent().length) {
@@ -314,7 +314,7 @@ function mdMaxlengthDirective($animate) {
       }
     });
 
-    ngModelCtrl.$validators['md-maxlength'] = function (modelValue, viewValue) {
+    ngModelCtrl.$validators['md-maxlength'] = function(modelValue, viewValue) {
       if (!angular.isNumber(maxlength) || maxlength < 0) {
         return true;
       }

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -33,7 +33,7 @@ md-input-container {
     top: 5px;
     left: 2px;
     + input {
-          margin-left: $icon-offset;
+      margin-left: $icon-offset;
     }
   }
 
@@ -80,7 +80,7 @@ md-input-container {
 
 
   label:not(.md-no-float),
-  .md-placeholder:not(.md-select-label) {
+  .md-placeholder {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
@@ -91,7 +91,7 @@ md-input-container {
 
     @include rtl(transform-origin, left top, right top);
   }
-  .md-placeholder:not(.md-select-label) {
+  .md-placeholder {
     position: absolute;
     top: 0;
     opacity: 0;
@@ -214,16 +214,16 @@ md-input-container.md-icon-float {
 
 
   > label  {
-      pointer-events:none;
-      position:absolute;
-      margin-left: $icon-offset;
+    pointer-events:none;
+    position:absolute;
+    margin-left: $icon-offset;
   }
 
   > md-icon {
     top: 26px;
     left: 2px;
     + input {
-          margin-left: $icon-offset;
+      margin-left: $icon-offset;
     }
   }
 
@@ -237,9 +237,9 @@ md-input-container.md-icon-float {
     margin-top: $icon-float-focused-top;
 
     label {
-        transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
-        transition: transform $swift-ease-out-timing-function 0.5s;
-      }
+      transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
+      transition: transform $swift-ease-out-timing-function 0.5s;
+    }
   }
 
 }

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -33,7 +33,7 @@ md-input-container {
     top: 5px;
     left: 2px;
     + input {
-      margin-left: $icon-offset;
+          margin-left: $icon-offset;
     }
   }
 
@@ -214,16 +214,16 @@ md-input-container.md-icon-float {
 
 
   > label  {
-    pointer-events:none;
-    position:absolute;
-    margin-left: $icon-offset;
+      pointer-events:none;
+      position:absolute;
+      margin-left: $icon-offset;
   }
 
   > md-icon {
     top: 26px;
     left: 2px;
     + input {
-      margin-left: $icon-offset;
+          margin-left: $icon-offset;
     }
   }
 
@@ -237,9 +237,9 @@ md-input-container.md-icon-float {
     margin-top: $icon-float-focused-top;
 
     label {
-      transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
-      transition: transform $swift-ease-out-timing-function 0.5s;
-    }
+        transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
+        transition: transform $swift-ease-out-timing-function 0.5s;
+      }
   }
 
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -76,7 +76,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
     restrict: 'E',
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
-    controller: function () {
+    controller: function() {
     } // empty placeholder controller to be initialized in link
   };
 
@@ -114,7 +114,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         'tabindex': '-1'
       });
       var opts = element.find('md-option');
-      angular.forEach(opts, function (el) {
+      angular.forEach(opts, function(el) {
         var newEl = angular.element('<option>' + el.innerHTML + '</option>');
         if (el.hasAttribute('ng-value')) newEl.attr('ng-value', el.getAttribute('ng-value'));
         else if (el.hasAttribute('value')) newEl.attr('value', el.getAttribute('value'));
@@ -171,7 +171,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         formCtrl.$removeControl(angular.element(selectEl).controller());
       }
 
-      var isErrorGetter = containerCtrl.isErrorGetter || function () {
+      var isErrorGetter = containerCtrl.isErrorGetter || function() {
           return ngModelCtrl.$invalid && ngModelCtrl.$touched;
         };
       scope.$watch(isErrorGetter, containerCtrl.setInvalid);
@@ -180,12 +180,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
 
       var originalRender = ngModelCtrl.$render;
-      ngModelCtrl.$render = function () {
+      ngModelCtrl.$render = function() {
         originalRender();
         syncLabelText();
       };
 
-      mdSelectCtrl.setLabelText = function (text) {
+      mdSelectCtrl.setLabelText = function(text) {
         mdSelectCtrl.setIsPlaceholder(!text);
         // if we have a label, use that as the placeholder in our md-select-value label,
         // otherwise fall back to the actual placeholder
@@ -195,7 +195,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         target.text(text);
       };
 
-      mdSelectCtrl.setIsPlaceholder = function (val) {
+      mdSelectCtrl.setIsPlaceholder = function(val) {
         if (val) {
           valueEl.addClass('md-select-placeholder');
           if (containerCtrl.label) {
@@ -211,24 +211,24 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       if (!isReadonly) {
         element
-          .on('focus', function (ev) {
+          .on('focus', function(ev) {
             // only set focus on if we don't currently have a selected value. This avoids the "bounce"
             // on the label transition because the focus will immediately switch to the open menu.
             if (containerCtrl.element.hasClass('md-input-has-value')) {
               containerCtrl.setFocused(true);
             }
           })
-          .on('blur', function (ev) {
+          .on('blur', function(ev) {
             containerCtrl.setFocused(false);
             inputCheckValue();
           });
       }
 
-      mdSelectCtrl.triggerClose = function () {
+      mdSelectCtrl.triggerClose = function() {
         $parse(attr.mdOnClose)(scope);
       };
 
-      scope.$$postDigest(function () {
+      scope.$$postDigest(function() {
         setAriaLabel();
         syncLabelText();
       });
@@ -249,12 +249,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
 
       var deregisterWatcher;
-      attr.$observe('ngMultiple', function (val) {
+      attr.$observe('ngMultiple', function(val) {
         if (deregisterWatcher) deregisterWatcher();
         var parser = $parse(val);
-        deregisterWatcher = scope.$watch(function () {
+        deregisterWatcher = scope.$watch(function() {
           return parser(scope);
-        }, function (multiple, prevVal) {
+        }, function(multiple, prevVal) {
           if (multiple === undefined && prevVal === undefined) return; // assume compiler did a good job
           if (multiple) {
             element.attr('multiple', 'multiple');
@@ -264,7 +264,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
           if (selectContainer) {
             selectMenuCtrl.setMultiple(multiple);
             originalRender = ngModelCtrl.$render;
-            ngModelCtrl.$render = function () {
+            ngModelCtrl.$render = function() {
               originalRender();
               syncLabelText();
             };
@@ -274,7 +274,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         });
       });
 
-      attr.$observe('disabled', function (disabled) {
+      attr.$observe('disabled', function(disabled) {
         if (typeof disabled == "string") {
           disabled = true;
         }
@@ -309,9 +309,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
       element.attr(ariaAttrs);
 
-      scope.$on('$destroy', function () {
+      scope.$on('$destroy', function() {
         if (isOpen) {
-          $mdSelect.cancel().then(function () {
+          $mdSelect.cancel().then(function() {
             selectContainer.remove();
           });
         } else {
@@ -367,7 +367,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
 
       function openSelect() {
-        scope.$evalAsync(function () {
+        scope.$evalAsync(function() {
           isOpen = true;
           $mdSelect.show({
             scope: selectScope,
@@ -377,7 +377,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
             target: element[0],
             hasBackdrop: true,
             loadingAsync: attr.mdOnOpen ? scope.$eval(attr.mdOnOpen) || true : false,
-          }).then(function (selectedText) {
+          }).then(function(selectedText) {
             isOpen = false;
           });
         });
@@ -429,7 +429,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       var optionHashKey = selectCtrl.hashGetter(optionCtrl.value);
       var isSelected = angular.isDefined(selectCtrl.selected[optionHashKey]);
 
-      scope.$apply(function () {
+      scope.$apply(function() {
         if (selectCtrl.isMultiple) {
           if (isSelected) {
             selectCtrl.deselect(optionHashKey);
@@ -457,14 +457,14 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     // and values matching every option's controller.
     self.options = {};
 
-    $scope.$watch(function () {
+    $scope.$watch(function() {
       return self.options;
-    }, function () {
+    }, function() {
       self.ngModel.$render();
     }, true);
 
     var deregisterCollectionWatch;
-    self.setMultiple = function (isMultiple) {
+    self.setMultiple = function(isMultiple) {
       var ngModel = self.ngModel;
       self.isMultiple = isMultiple;
       if (deregisterCollectionWatch) deregisterCollectionWatch();
@@ -475,7 +475,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
         // watchCollection on the model because by default ngModel only watches the model's
         // reference. This allowed the developer to also push and pop from their array.
-        $scope.$watchCollection($attrs.ngModel, function (value) {
+        $scope.$watchCollection($attrs.ngModel, function(value) {
           if (validateArray(value)) renderMultiple(value);
         });
       } else {
@@ -493,9 +493,9 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     var searchStr = '';
     var clearSearchTimeout, optNodes, optText;
     var CLEAR_SEARCH_AFTER = 300;
-    self.optNodeForKeyboardSearch = function (e) {
+    self.optNodeForKeyboardSearch = function(e) {
       clearSearchTimeout && clearTimeout(clearSearchTimeout);
-      clearSearchTimeout = setTimeout(function () {
+      clearSearchTimeout = setTimeout(function() {
         clearSearchTimeout = undefined;
         searchStr = '';
         optText = undefined;
@@ -506,7 +506,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       if (!optNodes) {
         optNodes = $element.find('md-option');
         optText = new Array(optNodes.length);
-        angular.forEach(optNodes, function (el, i) {
+        angular.forEach(optNodes, function(el, i) {
           optText[i] = el.textContent.trim();
         });
       }
@@ -518,7 +518,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     };
 
 
-    self.init = function (ngModel) {
+    self.init = function(ngModel) {
       self.ngModel = ngModel;
 
       // Allow users to provide `ng-model="foo" ng-model-options="{trackBy: 'foo.id'}"` so
@@ -526,7 +526,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       if (ngModel.$options && ngModel.$options.trackBy) {
         var trackByLocals = {};
         var trackByParsed = $parse(ngModel.$options.trackBy);
-        self.hashGetter = function (value, valueScope) {
+        self.hashGetter = function(value, valueScope) {
           trackByLocals.$value = value;
           return trackByParsed(valueScope || $scope, trackByLocals);
         };
@@ -543,10 +543,10 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       self.setMultiple(self.isMultiple);
     };
 
-    self.selectedLabels = function () {
+    self.selectedLabels = function() {
       var selectedOptionEls = $mdUtil.nodesToArray($element[0].querySelectorAll('md-option[selected]'));
       if (selectedOptionEls.length) {
-        return selectedOptionEls.map(function (el) {
+        return selectedOptionEls.map(function(el) {
           return el.textContent;
         }).join(', ');
       } else {
@@ -554,18 +554,18 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       }
     };
 
-    self.select = function (hashKey, hashedValue) {
+    self.select = function(hashKey, hashedValue) {
       var option = self.options[hashKey];
       option && option.setSelected(true);
       self.selected[hashKey] = hashedValue;
     };
-    self.deselect = function (hashKey) {
+    self.deselect = function(hashKey) {
       var option = self.options[hashKey];
       option && option.setSelected(false);
       delete self.selected[hashKey];
     };
 
-    self.addOption = function (hashKey, optionCtrl) {
+    self.addOption = function(hashKey, optionCtrl) {
       if (angular.isDefined(self.options[hashKey])) {
         throw new Error('Duplicate md-option values are not allowed in a select. ' +
         'Duplicate value "' + optionCtrl.value + '" found.');
@@ -578,13 +578,13 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         self.refreshViewValue();
       }
     };
-    self.removeOption = function (hashKey) {
+    self.removeOption = function(hashKey) {
       delete self.options[hashKey];
       // Don't deselect an option when it's removed - the user's ngModel should be allowed
       // to have values that do not match a currently available option.
     };
 
-    self.refreshViewValue = function () {
+    self.refreshViewValue = function() {
       var values = [];
       var option;
       for (var hashKey in self.selected) {
@@ -610,12 +610,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       var oldSelected = Object.keys(self.selected);
 
       var newSelectedHashes = newSelectedValues.map(self.hashGetter);
-      var deselected = oldSelected.filter(function (hash) {
+      var deselected = oldSelected.filter(function(hash) {
         return newSelectedHashes.indexOf(hash) === -1;
       });
 
       deselected.forEach(self.deselect);
-      newSelectedHashes.forEach(function (hashKey, i) {
+      newSelectedHashes.forEach(function(hashKey, i) {
         self.select(hashKey, newSelectedValues[i]);
       });
     }
@@ -655,13 +655,13 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     } else if (angular.isDefined(attr.value)) {
       setOptionValue(attr.value);
     } else {
-      scope.$watch(function () {
+      scope.$watch(function() {
         return element.text();
       }, setOptionValue);
     }
 
-    scope.$$postDigest(function () {
-      attr.$observe('selected', function (selected) {
+    scope.$$postDigest(function() {
+      attr.$observe('selected', function(selected) {
         if (!angular.isDefined(selected)) return;
         if (selected) {
           if (!selectCtrl.isMultiple) {
@@ -690,7 +690,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
       selectCtrl.addOption(newHashKey, optionCtrl);
     }
 
-    scope.$on('$destroy', function () {
+    scope.$on('$destroy', function() {
       selectCtrl.removeOption(optionCtrl.hashKey, optionCtrl);
     });
 
@@ -709,7 +709,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function OptionController($element) {
     this.selected = false;
-    this.setSelected = function (isSelected) {
+    this.setSelected = function(isSelected) {
       if (isSelected && !this.selected) {
         $element.attr({
           'selected': 'selected',
@@ -773,9 +773,9 @@ function SelectProvider($$interimElementProvider) {
         backdrop: opts.hasBackdrop && angular.element('<md-backdrop class="md-select-backdrop md-click-catcher">')
       });
 
-      opts.resizeFn = function () {
-        $$rAF(function () {
-          $$rAF(function () {
+      opts.resizeFn = function() {
+        $$rAF(function() {
+          $$rAF(function() {
             animateSelect(scope, element, opts);
           });
         });
@@ -792,11 +792,11 @@ function SelectProvider($$interimElementProvider) {
       var optionNodes = opts.selectEl[0].getElementsByTagName('md-option');
 
       if (opts.loadingAsync && opts.loadingAsync.then) {
-        opts.loadingAsync.then(function () {
+        opts.loadingAsync.then(function() {
           scope.$$loadingAsyncDone = true;
           // Give ourselves two frames for the progress loader to clear out.
-          $$rAF(function () {
-            $$rAF(function () {
+          $$rAF(function() {
+            $$rAF(function() {
               // Don't go forward if the select has been removed in this time...
               if (opts.isRemoved) return;
               animateSelect(scope, element, opts);
@@ -824,8 +824,8 @@ function SelectProvider($$interimElementProvider) {
 
       // Give the select a frame to 'initialize' in the DOM,
       // so we can read its height/width/position
-      $$rAF(function () {
-        $$rAF(function () {
+      $$rAF(function() {
+        $$rAF(function() {
           if (opts.isRemoved) return;
           animateSelect(scope, element, opts);
         });
@@ -842,7 +842,7 @@ function SelectProvider($$interimElementProvider) {
         var selectCtrl = opts.selectEl.controller('mdSelectMenu') || {};
         element.addClass('md-clickable');
 
-        opts.backdrop && opts.backdrop.on('click', function (e) {
+        opts.backdrop && opts.backdrop.on('click', function(e) {
           e.preventDefault();
           e.stopPropagation();
           opts.restoreFocus = false;
@@ -850,7 +850,7 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Escape to close
-        opts.selectEl.on('keydown', function (ev) {
+        opts.selectEl.on('keydown', function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.SPACE:
             case $mdConstant.KEY_CODE.ENTER:
@@ -872,7 +872,7 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Cycling of options, and closing on enter
-        opts.selectEl.on('keydown', function (ev) {
+        opts.selectEl.on('keydown', function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.UP_ARROW:
               return focusPrevOption();
@@ -911,7 +911,7 @@ function SelectProvider($$interimElementProvider) {
         }
 
         opts.selectEl.on('click', checkCloseMenu);
-        opts.selectEl.on('keydown', function (e) {
+        opts.selectEl.on('keydown', function(e) {
           if (e.keyCode == 32 || e.keyCode == 13) {
             checkCloseMenu();
           }
@@ -920,7 +920,7 @@ function SelectProvider($$interimElementProvider) {
         function checkCloseMenu() {
           if (!selectCtrl.isMultiple) {
             opts.restoreFocus = true;
-            scope.$evalAsync(function () {
+            scope.$evalAsync(function() {
               $mdSelect.hide(selectCtrl.ngModel.$viewValue);
             });
           }
@@ -945,7 +945,7 @@ function SelectProvider($$interimElementProvider) {
         mdSelect.setLabelText(opts.selectEl.controller('mdSelectMenu').selectedLabels());
       }
 
-      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function () {
+      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function() {
         element.removeClass('md-active');
         opts.backdrop && opts.backdrop.remove();
         if (element[0].parentNode === opts.parent[0]) {
@@ -1080,7 +1080,7 @@ function SelectProvider($$interimElementProvider) {
       ')';
 
 
-      $$rAF(function () {
+      $$rAF(function() {
         element.addClass('md-active');
         selectNode.style[$mdConstant.CSS.TRANSFORM] = '';
         if (focusedNode) {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -15,6 +15,7 @@
 
 ### TODO - POST RC1 ###
 - [ ] Abstract placement logic in $mdSelect service to $mdMenu service
+
 ***************************************************/
 
 var SELECT_EDGE_MARGIN = 8;
@@ -69,14 +70,12 @@ angular.module('material.components.select', [
  *   </md-input-container>
  * </hljs>
  */
-
 function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, $compile, $parse) {
   return {
     restrict: 'E',
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
-    controller: function() {
-    } // empty placeholder controller to be initialized in link
+    controller: function() { } // empty placeholder controller to be initialized in link
   };
 
   function compile(element, attr) {
@@ -90,17 +89,17 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
     // There's got to be an md-content inside. If there's not one, let's add it.
     if (!element.find('md-content').length) {
-      element.append(angular.element('<md-content>').append(element.contents()));
+      element.append( angular.element('<md-content>').append(element.contents()) );
     }
 
     // Add progress spinner for md-options-loading
     if (attr.mdOnOpen) {
       element.find('md-content').prepend(
         angular.element('<md-progress-circular>')
-          .attr('md-mode', 'indeterminate')
-          .attr('ng-hide', '$$loadingAsyncDone')
-          .wrap('<div>')
-          .parent()
+               .attr('md-mode', 'indeterminate')
+               .attr('ng-hide', '$$loadingAsyncDone')
+               .wrap('<div>')
+               .parent()
       );
     }
 
@@ -125,10 +124,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
     // Use everything that's left inside element.contents() as the contents of the menu
     var selectTemplate = '<div class="md-select-menu-container">' +
-      '<md-select-menu ' +
-      (angular.isDefined(attr.multiple) ? 'multiple' : '') + '>' +
-      element.html() +
-      '</md-select-menu></div>';
+        '<md-select-menu ' +
+        (angular.isDefined(attr.multiple) ? 'multiple' : '') + '>' +
+          element.html() +
+        '</md-select-menu></div>';
 
     element.empty().append(labelEl);
 
@@ -163,6 +162,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       var selectContainer, selectScope, selectMenuCtrl;
       createSelect();
+
       $mdTheming(element);
 
       if (attr.name && formCtrl) {
@@ -251,9 +251,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       attr.$observe('ngMultiple', function(val) {
         if (deregisterWatcher) deregisterWatcher();
         var parser = $parse(val);
-        deregisterWatcher = scope.$watch(function() {
-          return parser(scope);
-        }, function(multiple, prevVal) {
+        deregisterWatcher = scope.$watch(function() { return parser(scope); }, function(multiple, prevVal) {
           if (multiple === undefined && prevVal === undefined) return; // assume compiler did a good job
           if (multiple) {
             element.attr('multiple', 'multiple');
@@ -345,7 +343,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       function handleKeypress(e) {
         var allowedCodes = [32, 13, 38, 40];
-        if (allowedCodes.indexOf(e.keyCode) != -1) {
+        if (allowedCodes.indexOf(e.keyCode) != -1 ) {
           // prevent page scrolling on interaction
           e.preventDefault();
           openSelect(e);
@@ -356,7 +354,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
             if (!node) return;
             var optionCtrl = angular.element(node).controller('mdOption');
             if (!selectMenuCtrl.isMultiple) {
-              selectMenuCtrl.deselect(Object.keys(selectMenuCtrl.selected)[0]);
+              selectMenuCtrl.deselect( Object.keys(selectMenuCtrl.selected)[0] );
             }
             selectMenuCtrl.select(optionCtrl.hashKey, optionCtrl.value);
             selectMenuCtrl.refreshViewValue();
@@ -391,7 +389,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     restrict: 'E',
     require: ['mdSelectMenu', '?ngModel'],
     controller: SelectMenuController,
-    link: {pre: preLink}
+    link: { pre: preLink }
   };
 
   // We use preLink instead of postLink to ensure that the select is initialized before
@@ -437,15 +435,14 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
           }
         } else {
           if (!isSelected) {
-            selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
-            selectCtrl.select(optionHashKey, optionCtrl.value);
+            selectCtrl.deselect( Object.keys(selectCtrl.selected)[0] );
+            selectCtrl.select( optionHashKey, optionCtrl.value );
           }
         }
         selectCtrl.refreshViewValue();
       });
     }
   }
-
 
   function SelectMenuController($scope, $attrs, $element) {
     var self = this;
@@ -456,9 +453,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     // and values matching every option's controller.
     self.options = {};
 
-    $scope.$watch(function() {
-      return self.options;
-    }, function() {
+    $scope.$watch(function() { return self.options; }, function() {
       self.ngModel.$render();
     }, true);
 
@@ -529,8 +524,8 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
           trackByLocals.$value = value;
           return trackByParsed(valueScope || $scope, trackByLocals);
         };
-        // If the user doesn't provide a trackBy, we automatically generate an id for every
-        // value passed in
+      // If the user doesn't provide a trackBy, we automatically generate an id for every
+      // value passed in
       } else {
         self.hashGetter = function getHashValue(value) {
           if (angular.isObject(value)) {
@@ -545,9 +540,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     self.selectedLabels = function() {
       var selectedOptionEls = $mdUtil.nodesToArray($element[0].querySelectorAll('md-option[selected]'));
       if (selectedOptionEls.length) {
-        return selectedOptionEls.map(function(el) {
-          return el.textContent;
-        }).join(', ');
+        return selectedOptionEls.map(function(el) { return el.textContent; }).join(', ');
       } else {
         return '';
       }
@@ -587,17 +580,17 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       var values = [];
       var option;
       for (var hashKey in self.selected) {
-        // If this hashKey has an associated option, push that option's value to the model.
-        if ((option = self.options[hashKey])) {
-          values.push(option.value);
-        } else {
-          // Otherwise, the given hashKey has no associated option, and we got it
-          // from an ngModel value at an earlier time. Push the unhashed value of
-          // this hashKey to the model.
-          // This allows the developer to put a value in the model that doesn't yet have
-          // an associated option.
-          values.push(self.selected[hashKey]);
-        }
+         // If this hashKey has an associated option, push that option's value to the model.
+         if ((option = self.options[hashKey])) {
+           values.push(option.value);
+         } else {
+         // Otherwise, the given hashKey has no associated option, and we got it
+         // from an ngModel value at an earlier time. Push the unhashed value of
+         // this hashKey to the model.
+         // This allows the developer to put a value in the model that doesn't yet have
+         // an associated option.
+           values.push(self.selected[hashKey]);
+         }
       }
       self.ngModel.$setViewValue(self.isMultiple ? values : values[0]);
     };
@@ -618,11 +611,10 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         self.select(hashKey, newSelectedValues[i]);
       });
     }
-
     function renderSingular() {
       var value = self.ngModel.$viewValue || self.ngModel.$modelValue;
       Object.keys(self.selected).forEach(self.deselect);
-      self.select(self.hashGetter(value), value);
+      self.select( self.hashGetter(value), value );
     }
   }
 
@@ -639,7 +631,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
-    element.append(angular.element('<div class="md-text">').append(element.contents()));
+    element.append( angular.element('<div class="md-text">').append(element.contents()) );
 
     element.attr('tabindex', attr.tabindex || '0');
     return postLink;
@@ -654,9 +646,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     } else if (angular.isDefined(attr.value)) {
       setOptionValue(attr.value);
     } else {
-      scope.$watch(function() {
-        return element.text();
-      }, setOptionValue);
+      scope.$watch(function() { return element.text(); }, setOptionValue);
     }
 
     scope.$$postDigest(function() {
@@ -664,7 +654,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
         if (!angular.isDefined(selected)) return;
         if (selected) {
           if (!selectCtrl.isMultiple) {
-            selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
+            selectCtrl.deselect( Object.keys(selectCtrl.selected)[0] );
           }
           selectCtrl.select(optionCtrl.hashKey, optionCtrl.value);
         } else {
@@ -747,7 +737,7 @@ function SelectProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window) {
+  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window ) {
     return {
       parent: 'body',
       onShow: onShow,
@@ -760,7 +750,7 @@ function SelectProvider($$interimElementProvider) {
     function onShow(scope, element, opts) {
       if (!opts.target) {
         throw new Error('$mdSelect.show() expected a target element in options.target but got ' +
-        '"' + opts.target + '"!');
+                        '"' + opts.target + '"!');
       }
 
       angular.extend(opts, {
@@ -944,7 +934,7 @@ function SelectProvider($$interimElementProvider) {
         mdSelect.setLabelText(opts.selectEl.controller('mdSelectMenu').selectedLabels());
       }
 
-      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function() {
+      return $mdUtil.transitionEndPromise(element, { timeout: 350 }).then(function() {
         element.removeClass('md-active');
         opts.backdrop && opts.backdrop.remove();
         if (element[0].parentNode === opts.parent[0]) {
@@ -960,43 +950,43 @@ function SelectProvider($$interimElementProvider) {
 
     function animateSelect(scope, element, opts) {
       var containerNode = element[0],
-        targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
-        parentNode = opts.parent[0],
-        selectNode = opts.selectEl[0],
-        contentNode = opts.contentEl[0],
-        parentRect = parentNode.getBoundingClientRect(),
-        targetRect = targetNode.getBoundingClientRect(),
-        shouldOpenAroundTarget = false,
-        bounds = {
-          left: parentRect.left + SELECT_EDGE_MARGIN,
-          top: SELECT_EDGE_MARGIN,
-          bottom: parentRect.height - SELECT_EDGE_MARGIN,
-          right: parentRect.width - SELECT_EDGE_MARGIN - ($mdUtil.floatingScrollbars() ? 16 : 0)
-        },
-        spaceAvailable = {
-          top: targetRect.top - bounds.top,
-          left: targetRect.left - bounds.left,
-          right: bounds.right - (targetRect.left + targetRect.width),
-          bottom: bounds.bottom - (targetRect.top + targetRect.height)
-        },
-        maxWidth = parentRect.width - SELECT_EDGE_MARGIN * 2,
-        isScrollable = contentNode.scrollHeight > contentNode.offsetHeight,
-        selectedNode = selectNode.querySelector('md-option[selected]'),
-        optionNodes = selectNode.getElementsByTagName('md-option'),
-        optgroupNodes = selectNode.getElementsByTagName('md-optgroup');
+          targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
+          parentNode = opts.parent[0],
+          selectNode = opts.selectEl[0],
+          contentNode = opts.contentEl[0],
+          parentRect = parentNode.getBoundingClientRect(),
+          targetRect = targetNode.getBoundingClientRect(),
+          shouldOpenAroundTarget = false,
+          bounds = {
+            left: parentRect.left + SELECT_EDGE_MARGIN,
+            top: SELECT_EDGE_MARGIN,
+            bottom: parentRect.height - SELECT_EDGE_MARGIN,
+            right: parentRect.width - SELECT_EDGE_MARGIN - ($mdUtil.floatingScrollbars() ? 16 : 0)
+          },
+          spaceAvailable = {
+            top: targetRect.top - bounds.top,
+            left: targetRect.left - bounds.left,
+            right: bounds.right - (targetRect.left + targetRect.width),
+            bottom: bounds.bottom - (targetRect.top + targetRect.height)
+          },
+          maxWidth = parentRect.width - SELECT_EDGE_MARGIN * 2,
+          isScrollable = contentNode.scrollHeight > contentNode.offsetHeight,
+          selectedNode = selectNode.querySelector('md-option[selected]'),
+          optionNodes = selectNode.getElementsByTagName('md-option'),
+          optgroupNodes = selectNode.getElementsByTagName('md-optgroup');
 
 
       var centeredNode;
       // If a selected node, center around that
       if (selectedNode) {
         centeredNode = selectedNode;
-        // If there are option groups, center around the first option group
+      // If there are option groups, center around the first option group
       } else if (optgroupNodes.length) {
         centeredNode = optgroupNodes[0];
-        // Otherwise, center around the first optionNode
-      } else if (optionNodes.length) {
+      // Otherwise, center around the first optionNode
+      } else if (optionNodes.length){
         centeredNode = optionNodes[0];
-        // In case there are no options, center on whatever's in there... (eg progress indicator)
+      // In case there are no options, center on whatever's in there... (eg progress indicator)
       } else {
         centeredNode = contentNode.firstElementChild || contentNode;
       }
@@ -1057,14 +1047,14 @@ function SelectProvider($$interimElementProvider) {
       } else {
         left = targetRect.left + centeredRect.left - centeredRect.paddingLeft;
         top = Math.floor(targetRect.top + targetRect.height / 2 - centeredRect.height / 2 -
-        centeredRect.top + contentNode.scrollTop);
+          centeredRect.top + contentNode.scrollTop);
 
 
         transformOrigin = (centeredRect.left + targetRect.width / 2) + 'px ' +
         (centeredRect.top + centeredRect.height / 2 - contentNode.scrollTop) + 'px 0px';
 
         containerNode.style.minWidth = targetRect.width + centeredRect.paddingLeft +
-        centeredRect.paddingRight + 'px';
+          centeredRect.paddingRight + 'px';
       }
 
       // Keep left and top within the window
@@ -1074,8 +1064,8 @@ function SelectProvider($$interimElementProvider) {
       selectNode.style[$mdConstant.CSS.TRANSFORM_ORIGIN] = transformOrigin;
 
       selectNode.style[$mdConstant.CSS.TRANSFORM] = 'scale(' +
-      Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
-      Math.min(targetRect.height / selectMenuRect.height, 1.0) +
+        Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
+        Math.min(targetRect.height / selectMenuRect.height, 1.0) +
       ')';
 
 
@@ -1101,6 +1091,6 @@ function SelectProvider($$interimElementProvider) {
       top: node.offsetTop,
       width: node.offsetWidth,
       height: node.offsetHeight
-    } : {left: 0, top: 0, width: 0, height: 0};
+    } : { left: 0, top: 0, width: 0, height: 0 };
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -5,17 +5,17 @@
 
 /***************************************************
 
- ### TODO ###
- **DOCUMENTATION AND DEMOS**
+### TODO ###
+**DOCUMENTATION AND DEMOS**
 
- - [ ] ng-model with child mdOptions (basic)
- - [ ] ng-model="foo" ng-model-options="{ trackBy: '$value.id' }" for objects
- - [ ] mdOption with value
- - [ ] Usage with input inside
+- [ ] ng-model with child mdOptions (basic)
+- [ ] ng-model="foo" ng-model-options="{ trackBy: '$value.id' }" for objects
+- [ ] mdOption with value
+- [ ] Usage with input inside
 
- ### TODO - POST RC1 ###
- - [ ] Abstract placement logic in $mdSelect service to $mdMenu service
- ***************************************************/
+### TODO - POST RC1 ###
+- [ ] Abstract placement logic in $mdSelect service to $mdMenu service
+***************************************************/
 
 var SELECT_EDGE_MARGIN = 8;
 var selectNextId = 0;
@@ -24,11 +24,11 @@ angular.module('material.components.select',[
   'material.core',
   'material.components.backdrop'
 ])
-  .directive('mdSelect',SelectDirective)
-  .directive('mdSelectMenu',SelectMenuDirective)
-  .directive('mdOption',OptionDirective)
-  .directive('mdOptgroup',OptgroupDirective)
-  .provider('$mdSelect',SelectProvider);
+.directive('mdSelect',SelectDirective)
+.directive('mdSelectMenu',SelectMenuDirective)
+.directive('mdOption',OptionDirective)
+.directive('mdOptgroup',OptgroupDirective)
+.provider('$mdSelect',SelectProvider);
 
 
 /**

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -444,6 +444,8 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     }
   }
 
+
+
   function SelectMenuController($scope, $attrs, $element) {
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -5,18 +5,18 @@
 
 /***************************************************
 
-### TODO ###
-**DOCUMENTATION AND DEMOS**
+ ### TODO ###
+ **DOCUMENTATION AND DEMOS**
 
-- [ ] ng-model with child mdOptions (basic)
-- [ ] ng-model="foo" ng-model-options="{ trackBy: '$value.id' }" for objects
-- [ ] mdOption with value
-- [ ] Usage with input inside
+ - [ ] ng-model with child mdOptions (basic)
+ - [ ] ng-model="foo" ng-model-options="{ trackBy: '$value.id' }" for objects
+ - [ ] mdOption with value
+ - [ ] Usage with input inside
 
-### TODO - POST RC1 ###
-- [ ] Abstract placement logic in $mdSelect service to $mdMenu service
+ ### TODO - POST RC1 ###
+ - [ ] Abstract placement logic in $mdSelect service to $mdMenu service
 
-***************************************************/
+ ***************************************************/
 
 var SELECT_EDGE_MARGIN = 8;
 var selectNextId = 0;
@@ -25,11 +25,11 @@ angular.module('material.components.select', [
   'material.core',
   'material.components.backdrop'
 ])
-.directive('mdSelect', SelectDirective)
-.directive('mdSelectMenu', SelectMenuDirective)
-.directive('mdOption', OptionDirective)
-.directive('mdOptgroup', OptgroupDirective)
-.provider('$mdSelect', SelectProvider);
+  .directive('mdSelect', SelectDirective)
+  .directive('mdSelectMenu', SelectMenuDirective)
+  .directive('mdOption', OptionDirective)
+  .directive('mdOptgroup', OptgroupDirective)
+  .provider('$mdSelect', SelectProvider);
 
 
 /**
@@ -41,8 +41,8 @@ angular.module('material.components.select', [
  * @description Displays a select box, bound to an ng-model.
  *
  * @param {expression} ng-model The model!
- * @param {expression=} md-on-close expression to be evaluated when the select is closed
  * @param {boolean=} multiple Whether it's multiple.
+ * @param {expression=} md-on-close expression to be evaluated when the select is closed
  * @param {string=} placeholder Placeholder hint text.
  * @param {string=} aria-label Optional label for accessibility. Only necessary if no placeholder or
  * explicit label is present.
@@ -50,63 +50,58 @@ angular.module('material.components.select', [
  * @usage
  * With a placeholder (label and aria-label are added dynamically)
  * <hljs lang="html">
- *   <md-select
- *     ng-model="someModel"
- *     placeholder="Select a state">
- *     <md-option ng-value="opt" ng-repeat="opt in neighborhoods2">{{ opt }}</md-option>
- *   </md-select>
+ *   <md-input-container>
+ *     <md-select
+ *       ng-model="someModel"
+ *       placeholder="Select a state">
+ *       <md-option ng-value="opt" ng-repeat="opt in neighborhoods2">{{ opt }}</md-option>
+ *     </md-select>
+ *   </md-input-container>
  * </hljs>
  *
  * With an explicit label
  * <hljs lang="html">
- *   <md-select
- *     ng-model="someModel">
- *     <md-select-label>Select a state</md-select-label>
- *     <md-option ng-value="opt" ng-repeat="opt in neighborhoods2">{{ opt }}</md-option>
- *   </md-select>
+ *   <md-input-container>
+ *     <label>State</label>
+ *     <md-select
+ *       ng-model="someModel">
+ *       <md-option ng-value="opt" ng-repeat="opt in neighborhoods2">{{ opt }}</md-option>
+ *     </md-select>
+ *   </md-input-container>
  * </hljs>
  */
+
 function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, $compile, $parse) {
   return {
     restrict: 'E',
-    require: ['mdSelect', 'ngModel', '?^form'],
+    require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
-    controller: function() { } // empty placeholder controller to be initialized in link
+    controller: function () {
+    } // empty placeholder controller to be initialized in link
   };
 
   function compile(element, attr) {
-    // The user is allowed to provide a label for the select as md-select-label child
-    var labelEl = element.find('md-select-label').remove();
-
-    // If not provided, we automatically make one
-    if (!labelEl.length) {
-      labelEl = angular.element('<md-select-label><span></span></md-select-label>');
-    } else {
-      if (!labelEl[0].firstElementChild) {
-        var spanWrapper = angular.element('<span>');
-        spanWrapper.append(labelEl.contents());
-        labelEl.append(spanWrapper);
-      }
-    }
+    // add the select value that will hold our placeholder or selected option value
+    var labelEl = angular.element('<md-select-value><span></span></md-select-value>');
     labelEl.append('<span class="md-select-icon" aria-hidden="true"></span>');
-    labelEl.addClass('md-select-label');
+    labelEl.addClass('md-select-value');
     if (!labelEl[0].hasAttribute('id')) {
       labelEl.attr('id', 'select_label_' + $mdUtil.nextUid());
     }
 
     // There's got to be an md-content inside. If there's not one, let's add it.
     if (!element.find('md-content').length) {
-      element.append( angular.element('<md-content>').append(element.contents()) );
+      element.append(angular.element('<md-content>').append(element.contents()));
     }
 
     // Add progress spinner for md-options-loading
     if (attr.mdOnOpen) {
       element.find('md-content').prepend(
         angular.element('<md-progress-circular>')
-               .attr('md-mode', 'indeterminate')
-               .attr('ng-hide', '$$loadingAsyncDone')
-               .wrap('<div>')
-               .parent()
+          .attr('md-mode', 'indeterminate')
+          .attr('ng-hide', '$$loadingAsyncDone')
+          .wrap('<div>')
+          .parent()
       );
     }
 
@@ -119,7 +114,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         'tabindex': '-1'
       });
       var opts = element.find('md-option');
-      angular.forEach(opts, function(el) {
+      angular.forEach(opts, function (el) {
         var newEl = angular.element('<option>' + el.innerHTML + '</option>');
         if (el.hasAttribute('ng-value')) newEl.attr('ng-value', el.getAttribute('ng-value'));
         else if (el.hasAttribute('value')) newEl.attr('value', el.getAttribute('value'));
@@ -131,10 +126,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
     // Use everything that's left inside element.contents() as the contents of the menu
     var selectTemplate = '<div class="md-select-menu-container">' +
-        '<md-select-menu ' +
-        (angular.isDefined(attr.multiple) ? 'multiple' : '') + '>' +
-          element.html() +
-        '</md-select-menu></div>';
+      '<md-select-menu ' +
+      (angular.isDefined(attr.multiple) ? 'multiple' : '') + '>' +
+      element.html() +
+      '</md-select-menu></div>';
 
     element.empty().append(labelEl);
 
@@ -144,15 +139,31 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       var isOpen;
       var isDisabled;
 
-      var mdSelectCtrl = ctrls[0];
-      var ngModel = ctrls[1];
-      var formCtrl = ctrls[2];
+      var containerCtrl = ctrls[0];
+      var mdSelectCtrl = ctrls[1];
+      var ngModelCtrl = ctrls[2];
+      var formCtrl = ctrls[3];
+      // grab a reference to the select menu value label
+      var valueEl = element.find('md-select-value');
+      var isReadonly = angular.isDefined(attr.readonly);
 
-      var labelEl = element.find('md-select-label');
-      var customLabel = labelEl.text().length !== 0;
+      if (!containerCtrl) {
+        // remove the visible value label
+        valueEl.remove();
+        return;
+      }
+
+      if (containerCtrl.input) {
+        throw new Error("<md-input-container> can only have *one* child <input>, <textarea> or <select> element!");
+      }
+      containerCtrl.input = element;
+
+      if (!containerCtrl.label) {
+        $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+      }
+
       var selectContainer, selectScope, selectMenuCtrl;
       createSelect();
-
       $mdTheming(element);
 
       if (attr.name && formCtrl) {
@@ -160,29 +171,64 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         formCtrl.$removeControl(angular.element(selectEl).controller());
       }
 
-      var originalRender = ngModel.$render;
-      ngModel.$render = function() {
+      var isErrorGetter = containerCtrl.isErrorGetter || function () {
+          return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+        };
+      scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+
+      ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
+      ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
+
+      var originalRender = ngModelCtrl.$render;
+      ngModelCtrl.$render = function () {
         originalRender();
         syncLabelText();
       };
 
-      mdSelectCtrl.setLabelText = function(text) {
-        if (customLabel) return; // Assume that user is handling it on their own
+      mdSelectCtrl.setLabelText = function (text) {
         mdSelectCtrl.setIsPlaceholder(!text);
-        text = text || attr.placeholder || '';
-        var target = customLabel ? labelEl : labelEl.children().eq(0);
+        // if we have a label, use that as the placeholder in our md-select-value label,
+        // otherwise fall back to the actual placeholder
+        var tmpPlaceholder = containerCtrl.label ? containerCtrl.label.text() : attr.placeholder;
+        text = text || tmpPlaceholder || '';
+        var target = valueEl.children().eq(0);
         target.text(text);
       };
 
-      mdSelectCtrl.setIsPlaceholder = function(val) {
-        val ? labelEl.addClass('md-placeholder') : labelEl.removeClass('md-placeholder');
+      mdSelectCtrl.setIsPlaceholder = function (val) {
+        if (val) {
+          valueEl.addClass('md-select-placeholder');
+          if (containerCtrl.label) {
+            containerCtrl.label.addClass('md-placeholder');
+          }
+        } else {
+          valueEl.removeClass('md-select-placeholder');
+          if (containerCtrl.label) {
+            containerCtrl.label.removeClass('md-placeholder');
+          }
+        }
       };
 
-      mdSelectCtrl.triggerClose = function() {
+      if (!isReadonly) {
+        element
+          .on('focus', function (ev) {
+            // only set focus on if we don't currently have a selected value. This avoids the "bounce"
+            // on the label transition because the focus will immediately switch to the open menu.
+            if (containerCtrl.element.hasClass('md-input-has-value')) {
+              containerCtrl.setFocused(true);
+            }
+          })
+          .on('blur', function (ev) {
+            containerCtrl.setFocused(false);
+            inputCheckValue();
+          });
+      }
+
+      mdSelectCtrl.triggerClose = function () {
         $parse(attr.mdOnClose)(scope);
       };
 
-      scope.$$postDigest(function() {
+      scope.$$postDigest(function () {
         setAriaLabel();
         syncLabelText();
       });
@@ -190,7 +236,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       function setAriaLabel() {
         var labelText = element.attr('placeholder');
         if (!labelText) {
-          labelText = element.find('md-select-label').text();
+          labelText = containerCtrl.element.find('label').text();
         }
         $mdAria.expect(element, 'aria-label', labelText);
       }
@@ -203,10 +249,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
 
       var deregisterWatcher;
-      attr.$observe('ngMultiple', function(val) {
+      attr.$observe('ngMultiple', function (val) {
         if (deregisterWatcher) deregisterWatcher();
         var parser = $parse(val);
-        deregisterWatcher = scope.$watch(function() { return parser(scope); }, function(multiple, prevVal) {
+        deregisterWatcher = scope.$watch(function () {
+          return parser(scope);
+        }, function (multiple, prevVal) {
           if (multiple === undefined && prevVal === undefined) return; // assume compiler did a good job
           if (multiple) {
             element.attr('multiple', 'multiple');
@@ -215,18 +263,18 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
           }
           if (selectContainer) {
             selectMenuCtrl.setMultiple(multiple);
-            originalRender = ngModel.$render;
-            ngModel.$render = function() {
+            originalRender = ngModelCtrl.$render;
+            ngModelCtrl.$render = function () {
               originalRender();
               syncLabelText();
             };
             selectMenuCtrl.refreshViewValue();
-            ngModel.$render();
+            ngModelCtrl.$render();
           }
         });
       });
 
-      attr.$observe('disabled', function(disabled) {
+      attr.$observe('disabled', function (disabled) {
         if (typeof disabled == "string") {
           disabled = true;
         }
@@ -261,22 +309,35 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
       element.attr(ariaAttrs);
 
-      scope.$on('$destroy', function() {
+      scope.$on('$destroy', function () {
         if (isOpen) {
-          $mdSelect.cancel().then(function() {
+          $mdSelect.cancel().then(function () {
             selectContainer.remove();
           });
         } else {
           selectContainer.remove();
         }
+        containerCtrl.setFocused(false);
+        containerCtrl.setHasValue(false);
+        containerCtrl.input = null;
       });
 
+      function ngModelPipelineCheckValue(arg) {
+        containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
+        return arg;
+      }
+
+      function inputCheckValue() {
+        // The select counts as having a value if one or more options are selected,
+        // or if the input's validity state says it has bad input (eg string in a number input)
+        containerCtrl.setHasValue(selectMenuCtrl.selectedLabels().length > 0 || (element[0].validity || {}).badInput);
+      }
 
       // Create a fake select to find out the label value
       function createSelect() {
         selectContainer = angular.element(selectTemplate);
         var selectEl = selectContainer.find('md-select-menu');
-        selectEl.data('$ngModelController', ngModel);
+        selectEl.data('$ngModelController', ngModelCtrl);
         selectEl.data('$mdSelectController', mdSelectCtrl);
         selectScope = scope.$new();
         selectContainer = $compile(selectContainer)(selectScope);
@@ -285,7 +346,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       function handleKeypress(e) {
         var allowedCodes = [32, 13, 38, 40];
-        if (allowedCodes.indexOf(e.keyCode) != -1 ) {
+        if (allowedCodes.indexOf(e.keyCode) != -1) {
           // prevent page scrolling on interaction
           e.preventDefault();
           openSelect(e);
@@ -296,17 +357,17 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
             if (!node) return;
             var optionCtrl = angular.element(node).controller('mdOption');
             if (!selectMenuCtrl.isMultiple) {
-              selectMenuCtrl.deselect( Object.keys(selectMenuCtrl.selected)[0] );
+              selectMenuCtrl.deselect(Object.keys(selectMenuCtrl.selected)[0]);
             }
             selectMenuCtrl.select(optionCtrl.hashKey, optionCtrl.value);
             selectMenuCtrl.refreshViewValue();
-            ngModel.$render();
+            ngModelCtrl.$render();
           }
         }
       }
 
       function openSelect() {
-        scope.$evalAsync(function() {
+        scope.$evalAsync(function () {
           isOpen = true;
           $mdSelect.show({
             scope: selectScope,
@@ -316,7 +377,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
             target: element[0],
             hasBackdrop: true,
             loadingAsync: attr.mdOnOpen ? scope.$eval(attr.mdOnOpen) || true : false,
-          }).then(function(selectedText) {
+          }).then(function (selectedText) {
             isOpen = false;
           });
         });
@@ -331,7 +392,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     restrict: 'E',
     require: ['mdSelectMenu', '?ngModel'],
     controller: SelectMenuController,
-    link: { pre: preLink }
+    link: {pre: preLink}
   };
 
   // We use preLink instead of postLink to ensure that the select is initialized before
@@ -368,7 +429,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       var optionHashKey = selectCtrl.hashGetter(optionCtrl.value);
       var isSelected = angular.isDefined(selectCtrl.selected[optionHashKey]);
 
-      scope.$apply(function() {
+      scope.$apply(function () {
         if (selectCtrl.isMultiple) {
           if (isSelected) {
             selectCtrl.deselect(optionHashKey);
@@ -377,15 +438,14 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
           }
         } else {
           if (!isSelected) {
-            selectCtrl.deselect( Object.keys(selectCtrl.selected)[0] );
-            selectCtrl.select( optionHashKey, optionCtrl.value );
+            selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
+            selectCtrl.select(optionHashKey, optionCtrl.value);
           }
         }
         selectCtrl.refreshViewValue();
       });
     }
   }
-
 
 
   function SelectMenuController($scope, $attrs, $element) {
@@ -397,12 +457,14 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     // and values matching every option's controller.
     self.options = {};
 
-    $scope.$watch(function() { return self.options; }, function() {
+    $scope.$watch(function () {
+      return self.options;
+    }, function () {
       self.ngModel.$render();
     }, true);
 
     var deregisterCollectionWatch;
-    self.setMultiple = function(isMultiple) {
+    self.setMultiple = function (isMultiple) {
       var ngModel = self.ngModel;
       self.isMultiple = isMultiple;
       if (deregisterCollectionWatch) deregisterCollectionWatch();
@@ -413,7 +475,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
         // watchCollection on the model because by default ngModel only watches the model's
         // reference. This allowed the developer to also push and pop from their array.
-        $scope.$watchCollection($attrs.ngModel, function(value) {
+        $scope.$watchCollection($attrs.ngModel, function (value) {
           if (validateArray(value)) renderMultiple(value);
         });
       } else {
@@ -431,9 +493,9 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     var searchStr = '';
     var clearSearchTimeout, optNodes, optText;
     var CLEAR_SEARCH_AFTER = 300;
-    self.optNodeForKeyboardSearch = function(e) {
+    self.optNodeForKeyboardSearch = function (e) {
       clearSearchTimeout && clearTimeout(clearSearchTimeout);
-      clearSearchTimeout = setTimeout(function() {
+      clearSearchTimeout = setTimeout(function () {
         clearSearchTimeout = undefined;
         searchStr = '';
         optText = undefined;
@@ -444,7 +506,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       if (!optNodes) {
         optNodes = $element.find('md-option');
         optText = new Array(optNodes.length);
-        angular.forEach(optNodes, function(el, i) {
+        angular.forEach(optNodes, function (el, i) {
           optText[i] = el.textContent.trim();
         });
       }
@@ -456,7 +518,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     };
 
 
-    self.init = function(ngModel) {
+    self.init = function (ngModel) {
       self.ngModel = ngModel;
 
       // Allow users to provide `ng-model="foo" ng-model-options="{trackBy: 'foo.id'}"` so
@@ -464,12 +526,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       if (ngModel.$options && ngModel.$options.trackBy) {
         var trackByLocals = {};
         var trackByParsed = $parse(ngModel.$options.trackBy);
-        self.hashGetter = function(value, valueScope) {
+        self.hashGetter = function (value, valueScope) {
           trackByLocals.$value = value;
           return trackByParsed(valueScope || $scope, trackByLocals);
         };
-      // If the user doesn't provide a trackBy, we automatically generate an id for every
-      // value passed in
+        // If the user doesn't provide a trackBy, we automatically generate an id for every
+        // value passed in
       } else {
         self.hashGetter = function getHashValue(value) {
           if (angular.isObject(value)) {
@@ -481,30 +543,32 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       self.setMultiple(self.isMultiple);
     };
 
-    self.selectedLabels = function() {
+    self.selectedLabels = function () {
       var selectedOptionEls = $mdUtil.nodesToArray($element[0].querySelectorAll('md-option[selected]'));
       if (selectedOptionEls.length) {
-        return selectedOptionEls.map(function(el) { return el.textContent; }).join(', ');
+        return selectedOptionEls.map(function (el) {
+          return el.textContent;
+        }).join(', ');
       } else {
         return '';
       }
     };
 
-    self.select = function(hashKey, hashedValue) {
+    self.select = function (hashKey, hashedValue) {
       var option = self.options[hashKey];
       option && option.setSelected(true);
       self.selected[hashKey] = hashedValue;
     };
-    self.deselect = function(hashKey) {
+    self.deselect = function (hashKey) {
       var option = self.options[hashKey];
       option && option.setSelected(false);
       delete self.selected[hashKey];
     };
 
-    self.addOption = function(hashKey, optionCtrl) {
+    self.addOption = function (hashKey, optionCtrl) {
       if (angular.isDefined(self.options[hashKey])) {
         throw new Error('Duplicate md-option values are not allowed in a select. ' +
-                        'Duplicate value "' + optionCtrl.value + '" found.');
+        'Duplicate value "' + optionCtrl.value + '" found.');
       }
       self.options[hashKey] = optionCtrl;
 
@@ -514,27 +578,27 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         self.refreshViewValue();
       }
     };
-    self.removeOption = function(hashKey) {
+    self.removeOption = function (hashKey) {
       delete self.options[hashKey];
       // Don't deselect an option when it's removed - the user's ngModel should be allowed
       // to have values that do not match a currently available option.
     };
 
-    self.refreshViewValue = function() {
+    self.refreshViewValue = function () {
       var values = [];
       var option;
       for (var hashKey in self.selected) {
-         // If this hashKey has an associated option, push that option's value to the model.
-         if ((option = self.options[hashKey])) {
-           values.push(option.value);
-         } else {
-           // Otherwise, the given hashKey has no associated option, and we got it
-           // from an ngModel value at an earlier time. Push the unhashed value of
-           // this hashKey to the model.
-           // This allows the developer to put a value in the model that doesn't yet have
-           // an associated option.
-           values.push(self.selected[hashKey]);
-         }
+        // If this hashKey has an associated option, push that option's value to the model.
+        if ((option = self.options[hashKey])) {
+          values.push(option.value);
+        } else {
+          // Otherwise, the given hashKey has no associated option, and we got it
+          // from an ngModel value at an earlier time. Push the unhashed value of
+          // this hashKey to the model.
+          // This allows the developer to put a value in the model that doesn't yet have
+          // an associated option.
+          values.push(self.selected[hashKey]);
+        }
       }
       self.ngModel.$setViewValue(self.isMultiple ? values : values[0]);
     };
@@ -546,19 +610,20 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       var oldSelected = Object.keys(self.selected);
 
       var newSelectedHashes = newSelectedValues.map(self.hashGetter);
-      var deselected = oldSelected.filter(function(hash) {
+      var deselected = oldSelected.filter(function (hash) {
         return newSelectedHashes.indexOf(hash) === -1;
       });
 
       deselected.forEach(self.deselect);
-      newSelectedHashes.forEach(function(hashKey, i) {
+      newSelectedHashes.forEach(function (hashKey, i) {
         self.select(hashKey, newSelectedValues[i]);
       });
     }
+
     function renderSingular() {
       var value = self.ngModel.$viewValue || self.ngModel.$modelValue;
       Object.keys(self.selected).forEach(self.deselect);
-      self.select( self.hashGetter(value), value );
+      self.select(self.hashGetter(value), value);
     }
   }
 
@@ -575,7 +640,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
-    element.append( angular.element('<div class="md-text">').append(element.contents()) );
+    element.append(angular.element('<div class="md-text">').append(element.contents()));
 
     element.attr('tabindex', attr.tabindex || '0');
     return postLink;
@@ -590,15 +655,17 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     } else if (angular.isDefined(attr.value)) {
       setOptionValue(attr.value);
     } else {
-      scope.$watch(function() { return element.text(); }, setOptionValue);
+      scope.$watch(function () {
+        return element.text();
+      }, setOptionValue);
     }
 
-    scope.$$postDigest(function() {
-      attr.$observe('selected', function(selected) {
+    scope.$$postDigest(function () {
+      attr.$observe('selected', function (selected) {
         if (!angular.isDefined(selected)) return;
         if (selected) {
           if (!selectCtrl.isMultiple) {
-            selectCtrl.deselect( Object.keys(selectCtrl.selected)[0] );
+            selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
           }
           selectCtrl.select(optionCtrl.hashKey, optionCtrl.value);
         } else {
@@ -623,7 +690,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
       selectCtrl.addOption(newHashKey, optionCtrl);
     }
 
-    scope.$on('$destroy', function() {
+    scope.$on('$destroy', function () {
       selectCtrl.removeOption(optionCtrl.hashKey, optionCtrl);
     });
 
@@ -642,7 +709,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function OptionController($element) {
     this.selected = false;
-    this.setSelected = function(isSelected) {
+    this.setSelected = function (isSelected) {
       if (isSelected && !this.selected) {
         $element.attr({
           'selected': 'selected',
@@ -681,7 +748,7 @@ function SelectProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window ) {
+  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window) {
     return {
       parent: 'body',
       onShow: onShow,
@@ -694,7 +761,7 @@ function SelectProvider($$interimElementProvider) {
     function onShow(scope, element, opts) {
       if (!opts.target) {
         throw new Error('$mdSelect.show() expected a target element in options.target but got ' +
-                        '"' + opts.target + '"!');
+        '"' + opts.target + '"!');
       }
 
       angular.extend(opts, {
@@ -706,9 +773,9 @@ function SelectProvider($$interimElementProvider) {
         backdrop: opts.hasBackdrop && angular.element('<md-backdrop class="md-select-backdrop md-click-catcher">')
       });
 
-      opts.resizeFn = function() {
-        $$rAF(function() {
-          $$rAF(function() {
+      opts.resizeFn = function () {
+        $$rAF(function () {
+          $$rAF(function () {
             animateSelect(scope, element, opts);
           });
         });
@@ -725,11 +792,11 @@ function SelectProvider($$interimElementProvider) {
       var optionNodes = opts.selectEl[0].getElementsByTagName('md-option');
 
       if (opts.loadingAsync && opts.loadingAsync.then) {
-        opts.loadingAsync.then(function() {
+        opts.loadingAsync.then(function () {
           scope.$$loadingAsyncDone = true;
           // Give ourselves two frames for the progress loader to clear out.
-          $$rAF(function() {
-            $$rAF(function() {
+          $$rAF(function () {
+            $$rAF(function () {
               // Don't go forward if the select has been removed in this time...
               if (opts.isRemoved) return;
               animateSelect(scope, element, opts);
@@ -757,8 +824,8 @@ function SelectProvider($$interimElementProvider) {
 
       // Give the select a frame to 'initialize' in the DOM,
       // so we can read its height/width/position
-      $$rAF(function() {
-        $$rAF(function() {
+      $$rAF(function () {
+        $$rAF(function () {
           if (opts.isRemoved) return;
           animateSelect(scope, element, opts);
         });
@@ -775,7 +842,7 @@ function SelectProvider($$interimElementProvider) {
         var selectCtrl = opts.selectEl.controller('mdSelectMenu') || {};
         element.addClass('md-clickable');
 
-        opts.backdrop && opts.backdrop.on('click', function(e) {
+        opts.backdrop && opts.backdrop.on('click', function (e) {
           e.preventDefault();
           e.stopPropagation();
           opts.restoreFocus = false;
@@ -783,7 +850,7 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Escape to close
-        opts.selectEl.on('keydown', function(ev) {
+        opts.selectEl.on('keydown', function (ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.SPACE:
             case $mdConstant.KEY_CODE.ENTER:
@@ -805,10 +872,12 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Cycling of options, and closing on enter
-        opts.selectEl.on('keydown', function(ev) {
+        opts.selectEl.on('keydown', function (ev) {
           switch (ev.keyCode) {
-            case $mdConstant.KEY_CODE.UP_ARROW: return focusPrevOption();
-            case $mdConstant.KEY_CODE.DOWN_ARROW: return focusNextOption();
+            case $mdConstant.KEY_CODE.UP_ARROW:
+              return focusPrevOption();
+            case $mdConstant.KEY_CODE.DOWN_ARROW:
+              return focusNextOption();
             default:
               if (ev.keyCode >= 31 && ev.keyCode <= 90) {
                 var optNode = opts.selectEl.controller('mdSelectMenu').optNodeForKeyboardSearch(ev);
@@ -832,15 +901,17 @@ function SelectProvider($$interimElementProvider) {
           var newOption = opts.focusedNode = optionsArray[index];
           newOption && newOption.focus();
         }
+
         function focusNextOption() {
           focusOption('next');
         }
+
         function focusPrevOption() {
           focusOption('prev');
         }
 
         opts.selectEl.on('click', checkCloseMenu);
-        opts.selectEl.on('keydown', function(e) {
+        opts.selectEl.on('keydown', function (e) {
           if (e.keyCode == 32 || e.keyCode == 13) {
             checkCloseMenu();
           }
@@ -849,7 +920,7 @@ function SelectProvider($$interimElementProvider) {
         function checkCloseMenu() {
           if (!selectCtrl.isMultiple) {
             opts.restoreFocus = true;
-            scope.$evalAsync(function() {
+            scope.$evalAsync(function () {
               $mdSelect.hide(selectCtrl.ngModel.$viewValue);
             });
           }
@@ -874,7 +945,7 @@ function SelectProvider($$interimElementProvider) {
         mdSelect.setLabelText(opts.selectEl.controller('mdSelectMenu').selectedLabels());
       }
 
-      return $mdUtil.transitionEndPromise(element, { timeout: 350 }).then(function() {
+      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function () {
         element.removeClass('md-active');
         opts.backdrop && opts.backdrop.remove();
         if (element[0].parentNode === opts.parent[0]) {
@@ -890,43 +961,43 @@ function SelectProvider($$interimElementProvider) {
 
     function animateSelect(scope, element, opts) {
       var containerNode = element[0],
-          targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
-          parentNode = opts.parent[0],
-          selectNode = opts.selectEl[0],
-          contentNode = opts.contentEl[0],
-          parentRect = parentNode.getBoundingClientRect(),
-          targetRect = targetNode.getBoundingClientRect(),
-          shouldOpenAroundTarget = false,
-          bounds = {
-            left: parentRect.left + SELECT_EDGE_MARGIN,
-            top: SELECT_EDGE_MARGIN,
-            bottom: parentRect.height - SELECT_EDGE_MARGIN,
-            right: parentRect.width - SELECT_EDGE_MARGIN - ($mdUtil.floatingScrollbars() ? 16 : 0)
-          },
-          spaceAvailable = {
-            top: targetRect.top - bounds.top,
-            left: targetRect.left - bounds.left,
-            right: bounds.right - (targetRect.left + targetRect.width),
-            bottom: bounds.bottom - (targetRect.top + targetRect.height)
-          },
-          maxWidth = parentRect.width - SELECT_EDGE_MARGIN * 2,
-          isScrollable = contentNode.scrollHeight > contentNode.offsetHeight,
-          selectedNode = selectNode.querySelector('md-option[selected]'),
-          optionNodes = selectNode.getElementsByTagName('md-option'),
-          optgroupNodes = selectNode.getElementsByTagName('md-optgroup');
+        targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
+        parentNode = opts.parent[0],
+        selectNode = opts.selectEl[0],
+        contentNode = opts.contentEl[0],
+        parentRect = parentNode.getBoundingClientRect(),
+        targetRect = targetNode.getBoundingClientRect(),
+        shouldOpenAroundTarget = false,
+        bounds = {
+          left: parentRect.left + SELECT_EDGE_MARGIN,
+          top: SELECT_EDGE_MARGIN,
+          bottom: parentRect.height - SELECT_EDGE_MARGIN,
+          right: parentRect.width - SELECT_EDGE_MARGIN - ($mdUtil.floatingScrollbars() ? 16 : 0)
+        },
+        spaceAvailable = {
+          top: targetRect.top - bounds.top,
+          left: targetRect.left - bounds.left,
+          right: bounds.right - (targetRect.left + targetRect.width),
+          bottom: bounds.bottom - (targetRect.top + targetRect.height)
+        },
+        maxWidth = parentRect.width - SELECT_EDGE_MARGIN * 2,
+        isScrollable = contentNode.scrollHeight > contentNode.offsetHeight,
+        selectedNode = selectNode.querySelector('md-option[selected]'),
+        optionNodes = selectNode.getElementsByTagName('md-option'),
+        optgroupNodes = selectNode.getElementsByTagName('md-optgroup');
 
 
       var centeredNode;
       // If a selected node, center around that
       if (selectedNode) {
         centeredNode = selectedNode;
-      // If there are option groups, center around the first option group
+        // If there are option groups, center around the first option group
       } else if (optgroupNodes.length) {
         centeredNode = optgroupNodes[0];
-      // Otherwise, center around the first optionNode
-      } else if (optionNodes.length){
+        // Otherwise, center around the first optionNode
+      } else if (optionNodes.length) {
         centeredNode = optionNodes[0];
-      // In case there are no options, center on whatever's in there... (eg progress indicator)
+        // In case there are no options, center on whatever's in there... (eg progress indicator)
       } else {
         centeredNode = contentNode.firstElementChild || contentNode;
       }
@@ -987,14 +1058,14 @@ function SelectProvider($$interimElementProvider) {
       } else {
         left = targetRect.left + centeredRect.left - centeredRect.paddingLeft;
         top = Math.floor(targetRect.top + targetRect.height / 2 - centeredRect.height / 2 -
-          centeredRect.top + contentNode.scrollTop);
+        centeredRect.top + contentNode.scrollTop);
 
 
         transformOrigin = (centeredRect.left + targetRect.width / 2) + 'px ' +
         (centeredRect.top + centeredRect.height / 2 - contentNode.scrollTop) + 'px 0px';
 
         containerNode.style.minWidth = targetRect.width + centeredRect.paddingLeft +
-          centeredRect.paddingRight + 'px';
+        centeredRect.paddingRight + 'px';
       }
 
       // Keep left and top within the window
@@ -1004,12 +1075,12 @@ function SelectProvider($$interimElementProvider) {
       selectNode.style[$mdConstant.CSS.TRANSFORM_ORIGIN] = transformOrigin;
 
       selectNode.style[$mdConstant.CSS.TRANSFORM] = 'scale(' +
-        Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
-        Math.min(targetRect.height / selectMenuRect.height, 1.0) +
+      Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
+      Math.min(targetRect.height / selectMenuRect.height, 1.0) +
       ')';
 
 
-      $$rAF(function() {
+      $$rAF(function () {
         element.addClass('md-active');
         selectNode.style[$mdConstant.CSS.TRANSFORM] = '';
         if (focusedNode) {
@@ -1031,7 +1102,6 @@ function SelectProvider($$interimElementProvider) {
       top: node.offsetTop,
       width: node.offsetWidth,
       height: node.offsetHeight
-    } : { left: 0, top: 0, width: 0, height: 0 };
+    } : {left: 0, top: 0, width: 0, height: 0};
   }
 }
-

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -15,21 +15,20 @@
 
  ### TODO - POST RC1 ###
  - [ ] Abstract placement logic in $mdSelect service to $mdMenu service
-
  ***************************************************/
 
 var SELECT_EDGE_MARGIN = 8;
 var selectNextId = 0;
 
-angular.module('material.components.select', [
+angular.module('material.components.select',[
   'material.core',
   'material.components.backdrop'
 ])
-  .directive('mdSelect', SelectDirective)
-  .directive('mdSelectMenu', SelectMenuDirective)
-  .directive('mdOption', OptionDirective)
-  .directive('mdOptgroup', OptgroupDirective)
-  .provider('$mdSelect', SelectProvider);
+  .directive('mdSelect',SelectDirective)
+  .directive('mdSelectMenu',SelectMenuDirective)
+  .directive('mdOption',OptionDirective)
+  .directive('mdOptgroup',OptgroupDirective)
+  .provider('$mdSelect',SelectProvider);
 
 
 /**
@@ -71,22 +70,22 @@ angular.module('material.components.select', [
  * </hljs>
  */
 
-function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, $compile, $parse) {
+function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$compile,$parse) {
   return {
     restrict: 'E',
-    require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
+    require: ['^?mdInputContainer','mdSelect','ngModel','?^form'],
     compile: compile,
     controller: function() {
     } // empty placeholder controller to be initialized in link
   };
 
-  function compile(element, attr) {
+  function compile(element,attr) {
     // add the select value that will hold our placeholder or selected option value
     var labelEl = angular.element('<md-select-value><span></span></md-select-value>');
     labelEl.append('<span class="md-select-icon" aria-hidden="true"></span>');
     labelEl.addClass('md-select-value');
     if (!labelEl[0].hasAttribute('id')) {
-      labelEl.attr('id', 'select_label_' + $mdUtil.nextUid());
+      labelEl.attr('id','select_label_' + $mdUtil.nextUid());
     }
 
     // There's got to be an md-content inside. If there's not one, let's add it.
@@ -98,8 +97,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
     if (attr.mdOnOpen) {
       element.find('md-content').prepend(
         angular.element('<md-progress-circular>')
-          .attr('md-mode', 'indeterminate')
-          .attr('ng-hide', '$$loadingAsyncDone')
+          .attr('md-mode','indeterminate')
+          .attr('ng-hide','$$loadingAsyncDone')
           .wrap('<div>')
           .parent()
       );
@@ -114,10 +113,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         'tabindex': '-1'
       });
       var opts = element.find('md-option');
-      angular.forEach(opts, function(el) {
+      angular.forEach(opts,function(el) {
         var newEl = angular.element('<option>' + el.innerHTML + '</option>');
-        if (el.hasAttribute('ng-value')) newEl.attr('ng-value', el.getAttribute('ng-value'));
-        else if (el.hasAttribute('value')) newEl.attr('value', el.getAttribute('value'));
+        if (el.hasAttribute('ng-value')) newEl.attr('ng-value',el.getAttribute('ng-value'));
+        else if (el.hasAttribute('value')) newEl.attr('value',el.getAttribute('value'));
         autofillClone.append(newEl);
       });
 
@@ -135,7 +134,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
     attr.tabindex = attr.tabindex || '0';
 
-    return function postLink(scope, element, attr, ctrls) {
+    return function postLink(scope,element,attr,ctrls) {
       var isOpen;
       var isDisabled;
 
@@ -159,10 +158,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       containerCtrl.input = element;
 
       if (!containerCtrl.label) {
-        $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+        $mdAria.expect(element,'aria-label',element.attr('placeholder'));
       }
 
-      var selectContainer, selectScope, selectMenuCtrl;
+      var selectContainer,selectScope,selectMenuCtrl;
       createSelect();
       $mdTheming(element);
 
@@ -174,7 +173,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       var isErrorGetter = containerCtrl.isErrorGetter || function() {
           return ngModelCtrl.$invalid && ngModelCtrl.$touched;
         };
-      scope.$watch(isErrorGetter, containerCtrl.setInvalid);
+      scope.$watch(isErrorGetter,containerCtrl.setInvalid);
 
       ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
       ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
@@ -211,14 +210,14 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       if (!isReadonly) {
         element
-          .on('focus', function(ev) {
+          .on('focus',function(ev) {
             // only set focus on if we don't currently have a selected value. This avoids the "bounce"
             // on the label transition because the focus will immediately switch to the open menu.
             if (containerCtrl.element.hasClass('md-input-has-value')) {
               containerCtrl.setFocused(true);
             }
           })
-          .on('blur', function(ev) {
+          .on('blur',function(ev) {
             containerCtrl.setFocused(false);
             inputCheckValue();
           });
@@ -238,7 +237,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         if (!labelText) {
           labelText = containerCtrl.element.find('label').text();
         }
-        $mdAria.expect(element, 'aria-label', labelText);
+        $mdAria.expect(element,'aria-label',labelText);
       }
 
       function syncLabelText() {
@@ -249,15 +248,15 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
 
       var deregisterWatcher;
-      attr.$observe('ngMultiple', function(val) {
+      attr.$observe('ngMultiple',function(val) {
         if (deregisterWatcher) deregisterWatcher();
         var parser = $parse(val);
         deregisterWatcher = scope.$watch(function() {
           return parser(scope);
-        }, function(multiple, prevVal) {
+        },function(multiple,prevVal) {
           if (multiple === undefined && prevVal === undefined) return; // assume compiler did a good job
           if (multiple) {
-            element.attr('multiple', 'multiple');
+            element.attr('multiple','multiple');
           } else {
             element.removeAttr('multiple');
           }
@@ -274,7 +273,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         });
       });
 
-      attr.$observe('disabled', function(disabled) {
+      attr.$observe('disabled',function(disabled) {
         if (typeof disabled == "string") {
           disabled = true;
         }
@@ -284,20 +283,20 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
         }
         isDisabled = disabled;
         if (disabled) {
-          element.attr({'tabindex': -1, 'aria-disabled': 'true'});
-          element.off('click', openSelect);
-          element.off('keydown', handleKeypress);
+          element.attr({'tabindex': -1,'aria-disabled': 'true'});
+          element.off('click',openSelect);
+          element.off('keydown',handleKeypress);
         } else {
-          element.attr({'tabindex': attr.tabindex, 'aria-disabled': 'false'});
-          element.on('click', openSelect);
-          element.on('keydown', handleKeypress);
+          element.attr({'tabindex': attr.tabindex,'aria-disabled': 'false'});
+          element.on('click',openSelect);
+          element.on('keydown',handleKeypress);
         }
       });
 
       if (!attr.disabled && !attr.ngDisabled) {
-        element.attr({'tabindex': attr.tabindex, 'aria-disabled': 'false'});
-        element.on('click', openSelect);
-        element.on('keydown', handleKeypress);
+        element.attr({'tabindex': attr.tabindex,'aria-disabled': 'false'});
+        element.on('click',openSelect);
+        element.on('keydown',handleKeypress);
       }
 
       var ariaAttrs = {
@@ -309,7 +308,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       }
       element.attr(ariaAttrs);
 
-      scope.$on('$destroy', function() {
+      scope.$on('$destroy',function() {
         if (isOpen) {
           $mdSelect.cancel().then(function() {
             selectContainer.remove();
@@ -337,15 +336,15 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
       function createSelect() {
         selectContainer = angular.element(selectTemplate);
         var selectEl = selectContainer.find('md-select-menu');
-        selectEl.data('$ngModelController', ngModelCtrl);
-        selectEl.data('$mdSelectController', mdSelectCtrl);
+        selectEl.data('$ngModelController',ngModelCtrl);
+        selectEl.data('$mdSelectController',mdSelectCtrl);
         selectScope = scope.$new();
         selectContainer = $compile(selectContainer)(selectScope);
         selectMenuCtrl = selectContainer.find('md-select-menu').controller('mdSelectMenu');
       }
 
       function handleKeypress(e) {
-        var allowedCodes = [32, 13, 38, 40];
+        var allowedCodes = [32,13,38,40];
         if (allowedCodes.indexOf(e.keyCode) != -1) {
           // prevent page scrolling on interaction
           e.preventDefault();
@@ -359,7 +358,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
             if (!selectMenuCtrl.isMultiple) {
               selectMenuCtrl.deselect(Object.keys(selectMenuCtrl.selected)[0]);
             }
-            selectMenuCtrl.select(optionCtrl.hashKey, optionCtrl.value);
+            selectMenuCtrl.select(optionCtrl.hashKey,optionCtrl.value);
             selectMenuCtrl.refreshViewValue();
             ngModelCtrl.$render();
           }
@@ -386,24 +385,24 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
   }
 }
 
-function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
+function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
 
   return {
     restrict: 'E',
-    require: ['mdSelectMenu', '?ngModel'],
+    require: ['mdSelectMenu','?ngModel'],
     controller: SelectMenuController,
     link: {pre: preLink}
   };
 
   // We use preLink instead of postLink to ensure that the select is initialized before
   // its child options run postLink.
-  function preLink(scope, element, attr, ctrls) {
+  function preLink(scope,element,attr,ctrls) {
     var selectCtrl = ctrls[0];
     var ngModel = ctrls[1];
 
     $mdTheming(element);
-    element.on('click', clickListener);
-    element.on('keypress', keyListener);
+    element.on('click',clickListener);
+    element.on('keypress',keyListener);
     if (ngModel) selectCtrl.init(ngModel);
     configureAria();
 
@@ -422,7 +421,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     }
 
     function clickListener(ev) {
-      var option = $mdUtil.getClosest(ev.target, 'md-option');
+      var option = $mdUtil.getClosest(ev.target,'md-option');
       var optionCtrl = option && angular.element(option).data('$mdOptionController');
       if (!option || !optionCtrl) return;
 
@@ -434,12 +433,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
           if (isSelected) {
             selectCtrl.deselect(optionHashKey);
           } else {
-            selectCtrl.select(optionHashKey, optionCtrl.value);
+            selectCtrl.select(optionHashKey,optionCtrl.value);
           }
         } else {
           if (!isSelected) {
             selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
-            selectCtrl.select(optionHashKey, optionCtrl.value);
+            selectCtrl.select(optionHashKey,optionCtrl.value);
           }
         }
         selectCtrl.refreshViewValue();
@@ -448,7 +447,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
   }
 
 
-  function SelectMenuController($scope, $attrs, $element) {
+  function SelectMenuController($scope,$attrs,$element) {
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);
     // selected is an object with keys matching all of the selected options' hashed values
@@ -459,9 +458,9 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
     $scope.$watch(function() {
       return self.options;
-    }, function() {
+    },function() {
       self.ngModel.$render();
-    }, true);
+    },true);
 
     var deregisterCollectionWatch;
     self.setMultiple = function(isMultiple) {
@@ -475,7 +474,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
         // watchCollection on the model because by default ngModel only watches the model's
         // reference. This allowed the developer to also push and pop from their array.
-        $scope.$watchCollection($attrs.ngModel, function(value) {
+        $scope.$watchCollection($attrs.ngModel,function(value) {
           if (validateArray(value)) renderMultiple(value);
         });
       } else {
@@ -483,7 +482,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         ngModel.$render = renderSingular;
       }
 
-      function validateArray(modelValue, viewValue) {
+      function validateArray(modelValue,viewValue) {
         // If a value is truthy but not an array, reject it.
         // If value is undefined/falsy, accept that it's an empty array.
         return angular.isArray(modelValue || viewValue || []);
@@ -491,7 +490,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     };
 
     var searchStr = '';
-    var clearSearchTimeout, optNodes, optText;
+    var clearSearchTimeout,optNodes,optText;
     var CLEAR_SEARCH_AFTER = 300;
     self.optNodeForKeyboardSearch = function(e) {
       clearSearchTimeout && clearTimeout(clearSearchTimeout);
@@ -500,13 +499,13 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         searchStr = '';
         optText = undefined;
         optNodes = undefined;
-      }, CLEAR_SEARCH_AFTER);
+      },CLEAR_SEARCH_AFTER);
       searchStr += String.fromCharCode(e.keyCode);
-      var search = new RegExp('^' + searchStr, 'i');
+      var search = new RegExp('^' + searchStr,'i');
       if (!optNodes) {
         optNodes = $element.find('md-option');
         optText = new Array(optNodes.length);
-        angular.forEach(optNodes, function(el, i) {
+        angular.forEach(optNodes,function(el,i) {
           optText[i] = el.textContent.trim();
         });
       }
@@ -526,12 +525,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       if (ngModel.$options && ngModel.$options.trackBy) {
         var trackByLocals = {};
         var trackByParsed = $parse(ngModel.$options.trackBy);
-        self.hashGetter = function(value, valueScope) {
+        self.hashGetter = function(value,valueScope) {
           trackByLocals.$value = value;
-          return trackByParsed(valueScope || $scope, trackByLocals);
+          return trackByParsed(valueScope || $scope,trackByLocals);
         };
-        // If the user doesn't provide a trackBy, we automatically generate an id for every
-        // value passed in
+      // If the user doesn't provide a trackBy, we automatically generate an id for every
+      // value passed in
       } else {
         self.hashGetter = function getHashValue(value) {
           if (angular.isObject(value)) {
@@ -554,7 +553,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       }
     };
 
-    self.select = function(hashKey, hashedValue) {
+    self.select = function(hashKey,hashedValue) {
       var option = self.options[hashKey];
       option && option.setSelected(true);
       self.selected[hashKey] = hashedValue;
@@ -565,7 +564,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       delete self.selected[hashKey];
     };
 
-    self.addOption = function(hashKey, optionCtrl) {
+    self.addOption = function(hashKey,optionCtrl) {
       if (angular.isDefined(self.options[hashKey])) {
         throw new Error('Duplicate md-option values are not allowed in a select. ' +
         'Duplicate value "' + optionCtrl.value + '" found.');
@@ -574,7 +573,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
       // If this option's value was already in our ngModel, go ahead and select it.
       if (angular.isDefined(self.selected[hashKey])) {
-        self.select(hashKey, optionCtrl.value);
+        self.select(hashKey,optionCtrl.value);
         self.refreshViewValue();
       }
     };
@@ -615,59 +614,59 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
       });
 
       deselected.forEach(self.deselect);
-      newSelectedHashes.forEach(function(hashKey, i) {
-        self.select(hashKey, newSelectedValues[i]);
+      newSelectedHashes.forEach(function(hashKey,i) {
+        self.select(hashKey,newSelectedValues[i]);
       });
     }
 
     function renderSingular() {
       var value = self.ngModel.$viewValue || self.ngModel.$modelValue;
       Object.keys(self.selected).forEach(self.deselect);
-      self.select(self.hashGetter(value), value);
+      self.select(self.hashGetter(value),value);
     }
   }
 
 }
 
-function OptionDirective($mdButtonInkRipple, $mdUtil) {
+function OptionDirective($mdButtonInkRipple,$mdUtil) {
 
   return {
     restrict: 'E',
-    require: ['mdOption', '^^mdSelectMenu'],
+    require: ['mdOption','^^mdSelectMenu'],
     controller: OptionController,
     compile: compile
   };
 
-  function compile(element, attr) {
+  function compile(element,attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
     element.append(angular.element('<div class="md-text">').append(element.contents()));
 
-    element.attr('tabindex', attr.tabindex || '0');
+    element.attr('tabindex',attr.tabindex || '0');
     return postLink;
   }
 
-  function postLink(scope, element, attr, ctrls) {
+  function postLink(scope,element,attr,ctrls) {
     var optionCtrl = ctrls[0];
     var selectCtrl = ctrls[1];
 
     if (angular.isDefined(attr.ngValue)) {
-      scope.$watch(attr.ngValue, setOptionValue);
+      scope.$watch(attr.ngValue,setOptionValue);
     } else if (angular.isDefined(attr.value)) {
       setOptionValue(attr.value);
     } else {
       scope.$watch(function() {
         return element.text();
-      }, setOptionValue);
+      },setOptionValue);
     }
 
     scope.$$postDigest(function() {
-      attr.$observe('selected', function(selected) {
+      attr.$observe('selected',function(selected) {
         if (!angular.isDefined(selected)) return;
         if (selected) {
           if (!selectCtrl.isMultiple) {
             selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
           }
-          selectCtrl.select(optionCtrl.hashKey, optionCtrl.value);
+          selectCtrl.select(optionCtrl.hashKey,optionCtrl.value);
         } else {
           selectCtrl.deselect(optionCtrl.hashKey);
         }
@@ -676,22 +675,22 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
       });
     });
 
-    $mdButtonInkRipple.attach(scope, element);
+    $mdButtonInkRipple.attach(scope,element);
     configureAria();
 
-    function setOptionValue(newValue, oldValue) {
-      var oldHashKey = selectCtrl.hashGetter(oldValue, scope);
-      var newHashKey = selectCtrl.hashGetter(newValue, scope);
+    function setOptionValue(newValue,oldValue) {
+      var oldHashKey = selectCtrl.hashGetter(oldValue,scope);
+      var newHashKey = selectCtrl.hashGetter(newValue,scope);
 
       optionCtrl.hashKey = newHashKey;
       optionCtrl.value = newValue;
 
-      selectCtrl.removeOption(oldHashKey, optionCtrl);
-      selectCtrl.addOption(newHashKey, optionCtrl);
+      selectCtrl.removeOption(oldHashKey,optionCtrl);
+      selectCtrl.addOption(newHashKey,optionCtrl);
     }
 
-    scope.$on('$destroy', function() {
-      selectCtrl.removeOption(optionCtrl.hashKey, optionCtrl);
+    scope.$on('$destroy',function() {
+      selectCtrl.removeOption(optionCtrl.hashKey,optionCtrl);
     });
 
     function configureAria() {
@@ -717,7 +716,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
         });
       } else if (!isSelected && this.selected) {
         $element.removeAttr('selected');
-        $element.attr('aria-selected', 'false');
+        $element.attr('aria-selected','false');
       }
       this.selected = isSelected;
     };
@@ -730,7 +729,7 @@ function OptgroupDirective() {
     restrict: 'E',
     compile: compile
   };
-  function compile(el, attrs) {
+  function compile(el,attrs) {
     var labelElement = el.find('label');
     if (!labelElement.length) {
       labelElement = angular.element('<label>');
@@ -748,7 +747,7 @@ function SelectProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window) {
+  function selectDefaultOptions($mdSelect,$mdConstant,$$rAF,$mdUtil,$mdTheming,$timeout,$window) {
     return {
       parent: 'body',
       onShow: onShow,
@@ -758,13 +757,13 @@ function SelectProvider($$interimElementProvider) {
       themable: true
     };
 
-    function onShow(scope, element, opts) {
+    function onShow(scope,element,opts) {
       if (!opts.target) {
         throw new Error('$mdSelect.show() expected a target element in options.target but got ' +
         '"' + opts.target + '"!');
       }
 
-      angular.extend(opts, {
+      angular.extend(opts,{
         isRemoved: false,
         target: angular.element(opts.target), //make sure it's not a naked dom node
         parent: angular.element(opts.parent),
@@ -776,13 +775,13 @@ function SelectProvider($$interimElementProvider) {
       opts.resizeFn = function() {
         $$rAF(function() {
           $$rAF(function() {
-            animateSelect(scope, element, opts);
+            animateSelect(scope,element,opts);
           });
         });
       };
 
-      angular.element($window).on('resize', opts.resizeFn);
-      angular.element($window).on('orientationchange', opts.resizeFn);
+      angular.element($window).on('resize',opts.resizeFn);
+      angular.element($window).on('orientationchange',opts.resizeFn);
 
 
       configureAria();
@@ -799,7 +798,7 @@ function SelectProvider($$interimElementProvider) {
             $$rAF(function() {
               // Don't go forward if the select has been removed in this time...
               if (opts.isRemoved) return;
-              animateSelect(scope, element, opts);
+              animateSelect(scope,element,opts);
             });
           });
         });
@@ -807,17 +806,17 @@ function SelectProvider($$interimElementProvider) {
         scope.$$loadingAsyncDone = true;
       }
 
-      if (opts.disableParentScroll && !$mdUtil.getClosest(opts.target, 'MD-DIALOG')) {
+      if (opts.disableParentScroll && !$mdUtil.getClosest(opts.target,'MD-DIALOG')) {
         opts.restoreScroll = $mdUtil.disableScrollAround(opts.element);
       } else {
         opts.disableParentScroll = false;
       }
       // Only activate click listeners after a short time to stop accidental double taps/clicks
       // from clicking the wrong item
-      $timeout(activateInteraction, 75, false);
+      $timeout(activateInteraction,75,false);
 
       if (opts.backdrop) {
-        $mdTheming.inherit(opts.backdrop, opts.parent);
+        $mdTheming.inherit(opts.backdrop,opts.parent);
         opts.parent.append(opts.backdrop);
       }
       opts.parent.append(element);
@@ -827,14 +826,14 @@ function SelectProvider($$interimElementProvider) {
       $$rAF(function() {
         $$rAF(function() {
           if (opts.isRemoved) return;
-          animateSelect(scope, element, opts);
+          animateSelect(scope,element,opts);
         });
       });
 
-      return $mdUtil.transitionEndPromise(opts.selectEl, {timeout: 350});
+      return $mdUtil.transitionEndPromise(opts.selectEl,{timeout: 350});
 
       function configureAria() {
-        opts.target.attr('aria-expanded', 'true');
+        opts.target.attr('aria-expanded','true');
       }
 
       function activateInteraction() {
@@ -842,7 +841,7 @@ function SelectProvider($$interimElementProvider) {
         var selectCtrl = opts.selectEl.controller('mdSelectMenu') || {};
         element.addClass('md-clickable');
 
-        opts.backdrop && opts.backdrop.on('click', function(e) {
+        opts.backdrop && opts.backdrop.on('click',function(e) {
           e.preventDefault();
           e.stopPropagation();
           opts.restoreFocus = false;
@@ -850,11 +849,11 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Escape to close
-        opts.selectEl.on('keydown', function(ev) {
+        opts.selectEl.on('keydown',function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.SPACE:
             case $mdConstant.KEY_CODE.ENTER:
-              var option = $mdUtil.getClosest(ev.target, 'md-option');
+              var option = $mdUtil.getClosest(ev.target,'md-option');
               if (option) {
                 opts.selectEl.triggerHandler({
                   type: 'click',
@@ -872,7 +871,7 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Cycling of options, and closing on enter
-        opts.selectEl.on('keydown', function(ev) {
+        opts.selectEl.on('keydown',function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.UP_ARROW:
               return focusPrevOption();
@@ -910,8 +909,8 @@ function SelectProvider($$interimElementProvider) {
           focusOption('prev');
         }
 
-        opts.selectEl.on('click', checkCloseMenu);
-        opts.selectEl.on('keydown', function(e) {
+        opts.selectEl.on('click',checkCloseMenu);
+        opts.selectEl.on('keydown',function(e) {
           if (e.keyCode == 32 || e.keyCode == 13) {
             checkCloseMenu();
           }
@@ -929,15 +928,15 @@ function SelectProvider($$interimElementProvider) {
 
     }
 
-    function onRemove(scope, element, opts) {
+    function onRemove(scope,element,opts) {
       opts.isRemoved = true;
       element.addClass('md-leave')
         .removeClass('md-clickable');
-      opts.target.attr('aria-expanded', 'false');
+      opts.target.attr('aria-expanded','false');
 
 
-      angular.element($window).off('resize', opts.resizeFn);
-      angular.element($window).off('orientationchange', opts.resizefn);
+      angular.element($window).off('resize',opts.resizeFn);
+      angular.element($window).off('orientationchange',opts.resizefn);
       opts.resizeFn = undefined;
 
       var mdSelect = opts.selectEl.controller('mdSelect');
@@ -945,7 +944,7 @@ function SelectProvider($$interimElementProvider) {
         mdSelect.setLabelText(opts.selectEl.controller('mdSelectMenu').selectedLabels());
       }
 
-      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function() {
+      return $mdUtil.transitionEndPromise(element,{timeout: 350}).then(function() {
         element.removeClass('md-active');
         opts.backdrop && opts.backdrop.remove();
         if (element[0].parentNode === opts.parent[0]) {
@@ -959,7 +958,7 @@ function SelectProvider($$interimElementProvider) {
       });
     }
 
-    function animateSelect(scope, element, opts) {
+    function animateSelect(scope,element,opts) {
       var containerNode = element[0],
         targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
         parentNode = opts.parent[0],
@@ -991,13 +990,13 @@ function SelectProvider($$interimElementProvider) {
       // If a selected node, center around that
       if (selectedNode) {
         centeredNode = selectedNode;
-        // If there are option groups, center around the first option group
+      // If there are option groups, center around the first option group
       } else if (optgroupNodes.length) {
         centeredNode = optgroupNodes[0];
-        // Otherwise, center around the first optionNode
+      // Otherwise, center around the first optionNode
       } else if (optionNodes.length) {
         centeredNode = optionNodes[0];
-        // In case there are no options, center on whatever's in there... (eg progress indicator)
+      // In case there are no options, center on whatever's in there... (eg progress indicator)
       } else {
         centeredNode = contentNode.firstElementChild || contentNode;
       }
@@ -1020,8 +1019,8 @@ function SelectProvider($$interimElementProvider) {
 
       if (centeredNode) {
         var centeredStyle = $window.getComputedStyle(centeredNode);
-        centeredRect.paddingLeft = parseInt(centeredStyle.paddingLeft, 10) || 0;
-        centeredRect.paddingRight = parseInt(centeredStyle.paddingRight, 10) || 0;
+        centeredRect.paddingLeft = parseInt(centeredStyle.paddingLeft,10) || 0;
+        centeredRect.paddingRight = parseInt(centeredStyle.paddingRight,10) || 0;
       }
 
       var focusedNode = centeredNode;
@@ -1046,7 +1045,7 @@ function SelectProvider($$interimElementProvider) {
         }
       }
 
-      var left, top, transformOrigin;
+      var left,top,transformOrigin;
       if (shouldOpenAroundTarget) {
         left = targetRect.left;
         top = targetRect.top + targetRect.height;
@@ -1070,13 +1069,13 @@ function SelectProvider($$interimElementProvider) {
 
       // Keep left and top within the window
       var containerRect = containerNode.getBoundingClientRect();
-      containerNode.style.left = clamp(bounds.left, left, bounds.right - containerRect.width) + 'px';
-      containerNode.style.top = clamp(bounds.top, top, bounds.bottom - containerRect.height) + 'px';
+      containerNode.style.left = clamp(bounds.left,left,bounds.right - containerRect.width) + 'px';
+      containerNode.style.top = clamp(bounds.top,top,bounds.bottom - containerRect.height) + 'px';
       selectNode.style[$mdConstant.CSS.TRANSFORM_ORIGIN] = transformOrigin;
 
       selectNode.style[$mdConstant.CSS.TRANSFORM] = 'scale(' +
-      Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
-      Math.min(targetRect.height / selectMenuRect.height, 1.0) +
+      Math.min(targetRect.width / selectMenuRect.width,1.0) + ',' +
+      Math.min(targetRect.height / selectMenuRect.height,1.0) +
       ')';
 
 
@@ -1092,8 +1091,8 @@ function SelectProvider($$interimElementProvider) {
 
   }
 
-  function clamp(min, n, max) {
-    return Math.max(min, Math.min(n, max));
+  function clamp(min,n,max) {
+    return Math.max(min,Math.min(n,max));
   }
 
   function getOffsetRect(node) {
@@ -1102,6 +1101,6 @@ function SelectProvider($$interimElementProvider) {
       top: node.offsetTop,
       width: node.offsetWidth,
       height: node.offsetHeight
-    } : {left: 0, top: 0, width: 0, height: 0};
+    } : {left: 0,top: 0,width: 0,height: 0};
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -20,15 +20,15 @@
 var SELECT_EDGE_MARGIN = 8;
 var selectNextId = 0;
 
-angular.module('material.components.select',[
+angular.module('material.components.select', [
   'material.core',
   'material.components.backdrop'
 ])
-.directive('mdSelect',SelectDirective)
-.directive('mdSelectMenu',SelectMenuDirective)
-.directive('mdOption',OptionDirective)
-.directive('mdOptgroup',OptgroupDirective)
-.provider('$mdSelect',SelectProvider);
+.directive('mdSelect', SelectDirective)
+.directive('mdSelectMenu', SelectMenuDirective)
+.directive('mdOption', OptionDirective)
+.directive('mdOptgroup', OptgroupDirective)
+.provider('$mdSelect', SelectProvider);
 
 
 /**
@@ -70,22 +70,22 @@ angular.module('material.components.select',[
  * </hljs>
  */
 
-function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$compile,$parse) {
+function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, $compile, $parse) {
   return {
     restrict: 'E',
-    require: ['^?mdInputContainer','mdSelect','ngModel','?^form'],
+    require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
     controller: function() {
     } // empty placeholder controller to be initialized in link
   };
 
-  function compile(element,attr) {
+  function compile(element, attr) {
     // add the select value that will hold our placeholder or selected option value
     var labelEl = angular.element('<md-select-value><span></span></md-select-value>');
     labelEl.append('<span class="md-select-icon" aria-hidden="true"></span>');
     labelEl.addClass('md-select-value');
     if (!labelEl[0].hasAttribute('id')) {
-      labelEl.attr('id','select_label_' + $mdUtil.nextUid());
+      labelEl.attr('id', 'select_label_' + $mdUtil.nextUid());
     }
 
     // There's got to be an md-content inside. If there's not one, let's add it.
@@ -97,8 +97,8 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
     if (attr.mdOnOpen) {
       element.find('md-content').prepend(
         angular.element('<md-progress-circular>')
-          .attr('md-mode','indeterminate')
-          .attr('ng-hide','$$loadingAsyncDone')
+          .attr('md-mode', 'indeterminate')
+          .attr('ng-hide', '$$loadingAsyncDone')
           .wrap('<div>')
           .parent()
       );
@@ -113,10 +113,10 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
         'tabindex': '-1'
       });
       var opts = element.find('md-option');
-      angular.forEach(opts,function(el) {
+      angular.forEach(opts, function(el) {
         var newEl = angular.element('<option>' + el.innerHTML + '</option>');
-        if (el.hasAttribute('ng-value')) newEl.attr('ng-value',el.getAttribute('ng-value'));
-        else if (el.hasAttribute('value')) newEl.attr('value',el.getAttribute('value'));
+        if (el.hasAttribute('ng-value')) newEl.attr('ng-value', el.getAttribute('ng-value'));
+        else if (el.hasAttribute('value')) newEl.attr('value', el.getAttribute('value'));
         autofillClone.append(newEl);
       });
 
@@ -134,7 +134,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
 
     attr.tabindex = attr.tabindex || '0';
 
-    return function postLink(scope,element,attr,ctrls) {
+    return function postLink(scope, element, attr, ctrls) {
       var isOpen;
       var isDisabled;
 
@@ -158,10 +158,10 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
       containerCtrl.input = element;
 
       if (!containerCtrl.label) {
-        $mdAria.expect(element,'aria-label',element.attr('placeholder'));
+        $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
       }
 
-      var selectContainer,selectScope,selectMenuCtrl;
+      var selectContainer, selectScope, selectMenuCtrl;
       createSelect();
       $mdTheming(element);
 
@@ -173,7 +173,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
       var isErrorGetter = containerCtrl.isErrorGetter || function() {
           return ngModelCtrl.$invalid && ngModelCtrl.$touched;
         };
-      scope.$watch(isErrorGetter,containerCtrl.setInvalid);
+      scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
       ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
       ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
@@ -210,14 +210,14 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
 
       if (!isReadonly) {
         element
-          .on('focus',function(ev) {
+          .on('focus', function(ev) {
             // only set focus on if we don't currently have a selected value. This avoids the "bounce"
             // on the label transition because the focus will immediately switch to the open menu.
             if (containerCtrl.element.hasClass('md-input-has-value')) {
               containerCtrl.setFocused(true);
             }
           })
-          .on('blur',function(ev) {
+          .on('blur', function(ev) {
             containerCtrl.setFocused(false);
             inputCheckValue();
           });
@@ -237,7 +237,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
         if (!labelText) {
           labelText = containerCtrl.element.find('label').text();
         }
-        $mdAria.expect(element,'aria-label',labelText);
+        $mdAria.expect(element, 'aria-label', labelText);
       }
 
       function syncLabelText() {
@@ -248,15 +248,15 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
       }
 
       var deregisterWatcher;
-      attr.$observe('ngMultiple',function(val) {
+      attr.$observe('ngMultiple', function(val) {
         if (deregisterWatcher) deregisterWatcher();
         var parser = $parse(val);
         deregisterWatcher = scope.$watch(function() {
           return parser(scope);
-        },function(multiple,prevVal) {
+        }, function(multiple, prevVal) {
           if (multiple === undefined && prevVal === undefined) return; // assume compiler did a good job
           if (multiple) {
-            element.attr('multiple','multiple');
+            element.attr('multiple', 'multiple');
           } else {
             element.removeAttr('multiple');
           }
@@ -273,7 +273,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
         });
       });
 
-      attr.$observe('disabled',function(disabled) {
+      attr.$observe('disabled', function(disabled) {
         if (typeof disabled == "string") {
           disabled = true;
         }
@@ -283,20 +283,20 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
         }
         isDisabled = disabled;
         if (disabled) {
-          element.attr({'tabindex': -1,'aria-disabled': 'true'});
-          element.off('click',openSelect);
-          element.off('keydown',handleKeypress);
+          element.attr({'tabindex': -1, 'aria-disabled': 'true'});
+          element.off('click', openSelect);
+          element.off('keydown', handleKeypress);
         } else {
-          element.attr({'tabindex': attr.tabindex,'aria-disabled': 'false'});
-          element.on('click',openSelect);
-          element.on('keydown',handleKeypress);
+          element.attr({'tabindex': attr.tabindex, 'aria-disabled': 'false'});
+          element.on('click', openSelect);
+          element.on('keydown', handleKeypress);
         }
       });
 
       if (!attr.disabled && !attr.ngDisabled) {
-        element.attr({'tabindex': attr.tabindex,'aria-disabled': 'false'});
-        element.on('click',openSelect);
-        element.on('keydown',handleKeypress);
+        element.attr({'tabindex': attr.tabindex, 'aria-disabled': 'false'});
+        element.on('click', openSelect);
+        element.on('keydown', handleKeypress);
       }
 
       var ariaAttrs = {
@@ -308,7 +308,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
       }
       element.attr(ariaAttrs);
 
-      scope.$on('$destroy',function() {
+      scope.$on('$destroy', function() {
         if (isOpen) {
           $mdSelect.cancel().then(function() {
             selectContainer.remove();
@@ -336,15 +336,15 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
       function createSelect() {
         selectContainer = angular.element(selectTemplate);
         var selectEl = selectContainer.find('md-select-menu');
-        selectEl.data('$ngModelController',ngModelCtrl);
-        selectEl.data('$mdSelectController',mdSelectCtrl);
+        selectEl.data('$ngModelController', ngModelCtrl);
+        selectEl.data('$mdSelectController', mdSelectCtrl);
         selectScope = scope.$new();
         selectContainer = $compile(selectContainer)(selectScope);
         selectMenuCtrl = selectContainer.find('md-select-menu').controller('mdSelectMenu');
       }
 
       function handleKeypress(e) {
-        var allowedCodes = [32,13,38,40];
+        var allowedCodes = [32, 13, 38, 40];
         if (allowedCodes.indexOf(e.keyCode) != -1) {
           // prevent page scrolling on interaction
           e.preventDefault();
@@ -358,7 +358,7 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
             if (!selectMenuCtrl.isMultiple) {
               selectMenuCtrl.deselect(Object.keys(selectMenuCtrl.selected)[0]);
             }
-            selectMenuCtrl.select(optionCtrl.hashKey,optionCtrl.value);
+            selectMenuCtrl.select(optionCtrl.hashKey, optionCtrl.value);
             selectMenuCtrl.refreshViewValue();
             ngModelCtrl.$render();
           }
@@ -385,24 +385,24 @@ function SelectDirective($mdSelect,$mdUtil,$mdTheming,$mdAria,$interpolate,$comp
   }
 }
 
-function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
+function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
   return {
     restrict: 'E',
-    require: ['mdSelectMenu','?ngModel'],
+    require: ['mdSelectMenu', '?ngModel'],
     controller: SelectMenuController,
     link: {pre: preLink}
   };
 
   // We use preLink instead of postLink to ensure that the select is initialized before
   // its child options run postLink.
-  function preLink(scope,element,attr,ctrls) {
+  function preLink(scope, element, attr, ctrls) {
     var selectCtrl = ctrls[0];
     var ngModel = ctrls[1];
 
     $mdTheming(element);
-    element.on('click',clickListener);
-    element.on('keypress',keyListener);
+    element.on('click', clickListener);
+    element.on('keypress', keyListener);
     if (ngModel) selectCtrl.init(ngModel);
     configureAria();
 
@@ -421,7 +421,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
     }
 
     function clickListener(ev) {
-      var option = $mdUtil.getClosest(ev.target,'md-option');
+      var option = $mdUtil.getClosest(ev.target, 'md-option');
       var optionCtrl = option && angular.element(option).data('$mdOptionController');
       if (!option || !optionCtrl) return;
 
@@ -433,12 +433,12 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
           if (isSelected) {
             selectCtrl.deselect(optionHashKey);
           } else {
-            selectCtrl.select(optionHashKey,optionCtrl.value);
+            selectCtrl.select(optionHashKey, optionCtrl.value);
           }
         } else {
           if (!isSelected) {
             selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
-            selectCtrl.select(optionHashKey,optionCtrl.value);
+            selectCtrl.select(optionHashKey, optionCtrl.value);
           }
         }
         selectCtrl.refreshViewValue();
@@ -447,7 +447,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
   }
 
 
-  function SelectMenuController($scope,$attrs,$element) {
+  function SelectMenuController($scope, $attrs, $element) {
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);
     // selected is an object with keys matching all of the selected options' hashed values
@@ -458,9 +458,9 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
 
     $scope.$watch(function() {
       return self.options;
-    },function() {
+    }, function() {
       self.ngModel.$render();
-    },true);
+    }, true);
 
     var deregisterCollectionWatch;
     self.setMultiple = function(isMultiple) {
@@ -474,7 +474,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
 
         // watchCollection on the model because by default ngModel only watches the model's
         // reference. This allowed the developer to also push and pop from their array.
-        $scope.$watchCollection($attrs.ngModel,function(value) {
+        $scope.$watchCollection($attrs.ngModel, function(value) {
           if (validateArray(value)) renderMultiple(value);
         });
       } else {
@@ -482,7 +482,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
         ngModel.$render = renderSingular;
       }
 
-      function validateArray(modelValue,viewValue) {
+      function validateArray(modelValue, viewValue) {
         // If a value is truthy but not an array, reject it.
         // If value is undefined/falsy, accept that it's an empty array.
         return angular.isArray(modelValue || viewValue || []);
@@ -490,7 +490,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
     };
 
     var searchStr = '';
-    var clearSearchTimeout,optNodes,optText;
+    var clearSearchTimeout, optNodes, optText;
     var CLEAR_SEARCH_AFTER = 300;
     self.optNodeForKeyboardSearch = function(e) {
       clearSearchTimeout && clearTimeout(clearSearchTimeout);
@@ -499,13 +499,13 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
         searchStr = '';
         optText = undefined;
         optNodes = undefined;
-      },CLEAR_SEARCH_AFTER);
+      }, CLEAR_SEARCH_AFTER);
       searchStr += String.fromCharCode(e.keyCode);
-      var search = new RegExp('^' + searchStr,'i');
+      var search = new RegExp('^' + searchStr, 'i');
       if (!optNodes) {
         optNodes = $element.find('md-option');
         optText = new Array(optNodes.length);
-        angular.forEach(optNodes,function(el,i) {
+        angular.forEach(optNodes, function(el, i) {
           optText[i] = el.textContent.trim();
         });
       }
@@ -525,12 +525,12 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
       if (ngModel.$options && ngModel.$options.trackBy) {
         var trackByLocals = {};
         var trackByParsed = $parse(ngModel.$options.trackBy);
-        self.hashGetter = function(value,valueScope) {
+        self.hashGetter = function(value, valueScope) {
           trackByLocals.$value = value;
-          return trackByParsed(valueScope || $scope,trackByLocals);
+          return trackByParsed(valueScope || $scope, trackByLocals);
         };
-      // If the user doesn't provide a trackBy, we automatically generate an id for every
-      // value passed in
+        // If the user doesn't provide a trackBy, we automatically generate an id for every
+        // value passed in
       } else {
         self.hashGetter = function getHashValue(value) {
           if (angular.isObject(value)) {
@@ -553,7 +553,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
       }
     };
 
-    self.select = function(hashKey,hashedValue) {
+    self.select = function(hashKey, hashedValue) {
       var option = self.options[hashKey];
       option && option.setSelected(true);
       self.selected[hashKey] = hashedValue;
@@ -564,7 +564,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
       delete self.selected[hashKey];
     };
 
-    self.addOption = function(hashKey,optionCtrl) {
+    self.addOption = function(hashKey, optionCtrl) {
       if (angular.isDefined(self.options[hashKey])) {
         throw new Error('Duplicate md-option values are not allowed in a select. ' +
         'Duplicate value "' + optionCtrl.value + '" found.');
@@ -573,7 +573,7 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
 
       // If this option's value was already in our ngModel, go ahead and select it.
       if (angular.isDefined(self.selected[hashKey])) {
-        self.select(hashKey,optionCtrl.value);
+        self.select(hashKey, optionCtrl.value);
         self.refreshViewValue();
       }
     };
@@ -614,59 +614,59 @@ function SelectMenuDirective($parse,$mdUtil,$mdTheming) {
       });
 
       deselected.forEach(self.deselect);
-      newSelectedHashes.forEach(function(hashKey,i) {
-        self.select(hashKey,newSelectedValues[i]);
+      newSelectedHashes.forEach(function(hashKey, i) {
+        self.select(hashKey, newSelectedValues[i]);
       });
     }
 
     function renderSingular() {
       var value = self.ngModel.$viewValue || self.ngModel.$modelValue;
       Object.keys(self.selected).forEach(self.deselect);
-      self.select(self.hashGetter(value),value);
+      self.select(self.hashGetter(value), value);
     }
   }
 
 }
 
-function OptionDirective($mdButtonInkRipple,$mdUtil) {
+function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   return {
     restrict: 'E',
-    require: ['mdOption','^^mdSelectMenu'],
+    require: ['mdOption', '^^mdSelectMenu'],
     controller: OptionController,
     compile: compile
   };
 
-  function compile(element,attr) {
+  function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
     element.append(angular.element('<div class="md-text">').append(element.contents()));
 
-    element.attr('tabindex',attr.tabindex || '0');
+    element.attr('tabindex', attr.tabindex || '0');
     return postLink;
   }
 
-  function postLink(scope,element,attr,ctrls) {
+  function postLink(scope, element, attr, ctrls) {
     var optionCtrl = ctrls[0];
     var selectCtrl = ctrls[1];
 
     if (angular.isDefined(attr.ngValue)) {
-      scope.$watch(attr.ngValue,setOptionValue);
+      scope.$watch(attr.ngValue, setOptionValue);
     } else if (angular.isDefined(attr.value)) {
       setOptionValue(attr.value);
     } else {
       scope.$watch(function() {
         return element.text();
-      },setOptionValue);
+      }, setOptionValue);
     }
 
     scope.$$postDigest(function() {
-      attr.$observe('selected',function(selected) {
+      attr.$observe('selected', function(selected) {
         if (!angular.isDefined(selected)) return;
         if (selected) {
           if (!selectCtrl.isMultiple) {
             selectCtrl.deselect(Object.keys(selectCtrl.selected)[0]);
           }
-          selectCtrl.select(optionCtrl.hashKey,optionCtrl.value);
+          selectCtrl.select(optionCtrl.hashKey, optionCtrl.value);
         } else {
           selectCtrl.deselect(optionCtrl.hashKey);
         }
@@ -675,22 +675,22 @@ function OptionDirective($mdButtonInkRipple,$mdUtil) {
       });
     });
 
-    $mdButtonInkRipple.attach(scope,element);
+    $mdButtonInkRipple.attach(scope, element);
     configureAria();
 
-    function setOptionValue(newValue,oldValue) {
-      var oldHashKey = selectCtrl.hashGetter(oldValue,scope);
-      var newHashKey = selectCtrl.hashGetter(newValue,scope);
+    function setOptionValue(newValue, oldValue) {
+      var oldHashKey = selectCtrl.hashGetter(oldValue, scope);
+      var newHashKey = selectCtrl.hashGetter(newValue, scope);
 
       optionCtrl.hashKey = newHashKey;
       optionCtrl.value = newValue;
 
-      selectCtrl.removeOption(oldHashKey,optionCtrl);
-      selectCtrl.addOption(newHashKey,optionCtrl);
+      selectCtrl.removeOption(oldHashKey, optionCtrl);
+      selectCtrl.addOption(newHashKey, optionCtrl);
     }
 
-    scope.$on('$destroy',function() {
-      selectCtrl.removeOption(optionCtrl.hashKey,optionCtrl);
+    scope.$on('$destroy', function() {
+      selectCtrl.removeOption(optionCtrl.hashKey, optionCtrl);
     });
 
     function configureAria() {
@@ -716,7 +716,7 @@ function OptionDirective($mdButtonInkRipple,$mdUtil) {
         });
       } else if (!isSelected && this.selected) {
         $element.removeAttr('selected');
-        $element.attr('aria-selected','false');
+        $element.attr('aria-selected', 'false');
       }
       this.selected = isSelected;
     };
@@ -729,7 +729,7 @@ function OptgroupDirective() {
     restrict: 'E',
     compile: compile
   };
-  function compile(el,attrs) {
+  function compile(el, attrs) {
     var labelElement = el.find('label');
     if (!labelElement.length) {
       labelElement = angular.element('<label>');
@@ -747,7 +747,7 @@ function SelectProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function selectDefaultOptions($mdSelect,$mdConstant,$$rAF,$mdUtil,$mdTheming,$timeout,$window) {
+  function selectDefaultOptions($mdSelect, $mdConstant, $$rAF, $mdUtil, $mdTheming, $timeout, $window) {
     return {
       parent: 'body',
       onShow: onShow,
@@ -757,13 +757,13 @@ function SelectProvider($$interimElementProvider) {
       themable: true
     };
 
-    function onShow(scope,element,opts) {
+    function onShow(scope, element, opts) {
       if (!opts.target) {
         throw new Error('$mdSelect.show() expected a target element in options.target but got ' +
         '"' + opts.target + '"!');
       }
 
-      angular.extend(opts,{
+      angular.extend(opts, {
         isRemoved: false,
         target: angular.element(opts.target), //make sure it's not a naked dom node
         parent: angular.element(opts.parent),
@@ -775,13 +775,13 @@ function SelectProvider($$interimElementProvider) {
       opts.resizeFn = function() {
         $$rAF(function() {
           $$rAF(function() {
-            animateSelect(scope,element,opts);
+            animateSelect(scope, element, opts);
           });
         });
       };
 
-      angular.element($window).on('resize',opts.resizeFn);
-      angular.element($window).on('orientationchange',opts.resizeFn);
+      angular.element($window).on('resize', opts.resizeFn);
+      angular.element($window).on('orientationchange', opts.resizeFn);
 
 
       configureAria();
@@ -798,7 +798,7 @@ function SelectProvider($$interimElementProvider) {
             $$rAF(function() {
               // Don't go forward if the select has been removed in this time...
               if (opts.isRemoved) return;
-              animateSelect(scope,element,opts);
+              animateSelect(scope, element, opts);
             });
           });
         });
@@ -806,17 +806,17 @@ function SelectProvider($$interimElementProvider) {
         scope.$$loadingAsyncDone = true;
       }
 
-      if (opts.disableParentScroll && !$mdUtil.getClosest(opts.target,'MD-DIALOG')) {
+      if (opts.disableParentScroll && !$mdUtil.getClosest(opts.target, 'MD-DIALOG')) {
         opts.restoreScroll = $mdUtil.disableScrollAround(opts.element);
       } else {
         opts.disableParentScroll = false;
       }
       // Only activate click listeners after a short time to stop accidental double taps/clicks
       // from clicking the wrong item
-      $timeout(activateInteraction,75,false);
+      $timeout(activateInteraction, 75, false);
 
       if (opts.backdrop) {
-        $mdTheming.inherit(opts.backdrop,opts.parent);
+        $mdTheming.inherit(opts.backdrop, opts.parent);
         opts.parent.append(opts.backdrop);
       }
       opts.parent.append(element);
@@ -826,14 +826,14 @@ function SelectProvider($$interimElementProvider) {
       $$rAF(function() {
         $$rAF(function() {
           if (opts.isRemoved) return;
-          animateSelect(scope,element,opts);
+          animateSelect(scope, element, opts);
         });
       });
 
-      return $mdUtil.transitionEndPromise(opts.selectEl,{timeout: 350});
+      return $mdUtil.transitionEndPromise(opts.selectEl, {timeout: 350});
 
       function configureAria() {
-        opts.target.attr('aria-expanded','true');
+        opts.target.attr('aria-expanded', 'true');
       }
 
       function activateInteraction() {
@@ -841,7 +841,7 @@ function SelectProvider($$interimElementProvider) {
         var selectCtrl = opts.selectEl.controller('mdSelectMenu') || {};
         element.addClass('md-clickable');
 
-        opts.backdrop && opts.backdrop.on('click',function(e) {
+        opts.backdrop && opts.backdrop.on('click', function(e) {
           e.preventDefault();
           e.stopPropagation();
           opts.restoreFocus = false;
@@ -849,11 +849,11 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Escape to close
-        opts.selectEl.on('keydown',function(ev) {
+        opts.selectEl.on('keydown', function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.SPACE:
             case $mdConstant.KEY_CODE.ENTER:
-              var option = $mdUtil.getClosest(ev.target,'md-option');
+              var option = $mdUtil.getClosest(ev.target, 'md-option');
               if (option) {
                 opts.selectEl.triggerHandler({
                   type: 'click',
@@ -871,7 +871,7 @@ function SelectProvider($$interimElementProvider) {
         });
 
         // Cycling of options, and closing on enter
-        opts.selectEl.on('keydown',function(ev) {
+        opts.selectEl.on('keydown', function(ev) {
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.UP_ARROW:
               return focusPrevOption();
@@ -909,8 +909,8 @@ function SelectProvider($$interimElementProvider) {
           focusOption('prev');
         }
 
-        opts.selectEl.on('click',checkCloseMenu);
-        opts.selectEl.on('keydown',function(e) {
+        opts.selectEl.on('click', checkCloseMenu);
+        opts.selectEl.on('keydown', function(e) {
           if (e.keyCode == 32 || e.keyCode == 13) {
             checkCloseMenu();
           }
@@ -928,15 +928,15 @@ function SelectProvider($$interimElementProvider) {
 
     }
 
-    function onRemove(scope,element,opts) {
+    function onRemove(scope, element, opts) {
       opts.isRemoved = true;
       element.addClass('md-leave')
         .removeClass('md-clickable');
-      opts.target.attr('aria-expanded','false');
+      opts.target.attr('aria-expanded', 'false');
 
 
-      angular.element($window).off('resize',opts.resizeFn);
-      angular.element($window).off('orientationchange',opts.resizefn);
+      angular.element($window).off('resize', opts.resizeFn);
+      angular.element($window).off('orientationchange', opts.resizefn);
       opts.resizeFn = undefined;
 
       var mdSelect = opts.selectEl.controller('mdSelect');
@@ -944,7 +944,7 @@ function SelectProvider($$interimElementProvider) {
         mdSelect.setLabelText(opts.selectEl.controller('mdSelectMenu').selectedLabels());
       }
 
-      return $mdUtil.transitionEndPromise(element,{timeout: 350}).then(function() {
+      return $mdUtil.transitionEndPromise(element, {timeout: 350}).then(function() {
         element.removeClass('md-active');
         opts.backdrop && opts.backdrop.remove();
         if (element[0].parentNode === opts.parent[0]) {
@@ -958,7 +958,7 @@ function SelectProvider($$interimElementProvider) {
       });
     }
 
-    function animateSelect(scope,element,opts) {
+    function animateSelect(scope, element, opts) {
       var containerNode = element[0],
         targetNode = opts.target[0].firstElementChild.firstElementChild, // target the first span, functioning as the label
         parentNode = opts.parent[0],
@@ -990,13 +990,13 @@ function SelectProvider($$interimElementProvider) {
       // If a selected node, center around that
       if (selectedNode) {
         centeredNode = selectedNode;
-      // If there are option groups, center around the first option group
+        // If there are option groups, center around the first option group
       } else if (optgroupNodes.length) {
         centeredNode = optgroupNodes[0];
-      // Otherwise, center around the first optionNode
+        // Otherwise, center around the first optionNode
       } else if (optionNodes.length) {
         centeredNode = optionNodes[0];
-      // In case there are no options, center on whatever's in there... (eg progress indicator)
+        // In case there are no options, center on whatever's in there... (eg progress indicator)
       } else {
         centeredNode = contentNode.firstElementChild || contentNode;
       }
@@ -1019,8 +1019,8 @@ function SelectProvider($$interimElementProvider) {
 
       if (centeredNode) {
         var centeredStyle = $window.getComputedStyle(centeredNode);
-        centeredRect.paddingLeft = parseInt(centeredStyle.paddingLeft,10) || 0;
-        centeredRect.paddingRight = parseInt(centeredStyle.paddingRight,10) || 0;
+        centeredRect.paddingLeft = parseInt(centeredStyle.paddingLeft, 10) || 0;
+        centeredRect.paddingRight = parseInt(centeredStyle.paddingRight, 10) || 0;
       }
 
       var focusedNode = centeredNode;
@@ -1045,7 +1045,7 @@ function SelectProvider($$interimElementProvider) {
         }
       }
 
-      var left,top,transformOrigin;
+      var left, top, transformOrigin;
       if (shouldOpenAroundTarget) {
         left = targetRect.left;
         top = targetRect.top + targetRect.height;
@@ -1069,13 +1069,13 @@ function SelectProvider($$interimElementProvider) {
 
       // Keep left and top within the window
       var containerRect = containerNode.getBoundingClientRect();
-      containerNode.style.left = clamp(bounds.left,left,bounds.right - containerRect.width) + 'px';
-      containerNode.style.top = clamp(bounds.top,top,bounds.bottom - containerRect.height) + 'px';
+      containerNode.style.left = clamp(bounds.left, left, bounds.right - containerRect.width) + 'px';
+      containerNode.style.top = clamp(bounds.top, top, bounds.bottom - containerRect.height) + 'px';
       selectNode.style[$mdConstant.CSS.TRANSFORM_ORIGIN] = transformOrigin;
 
       selectNode.style[$mdConstant.CSS.TRANSFORM] = 'scale(' +
-      Math.min(targetRect.width / selectMenuRect.width,1.0) + ',' +
-      Math.min(targetRect.height / selectMenuRect.height,1.0) +
+      Math.min(targetRect.width / selectMenuRect.width, 1.0) + ',' +
+      Math.min(targetRect.height / selectMenuRect.height, 1.0) +
       ')';
 
 
@@ -1091,8 +1091,8 @@ function SelectProvider($$interimElementProvider) {
 
   }
 
-  function clamp(min,n,max) {
-    return Math.max(min,Math.min(n,max));
+  function clamp(min, n, max) {
+    return Math.max(min, Math.min(n, max));
   }
 
   function getOffsetRect(node) {
@@ -1101,6 +1101,6 @@ function SelectProvider($$interimElementProvider) {
       top: node.offsetTop,
       width: node.offsetWidth,
       height: node.offsetHeight
-    } : {left: 0,top: 0,width: 0,height: 0};
+    } : {left: 0, top: 0, width: 0, height: 0};
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -560,7 +560,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     self.addOption = function(hashKey, optionCtrl) {
       if (angular.isDefined(self.options[hashKey])) {
         throw new Error('Duplicate md-option values are not allowed in a select. ' +
-        'Duplicate value "' + optionCtrl.value + '" found.');
+                        'Duplicate value "' + optionCtrl.value + '" found.');
       }
       self.options[hashKey] = optionCtrl;
 
@@ -584,11 +584,11 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
          if ((option = self.options[hashKey])) {
            values.push(option.value);
          } else {
-         // Otherwise, the given hashKey has no associated option, and we got it
-         // from an ngModel value at an earlier time. Push the unhashed value of
-         // this hashKey to the model.
-         // This allows the developer to put a value in the model that doesn't yet have
-         // an associated option.
+           // Otherwise, the given hashKey has no associated option, and we got it
+           // from an ngModel value at an earlier time. Push the unhashed value of
+           // this hashKey to the model.
+           // This allows the developer to put a value in the model that doesn't yet have
+           // an associated option.
            values.push(self.selected[hashKey]);
          }
       }
@@ -863,10 +863,8 @@ function SelectProvider($$interimElementProvider) {
         // Cycling of options, and closing on enter
         opts.selectEl.on('keydown', function(ev) {
           switch (ev.keyCode) {
-            case $mdConstant.KEY_CODE.UP_ARROW:
-              return focusPrevOption();
-            case $mdConstant.KEY_CODE.DOWN_ARROW:
-              return focusNextOption();
+            case $mdConstant.KEY_CODE.UP_ARROW: return focusPrevOption();
+            case $mdConstant.KEY_CODE.DOWN_ARROW: return focusNextOption();
             default:
               if (ev.keyCode >= 31 && ev.keyCode <= 90) {
                 var optNode = opts.selectEl.controller('mdSelectMenu').optNodeForKeyboardSearch(ev);
@@ -890,11 +888,9 @@ function SelectProvider($$interimElementProvider) {
           var newOption = opts.focusedNode = optionsArray[index];
           newOption && newOption.focus();
         }
-
         function focusNextOption() {
           focusOption('next');
         }
-
         function focusPrevOption() {
           focusOption('prev');
         }
@@ -1094,3 +1090,4 @@ function SelectProvider($$interimElementProvider) {
     } : { left: 0, top: 0, width: 0, height: 0 };
   }
 }
+

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -48,12 +48,11 @@ $select-max-visible-options: 5;
 
 md-input-container > md-select {
   margin: 0;
-  margin-top: 3px;
 }
 
 md-select {
-  padding: 24px 2px 26px;
   display: flex;
+  order: 2;
   &:focus {
     outline: none;
   }
@@ -65,14 +64,13 @@ md-select {
       cursor: pointer
     }
     &.ng-invalid.ng-dirty {
-      .md-select-label {
-        border-bottom-width: 2px;
-        border-bottom-style: solid;
+      .md-select-value {
+        border-bottom: 2px solid;
         padding-bottom: 0;
       }
     }
     &:focus {
-      .md-select-label {
+      .md-select-value {
         border-bottom-width: 2px;
         border-bottom-style: solid;
         padding-bottom: 0;
@@ -82,7 +80,7 @@ md-select {
 }
 
 
-.md-select-label {
+.md-select-value {
   display: flex;
   align-items: center;
   padding: 2px 2px 1px;
@@ -118,6 +116,17 @@ md-select {
     speak: none;
     transform: scaleY(0.6) scaleX(1);
   }
+
+  &.md-select-placeholder {
+    display: flex;
+    order: 1;
+    pointer-events: none;
+    -webkit-font-smoothing: antialiased;
+    padding-left: 2px;
+    z-index: 1;
+    color: rgba(0,0,0,0.26);
+  }
+
 }
 
 md-select-menu {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,17 +1,17 @@
-describe('<md-select>', function() {
+describe('<md-select>',function() {
 
   beforeEach(module('material.components.input'));
-  beforeEach(module('material.components.select', 'ngAnimateMock'));
+  beforeEach(module('material.components.select','ngAnimateMock'));
 
-  beforeEach(inject(function($mdUtil, $$q) {
+  beforeEach(inject(function($mdUtil,$$q) {
     $mdUtil.transitionEndPromise = function() {
       return $$q.when(true);
     };
   }));
 
-  function setupSelect(attrs, options, bNoLabel) {
+  function setupSelect(attrs,options,bNoLabel) {
     var el;
-    inject(function($compile, $rootScope) {
+    inject(function($compile,$rootScope) {
       var src = '<md-input-container>';
       if (!bNoLabel) {
         src += '<label>Label</label>';
@@ -25,9 +25,9 @@ describe('<md-select>', function() {
     return el;
   }
 
-  function setup(attrs, options) {
+  function setup(attrs,options) {
     var el;
-    inject(function($compile, $rootScope) {
+    inject(function($compile,$rootScope) {
       var optionsTpl = optTemplate(options);
       var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
         '</md-select-menu>';
@@ -37,9 +37,9 @@ describe('<md-select>', function() {
     return el;
   }
 
-  function setupMultiple(attrs, options) {
+  function setupMultiple(attrs,options) {
     attrs = (attrs || '') + ' multiple';
-    return setup(attrs, options);
+    return setup(attrs,options);
   }
 
   function optTemplate(options) {
@@ -71,7 +71,7 @@ describe('<md-select>', function() {
   }
 
 
-  function pressKey(el, code) {
+  function pressKey(el,code) {
     el.triggerHandler({
       type: 'keydown',
       keyCode: code
@@ -80,7 +80,7 @@ describe('<md-select>', function() {
 
   function waitForSelectOpen() {
     try {
-      inject(function($rootScope, $animate) {
+      inject(function($rootScope,$animate) {
         $rootScope.$digest();
         $animate.triggerCallbacks();
       });
@@ -90,7 +90,7 @@ describe('<md-select>', function() {
 
   function waitForSelectClose() {
     try {
-      inject(function($rootScope, $animate) {
+      inject(function($rootScope,$animate) {
         $rootScope.$apply();
         $animate.triggerCallbacks();
 
@@ -99,29 +99,29 @@ describe('<md-select>', function() {
     }
   }
 
-  it('should preserve tabindex', inject(function($document) {
+  it('should preserve tabindex',inject(function($document) {
     var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
     expect(select.attr('tabindex')).toBe('2');
   }));
 
-  it('supports non-disabled state', inject(function($document) {
+  it('supports non-disabled state',inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     expect(select.attr('aria-disabled')).toBe('false');
   }));
 
-  it('supports disabled state', inject(function($document) {
+  it('supports disabled state',inject(function($document) {
     var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
     openSelect(select);
     expect($document.find('md-select-menu').length).toBe(0);
     expect(select.attr('aria-disabled')).toBe('true');
   }));
 
-  it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
+  it('closes the menu if the element is destroyed',inject(function($document,$rootScope) {
     var called = false;
     $rootScope.onClose = function() {
       called = true;
     };
-    var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
+    var select = setupSelect('ng-model="val", md-on-close="onClose()"',[1,2,3]).find('md-select');
     openSelect(select);
 
     $document.find('md-option')[0].click();
@@ -130,24 +130,24 @@ describe('<md-select>', function() {
     expect(called).toBe(true);
   }));
 
-  it('restores focus to select when the menu is closed', inject(function($document) {
+  it('restores focus to select when the menu is closed',inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);
 
     $document[0].body.appendChild(select[0]);
 
     var selectMenu = $document.find('md-select-menu');
-    pressKey(selectMenu, 27);
+    pressKey(selectMenu,27);
     waitForSelectClose();
 
     expect($document[0].activeElement).toBe(select[0]);
     select.remove();
   }));
 
-  describe('input container', function() {
-    it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
+  describe('input container',function() {
+    it('should set has-value class on container for non-ng-model input',inject(function($rootScope) {
       $rootScope.model = 0;
-      var el = setupSelect('ng-model="$root.model"', [1, 2, 3]);
+      var el = setupSelect('ng-model="$root.model"',[1,2,3]);
       var select = el.find('md-select');
       expect(selectedOptions(select).length).toBe(0);
 
@@ -159,7 +159,7 @@ describe('<md-select>', function() {
       expect(el).toHaveClass('md-input-has-value');
     }));
 
-    it('should set has-value class on container for ng-model input', inject(function($rootScope) {
+    it('should set has-value class on container for ng-model input',inject(function($rootScope) {
       $rootScope.value = 'test';
       var el = setupSelect('ng-model="$root.value"');
       expect(el).toHaveClass('md-input-has-value');
@@ -171,28 +171,28 @@ describe('<md-select>', function() {
       expect(el).not.toHaveClass('md-input-has-value');
     }));
 
-    it('should match label to given input id', inject(function($rootScope) {
+    it('should match label to given input id',inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value", id="foo"');
       expect(el.find('label').attr('for')).toBe('foo');
       expect(el.find('md-select').attr('id')).toBe('foo');
     }));
 
-    it('should match label to automatic input id', inject(function($rootScope) {
+    it('should match label to automatic input id',inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value"');
       expect(el.find('md-select').attr('id')).toBeTruthy();
       expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
     }));
   });
 
-  describe('label behavior', function() {
-    it('defaults to the placeholder text', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+  describe('label behavior',function() {
+    it('defaults to the placeholder text',function() {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"',null,true).find('md-select');
       var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
       expect(label.hasClass('md-select-placeholder')).toBe(true);
     });
 
-    it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
+    it('sets itself to the selected option\'s label',inject(function($rootScope,$compile) {
       $rootScope.val = 2;
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
@@ -209,8 +209,8 @@ describe('<md-select>', function() {
       expect(label.hasClass('md-select-placeholder')).toBe(false);
     }));
 
-    it('supports rendering multiple', inject(function($rootScope, $compile) {
-      $rootScope.val = [1, 3];
+    it('supports rendering multiple',inject(function($rootScope,$compile) {
+      $rootScope.val = [1,3];
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
       '<md-select multiple ng-model="val" placeholder="Hello World">' +
@@ -227,22 +227,22 @@ describe('<md-select>', function() {
     }));
   });
 
-  it('auto-infers a value when none specified', inject(function($rootScope) {
+  it('auto-infers a value when none specified',inject(function($rootScope) {
     $rootScope.name = "Hannah";
-    var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
+    var el = setup('ng-model="name"','<md-option>Tom</md-option>' +
     '<md-option>Hannah</md-option>');
     expect(selectedOptions(el).length).toBe(1);
   }));
 
-  it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
+  it('errors for duplicate md-options, non-dynamic value',inject(function($rootScope) {
     expect(function() {
-      setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
+      setup('ng-model="$root.model"','<md-option value="a">Hello</md-option>' +
       '<md-option value="a">Goodbye</md-option>');
     }).toThrow();
   }));
 
-  it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
-    setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
+  it('errors for duplicate md-options, ng-value',inject(function($rootScope) {
+    setup('ng-model="$root.model"','<md-option ng-value="foo">Hello</md-option>' +
     '<md-option ng-value="bar">Goodbye</md-option>');
     $rootScope.$apply('foo = "a"');
     expect(function() {
@@ -250,37 +250,37 @@ describe('<md-select>', function() {
     }).toThrow();
   }));
 
-  it('watches the collection for changes', inject(function($rootScope) {
+  it('watches the collection for changes',inject(function($rootScope) {
     $rootScope.val = 1;
-    var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
+    var select = setupSelect('ng-model="val"',[1,2,3]).find('md-select');
     var label = select.find('md-select-value')[0];
     expect(label.textContent).toBe('1');
     $rootScope.val = 4;
-    $rootScope.$$values = [4, 5, 6];
+    $rootScope.$$values = [4,5,6];
     $rootScope.$digest();
     expect(label.textContent).toBe('4');
   }));
 
-  describe('non-multiple', function() {
+  describe('non-multiple',function() {
 
-    describe('model->view', function() {
+    describe('model->view',function() {
 
-      it('renders initial model value', inject(function($rootScope) {
+      it('renders initial model value',inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"',['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
       }));
 
-      it('renders nothing if no initial value is set', function() {
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+      it('renders nothing if no initial value is set',function() {
+        var el = setup('ng-model="$root.model"',['a','b','c']);
         expect(selectedOptions(el).length).toBe(0);
       });
 
-      it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
+      it('renders model change by selecting new and deselecting old',inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"',['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -290,9 +290,9 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(1);
       }));
 
-      it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
+      it('renders invalid model change by deselecting old and selecting nothing',inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"',['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -301,9 +301,9 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
+      it('renders model change to undefined by deselecting old and selecting nothing',inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"',['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -312,10 +312,10 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('uses track by if given to compare objects', inject(function($rootScope) {
+      it('uses track by if given to compare objects',inject(function($rootScope) {
         $rootScope.$apply('model = {id:2}');
         var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1}, {id: 2}, {id: 3}]);
+          [{id: 1},{id: 2},{id: 3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -326,10 +326,10 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects', inject(function($rootScope) {
-        var one = {}, two = {}, three = {};
+      it('uses uid by default to compare objects',inject(function($rootScope) {
+        var one = {},two = {},three = {};
         $rootScope.model = two;
-        var el = setup('ng-model="$root.model"', [one, two, three]);
+        var el = setup('ng-model="$root.model"',[one,two,three]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -341,11 +341,11 @@ describe('<md-select>', function() {
 
     });
 
-    describe('view->model', function() {
+    describe('view->model',function() {
 
-      it('should do nothing if clicking selected option', inject(function($rootScope) {
+      it('should do nothing if clicking selected option',inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+        var el = setup('ng-model="$root.model"',[1,2,3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -359,13 +359,13 @@ describe('<md-select>', function() {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should support the ng-change event', inject(function($rootScope, $document) {
+      it('should support the ng-change event',inject(function($rootScope,$document) {
         var changeCalled = false;
         $rootScope.changed = function() {
           changeCalled = true;
         };
 
-        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
+        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"',[1,2,3]).find('md-select');
         openSelect(selectEl);
 
         var menuEl = $document.find('md-select-menu');
@@ -376,9 +376,9 @@ describe('<md-select>', function() {
         expect(changeCalled).toBe(true);
       }));
 
-      it('should deselect old and select new on click', inject(function($rootScope) {
+      it('should deselect old and select new on click',inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+        var el = setup('ng-model="$root.model"',[1,2,3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -392,10 +392,10 @@ describe('<md-select>', function() {
         expect($rootScope.model).toBe(2);
       }));
 
-      it('should keep model value if selected option is removed', inject(function($rootScope) {
+      it('should keep model value if selected option is removed',inject(function($rootScope) {
         $rootScope.model = 3;
-        $rootScope.values = [1, 2, 3];
-        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+        $rootScope.values = [1,2,3];
+        var el = setup('ng-model="$root.model"','<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -407,10 +407,10 @@ describe('<md-select>', function() {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
+      it('should select an option that was just added matching the modelValue',inject(function($rootScope) {
         $rootScope.model = 4;
-        $rootScope.values = [1, 2, 3];
-        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+        $rootScope.values = [1,2,3];
+        var el = setup('ng-model="$root.model"','<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(0);
 
@@ -425,31 +425,31 @@ describe('<md-select>', function() {
     });
   });
 
-  describe('multiple', function() {
+  describe('multiple',function() {
 
-    describe('model->view', function() {
+    describe('model->view',function() {
 
-      it('renders initial model value', inject(function($rootScope) {
-        $rootScope.model = [1, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+      it('renders initial model value',inject(function($rootScope) {
+        $rootScope.model = [1,3];
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
       }));
 
-      it('renders nothing if empty array is set', inject(function($rootScope) {
+      it('renders nothing if empty array is set',inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding a valid value to the model selects its option', inject(function($rootScope) {
+      it('adding a valid value to the model selects its option',inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -461,12 +461,12 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([2]);
       }));
 
-      it('removing a valid value from the model deselects its option', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+      it('removing a valid value from the model deselects its option',inject(function($rootScope) {
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model.shift()');
 
@@ -475,12 +475,12 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([3]);
       }));
 
-      it('deselects all options when setting to an empty model', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+      it('deselects all options when setting to an empty model',inject(function($rootScope) {
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model = []');
 
@@ -488,12 +488,12 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+      it('adding multiple valid values to a model selects their options',inject(function($rootScope) {
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model = model.concat([1,4])');
 
@@ -502,15 +502,15 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([2, 3, 1, 4]);
+        expect($rootScope.model).toEqual([2,3,1,4]);
       }));
 
-      it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
-        $rootScope.model = [2, 4, 5, 6];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+      it('correctly selects and deselects options for complete reassignment of model',inject(function($rootScope) {
+        $rootScope.model = [2,4,5,6];
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4,5,6]);
 
         expect(selectedOptions(el).length).toBe(4);
-        expect($rootScope.model).toEqual([2, 4, 5, 6]);
+        expect($rootScope.model).toEqual([2,4,5,6]);
 
         $rootScope.$apply('model = [1,2,3]');
 
@@ -518,13 +518,13 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 2, 3]);
+        expect($rootScope.model).toEqual([1,2,3]);
       }));
 
-      it('does not select any options if the models value does not match an option', inject(function($rootScope) {
+      it('does not select any options if the models value does not match an option',inject(function($rootScope) {
         $rootScope.model = [];
         $rootScope.obj = {};
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4,5,6]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -532,13 +532,13 @@ describe('<md-select>', function() {
         $rootScope.$apply('model = ["bar", obj]');
 
         expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
+        expect($rootScope.model).toEqual(["bar",$rootScope.obj]);
       }));
 
-      it('uses track by if given to compare objects', inject(function($rootScope) {
+      it('uses track by if given to compare objects',inject(function($rootScope) {
         $rootScope.$apply('model = [{id:2}]');
         var el = setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1}, {id: 2}, {id: 3}]);
+          [{id: 1},{id: 2},{id: 3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -550,10 +550,10 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects', inject(function($rootScope) {
-        var one = {}, two = {}, three = {};
+      it('uses uid by default to compare objects',inject(function($rootScope) {
+        var one = {},two = {},three = {};
         $rootScope.model = [two];
-        var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
+        var el = setupMultiple('ng-model="$root.model"',[one,two,three]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -563,9 +563,9 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
+      it('errors the model if model value is truthy and not an array',inject(function($rootScope) {
         $rootScope.model = 'string';
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2,3]);
         var ngModelCtrl = el.controller('ngModel');
 
         expect(ngModelCtrl.$error['md-multiple']).toBe(true);
@@ -576,11 +576,11 @@ describe('<md-select>', function() {
 
     });
 
-    describe('view->model', function() {
+    describe('view->model',function() {
 
-      it('should deselect a selected option on click', inject(function($rootScope) {
+      it('should deselect a selected option on click',inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -594,9 +594,9 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('selects a deselected option on click', inject(function($rootScope) {
+      it('selects a deselected option on click',inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+        var el = setupMultiple('ng-model="$root.model"',[1,2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -607,12 +607,12 @@ describe('<md-select>', function() {
         });
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([1, 2]);
+        expect($rootScope.model).toEqual([1,2]);
       }));
 
-      it('should keep model value if a selected option is removed', inject(function($rootScope) {
+      it('should keep model value if a selected option is removed',inject(function($rootScope) {
         $rootScope.model = [1];
-        $rootScope.values = [1, 2];
+        $rootScope.values = [1,2];
         var el = setupMultiple('ng-model="$root.model"',
           '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
@@ -625,40 +625,40 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([1]);
       }));
 
-      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-        $rootScope.model = [1, 3];
-        $rootScope.values = [1, 2];
+      it('should select an option that was just added matching the modelValue',inject(function($rootScope) {
+        $rootScope.model = [1,3];
+        $rootScope.values = [1,2];
         var el = setupMultiple('ng-model="$root.model"',
           '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
 
         $rootScope.$apply('values.push(3)');
 
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
       }));
 
     });
   });
 
-  describe('aria', function() {
+  describe('aria',function() {
     var el;
-    beforeEach(inject(function($q, $document) {
-      el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+    beforeEach(inject(function($q,$document) {
+      el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
       var selectMenus = $document.find('md-select-menu');
       selectMenus.remove();
     }));
 
-    it('adds an aria-label from placeholder', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+    it('adds an aria-label from placeholder',function() {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"',null,true).find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     });
 
-    it('preserves aria-label on value change', inject(function($rootScope, $compile) {
+    it('preserves aria-label on value change',inject(function($rootScope,$compile) {
       var select = $compile('<md-input-container>' +
       '<label>Pick</label>' +
       '<md-select ng-model="val">' +
@@ -673,14 +673,14 @@ describe('<md-select>', function() {
       expect(select.attr('aria-label')).toBe('Pick');
     }));
 
-    it('preserves existing aria-label', inject(function($rootScope) {
+    it('preserves existing aria-label',inject(function($rootScope) {
       var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     }));
 
-    it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
-      spyOn($log, 'warn');
-      var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
+    it('should expect an aria-label if none is present',inject(function($compile,$rootScope,$log) {
+      spyOn($log,'warn');
+      var select = setupSelect('ng-model="someVal"',null,true).find('md-select');
       $rootScope.$apply();
       expect($log.warn).toHaveBeenCalled();
 
@@ -690,24 +690,24 @@ describe('<md-select>', function() {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('sets up the aria-expanded attribute', inject(function($document) {
+    it('sets up the aria-expanded attribute',inject(function($document) {
       expect(el.attr('aria-expanded')).toBe('false');
       openSelect(el);
       expect(el.attr('aria-expanded')).toBe('true');
 
       var selectMenu = $document.find('md-select-menu');
-      pressKey(selectMenu, 27);
+      pressKey(selectMenu,27);
       waitForSelectClose();
       expect(el.attr('aria-expanded')).toBe('false');
     }));
-    it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
-      $rootScope.model = [1, 3];
-      var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
+    it('sets up the aria-multiselectable attribute',inject(function($document,$rootScope) {
+      $rootScope.model = [1,3];
+      var el = setupMultiple('ng-model="$root.model"',[1,2,3]);
 
       expect(el.attr('aria-multiselectable')).toBe('true');
     }));
-    it('sets up the aria-selected attribute', inject(function($rootScope) {
-      var el = setup('ng-model="$root.model"', [1, 2, 3]);
+    it('sets up the aria-selected attribute',inject(function($rootScope) {
+      var el = setup('ng-model="$root.model"',[1,2,3]);
       var options = el.find('md-option');
       expect(options.eq(2).attr('aria-selected')).toBe('false');
       el.triggerHandler({
@@ -718,7 +718,7 @@ describe('<md-select>', function() {
     }));
   });
 
-  describe('keyboard controls', function() {
+  describe('keyboard controls',function() {
 
 
     afterEach(inject(function($document) {
@@ -726,53 +726,53 @@ describe('<md-select>', function() {
       selectMenus.remove();
     }));
 
-    describe('md-select', function() {
-      it('can be opened with a space key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-        pressKey(el, 32);
+    describe('md-select',function() {
+      it('can be opened with a space key',inject(function($document) {
+        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+        pressKey(el,32);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with an enter key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-        pressKey(el, 13);
+      it('can be opened with an enter key',inject(function($document) {
+        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+        pressKey(el,13);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the up key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-        pressKey(el, 38);
+      it('can be opened with the up key',inject(function($document) {
+        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+        pressKey(el,38);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the down key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-        pressKey(el, 40);
+      it('can be opened with the down key',inject(function($document) {
+        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+        pressKey(el,40);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('supports typing an option name', inject(function($document, $rootScope) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-        pressKey(el, 50);
+      it('supports typing an option name',inject(function($document,$rootScope) {
+        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+        pressKey(el,50);
         expect($rootScope.someModel).toBe(2);
       }));
     });
 
-    describe('md-select-menu', function() {
-      it('can be closed with escape', inject(function($document, $rootScope, $animate) {
-        var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
+    describe('md-select-menu',function() {
+      it('can be closed with escape',inject(function($document,$rootScope,$animate) {
+        var el = setupSelect('ng-model="someVal"',[1,2,3]).find('md-select');
         openSelect(el);
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
-        pressKey(selectMenu, 27);
+        pressKey(selectMenu,27);
         waitForSelectClose();
         expect($document.find('md-select-menu').length).toBe(0);
       }));

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,748 +1,778 @@
 describe('<md-select>', function() {
 
-  beforeEach(module('material.components.select', 'ngAnimateMock'));
+    beforeEach(module('material.components.input'));
+    beforeEach(module('material.components.select', 'ngAnimateMock'));
 
-  beforeEach(inject(function($mdUtil, $$q) {
-    $mdUtil.transitionEndPromise = function() {
-      return $$q.when(true);
-    };
-  }));
-
-  function setupSelect(attrs, options) {
-    var el;
-    inject(function($compile, $rootScope) {
-      var src = '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select>';
-      var template = angular.element(src);
-      el = $compile(template)($rootScope);
-      $rootScope.$digest();
-      $rootScope.$digest();
-    });
-    return el;
-  }
-
-  function setup(attrs, options) {
-    var el;
-    inject(function($compile, $rootScope) {
-      var optionsTpl = optTemplate(options);
-      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
-               '</md-select-menu>';
-      el = $compile(fullTpl)($rootScope);
-      $rootScope.$apply();
-    });
-    return el;
-  }
-
-  function setupMultiple(attrs, options) {
-    attrs = (attrs || '') + ' multiple';
-    return setup(attrs, options);
-  }
-
-  function optTemplate(options) {
-    var optionsTpl = '';
-    inject(function($rootScope) {
-      if (angular.isArray(options)) {
-        $rootScope.$$values = options;
-        optionsTpl = '<md-option ng-repeat="value in $$values" ng-value="value">{{value}}</md-option>';
-      } else if (angular.isString(options)) {
-        optionsTpl = options;
-      }
-    });
-    return optionsTpl;
-  }
-
-  function selectedOptions(el) {
-    return angular.element(el[0].querySelectorAll('md-option[selected]'));
-  }
-
-  function openSelect(el) {
-    try {
-      el.triggerHandler('click');
-      waitForSelectOpen();
-      inject(function($timeout) {
-        $timeout.flush();
-      });
-    } catch(e) { }
-  }
-
-
-  function pressKey(el, code) {
-      el.triggerHandler({
-        type: 'keydown',
-        keyCode: code
-      });
-  }
-
-  function waitForSelectOpen() {
-    try {
-      inject(function($rootScope, $animate) {
-          $rootScope.$digest();
-          $animate.triggerCallbacks();
-      });
-    } catch(e) { }
-  }
-
-  function waitForSelectClose() {
-    try {
-      inject(function($rootScope, $animate ) {
-        $rootScope.$apply();
-        $animate.triggerCallbacks();
-
-      });
-    } catch(e) { }
-  }
-
-  it('should preserve tabindex', inject(function($document) {
-    var select = setupSelect('tabindex="2", ng-model="val"');
-    expect(select.attr('tabindex')).toBe('2');
-  }));
-
-  it('supports non-disabled state', inject(function($document) {
-    var select = setupSelect('ng-model="val"');
-    expect(select.attr('aria-disabled')).toBe('false');
-  }));
-
-  it('supports disabled state', inject(function($document) {
-    var select = setupSelect('disabled="disabled", ng-model="val"');
-    openSelect(select);
-    expect($document.find('md-select-menu').length).toBe(0);
-    expect(select.attr('aria-disabled')).toBe('true');
-  }));
-
-  it('calls the md-on-close fn on close', inject(function($document, $rootScope) {
-    var called = false;
-    $rootScope.onClose = function() {
-      called = true;
-    };
-    var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]);
-    openSelect(select);
-
-    $document.find('md-option')[0].click();
-    waitForSelectClose();
-
-    expect(called).toBe(true);
-  }));
-
-  xit('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
-    var select = setupSelect('ng-model="val"');
-
-    openSelect(select);
-    expect($document.find('md-select-menu').length).toBe(1);
-
-    select.scope().$destroy();
-    waitForSelectClose();
-
-    expect($document.find('md-select-menu').length).toBe(0);
-  }));
-
-  it('restores focus to select when the menu is closed', inject(function($document) {
-    var select = setupSelect('ng-model="val"');
-    openSelect(select);
-
-    $document[0].body.appendChild(select[0]);
-
-    var selectMenu = $document.find('md-select-menu');
-    pressKey(selectMenu, 27);
-    waitForSelectClose();
-
-    expect($document[0].activeElement).toBe(select[0]);
-    select.remove();
-  }));
-
-  describe('label behavior', function() {
-    it('defaults to the placeholder text', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"');
-      var label = select.find('md-select-label');
-      expect(label.text()).toBe('Hello world');
-      expect(label.hasClass('md-placeholder')).toBe(true);
-    });
-
-    it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
-      $rootScope.val = 2;
-      var select = $compile('<md-select ng-model="val" placeholder="Hello World">' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      var label = select.find('md-select-label');
-      $rootScope.$digest();
-
-      expect(label.text()).toBe('Two');
-      expect(label.hasClass('md-placeholder')).toBe(false);
+    beforeEach(inject(function($mdUtil, $$q) {
+        $mdUtil.transitionEndPromise = function() {
+            return $$q.when(true);
+        };
     }));
 
-    it('supports rendering multiple', inject(function($rootScope, $compile) {
-      $rootScope.val = [1, 3];
-      var select = $compile('<md-select multiple ng-model="val" placeholder="Hello World">' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      var label = select.find('md-select-label');
-      $rootScope.$digest();
-
-      expect(label.text()).toBe('One, Three');
-      expect(label.hasClass('md-placeholder')).toBe(false);
-    }));
-  });
-
-  it('auto-infers a value when none specified', inject(function($rootScope) {
-      $rootScope.name = "Hannah";
-      var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
-            '<md-option>Hannah</md-option>');
-      expect(selectedOptions(el).length).toBe(1);
-  }));
-
-  it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
-    expect(function() {
-      setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
-            '<md-option value="a">Goodbye</md-option>');
-    }).toThrow();
-  }));
-
-  it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
-    setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
-          '<md-option ng-value="bar">Goodbye</md-option>');
-    $rootScope.$apply('foo = "a"');
-    expect(function() {
-      $rootScope.$apply('bar = "a"');
-    }).toThrow();
-  }));
-
-  it('watches the collection for changes', inject(function($rootScope) {
-    $rootScope.val = 1;
-    var select = setupSelect('ng-model="val"', [1, 2, 3]);
-    var label = select.find('md-select-label')[0];
-    expect(label.textContent).toBe('1');
-    $rootScope.val = 4;
-    $rootScope.$$values = [4, 5, 6];
-    $rootScope.$digest();
-    expect(label.textContent).toBe('4');
-  }));
-
-  describe('non-multiple', function() {
-
-    describe('model->view', function() {
-
-      it('renders initial model value', inject(function($rootScope) {
-        $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-      }));
-
-      it('renders nothing if no initial value is set', function() {
-        var el = setup('ng-model="$root.model"', ['a','b','c']);
-        expect(selectedOptions(el).length).toBe(0);
-      });
-
-      it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
-        $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = "c"');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect(selectedOptions(el).length).toBe(1);
-      }));
-
-      it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
-        $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a','b','c']);
-        
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = "d"');
-        expect(selectedOptions(el).length).toBe(0);
-      }));
-
-      it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
-        $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a','b','c']);
-        
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = undefined');
-        expect(selectedOptions(el).length).toBe(0);
-      }));
-
-      it('uses track by if given to compare objects', inject(function($rootScope) {
-        $rootScope.$apply('model = {id:2}');
-        var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-            [{id:1}, {id:2}, {id:3}]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = {id: 3}');
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-      }));
-
-      it('uses uid by default to compare objects', inject(function($rootScope) {
-        var one = {}, two = {}, three = {};
-        $rootScope.model = two;
-        var el = setup('ng-model="$root.model"', [one, two, three]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = {}');
-
-        expect(selectedOptions(el).length).toBe(0);
-      }));
-
-    });
-
-    describe('view->model', function() {
-
-      it('should do nothing if clicking selected option', inject(function($rootScope) {
-        $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1,2,3]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
-        el.triggerHandler({
-          type: 'click',
-          target: el.find('md-option')[2]
+    function setupSelect(attrs, options, bNoLabel) {
+        var el;
+        inject(function($compile, $rootScope) {
+            var src = '<md-input-container>';
+            if (!bNoLabel) {
+                src += '<label>Label</label>';
+            }
+            src += '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select></md-input-container>';
+            var template = angular.element(src);
+            el = $compile(template)($rootScope);
+            $rootScope.$digest();
+            $rootScope.$digest();
         });
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toBe(3);
-      }));
+        return el;
+    }
 
-      it('should support the ng-change event', inject(function($rootScope, $document) {
-          var changeCalled = false;
-          $rootScope.changed = function() {
-            changeCalled = true;
-          };
-
-          var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]);
-          openSelect(selectEl);
-
-          var menuEl = $document.find('md-select-menu');
-          menuEl.triggerHandler({
-            type: 'click',
-            target: menuEl.find('md-option')[1]
-          });
-          expect(changeCalled).toBe(true);
-      }));
-
-      it('should deselect old and select new on click', inject(function($rootScope) {
-        $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1,2,3]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        
-        el.triggerHandler({
-          type: 'click',
-          target: el.find('md-option')[1]
+    function setup(attrs, options) {
+        var el;
+        inject(function($compile, $rootScope) {
+            var optionsTpl = optTemplate(options);
+            var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
+                '</md-select-menu>';
+            el = $compile(fullTpl)($rootScope);
+            $rootScope.$apply();
         });
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-        expect($rootScope.model).toBe(2);
-      }));
+        return el;
+    }
 
-      it('should keep model value if selected option is removed', inject(function($rootScope) {
-        $rootScope.model = 3;
-        $rootScope.values = [1,2,3];
-        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+    function setupMultiple(attrs, options) {
+        attrs = (attrs || '') + ' multiple';
+        return setup(attrs, options);
+    }
 
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('values.pop()');
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect(el.find('md-option').length).toBe(2);
-        expect($rootScope.model).toBe(3);
-      }));
-
-      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-        $rootScope.model = 4;
-        $rootScope.values = [1,2,3];
-        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-        expect(selectedOptions(el).length).toBe(0);
-
-        $rootScope.$apply('values.unshift(4)');
-
-        expect(el.find('md-option').length).toBe(4);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toBe(4);
-      }));
-
-    });
-  });
-
-  describe('multiple', function() {
-
-    describe('model->view', function() {
-
-      it('renders initial model value', inject(function($rootScope) {
-        $rootScope.model = [1,3];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-        
-        expect(selectedOptions(el).length).toBe(2);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,3]);
-      }));
-
-      it('renders nothing if empty array is set', inject(function($rootScope) {
-        $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([]);
-      }));
-
-      it('adding a valid value to the model selects its option', inject(function($rootScope) {
-        $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([]);
-
-        $rootScope.$apply('model.push(2)');
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([2]);
-      }));
-      
-      it('removing a valid value from the model deselects its option', inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-        expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
-
-        $rootScope.$apply('model.shift()');
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([3]);
-      }));
-
-      it('deselects all options when setting to an empty model', inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-        expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
-
-        $rootScope.$apply('model = []');
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([]);
-      }));
-
-      it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-        expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
-
-        $rootScope.$apply('model = model.concat([1,4])');
-
-        expect(selectedOptions(el).length).toBe(4);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([2,3,1,4]);
-      }));
-
-      it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
-        $rootScope.model = [2,4,5,6];
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
-
-        expect(selectedOptions(el).length).toBe(4);
-        expect($rootScope.model).toEqual([2,4,5,6]);
-
-        $rootScope.$apply('model = [1,2,3]');
-
-        expect(selectedOptions(el).length).toBe(3);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,2,3]);
-      }));
-
-      it('does not select any options if the models value does not match an option', inject(function($rootScope) {
-        $rootScope.model = [];
-        $rootScope.obj = {};
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([]);
-
-        $rootScope.$apply('model = ["bar", obj]');
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
-      }));
-
-      it('uses track by if given to compare objects', inject(function($rootScope) {
-        $rootScope.$apply('model = [{id:2}]');
-        var el=setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-            [{id:1}, {id:2}, {id:3}]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model.push({id: 3}); model.push({id:1}); model.shift();');
-
-        expect(selectedOptions(el).length).toBe(2);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-      }));
-
-      it('uses uid by default to compare objects', inject(function($rootScope) {
-        var one = {}, two = {}, three = {};
-        $rootScope.model = [two];
-        var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-        $rootScope.$apply('model = [{}]');
-
-        expect(selectedOptions(el).length).toBe(0);
-      }));
-
-      it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
-        $rootScope.model = 'string';
-        var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
-        var ngModelCtrl = el.controller('ngModel');
-
-        expect(ngModelCtrl.$error['md-multiple']).toBe(true);
-
-        $rootScope.$apply('model = []');
-        expect(ngModelCtrl.$valid).toBe(true);
-      }));
-
-    });
-
-    describe('view->model', function() {
-
-      it('should deselect a selected option on click', inject(function($rootScope) {
-        $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1,2]);
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1]);
-
-        el.triggerHandler({
-          type: 'click',
-          target: el.find('md-option')[0]
+    function optTemplate(options) {
+        var optionsTpl = '';
+        inject(function($rootScope) {
+            if (angular.isArray(options)) {
+                $rootScope.$$values = options;
+                optionsTpl = '<md-option ng-repeat="value in $$values" ng-value="value">{{value}}</md-option>';
+            } else if (angular.isString(options)) {
+                optionsTpl = options;
+            }
         });
+        return optionsTpl;
+    }
 
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([]);
-      }));
-      
-      it('selects a deselected option on click', inject(function($rootScope) {
-        $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1,2]);
+    function selectedOptions(el) {
+        return angular.element(el[0].querySelectorAll('md-option[selected]'));
+    }
 
-        expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1]);
+    function openSelect(el) {
+        try {
+            el.triggerHandler('click');
+            waitForSelectOpen();
+            inject(function($timeout) {
+                $timeout.flush();
+            });
+        } catch(e) { }
+    }
 
+
+    function pressKey(el, code) {
         el.triggerHandler({
-          type: 'click',
-          target: el.find('md-option')[1]
+            type: 'keydown',
+            keyCode: code
         });
+    }
 
-        expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([1,2]);
-      }));
+    function waitForSelectOpen() {
+        try {
+            inject(function($rootScope, $animate) {
+                $rootScope.$digest();
+                $animate.triggerCallbacks();
+            });
+        } catch(e) { }
+    }
 
-      it('should keep model value if a selected option is removed', inject(function($rootScope) {
-        $rootScope.model = [1];
-        $rootScope.values = [1,2];
-        var el = setupMultiple('ng-model="$root.model"', 
-            '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+    function waitForSelectClose() {
+        try {
+            inject(function($rootScope, $animate ) {
+                $rootScope.$apply();
+                $animate.triggerCallbacks();
 
-        expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1]);
+            });
+        } catch(e) { }
+    }
 
-        $rootScope.$apply('values.shift()');
-
-        expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual([1]);
-      }));
-     
-      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-        $rootScope.model = [1,3];
-        $rootScope.values = [1,2];
-        var el = setupMultiple('ng-model="$root.model"', 
-            '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-        expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1,3]);
-
-        $rootScope.$apply('values.push(3)');
-
-        expect(selectedOptions(el).length).toBe(2);
-        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,3]);
-      }));
-
-    });
-  });
-
-  describe('aria', function() {
-    var el;
-    beforeEach(inject(function($q, $document) {
-      el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-      var selectMenus = $document.find('md-select-menu');
-      selectMenus.remove();
+    it('should preserve tabindex', inject(function($document) {
+        var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
+        expect(select.attr('tabindex')).toBe('2');
     }));
 
-    it('adds an aria-label from placeholder', function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"');
-      expect(select.attr('aria-label')).toBe('Hello world');
-    });
-
-    it('adds aria-label from label element', inject(function($rootScope, $compile) {
-      var select = $compile('<md-select ng-model="val">' +
-                              '<md-select-label>{{"Pick"}}</md-select-label>' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      $rootScope.$digest();
-      expect(select.attr('aria-label')).toBe('Pick');
+    it('supports non-disabled state', inject(function($document) {
+        var select = setupSelect('ng-model="val"' ).find('md-select');
+        expect(select.attr('aria-disabled')).toBe('false');
     }));
 
-    it('preserves aria-label on value change', inject(function($rootScope, $compile) {
-      var select = $compile('<md-select ng-model="val">' +
-                              '<md-select-label>Pick</md-select-label>' +
-                              '<md-option value="1">One</md-option>' +
-                              '<md-option value="2">Two</md-option>' +
-                              '<md-option value="3">Three</md-option>' +
-                            '</md-select>')($rootScope);
-      $rootScope.$apply('model = 1');
-      $rootScope.$digest();
-
-      expect(select.attr('aria-label')).toBe('Pick');
+    it('supports disabled state', inject(function($document) {
+        var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
+        openSelect(select);
+        expect($document.find('md-select-menu').length).toBe(0);
+        expect(select.attr('aria-disabled')).toBe('true');
     }));
 
-    it('preserves existing aria-label', inject(function($rootScope) {
-      var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"');
-      expect(select.attr('aria-label')).toBe('Hello world');
-    }));
+    it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
+      var called = false;
+      $rootScope.onClose = function() {
+        called = true;
+      };
+      var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
+      openSelect(select);
 
-    it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
-      spyOn($log, 'warn');
-      var select = setupSelect('ng-model="someVal"');
-      $rootScope.$apply();
-      expect($log.warn).toHaveBeenCalled();
-
-      $log.warn.calls.reset();
-      select = setupSelect('ng-model="someVal", aria-label="Hello world"');
-      $rootScope.$apply();
-      expect($log.warn).not.toHaveBeenCalled();
-    }));
-
-    it('sets up the aria-expanded attribute', inject(function($document) {
-      expect(el.attr('aria-expanded')).toBe('false');
-      openSelect(el);
-      expect(el.attr('aria-expanded')).toBe('true');
-
-      var selectMenu = $document.find('md-select-menu');
-      pressKey(selectMenu, 27);
+      $document.find('md-option')[0].click();
       waitForSelectClose();
-      expect(el.attr('aria-expanded')).toBe('false');
-    }));
-    it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
-      $rootScope.model = [1,3];
-      var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
 
-      expect(el.attr('aria-multiselectable')).toBe('true');
-    }));
-    it('sets up the aria-selected attribute', inject(function($rootScope) {
-      var el = setup('ng-model="$root.model"', [1,2,3]);
-      var options = el.find('md-option');
-      expect(options.eq(2).attr('aria-selected')).toBe('false');
-      el.triggerHandler({
-        type: 'click',
-        target: el.find('md-option')[2]
-      });
-      expect(options.eq(2).attr('aria-selected')).toBe('true');
-    }));
-  });
-
-  describe('keyboard controls', function() {
-
-
-    afterEach(inject(function($document) {
-      var selectMenus = $document.find('md-select-menu');
-      selectMenus.remove();
+      expect(called).toBe(true);
     }));
 
-    describe('md-select', function() {
-      it('can be opened with a space key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-        pressKey(el, 32);
-        waitForSelectOpen();
-        var selectMenu = angular.element($document.find('md-select-menu'));
-        expect(selectMenu.length).toBe(1);
-      }));
+    it('restores focus to select when the menu is closed', inject(function($document) {
+        var select = setupSelect('ng-model="val"').find('md-select');
+        openSelect(select);
 
-      it('can be opened with an enter key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-        pressKey(el, 13);
-        waitForSelectOpen();
-        var selectMenu = angular.element($document.find('md-select-menu'));
-        expect(selectMenu.length).toBe(1);
-      }));
+        $document[0].body.appendChild(select[0]);
 
-      it('can be opened with the up key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-        pressKey(el, 38);
-        waitForSelectOpen();
-        var selectMenu = angular.element($document.find('md-select-menu'));
-        expect(selectMenu.length).toBe(1);
-      }));
-
-      it('can be opened with the down key', inject(function($document) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-        pressKey(el, 40);
-        waitForSelectOpen();
-        var selectMenu = angular.element($document.find('md-select-menu'));
-        expect(selectMenu.length).toBe(1);
-      }));
-
-      it('supports typing an option name', inject(function($document, $rootScope) {
-        var el = setupSelect('ng-model="someModel"', [1, 2, 3]);
-        pressKey(el, 50);
-        expect($rootScope.someModel).toBe(2);
-      }));
-    });
-
-    describe('md-select-menu', function() {
-      it('can be closed with escape', inject(function($document, $rootScope, $animate) {
-        var el = setupSelect('ng-model="someVal"', [1, 2, 3]);
-        openSelect(el);
-        var selectMenu = angular.element($document.find('md-select-menu'));
-        expect(selectMenu.length).toBe(1);
+        var selectMenu = $document.find('md-select-menu');
         pressKey(selectMenu, 27);
         waitForSelectClose();
-        expect($document.find('md-select-menu').length).toBe(0);
-      }));
+
+        expect($document[0].activeElement).toBe(select[0]);
+        select.remove();
+    }));
+
+    describe('input container', function () {
+        it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
+            $rootScope.model = 0;
+            var el = setupSelect('ng-model="$root.model"', [1,2,3] );
+            var select = el.find('md-select');
+            expect(selectedOptions(select).length).toBe(0);
+
+            el.triggerHandler({
+                type: 'click',
+                target: select.find('md-option')[1]
+            });
+
+            expect(el).toHaveClass('md-input-has-value');
+        }));
+
+        it('should set has-value class on container for ng-model input', inject(function($rootScope) {
+            $rootScope.value = 'test';
+            var el = setupSelect('ng-model="$root.value"');
+            expect(el).toHaveClass('md-input-has-value');
+
+            $rootScope.$apply('value = "3"');
+            expect(el).toHaveClass('md-input-has-value');
+
+            $rootScope.$apply('value = null');
+            expect(el).not.toHaveClass('md-input-has-value');
+        }));
+
+        it('should match label to given input id', inject(function($rootScope) {
+            var el = setupSelect('ng-model="$root.value", id="foo"');
+            expect(el.find('label').attr('for')).toBe('foo');
+            expect(el.find('md-select').attr('id')).toBe('foo');
+        }));
+
+        it('should match label to automatic input id', inject(function($rootScope) {
+            var el = setupSelect('ng-model="$root.value"');
+            expect(el.find('md-select').attr('id')).toBeTruthy();
+            expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
+        }));
     });
-  });
+
+    describe('label behavior', function() {
+        it('defaults to the placeholder text', function() {
+            var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+            var label = select.find('md-select-value');
+            expect(label.text()).toBe('Hello world');
+            expect(label.hasClass('md-select-placeholder')).toBe(true);
+        });
+
+        it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
+            $rootScope.val = 2;
+            var select = $compile('<md-input-container>' +
+            '<label>Label</label>' +
+            '<md-select ng-model="val" placeholder="Hello World">' +
+            '<md-option value="1">One</md-option>' +
+            '<md-option value="2">Two</md-option>' +
+            '<md-option value="3">Three</md-option>' +
+            '</md-select>' +
+            '</md-input-container>')($rootScope).find('md-select');
+            var label = select.find('md-select-value');
+            $rootScope.$digest();
+
+            expect(label.text()).toBe('Two');
+            expect(label.hasClass('md-select-placeholder')).toBe(false);
+        }));
+
+        it('supports rendering multiple', inject(function($rootScope, $compile) {
+            $rootScope.val = [1, 3];
+            var select = $compile('<md-input-container>' +
+            '<label>Label</label>' +
+            '<md-select multiple ng-model="val" placeholder="Hello World">' +
+            '<md-option value="1">One</md-option>' +
+            '<md-option value="2">Two</md-option>' +
+            '<md-option value="3">Three</md-option>' +
+            '</md-select>' +
+            '</md-input-container>')($rootScope).find('md-select');
+            var label = select.find('md-select-value');
+            $rootScope.$digest();
+
+            expect(label.text()).toBe('One, Three');
+            expect(label.hasClass('md-select-placeholder')).toBe(false);
+        }));
+    });
+
+    it('auto-infers a value when none specified', inject(function($rootScope) {
+        $rootScope.name = "Hannah";
+        var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
+        '<md-option>Hannah</md-option>');
+        expect(selectedOptions(el).length).toBe(1);
+    }));
+
+    it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
+        expect(function() {
+            setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
+            '<md-option value="a">Goodbye</md-option>');
+        }).toThrow();
+    }));
+
+    it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
+        setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
+        '<md-option ng-value="bar">Goodbye</md-option>');
+        $rootScope.$apply('foo = "a"');
+        expect(function() {
+            $rootScope.$apply('bar = "a"');
+        }).toThrow();
+    }));
+
+    it('watches the collection for changes', inject(function($rootScope) {
+        $rootScope.val = 1;
+        var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
+        var label = select.find('md-select-value')[0];
+        expect(label.textContent).toBe('1');
+        $rootScope.val = 4;
+        $rootScope.$$values = [4, 5, 6];
+        $rootScope.$digest();
+        expect(label.textContent).toBe('4');
+    }));
+
+    describe('non-multiple', function() {
+
+        describe('model->view', function() {
+
+            it('renders initial model value', inject(function($rootScope) {
+                $rootScope.$apply('model = "b"');
+                var el = setup('ng-model="$root.model"', ['a','b','c']);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+            }));
+
+            it('renders nothing if no initial value is set', function() {
+                var el = setup('ng-model="$root.model"', ['a','b','c']);
+                expect(selectedOptions(el).length).toBe(0);
+            });
+
+            it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
+                $rootScope.$apply('model = "b"');
+                var el = setup('ng-model="$root.model"', ['a','b','c']);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = "c"');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect(selectedOptions(el).length).toBe(1);
+            }));
+
+            it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
+                $rootScope.$apply('model = "b"');
+                var el = setup('ng-model="$root.model"', ['a','b','c']);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = "d"');
+                expect(selectedOptions(el).length).toBe(0);
+            }));
+
+            it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
+                $rootScope.$apply('model = "b"');
+                var el = setup('ng-model="$root.model"', ['a','b','c']);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = undefined');
+                expect(selectedOptions(el).length).toBe(0);
+            }));
+
+            it('uses track by if given to compare objects', inject(function($rootScope) {
+                $rootScope.$apply('model = {id:2}');
+                var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
+                    [{id:1}, {id:2}, {id:3}]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = {id: 3}');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+            }));
+
+            it('uses uid by default to compare objects', inject(function($rootScope) {
+                var one = {}, two = {}, three = {};
+                $rootScope.model = two;
+                var el = setup('ng-model="$root.model"', [one, two, three]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = {}');
+
+                expect(selectedOptions(el).length).toBe(0);
+            }));
+
+        });
+
+        describe('view->model', function() {
+
+            it('should do nothing if clicking selected option', inject(function($rootScope) {
+                $rootScope.model = 3;
+                var el = setup('ng-model="$root.model"', [1,2,3]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
+                el.triggerHandler({
+                    type: 'click',
+                    target: el.find('md-option')[2]
+                });
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect($rootScope.model).toBe(3);
+            }));
+
+            it('should support the ng-change event', inject(function($rootScope, $document) {
+                var changeCalled = false;
+                $rootScope.changed = function() {
+                    changeCalled = true;
+                };
+
+                var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3] ).find('md-select');
+                openSelect(selectEl);
+
+                var menuEl = $document.find('md-select-menu');
+                menuEl.triggerHandler({
+                    type: 'click',
+                    target: menuEl.find('md-option')[1]
+                });
+                expect(changeCalled).toBe(true);
+            }));
+
+            it('should deselect old and select new on click', inject(function($rootScope) {
+                $rootScope.model = 3;
+                var el = setup('ng-model="$root.model"', [1,2,3]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
+                el.triggerHandler({
+                    type: 'click',
+                    target: el.find('md-option')[1]
+                });
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+                expect($rootScope.model).toBe(2);
+            }));
+
+            it('should keep model value if selected option is removed', inject(function($rootScope) {
+                $rootScope.model = 3;
+                $rootScope.values = [1,2,3];
+                var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('values.pop()');
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect(el.find('md-option').length).toBe(2);
+                expect($rootScope.model).toBe(3);
+            }));
+
+            it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
+                $rootScope.model = 4;
+                $rootScope.values = [1,2,3];
+                var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+                expect(selectedOptions(el).length).toBe(0);
+
+                $rootScope.$apply('values.unshift(4)');
+
+                expect(el.find('md-option').length).toBe(4);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(selectedOptions(el).length).toBe(1);
+                expect($rootScope.model).toBe(4);
+            }));
+
+        });
+    });
+
+    describe('multiple', function() {
+
+        describe('model->view', function() {
+
+            it('renders initial model value', inject(function($rootScope) {
+                $rootScope.model = [1,3];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([1,3]);
+            }));
+
+            it('renders nothing if empty array is set', inject(function($rootScope) {
+                $rootScope.model = [];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([]);
+            }));
+
+            it('adding a valid value to the model selects its option', inject(function($rootScope) {
+                $rootScope.model = [];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([]);
+
+                $rootScope.$apply('model.push(2)');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([2]);
+            }));
+
+            it('removing a valid value from the model deselects its option', inject(function($rootScope) {
+                $rootScope.model = [2,3];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect($rootScope.model).toEqual([2,3]);
+
+                $rootScope.$apply('model.shift()');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([3]);
+            }));
+
+            it('deselects all options when setting to an empty model', inject(function($rootScope) {
+                $rootScope.model = [2,3];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect($rootScope.model).toEqual([2,3]);
+
+                $rootScope.$apply('model = []');
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([]);
+            }));
+
+            it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
+                $rootScope.model = [2,3];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect($rootScope.model).toEqual([2,3]);
+
+                $rootScope.$apply('model = model.concat([1,4])');
+
+                expect(selectedOptions(el).length).toBe(4);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([2,3,1,4]);
+            }));
+
+            it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
+                $rootScope.model = [2,4,5,6];
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
+
+                expect(selectedOptions(el).length).toBe(4);
+                expect($rootScope.model).toEqual([2,4,5,6]);
+
+                $rootScope.$apply('model = [1,2,3]');
+
+                expect(selectedOptions(el).length).toBe(3);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([1,2,3]);
+            }));
+
+            it('does not select any options if the models value does not match an option', inject(function($rootScope) {
+                $rootScope.model = [];
+                $rootScope.obj = {};
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([]);
+
+                $rootScope.$apply('model = ["bar", obj]');
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
+            }));
+
+            it('uses track by if given to compare objects', inject(function($rootScope) {
+                $rootScope.$apply('model = [{id:2}]');
+                var el=setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
+                    [{id:1}, {id:2}, {id:3}]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model.push({id: 3}); model.push({id:1}); model.shift();');
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+            }));
+
+            it('uses uid by default to compare objects', inject(function($rootScope) {
+                var one = {}, two = {}, three = {};
+                $rootScope.model = [two];
+                var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+                $rootScope.$apply('model = [{}]');
+
+                expect(selectedOptions(el).length).toBe(0);
+            }));
+
+            it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
+                $rootScope.model = 'string';
+                var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
+                var ngModelCtrl = el.controller('ngModel');
+
+                expect(ngModelCtrl.$error['md-multiple']).toBe(true);
+
+                $rootScope.$apply('model = []');
+                expect(ngModelCtrl.$valid).toBe(true);
+            }));
+
+        });
+
+        describe('view->model', function() {
+
+            it('should deselect a selected option on click', inject(function($rootScope) {
+                $rootScope.model = [1];
+                var el = setupMultiple('ng-model="$root.model"', [1,2]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect($rootScope.model).toEqual([1]);
+
+                el.triggerHandler({
+                    type: 'click',
+                    target: el.find('md-option')[0]
+                });
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([]);
+            }));
+
+            it('selects a deselected option on click', inject(function($rootScope) {
+                $rootScope.model = [1];
+                var el = setupMultiple('ng-model="$root.model"', [1,2]);
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect($rootScope.model).toEqual([1]);
+
+                el.triggerHandler({
+                    type: 'click',
+                    target: el.find('md-option')[1]
+                });
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect($rootScope.model).toEqual([1,2]);
+            }));
+
+            it('should keep model value if a selected option is removed', inject(function($rootScope) {
+                $rootScope.model = [1];
+                $rootScope.values = [1,2];
+                var el = setupMultiple('ng-model="$root.model"',
+                    '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect($rootScope.model).toEqual([1]);
+
+                $rootScope.$apply('values.shift()');
+
+                expect(selectedOptions(el).length).toBe(0);
+                expect($rootScope.model).toEqual([1]);
+            }));
+
+            it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
+                $rootScope.model = [1,3];
+                $rootScope.values = [1,2];
+                var el = setupMultiple('ng-model="$root.model"',
+                    '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+                expect(selectedOptions(el).length).toBe(1);
+                expect($rootScope.model).toEqual([1,3]);
+
+                $rootScope.$apply('values.push(3)');
+
+                expect(selectedOptions(el).length).toBe(2);
+                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+                expect($rootScope.model).toEqual([1,3]);
+            }));
+
+        });
+    });
+
+    describe('aria', function() {
+        var el;
+        beforeEach(inject(function($q, $document) {
+            el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+            var selectMenus = $document.find('md-select-menu');
+            selectMenus.remove();
+        }));
+
+        it('adds an aria-label from placeholder', function() {
+            var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+            expect(select.attr('aria-label')).toBe('Hello world');
+        });
+
+        it('preserves aria-label on value change', inject(function($rootScope, $compile) {
+            var select = $compile('<md-input-container>' +
+            '<label>Pick</label>' +
+            '<md-select ng-model="val">' +
+            '<md-option value="1">One</md-option>' +
+            '<md-option value="2">Two</md-option>' +
+            '<md-option value="3">Three</md-option>' +
+            '</md-select>' +
+            '</md-input-container>')($rootScope).find('md-select');
+            $rootScope.$apply('model = 1');
+            $rootScope.$digest();
+
+            expect(select.attr('aria-label')).toBe('Pick');
+        }));
+
+        it('preserves existing aria-label', inject(function($rootScope) {
+            var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
+            expect(select.attr('aria-label')).toBe('Hello world');
+        }));
+
+        it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
+            spyOn($log, 'warn');
+            var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
+            $rootScope.$apply();
+            expect($log.warn).toHaveBeenCalled();
+
+            $log.warn.calls.reset();
+            select = setupSelect('ng-model="someVal", aria-label="Hello world"').find('md-select');
+            $rootScope.$apply();
+            expect($log.warn).not.toHaveBeenCalled();
+        }));
+
+        it('sets up the aria-expanded attribute', inject(function($document) {
+            expect(el.attr('aria-expanded')).toBe('false');
+            openSelect(el);
+            expect(el.attr('aria-expanded')).toBe('true');
+
+            var selectMenu = $document.find('md-select-menu');
+            pressKey(selectMenu, 27);
+            waitForSelectClose();
+            expect(el.attr('aria-expanded')).toBe('false');
+        }));
+        it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
+            $rootScope.model = [1,3];
+            var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
+
+            expect(el.attr('aria-multiselectable')).toBe('true');
+        }));
+        it('sets up the aria-selected attribute', inject(function($rootScope) {
+            var el = setup('ng-model="$root.model"', [1,2,3]);
+            var options = el.find('md-option');
+            expect(options.eq(2).attr('aria-selected')).toBe('false');
+            el.triggerHandler({
+                type: 'click',
+                target: el.find('md-option')[2]
+            });
+            expect(options.eq(2).attr('aria-selected')).toBe('true');
+        }));
+    });
+
+    describe('keyboard controls', function() {
+
+
+        afterEach(inject(function($document) {
+            var selectMenus = $document.find('md-select-menu');
+            selectMenus.remove();
+        }));
+
+        describe('md-select', function() {
+            it('can be opened with a space key', inject(function($document) {
+                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+                pressKey(el, 32);
+                waitForSelectOpen();
+                var selectMenu = angular.element($document.find('md-select-menu'));
+                expect(selectMenu.length).toBe(1);
+            }));
+
+            it('can be opened with an enter key', inject(function($document) {
+                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+                pressKey(el, 13);
+                waitForSelectOpen();
+                var selectMenu = angular.element($document.find('md-select-menu'));
+                expect(selectMenu.length).toBe(1);
+            }));
+
+            it('can be opened with the up key', inject(function($document) {
+                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+                pressKey(el, 38);
+                waitForSelectOpen();
+                var selectMenu = angular.element($document.find('md-select-menu'));
+                expect(selectMenu.length).toBe(1);
+            }));
+
+            it('can be opened with the down key', inject(function($document) {
+                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+                pressKey(el, 40);
+                waitForSelectOpen();
+                var selectMenu = angular.element($document.find('md-select-menu'));
+                expect(selectMenu.length).toBe(1);
+            }));
+
+            it('supports typing an option name', inject(function($document, $rootScope) {
+                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+                pressKey(el, 50);
+                expect($rootScope.someModel).toBe(2);
+            }));
+        });
+
+        describe('md-select-menu', function() {
+            it('can be closed with escape', inject(function($document, $rootScope, $animate) {
+                var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
+                openSelect(el);
+                var selectMenu = angular.element($document.find('md-select-menu'));
+                expect(selectMenu.length).toBe(1);
+                pressKey(selectMenu, 27);
+                waitForSelectClose();
+                expect($document.find('md-select-menu').length).toBe(0);
+            }));
+        });
+    });
 });

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,17 +1,17 @@
-describe('<md-select>',function() {
+describe('<md-select>', function() {
 
   beforeEach(module('material.components.input'));
-  beforeEach(module('material.components.select','ngAnimateMock'));
+  beforeEach(module('material.components.select', 'ngAnimateMock'));
 
-  beforeEach(inject(function($mdUtil,$$q) {
+  beforeEach(inject(function($mdUtil, $$q) {
     $mdUtil.transitionEndPromise = function() {
       return $$q.when(true);
     };
   }));
 
-  function setupSelect(attrs,options,bNoLabel) {
+  function setupSelect(attrs, options, bNoLabel) {
     var el;
-    inject(function($compile,$rootScope) {
+    inject(function($compile, $rootScope) {
       var src = '<md-input-container>';
       if (!bNoLabel) {
         src += '<label>Label</label>';
@@ -25,9 +25,9 @@ describe('<md-select>',function() {
     return el;
   }
 
-  function setup(attrs,options) {
+  function setup(attrs, options) {
     var el;
-    inject(function($compile,$rootScope) {
+    inject(function($compile, $rootScope) {
       var optionsTpl = optTemplate(options);
       var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
         '</md-select-menu>';
@@ -37,9 +37,9 @@ describe('<md-select>',function() {
     return el;
   }
 
-  function setupMultiple(attrs,options) {
+  function setupMultiple(attrs, options) {
     attrs = (attrs || '') + ' multiple';
-    return setup(attrs,options);
+    return setup(attrs, options);
   }
 
   function optTemplate(options) {
@@ -71,7 +71,7 @@ describe('<md-select>',function() {
   }
 
 
-  function pressKey(el,code) {
+  function pressKey(el, code) {
     el.triggerHandler({
       type: 'keydown',
       keyCode: code
@@ -80,7 +80,7 @@ describe('<md-select>',function() {
 
   function waitForSelectOpen() {
     try {
-      inject(function($rootScope,$animate) {
+      inject(function($rootScope, $animate) {
         $rootScope.$digest();
         $animate.triggerCallbacks();
       });
@@ -90,7 +90,7 @@ describe('<md-select>',function() {
 
   function waitForSelectClose() {
     try {
-      inject(function($rootScope,$animate) {
+      inject(function($rootScope, $animate) {
         $rootScope.$apply();
         $animate.triggerCallbacks();
 
@@ -99,29 +99,29 @@ describe('<md-select>',function() {
     }
   }
 
-  it('should preserve tabindex',inject(function($document) {
+  it('should preserve tabindex', inject(function($document) {
     var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
     expect(select.attr('tabindex')).toBe('2');
   }));
 
-  it('supports non-disabled state',inject(function($document) {
+  it('supports non-disabled state', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     expect(select.attr('aria-disabled')).toBe('false');
   }));
 
-  it('supports disabled state',inject(function($document) {
+  it('supports disabled state', inject(function($document) {
     var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
     openSelect(select);
     expect($document.find('md-select-menu').length).toBe(0);
     expect(select.attr('aria-disabled')).toBe('true');
   }));
 
-  it('closes the menu if the element is destroyed',inject(function($document,$rootScope) {
+  it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
     var called = false;
     $rootScope.onClose = function() {
       called = true;
     };
-    var select = setupSelect('ng-model="val", md-on-close="onClose()"',[1,2,3]).find('md-select');
+    var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
     openSelect(select);
 
     $document.find('md-option')[0].click();
@@ -130,24 +130,24 @@ describe('<md-select>',function() {
     expect(called).toBe(true);
   }));
 
-  it('restores focus to select when the menu is closed',inject(function($document) {
+  it('restores focus to select when the menu is closed', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);
 
     $document[0].body.appendChild(select[0]);
 
     var selectMenu = $document.find('md-select-menu');
-    pressKey(selectMenu,27);
+    pressKey(selectMenu, 27);
     waitForSelectClose();
 
     expect($document[0].activeElement).toBe(select[0]);
     select.remove();
   }));
 
-  describe('input container',function() {
-    it('should set has-value class on container for non-ng-model input',inject(function($rootScope) {
+  describe('input container', function() {
+    it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
       $rootScope.model = 0;
-      var el = setupSelect('ng-model="$root.model"',[1,2,3]);
+      var el = setupSelect('ng-model="$root.model"', [1, 2, 3]);
       var select = el.find('md-select');
       expect(selectedOptions(select).length).toBe(0);
 
@@ -159,7 +159,7 @@ describe('<md-select>',function() {
       expect(el).toHaveClass('md-input-has-value');
     }));
 
-    it('should set has-value class on container for ng-model input',inject(function($rootScope) {
+    it('should set has-value class on container for ng-model input', inject(function($rootScope) {
       $rootScope.value = 'test';
       var el = setupSelect('ng-model="$root.value"');
       expect(el).toHaveClass('md-input-has-value');
@@ -171,28 +171,28 @@ describe('<md-select>',function() {
       expect(el).not.toHaveClass('md-input-has-value');
     }));
 
-    it('should match label to given input id',inject(function($rootScope) {
+    it('should match label to given input id', inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value", id="foo"');
       expect(el.find('label').attr('for')).toBe('foo');
       expect(el.find('md-select').attr('id')).toBe('foo');
     }));
 
-    it('should match label to automatic input id',inject(function($rootScope) {
+    it('should match label to automatic input id', inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value"');
       expect(el.find('md-select').attr('id')).toBeTruthy();
       expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
     }));
   });
 
-  describe('label behavior',function() {
-    it('defaults to the placeholder text',function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"',null,true).find('md-select');
+  describe('label behavior', function() {
+    it('defaults to the placeholder text', function() {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
       expect(label.hasClass('md-select-placeholder')).toBe(true);
     });
 
-    it('sets itself to the selected option\'s label',inject(function($rootScope,$compile) {
+    it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
       $rootScope.val = 2;
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
@@ -209,8 +209,8 @@ describe('<md-select>',function() {
       expect(label.hasClass('md-select-placeholder')).toBe(false);
     }));
 
-    it('supports rendering multiple',inject(function($rootScope,$compile) {
-      $rootScope.val = [1,3];
+    it('supports rendering multiple', inject(function($rootScope, $compile) {
+      $rootScope.val = [1, 3];
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
       '<md-select multiple ng-model="val" placeholder="Hello World">' +
@@ -227,22 +227,22 @@ describe('<md-select>',function() {
     }));
   });
 
-  it('auto-infers a value when none specified',inject(function($rootScope) {
+  it('auto-infers a value when none specified', inject(function($rootScope) {
     $rootScope.name = "Hannah";
-    var el = setup('ng-model="name"','<md-option>Tom</md-option>' +
+    var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
     '<md-option>Hannah</md-option>');
     expect(selectedOptions(el).length).toBe(1);
   }));
 
-  it('errors for duplicate md-options, non-dynamic value',inject(function($rootScope) {
+  it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
     expect(function() {
-      setup('ng-model="$root.model"','<md-option value="a">Hello</md-option>' +
+      setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
       '<md-option value="a">Goodbye</md-option>');
     }).toThrow();
   }));
 
-  it('errors for duplicate md-options, ng-value',inject(function($rootScope) {
-    setup('ng-model="$root.model"','<md-option ng-value="foo">Hello</md-option>' +
+  it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
+    setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
     '<md-option ng-value="bar">Goodbye</md-option>');
     $rootScope.$apply('foo = "a"');
     expect(function() {
@@ -250,37 +250,37 @@ describe('<md-select>',function() {
     }).toThrow();
   }));
 
-  it('watches the collection for changes',inject(function($rootScope) {
+  it('watches the collection for changes', inject(function($rootScope) {
     $rootScope.val = 1;
-    var select = setupSelect('ng-model="val"',[1,2,3]).find('md-select');
+    var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
     var label = select.find('md-select-value')[0];
     expect(label.textContent).toBe('1');
     $rootScope.val = 4;
-    $rootScope.$$values = [4,5,6];
+    $rootScope.$$values = [4, 5, 6];
     $rootScope.$digest();
     expect(label.textContent).toBe('4');
   }));
 
-  describe('non-multiple',function() {
+  describe('non-multiple', function() {
 
-    describe('model->view',function() {
+    describe('model->view', function() {
 
-      it('renders initial model value',inject(function($rootScope) {
+      it('renders initial model value', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"',['a','b','c']);
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
       }));
 
-      it('renders nothing if no initial value is set',function() {
-        var el = setup('ng-model="$root.model"',['a','b','c']);
+      it('renders nothing if no initial value is set', function() {
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
         expect(selectedOptions(el).length).toBe(0);
       });
 
-      it('renders model change by selecting new and deselecting old',inject(function($rootScope) {
+      it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"',['a','b','c']);
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -290,9 +290,9 @@ describe('<md-select>',function() {
         expect(selectedOptions(el).length).toBe(1);
       }));
 
-      it('renders invalid model change by deselecting old and selecting nothing',inject(function($rootScope) {
+      it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"',['a','b','c']);
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -301,9 +301,9 @@ describe('<md-select>',function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('renders model change to undefined by deselecting old and selecting nothing',inject(function($rootScope) {
+      it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"',['a','b','c']);
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -312,10 +312,10 @@ describe('<md-select>',function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('uses track by if given to compare objects',inject(function($rootScope) {
+      it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = {id:2}');
         var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1},{id: 2},{id: 3}]);
+          [{id: 1}, {id: 2}, {id: 3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -326,10 +326,10 @@ describe('<md-select>',function() {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects',inject(function($rootScope) {
-        var one = {},two = {},three = {};
+      it('uses uid by default to compare objects', inject(function($rootScope) {
+        var one = {}, two = {}, three = {};
         $rootScope.model = two;
-        var el = setup('ng-model="$root.model"',[one,two,three]);
+        var el = setup('ng-model="$root.model"', [one, two, three]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -341,11 +341,11 @@ describe('<md-select>',function() {
 
     });
 
-    describe('view->model',function() {
+    describe('view->model', function() {
 
-      it('should do nothing if clicking selected option',inject(function($rootScope) {
+      it('should do nothing if clicking selected option', inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"',[1,2,3]);
+        var el = setup('ng-model="$root.model"', [1, 2, 3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -359,13 +359,13 @@ describe('<md-select>',function() {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should support the ng-change event',inject(function($rootScope,$document) {
+      it('should support the ng-change event', inject(function($rootScope, $document) {
         var changeCalled = false;
         $rootScope.changed = function() {
           changeCalled = true;
         };
 
-        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"',[1,2,3]).find('md-select');
+        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
         openSelect(selectEl);
 
         var menuEl = $document.find('md-select-menu');
@@ -376,9 +376,9 @@ describe('<md-select>',function() {
         expect(changeCalled).toBe(true);
       }));
 
-      it('should deselect old and select new on click',inject(function($rootScope) {
+      it('should deselect old and select new on click', inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"',[1,2,3]);
+        var el = setup('ng-model="$root.model"', [1, 2, 3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -392,10 +392,10 @@ describe('<md-select>',function() {
         expect($rootScope.model).toBe(2);
       }));
 
-      it('should keep model value if selected option is removed',inject(function($rootScope) {
+      it('should keep model value if selected option is removed', inject(function($rootScope) {
         $rootScope.model = 3;
-        $rootScope.values = [1,2,3];
-        var el = setup('ng-model="$root.model"','<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+        $rootScope.values = [1, 2, 3];
+        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -407,10 +407,10 @@ describe('<md-select>',function() {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should select an option that was just added matching the modelValue',inject(function($rootScope) {
+      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
         $rootScope.model = 4;
-        $rootScope.values = [1,2,3];
-        var el = setup('ng-model="$root.model"','<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+        $rootScope.values = [1, 2, 3];
+        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(0);
 
@@ -425,31 +425,31 @@ describe('<md-select>',function() {
     });
   });
 
-  describe('multiple',function() {
+  describe('multiple', function() {
 
-    describe('model->view',function() {
+    describe('model->view', function() {
 
-      it('renders initial model value',inject(function($rootScope) {
-        $rootScope.model = [1,3];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+      it('renders initial model value', inject(function($rootScope) {
+        $rootScope.model = [1, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,3]);
+        expect($rootScope.model).toEqual([1, 3]);
       }));
 
-      it('renders nothing if empty array is set',inject(function($rootScope) {
+      it('renders nothing if empty array is set', inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding a valid value to the model selects its option',inject(function($rootScope) {
+      it('adding a valid value to the model selects its option', inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -461,12 +461,12 @@ describe('<md-select>',function() {
         expect($rootScope.model).toEqual([2]);
       }));
 
-      it('removing a valid value from the model deselects its option',inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+      it('removing a valid value from the model deselects its option', inject(function($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
+        expect($rootScope.model).toEqual([2, 3]);
 
         $rootScope.$apply('model.shift()');
 
@@ -475,12 +475,12 @@ describe('<md-select>',function() {
         expect($rootScope.model).toEqual([3]);
       }));
 
-      it('deselects all options when setting to an empty model',inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+      it('deselects all options when setting to an empty model', inject(function($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
+        expect($rootScope.model).toEqual([2, 3]);
 
         $rootScope.$apply('model = []');
 
@@ -488,12 +488,12 @@ describe('<md-select>',function() {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding multiple valid values to a model selects their options',inject(function($rootScope) {
-        $rootScope.model = [2,3];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4]);
+      it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2,3]);
+        expect($rootScope.model).toEqual([2, 3]);
 
         $rootScope.$apply('model = model.concat([1,4])');
 
@@ -502,15 +502,15 @@ describe('<md-select>',function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([2,3,1,4]);
+        expect($rootScope.model).toEqual([2, 3, 1, 4]);
       }));
 
-      it('correctly selects and deselects options for complete reassignment of model',inject(function($rootScope) {
-        $rootScope.model = [2,4,5,6];
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4,5,6]);
+      it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
+        $rootScope.model = [2, 4, 5, 6];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
 
         expect(selectedOptions(el).length).toBe(4);
-        expect($rootScope.model).toEqual([2,4,5,6]);
+        expect($rootScope.model).toEqual([2, 4, 5, 6]);
 
         $rootScope.$apply('model = [1,2,3]');
 
@@ -518,13 +518,13 @@ describe('<md-select>',function() {
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,2,3]);
+        expect($rootScope.model).toEqual([1, 2, 3]);
       }));
 
-      it('does not select any options if the models value does not match an option',inject(function($rootScope) {
+      it('does not select any options if the models value does not match an option', inject(function($rootScope) {
         $rootScope.model = [];
         $rootScope.obj = {};
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3,4,5,6]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -532,13 +532,13 @@ describe('<md-select>',function() {
         $rootScope.$apply('model = ["bar", obj]');
 
         expect(selectedOptions(el).length).toBe(0);
-        expect($rootScope.model).toEqual(["bar",$rootScope.obj]);
+        expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
       }));
 
-      it('uses track by if given to compare objects',inject(function($rootScope) {
+      it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = [{id:2}]');
         var el = setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1},{id: 2},{id: 3}]);
+          [{id: 1}, {id: 2}, {id: 3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -550,10 +550,10 @@ describe('<md-select>',function() {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects',inject(function($rootScope) {
-        var one = {},two = {},three = {};
+      it('uses uid by default to compare objects', inject(function($rootScope) {
+        var one = {}, two = {}, three = {};
         $rootScope.model = [two];
-        var el = setupMultiple('ng-model="$root.model"',[one,two,three]);
+        var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -563,9 +563,9 @@ describe('<md-select>',function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('errors the model if model value is truthy and not an array',inject(function($rootScope) {
+      it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
         $rootScope.model = 'string';
-        var el = setupMultiple('ng-model="$root.model"',[1,2,3]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
         var ngModelCtrl = el.controller('ngModel');
 
         expect(ngModelCtrl.$error['md-multiple']).toBe(true);
@@ -576,11 +576,11 @@ describe('<md-select>',function() {
 
     });
 
-    describe('view->model',function() {
+    describe('view->model', function() {
 
-      it('should deselect a selected option on click',inject(function($rootScope) {
+      it('should deselect a selected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"',[1,2]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -594,9 +594,9 @@ describe('<md-select>',function() {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('selects a deselected option on click',inject(function($rootScope) {
+      it('selects a deselected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"',[1,2]);
+        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -607,12 +607,12 @@ describe('<md-select>',function() {
         });
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([1,2]);
+        expect($rootScope.model).toEqual([1, 2]);
       }));
 
-      it('should keep model value if a selected option is removed',inject(function($rootScope) {
+      it('should keep model value if a selected option is removed', inject(function($rootScope) {
         $rootScope.model = [1];
-        $rootScope.values = [1,2];
+        $rootScope.values = [1, 2];
         var el = setupMultiple('ng-model="$root.model"',
           '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
@@ -625,40 +625,40 @@ describe('<md-select>',function() {
         expect($rootScope.model).toEqual([1]);
       }));
 
-      it('should select an option that was just added matching the modelValue',inject(function($rootScope) {
-        $rootScope.model = [1,3];
-        $rootScope.values = [1,2];
+      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
+        $rootScope.model = [1, 3];
+        $rootScope.values = [1, 2];
         var el = setupMultiple('ng-model="$root.model"',
           '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1,3]);
+        expect($rootScope.model).toEqual([1, 3]);
 
         $rootScope.$apply('values.push(3)');
 
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1,3]);
+        expect($rootScope.model).toEqual([1, 3]);
       }));
 
     });
   });
 
-  describe('aria',function() {
+  describe('aria', function() {
     var el;
-    beforeEach(inject(function($q,$document) {
-      el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
+    beforeEach(inject(function($q, $document) {
+      el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
       var selectMenus = $document.find('md-select-menu');
       selectMenus.remove();
     }));
 
-    it('adds an aria-label from placeholder',function() {
-      var select = setupSelect('ng-model="someVal", placeholder="Hello world"',null,true).find('md-select');
+    it('adds an aria-label from placeholder', function() {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     });
 
-    it('preserves aria-label on value change',inject(function($rootScope,$compile) {
+    it('preserves aria-label on value change', inject(function($rootScope, $compile) {
       var select = $compile('<md-input-container>' +
       '<label>Pick</label>' +
       '<md-select ng-model="val">' +
@@ -673,14 +673,14 @@ describe('<md-select>',function() {
       expect(select.attr('aria-label')).toBe('Pick');
     }));
 
-    it('preserves existing aria-label',inject(function($rootScope) {
+    it('preserves existing aria-label', inject(function($rootScope) {
       var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     }));
 
-    it('should expect an aria-label if none is present',inject(function($compile,$rootScope,$log) {
-      spyOn($log,'warn');
-      var select = setupSelect('ng-model="someVal"',null,true).find('md-select');
+    it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
+      spyOn($log, 'warn');
+      var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
       $rootScope.$apply();
       expect($log.warn).toHaveBeenCalled();
 
@@ -690,24 +690,24 @@ describe('<md-select>',function() {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('sets up the aria-expanded attribute',inject(function($document) {
+    it('sets up the aria-expanded attribute', inject(function($document) {
       expect(el.attr('aria-expanded')).toBe('false');
       openSelect(el);
       expect(el.attr('aria-expanded')).toBe('true');
 
       var selectMenu = $document.find('md-select-menu');
-      pressKey(selectMenu,27);
+      pressKey(selectMenu, 27);
       waitForSelectClose();
       expect(el.attr('aria-expanded')).toBe('false');
     }));
-    it('sets up the aria-multiselectable attribute',inject(function($document,$rootScope) {
-      $rootScope.model = [1,3];
-      var el = setupMultiple('ng-model="$root.model"',[1,2,3]);
+    it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
+      $rootScope.model = [1, 3];
+      var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
 
       expect(el.attr('aria-multiselectable')).toBe('true');
     }));
-    it('sets up the aria-selected attribute',inject(function($rootScope) {
-      var el = setup('ng-model="$root.model"',[1,2,3]);
+    it('sets up the aria-selected attribute', inject(function($rootScope) {
+      var el = setup('ng-model="$root.model"', [1, 2, 3]);
       var options = el.find('md-option');
       expect(options.eq(2).attr('aria-selected')).toBe('false');
       el.triggerHandler({
@@ -718,7 +718,7 @@ describe('<md-select>',function() {
     }));
   });
 
-  describe('keyboard controls',function() {
+  describe('keyboard controls', function() {
 
 
     afterEach(inject(function($document) {
@@ -726,53 +726,53 @@ describe('<md-select>',function() {
       selectMenus.remove();
     }));
 
-    describe('md-select',function() {
-      it('can be opened with a space key',inject(function($document) {
-        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
-        pressKey(el,32);
+    describe('md-select', function() {
+      it('can be opened with a space key', inject(function($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 32);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with an enter key',inject(function($document) {
-        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
-        pressKey(el,13);
+      it('can be opened with an enter key', inject(function($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 13);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the up key',inject(function($document) {
-        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
-        pressKey(el,38);
+      it('can be opened with the up key', inject(function($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 38);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the down key',inject(function($document) {
-        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
-        pressKey(el,40);
+      it('can be opened with the down key', inject(function($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 40);
         waitForSelectOpen();
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('supports typing an option name',inject(function($document,$rootScope) {
-        var el = setupSelect('ng-model="someModel"',[1,2,3]).find('md-select');
-        pressKey(el,50);
+      it('supports typing an option name', inject(function($document, $rootScope) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 50);
         expect($rootScope.someModel).toBe(2);
       }));
     });
 
-    describe('md-select-menu',function() {
-      it('can be closed with escape',inject(function($document,$rootScope,$animate) {
-        var el = setupSelect('ng-model="someVal"',[1,2,3]).find('md-select');
+    describe('md-select-menu', function() {
+      it('can be closed with escape', inject(function($document, $rootScope, $animate) {
+        var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
         openSelect(el);
         var selectMenu = angular.element($document.find('md-select-menu'));
         expect(selectMenu.length).toBe(1);
-        pressKey(selectMenu,27);
+        pressKey(selectMenu, 27);
         waitForSelectClose();
         expect($document.find('md-select-menu').length).toBe(0);
       }));

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -65,7 +65,7 @@ describe('<md-select>', function() {
       inject(function($timeout) {
         $timeout.flush();
       });
-    } catch (e) { }
+    } catch(e) { }
   }
 
 
@@ -79,11 +79,10 @@ describe('<md-select>', function() {
   function waitForSelectOpen() {
     try {
       inject(function($rootScope, $animate) {
-        $rootScope.$digest();
-        $animate.triggerCallbacks();
+          $rootScope.$digest();
+          $animate.triggerCallbacks();
       });
-    } catch (e) {
-    }
+    } catch(e) { }
   }
 
   function waitForSelectClose() {
@@ -93,7 +92,7 @@ describe('<md-select>', function() {
         $animate.triggerCallbacks();
 
       });
-    } catch (e) { }
+    } catch(e) { }
   }
 
   it('should preserve tabindex', inject(function($document) {
@@ -209,13 +208,13 @@ describe('<md-select>', function() {
     it('supports rendering multiple', inject(function($rootScope, $compile) {
       $rootScope.val = [1, 3];
       var select = $compile('<md-input-container>' +
-      '<label>Label</label>' +
-      '<md-select multiple ng-model="val" placeholder="Hello World">' +
-      '<md-option value="1">One</md-option>' +
-      '<md-option value="2">Two</md-option>' +
-      '<md-option value="3">Three</md-option>' +
-      '</md-select>' +
-      '</md-input-container>')($rootScope).find('md-select');
+                              '<label>Label</label>' +
+                              '<md-select multiple ng-model="val" placeholder="Hello World">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
       var label = select.find('md-select-value');
       $rootScope.$digest();
 
@@ -289,8 +288,7 @@ describe('<md-select>', function() {
 
       it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
-
+        var el = setup('ng-model="$root.model"', ['a','b','c']);
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
 
@@ -300,8 +298,7 @@ describe('<md-select>', function() {
 
       it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
-
+        var el = setup('ng-model="$root.model"', ['a','b','c']);
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
 
@@ -359,7 +356,7 @@ describe('<md-select>', function() {
       it('should support the ng-change event', inject(function($rootScope, $document) {
           var changeCalled = false;
           $rootScope.changed = function() {
-              changeCalled = true;
+            changeCalled = true;
           };
 
           var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
@@ -367,8 +364,8 @@ describe('<md-select>', function() {
 
           var menuEl = $document.find('md-select-menu');
           menuEl.triggerHandler({
-              type: 'click',
-              target: menuEl.find('md-option')[1]
+            type: 'click',
+            target: menuEl.find('md-option')[1]
           });
           expect(changeCalled).toBe(true);
       }));
@@ -379,7 +376,6 @@ describe('<md-select>', function() {
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
         el.triggerHandler({
           type: 'click',
           target: el.find('md-option')[1]
@@ -429,16 +425,15 @@ describe('<md-select>', function() {
       it('renders initial model value', inject(function($rootScope) {
         $rootScope.model = [1,3];
         var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
       }));
 
       it('renders nothing if empty array is set', inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -446,7 +441,7 @@ describe('<md-select>', function() {
 
       it('adding a valid value to the model selects its option', inject(function($rootScope) {
         $rootScope.model = [];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -457,6 +452,7 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect($rootScope.model).toEqual([2]);
       }));
+
       it('removing a valid value from the model deselects its option', inject(function($rootScope) {
         $rootScope.model = [2,3];
         var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
@@ -489,7 +485,7 @@ describe('<md-select>', function() {
         var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model = model.concat([1,4])');
 
@@ -514,13 +510,13 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 2, 3]);
+        expect($rootScope.model).toEqual([1,2,3]);
       }));
 
       it('does not select any options if the models value does not match an option', inject(function($rootScope) {
         $rootScope.model = [];
         $rootScope.obj = {};
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
 
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
@@ -589,6 +585,7 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
       }));
+
       it('selects a deselected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
         var el = setupMultiple('ng-model="$root.model"', [1,2]);
@@ -654,13 +651,13 @@ describe('<md-select>', function() {
 
     it('preserves aria-label on value change', inject(function($rootScope, $compile) {
       var select = $compile('<md-input-container>' +
-      '<label>Pick</label>' +
-      '<md-select ng-model="val">' +
-      '<md-option value="1">One</md-option>' +
-      '<md-option value="2">Two</md-option>' +
-      '<md-option value="3">Three</md-option>' +
-      '</md-select>' +
-      '</md-input-container>')($rootScope).find('md-select');
+                              '<label>Pick</label>' +
+                              '<md-select ng-model="val">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
       $rootScope.$apply('model = 1');
       $rootScope.$digest();
 

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -29,7 +29,8 @@ describe('<md-select>', function() {
     var el;
     inject(function($compile, $rootScope) {
       var optionsTpl = optTemplate(options);
-      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl + '</md-select-menu>';
+      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
+               '</md-select-menu>';
       el = $compile(fullTpl)($rootScope);
       $rootScope.$apply();
     });
@@ -376,6 +377,7 @@ describe('<md-select>', function() {
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
         el.triggerHandler({
           type: 'click',
           target: el.find('md-option')[1]
@@ -425,6 +427,7 @@ describe('<md-select>', function() {
       it('renders initial model value', inject(function($rootScope) {
         $rootScope.model = [1,3];
         var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
+
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -452,6 +455,7 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect($rootScope.model).toEqual([2]);
       }));
+
 
       it('removing a valid value from the model deselects its option', inject(function($rootScope) {
         $rootScope.model = [2,3];
@@ -530,7 +534,7 @@ describe('<md-select>', function() {
       it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = [{id:2}]');
         var el=setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id:1}, {id:2}, {id:3}]);
+            [{id:1}, {id:2}, {id:3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -616,6 +620,7 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([1]);
       }));
+
       it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
         $rootScope.model = [1,3];
         $rootScope.values = [1,2];
@@ -630,7 +635,7 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
       }));
 
     });

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -29,8 +29,7 @@ describe('<md-select>', function() {
     var el;
     inject(function($compile, $rootScope) {
       var optionsTpl = optTemplate(options);
-      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
-        '</md-select-menu>';
+      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl + '</md-select-menu>';
       el = $compile(fullTpl)($rootScope);
       $rootScope.$apply();
     });
@@ -66,16 +65,15 @@ describe('<md-select>', function() {
       inject(function($timeout) {
         $timeout.flush();
       });
-    } catch (e) {
-    }
+    } catch (e) { }
   }
 
 
   function pressKey(el, code) {
-    el.triggerHandler({
-      type: 'keydown',
-      keyCode: code
-    });
+      el.triggerHandler({
+        type: 'keydown',
+        keyCode: code
+      });
   }
 
   function waitForSelectOpen() {
@@ -90,13 +88,12 @@ describe('<md-select>', function() {
 
   function waitForSelectClose() {
     try {
-      inject(function($rootScope, $animate) {
+      inject(function($rootScope, $animate ) {
         $rootScope.$apply();
         $animate.triggerCallbacks();
 
       });
-    } catch (e) {
-    }
+    } catch (e) { }
   }
 
   it('should preserve tabindex', inject(function($document) {
@@ -195,13 +192,13 @@ describe('<md-select>', function() {
     it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
       $rootScope.val = 2;
       var select = $compile('<md-input-container>' +
-      '<label>Label</label>' +
-      '<md-select ng-model="val" placeholder="Hello World">' +
-      '<md-option value="1">One</md-option>' +
-      '<md-option value="2">Two</md-option>' +
-      '<md-option value="3">Three</md-option>' +
-      '</md-select>' +
-      '</md-input-container>')($rootScope).find('md-select');
+                              '<label>Label</label>' +
+                              '<md-select ng-model="val" placeholder="Hello World">' +
+                                '<md-option value="1">One</md-option>' +
+                                '<md-option value="2">Two</md-option>' +
+                                '<md-option value="3">Three</md-option>' +
+                              '</md-select>' +
+                            '</md-input-container>')($rootScope).find('md-select');
       var label = select.find('md-select-value');
       $rootScope.$digest();
 
@@ -228,22 +225,22 @@ describe('<md-select>', function() {
   });
 
   it('auto-infers a value when none specified', inject(function($rootScope) {
-    $rootScope.name = "Hannah";
-    var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
-    '<md-option>Hannah</md-option>');
-    expect(selectedOptions(el).length).toBe(1);
+      $rootScope.name = "Hannah";
+      var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
+            '<md-option>Hannah</md-option>');
+      expect(selectedOptions(el).length).toBe(1);
   }));
 
   it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
     expect(function() {
       setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
-      '<md-option value="a">Goodbye</md-option>');
+            '<md-option value="a">Goodbye</md-option>');
     }).toThrow();
   }));
 
   it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
     setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
-    '<md-option ng-value="bar">Goodbye</md-option>');
+          '<md-option ng-value="bar">Goodbye</md-option>');
     $rootScope.$apply('foo = "a"');
     expect(function() {
       $rootScope.$apply('bar = "a"');
@@ -267,20 +264,20 @@ describe('<md-select>', function() {
 
       it('renders initial model value', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"', ['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
       }));
 
       it('renders nothing if no initial value is set', function() {
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"', ['a','b','c']);
         expect(selectedOptions(el).length).toBe(0);
       });
 
       it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
-        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        var el = setup('ng-model="$root.model"', ['a','b','c']);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -315,7 +312,7 @@ describe('<md-select>', function() {
       it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = {id:2}');
         var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1}, {id: 2}, {id: 3}]);
+            [{id:1}, {id:2}, {id:3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -345,7 +342,7 @@ describe('<md-select>', function() {
 
       it('should do nothing if clicking selected option', inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+        var el = setup('ng-model="$root.model"', [1,2,3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -360,25 +357,25 @@ describe('<md-select>', function() {
       }));
 
       it('should support the ng-change event', inject(function($rootScope, $document) {
-        var changeCalled = false;
-        $rootScope.changed = function() {
-          changeCalled = true;
-        };
+          var changeCalled = false;
+          $rootScope.changed = function() {
+              changeCalled = true;
+          };
 
-        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
-        openSelect(selectEl);
+          var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
+          openSelect(selectEl);
 
-        var menuEl = $document.find('md-select-menu');
-        menuEl.triggerHandler({
-          type: 'click',
-          target: menuEl.find('md-option')[1]
-        });
-        expect(changeCalled).toBe(true);
+          var menuEl = $document.find('md-select-menu');
+          menuEl.triggerHandler({
+              type: 'click',
+              target: menuEl.find('md-option')[1]
+          });
+          expect(changeCalled).toBe(true);
       }));
 
       it('should deselect old and select new on click', inject(function($rootScope) {
         $rootScope.model = 3;
-        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+        var el = setup('ng-model="$root.model"', [1,2,3]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
@@ -394,7 +391,7 @@ describe('<md-select>', function() {
 
       it('should keep model value if selected option is removed', inject(function($rootScope) {
         $rootScope.model = 3;
-        $rootScope.values = [1, 2, 3];
+        $rootScope.values = [1,2,3];
         var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
@@ -409,7 +406,7 @@ describe('<md-select>', function() {
 
       it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
         $rootScope.model = 4;
-        $rootScope.values = [1, 2, 3];
+        $rootScope.values = [1,2,3];
         var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(0);
@@ -430,8 +427,8 @@ describe('<md-select>', function() {
     describe('model->view', function() {
 
       it('renders initial model value', inject(function($rootScope) {
-        $rootScope.model = [1, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        $rootScope.model = [1,3];
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
         expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
@@ -460,13 +457,12 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect($rootScope.model).toEqual([2]);
       }));
-
       it('removing a valid value from the model deselects its option', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model.shift()');
 
@@ -476,11 +472,11 @@ describe('<md-select>', function() {
       }));
 
       it('deselects all options when setting to an empty model', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([2, 3]);
+        expect($rootScope.model).toEqual([2,3]);
 
         $rootScope.$apply('model = []');
 
@@ -489,8 +485,8 @@ describe('<md-select>', function() {
       }));
 
       it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
-        $rootScope.model = [2, 3];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+        $rootScope.model = [2,3];
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 
         expect(selectedOptions(el).length).toBe(2);
         expect($rootScope.model).toEqual([2, 3]);
@@ -502,15 +498,15 @@ describe('<md-select>', function() {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
         expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
-        expect($rootScope.model).toEqual([2, 3, 1, 4]);
+        expect($rootScope.model).toEqual([2,3,1,4]);
       }));
 
       it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
-        $rootScope.model = [2, 4, 5, 6];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+        $rootScope.model = [2,4,5,6];
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
 
         expect(selectedOptions(el).length).toBe(4);
-        expect($rootScope.model).toEqual([2, 4, 5, 6]);
+        expect($rootScope.model).toEqual([2,4,5,6]);
 
         $rootScope.$apply('model = [1,2,3]');
 
@@ -537,8 +533,8 @@ describe('<md-select>', function() {
 
       it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = [{id:2}]');
-        var el = setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-          [{id: 1}, {id: 2}, {id: 3}]);
+        var el=setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
+          [{id:1}, {id:2}, {id:3}]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
@@ -565,7 +561,7 @@ describe('<md-select>', function() {
 
       it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
         $rootScope.model = 'string';
-        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
         var ngModelCtrl = el.controller('ngModel');
 
         expect(ngModelCtrl.$error['md-multiple']).toBe(true);
@@ -580,7 +576,7 @@ describe('<md-select>', function() {
 
       it('should deselect a selected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -593,10 +589,9 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([]);
       }));
-
       it('selects a deselected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
-        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+        var el = setupMultiple('ng-model="$root.model"', [1,2]);
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -607,14 +602,14 @@ describe('<md-select>', function() {
         });
 
         expect(selectedOptions(el).length).toBe(2);
-        expect($rootScope.model).toEqual([1, 2]);
+        expect($rootScope.model).toEqual([1,2]);
       }));
 
       it('should keep model value if a selected option is removed', inject(function($rootScope) {
         $rootScope.model = [1];
-        $rootScope.values = [1, 2];
+        $rootScope.values = [1,2];
         var el = setupMultiple('ng-model="$root.model"',
-          '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+            '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
         expect($rootScope.model).toEqual([1]);
@@ -624,15 +619,14 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
         expect($rootScope.model).toEqual([1]);
       }));
-
       it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-        $rootScope.model = [1, 3];
-        $rootScope.values = [1, 2];
+        $rootScope.model = [1,3];
+        $rootScope.values = [1,2];
         var el = setupMultiple('ng-model="$root.model"',
-          '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+            '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
 
         expect(selectedOptions(el).length).toBe(1);
-        expect($rootScope.model).toEqual([1, 3]);
+        expect($rootScope.model).toEqual([1,3]);
 
         $rootScope.$apply('values.push(3)');
 
@@ -701,13 +695,13 @@ describe('<md-select>', function() {
       expect(el.attr('aria-expanded')).toBe('false');
     }));
     it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
-      $rootScope.model = [1, 3];
-      var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
+      $rootScope.model = [1,3];
+      var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
 
       expect(el.attr('aria-multiselectable')).toBe('true');
     }));
     it('sets up the aria-selected attribute', inject(function($rootScope) {
-      var el = setup('ng-model="$root.model"', [1, 2, 3]);
+      var el = setup('ng-model="$root.model"', [1,2,3]);
       var options = el.find('md-option');
       expect(options.eq(2).attr('aria-selected')).toBe('false');
       el.triggerHandler({

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,778 +1,781 @@
-describe('<md-select>', function() {
+describe('<md-select>', function () {
 
-    beforeEach(module('material.components.input'));
-    beforeEach(module('material.components.select', 'ngAnimateMock'));
+  beforeEach(module('material.components.input'));
+  beforeEach(module('material.components.select', 'ngAnimateMock'));
 
-    beforeEach(inject(function($mdUtil, $$q) {
-        $mdUtil.transitionEndPromise = function() {
-            return $$q.when(true);
-        };
+  beforeEach(inject(function ($mdUtil, $$q) {
+    $mdUtil.transitionEndPromise = function () {
+      return $$q.when(true);
+    };
+  }));
+
+  function setupSelect(attrs, options, bNoLabel) {
+    var el;
+    inject(function ($compile, $rootScope) {
+      var src = '<md-input-container>';
+      if (!bNoLabel) {
+        src += '<label>Label</label>';
+      }
+      src += '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select></md-input-container>';
+      var template = angular.element(src);
+      el = $compile(template)($rootScope);
+      $rootScope.$digest();
+      $rootScope.$digest();
+    });
+    return el;
+  }
+
+  function setup(attrs, options) {
+    var el;
+    inject(function ($compile, $rootScope) {
+      var optionsTpl = optTemplate(options);
+      var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
+        '</md-select-menu>';
+      el = $compile(fullTpl)($rootScope);
+      $rootScope.$apply();
+    });
+    return el;
+  }
+
+  function setupMultiple(attrs, options) {
+    attrs = (attrs || '') + ' multiple';
+    return setup(attrs, options);
+  }
+
+  function optTemplate(options) {
+    var optionsTpl = '';
+    inject(function ($rootScope) {
+      if (angular.isArray(options)) {
+        $rootScope.$$values = options;
+        optionsTpl = '<md-option ng-repeat="value in $$values" ng-value="value">{{value}}</md-option>';
+      } else if (angular.isString(options)) {
+        optionsTpl = options;
+      }
+    });
+    return optionsTpl;
+  }
+
+  function selectedOptions(el) {
+    return angular.element(el[0].querySelectorAll('md-option[selected]'));
+  }
+
+  function openSelect(el) {
+    try {
+      el.triggerHandler('click');
+      waitForSelectOpen();
+      inject(function ($timeout) {
+        $timeout.flush();
+      });
+    } catch (e) {
+    }
+  }
+
+
+  function pressKey(el, code) {
+    el.triggerHandler({
+      type: 'keydown',
+      keyCode: code
+    });
+  }
+
+  function waitForSelectOpen() {
+    try {
+      inject(function ($rootScope, $animate) {
+        $rootScope.$digest();
+        $animate.triggerCallbacks();
+      });
+    } catch (e) {
+    }
+  }
+
+  function waitForSelectClose() {
+    try {
+      inject(function ($rootScope, $animate) {
+        $rootScope.$apply();
+        $animate.triggerCallbacks();
+
+      });
+    } catch (e) {
+    }
+  }
+
+  it('should preserve tabindex', inject(function ($document) {
+    var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
+    expect(select.attr('tabindex')).toBe('2');
+  }));
+
+  it('supports non-disabled state', inject(function ($document) {
+    var select = setupSelect('ng-model="val"').find('md-select');
+    expect(select.attr('aria-disabled')).toBe('false');
+  }));
+
+  it('supports disabled state', inject(function ($document) {
+    var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
+    openSelect(select);
+    expect($document.find('md-select-menu').length).toBe(0);
+    expect(select.attr('aria-disabled')).toBe('true');
+  }));
+
+  it('closes the menu if the element is destroyed', inject(function ($document, $rootScope) {
+    var called = false;
+    $rootScope.onClose = function () {
+      called = true;
+    };
+    var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
+    openSelect(select);
+
+    $document.find('md-option')[0].click();
+    waitForSelectClose();
+
+    expect(called).toBe(true);
+  }));
+
+  it('restores focus to select when the menu is closed', inject(function ($document) {
+    var select = setupSelect('ng-model="val"').find('md-select');
+    openSelect(select);
+
+    $document[0].body.appendChild(select[0]);
+
+    var selectMenu = $document.find('md-select-menu');
+    pressKey(selectMenu, 27);
+    waitForSelectClose();
+
+    expect($document[0].activeElement).toBe(select[0]);
+    select.remove();
+  }));
+
+  describe('input container', function () {
+    it('should set has-value class on container for non-ng-model input', inject(function ($rootScope) {
+      $rootScope.model = 0;
+      var el = setupSelect('ng-model="$root.model"', [1, 2, 3]);
+      var select = el.find('md-select');
+      expect(selectedOptions(select).length).toBe(0);
+
+      el.triggerHandler({
+        type: 'click',
+        target: select.find('md-option')[1]
+      });
+
+      expect(el).toHaveClass('md-input-has-value');
     }));
 
-    function setupSelect(attrs, options, bNoLabel) {
-        var el;
-        inject(function($compile, $rootScope) {
-            var src = '<md-input-container>';
-            if (!bNoLabel) {
-                src += '<label>Label</label>';
-            }
-            src += '<md-select ' + (attrs || '') + '>' + optTemplate(options) + '</md-select></md-input-container>';
-            var template = angular.element(src);
-            el = $compile(template)($rootScope);
-            $rootScope.$digest();
-            $rootScope.$digest();
-        });
-        return el;
-    }
+    it('should set has-value class on container for ng-model input', inject(function ($rootScope) {
+      $rootScope.value = 'test';
+      var el = setupSelect('ng-model="$root.value"');
+      expect(el).toHaveClass('md-input-has-value');
 
-    function setup(attrs, options) {
-        var el;
-        inject(function($compile, $rootScope) {
-            var optionsTpl = optTemplate(options);
-            var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
-                '</md-select-menu>';
-            el = $compile(fullTpl)($rootScope);
-            $rootScope.$apply();
-        });
-        return el;
-    }
+      $rootScope.$apply('value = "3"');
+      expect(el).toHaveClass('md-input-has-value');
 
-    function setupMultiple(attrs, options) {
-        attrs = (attrs || '') + ' multiple';
-        return setup(attrs, options);
-    }
+      $rootScope.$apply('value = null');
+      expect(el).not.toHaveClass('md-input-has-value');
+    }));
 
-    function optTemplate(options) {
-        var optionsTpl = '';
-        inject(function($rootScope) {
-            if (angular.isArray(options)) {
-                $rootScope.$$values = options;
-                optionsTpl = '<md-option ng-repeat="value in $$values" ng-value="value">{{value}}</md-option>';
-            } else if (angular.isString(options)) {
-                optionsTpl = options;
-            }
-        });
-        return optionsTpl;
-    }
+    it('should match label to given input id', inject(function ($rootScope) {
+      var el = setupSelect('ng-model="$root.value", id="foo"');
+      expect(el.find('label').attr('for')).toBe('foo');
+      expect(el.find('md-select').attr('id')).toBe('foo');
+    }));
 
-    function selectedOptions(el) {
-        return angular.element(el[0].querySelectorAll('md-option[selected]'));
-    }
+    it('should match label to automatic input id', inject(function ($rootScope) {
+      var el = setupSelect('ng-model="$root.value"');
+      expect(el.find('md-select').attr('id')).toBeTruthy();
+      expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
+    }));
+  });
 
-    function openSelect(el) {
-        try {
-            el.triggerHandler('click');
-            waitForSelectOpen();
-            inject(function($timeout) {
-                $timeout.flush();
-            });
-        } catch(e) { }
-    }
+  describe('label behavior', function () {
+    it('defaults to the placeholder text', function () {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+      var label = select.find('md-select-value');
+      expect(label.text()).toBe('Hello world');
+      expect(label.hasClass('md-select-placeholder')).toBe(true);
+    });
 
+    it('sets itself to the selected option\'s label', inject(function ($rootScope, $compile) {
+      $rootScope.val = 2;
+      var select = $compile('<md-input-container>' +
+      '<label>Label</label>' +
+      '<md-select ng-model="val" placeholder="Hello World">' +
+      '<md-option value="1">One</md-option>' +
+      '<md-option value="2">Two</md-option>' +
+      '<md-option value="3">Three</md-option>' +
+      '</md-select>' +
+      '</md-input-container>')($rootScope).find('md-select');
+      var label = select.find('md-select-value');
+      $rootScope.$digest();
 
-    function pressKey(el, code) {
+      expect(label.text()).toBe('Two');
+      expect(label.hasClass('md-select-placeholder')).toBe(false);
+    }));
+
+    it('supports rendering multiple', inject(function ($rootScope, $compile) {
+      $rootScope.val = [1, 3];
+      var select = $compile('<md-input-container>' +
+      '<label>Label</label>' +
+      '<md-select multiple ng-model="val" placeholder="Hello World">' +
+      '<md-option value="1">One</md-option>' +
+      '<md-option value="2">Two</md-option>' +
+      '<md-option value="3">Three</md-option>' +
+      '</md-select>' +
+      '</md-input-container>')($rootScope).find('md-select');
+      var label = select.find('md-select-value');
+      $rootScope.$digest();
+
+      expect(label.text()).toBe('One, Three');
+      expect(label.hasClass('md-select-placeholder')).toBe(false);
+    }));
+  });
+
+  it('auto-infers a value when none specified', inject(function ($rootScope) {
+    $rootScope.name = "Hannah";
+    var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
+    '<md-option>Hannah</md-option>');
+    expect(selectedOptions(el).length).toBe(1);
+  }));
+
+  it('errors for duplicate md-options, non-dynamic value', inject(function ($rootScope) {
+    expect(function () {
+      setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
+      '<md-option value="a">Goodbye</md-option>');
+    }).toThrow();
+  }));
+
+  it('errors for duplicate md-options, ng-value', inject(function ($rootScope) {
+    setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
+    '<md-option ng-value="bar">Goodbye</md-option>');
+    $rootScope.$apply('foo = "a"');
+    expect(function () {
+      $rootScope.$apply('bar = "a"');
+    }).toThrow();
+  }));
+
+  it('watches the collection for changes', inject(function ($rootScope) {
+    $rootScope.val = 1;
+    var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
+    var label = select.find('md-select-value')[0];
+    expect(label.textContent).toBe('1');
+    $rootScope.val = 4;
+    $rootScope.$$values = [4, 5, 6];
+    $rootScope.$digest();
+    expect(label.textContent).toBe('4');
+  }));
+
+  describe('non-multiple', function () {
+
+    describe('model->view', function () {
+
+      it('renders initial model value', inject(function ($rootScope) {
+        $rootScope.$apply('model = "b"');
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+      }));
+
+      it('renders nothing if no initial value is set', function () {
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+        expect(selectedOptions(el).length).toBe(0);
+      });
+
+      it('renders model change by selecting new and deselecting old', inject(function ($rootScope) {
+        $rootScope.$apply('model = "b"');
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = "c"');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect(selectedOptions(el).length).toBe(1);
+      }));
+
+      it('renders invalid model change by deselecting old and selecting nothing', inject(function ($rootScope) {
+        $rootScope.$apply('model = "b"');
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = "d"');
+        expect(selectedOptions(el).length).toBe(0);
+      }));
+
+      it('renders model change to undefined by deselecting old and selecting nothing', inject(function ($rootScope) {
+        $rootScope.$apply('model = "b"');
+        var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = undefined');
+        expect(selectedOptions(el).length).toBe(0);
+      }));
+
+      it('uses track by if given to compare objects', inject(function ($rootScope) {
+        $rootScope.$apply('model = {id:2}');
+        var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
+          [{id: 1}, {id: 2}, {id: 3}]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = {id: 3}');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+      }));
+
+      it('uses uid by default to compare objects', inject(function ($rootScope) {
+        var one = {}, two = {}, three = {};
+        $rootScope.model = two;
+        var el = setup('ng-model="$root.model"', [one, two, three]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = {}');
+
+        expect(selectedOptions(el).length).toBe(0);
+      }));
+
+    });
+
+    describe('view->model', function () {
+
+      it('should do nothing if clicking selected option', inject(function ($rootScope) {
+        $rootScope.model = 3;
+        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
         el.triggerHandler({
-            type: 'keydown',
-            keyCode: code
+          type: 'click',
+          target: el.find('md-option')[2]
         });
-    }
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect($rootScope.model).toBe(3);
+      }));
 
-    function waitForSelectOpen() {
-        try {
-            inject(function($rootScope, $animate) {
-                $rootScope.$digest();
-                $animate.triggerCallbacks();
-            });
-        } catch(e) { }
-    }
+      it('should support the ng-change event', inject(function ($rootScope, $document) {
+        var changeCalled = false;
+        $rootScope.changed = function () {
+          changeCalled = true;
+        };
 
-    function waitForSelectClose() {
-        try {
-            inject(function($rootScope, $animate ) {
-                $rootScope.$apply();
-                $animate.triggerCallbacks();
+        var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3]).find('md-select');
+        openSelect(selectEl);
 
-            });
-        } catch(e) { }
-    }
+        var menuEl = $document.find('md-select-menu');
+        menuEl.triggerHandler({
+          type: 'click',
+          target: menuEl.find('md-option')[1]
+        });
+        expect(changeCalled).toBe(true);
+      }));
 
-    it('should preserve tabindex', inject(function($document) {
-        var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
-        expect(select.attr('tabindex')).toBe('2');
+      it('should deselect old and select new on click', inject(function ($rootScope) {
+        $rootScope.model = 3;
+        var el = setup('ng-model="$root.model"', [1, 2, 3]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
+        el.triggerHandler({
+          type: 'click',
+          target: el.find('md-option')[1]
+        });
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+        expect($rootScope.model).toBe(2);
+      }));
+
+      it('should keep model value if selected option is removed', inject(function ($rootScope) {
+        $rootScope.model = 3;
+        $rootScope.values = [1, 2, 3];
+        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('values.pop()');
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect(el.find('md-option').length).toBe(2);
+        expect($rootScope.model).toBe(3);
+      }));
+
+      it('should select an option that was just added matching the modelValue', inject(function ($rootScope) {
+        $rootScope.model = 4;
+        $rootScope.values = [1, 2, 3];
+        var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+        expect(selectedOptions(el).length).toBe(0);
+
+        $rootScope.$apply('values.unshift(4)');
+
+        expect(el.find('md-option').length).toBe(4);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(selectedOptions(el).length).toBe(1);
+        expect($rootScope.model).toBe(4);
+      }));
+
+    });
+  });
+
+  describe('multiple', function () {
+
+    describe('model->view', function () {
+
+      it('renders initial model value', inject(function ($rootScope) {
+        $rootScope.model = [1, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([1, 3]);
+      }));
+
+      it('renders nothing if empty array is set', inject(function ($rootScope) {
+        $rootScope.model = [];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([]);
+      }));
+
+      it('adding a valid value to the model selects its option', inject(function ($rootScope) {
+        $rootScope.model = [];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([]);
+
+        $rootScope.$apply('model.push(2)');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([2]);
+      }));
+
+      it('removing a valid value from the model deselects its option', inject(function ($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect($rootScope.model).toEqual([2, 3]);
+
+        $rootScope.$apply('model.shift()');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([3]);
+      }));
+
+      it('deselects all options when setting to an empty model', inject(function ($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect($rootScope.model).toEqual([2, 3]);
+
+        $rootScope.$apply('model = []');
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([]);
+      }));
+
+      it('adding multiple valid values to a model selects their options', inject(function ($rootScope) {
+        $rootScope.model = [2, 3];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect($rootScope.model).toEqual([2, 3]);
+
+        $rootScope.$apply('model = model.concat([1,4])');
+
+        expect(selectedOptions(el).length).toBe(4);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([2, 3, 1, 4]);
+      }));
+
+      it('correctly selects and deselects options for complete reassignment of model', inject(function ($rootScope) {
+        $rootScope.model = [2, 4, 5, 6];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+
+        expect(selectedOptions(el).length).toBe(4);
+        expect($rootScope.model).toEqual([2, 4, 5, 6]);
+
+        $rootScope.$apply('model = [1,2,3]');
+
+        expect(selectedOptions(el).length).toBe(3);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([1, 2, 3]);
+      }));
+
+      it('does not select any options if the models value does not match an option', inject(function ($rootScope) {
+        $rootScope.model = [];
+        $rootScope.obj = {};
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([]);
+
+        $rootScope.$apply('model = ["bar", obj]');
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
+      }));
+
+      it('uses track by if given to compare objects', inject(function ($rootScope) {
+        $rootScope.$apply('model = [{id:2}]');
+        var el = setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
+          [{id: 1}, {id: 2}, {id: 3}]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model.push({id: 3}); model.push({id:1}); model.shift();');
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+      }));
+
+      it('uses uid by default to compare objects', inject(function ($rootScope) {
+        var one = {}, two = {}, three = {};
+        $rootScope.model = [two];
+        var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
+
+        $rootScope.$apply('model = [{}]');
+
+        expect(selectedOptions(el).length).toBe(0);
+      }));
+
+      it('errors the model if model value is truthy and not an array', inject(function ($rootScope) {
+        $rootScope.model = 'string';
+        var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
+        var ngModelCtrl = el.controller('ngModel');
+
+        expect(ngModelCtrl.$error['md-multiple']).toBe(true);
+
+        $rootScope.$apply('model = []');
+        expect(ngModelCtrl.$valid).toBe(true);
+      }));
+
+    });
+
+    describe('view->model', function () {
+
+      it('should deselect a selected option on click', inject(function ($rootScope) {
+        $rootScope.model = [1];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect($rootScope.model).toEqual([1]);
+
+        el.triggerHandler({
+          type: 'click',
+          target: el.find('md-option')[0]
+        });
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([]);
+      }));
+
+      it('selects a deselected option on click', inject(function ($rootScope) {
+        $rootScope.model = [1];
+        var el = setupMultiple('ng-model="$root.model"', [1, 2]);
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect($rootScope.model).toEqual([1]);
+
+        el.triggerHandler({
+          type: 'click',
+          target: el.find('md-option')[1]
+        });
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect($rootScope.model).toEqual([1, 2]);
+      }));
+
+      it('should keep model value if a selected option is removed', inject(function ($rootScope) {
+        $rootScope.model = [1];
+        $rootScope.values = [1, 2];
+        var el = setupMultiple('ng-model="$root.model"',
+          '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect($rootScope.model).toEqual([1]);
+
+        $rootScope.$apply('values.shift()');
+
+        expect(selectedOptions(el).length).toBe(0);
+        expect($rootScope.model).toEqual([1]);
+      }));
+
+      it('should select an option that was just added matching the modelValue', inject(function ($rootScope) {
+        $rootScope.model = [1, 3];
+        $rootScope.values = [1, 2];
+        var el = setupMultiple('ng-model="$root.model"',
+          '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
+
+        expect(selectedOptions(el).length).toBe(1);
+        expect($rootScope.model).toEqual([1, 3]);
+
+        $rootScope.$apply('values.push(3)');
+
+        expect(selectedOptions(el).length).toBe(2);
+        expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
+        expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
+        expect($rootScope.model).toEqual([1, 3]);
+      }));
+
+    });
+  });
+
+  describe('aria', function () {
+    var el;
+    beforeEach(inject(function ($q, $document) {
+      el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+      var selectMenus = $document.find('md-select-menu');
+      selectMenus.remove();
     }));
 
-    it('supports non-disabled state', inject(function($document) {
-        var select = setupSelect('ng-model="val"' ).find('md-select');
-        expect(select.attr('aria-disabled')).toBe('false');
+    it('adds an aria-label from placeholder', function () {
+      var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
+      expect(select.attr('aria-label')).toBe('Hello world');
+    });
+
+    it('preserves aria-label on value change', inject(function ($rootScope, $compile) {
+      var select = $compile('<md-input-container>' +
+      '<label>Pick</label>' +
+      '<md-select ng-model="val">' +
+      '<md-option value="1">One</md-option>' +
+      '<md-option value="2">Two</md-option>' +
+      '<md-option value="3">Three</md-option>' +
+      '</md-select>' +
+      '</md-input-container>')($rootScope).find('md-select');
+      $rootScope.$apply('model = 1');
+      $rootScope.$digest();
+
+      expect(select.attr('aria-label')).toBe('Pick');
     }));
 
-    it('supports disabled state', inject(function($document) {
-        var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
-        openSelect(select);
-        expect($document.find('md-select-menu').length).toBe(0);
-        expect(select.attr('aria-disabled')).toBe('true');
+    it('preserves existing aria-label', inject(function ($rootScope) {
+      var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
+      expect(select.attr('aria-label')).toBe('Hello world');
     }));
 
-    it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
-      var called = false;
-      $rootScope.onClose = function() {
-        called = true;
-      };
-      var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
-      openSelect(select);
+    it('should expect an aria-label if none is present', inject(function ($compile, $rootScope, $log) {
+      spyOn($log, 'warn');
+      var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
+      $rootScope.$apply();
+      expect($log.warn).toHaveBeenCalled();
 
-      $document.find('md-option')[0].click();
+      $log.warn.calls.reset();
+      select = setupSelect('ng-model="someVal", aria-label="Hello world"').find('md-select');
+      $rootScope.$apply();
+      expect($log.warn).not.toHaveBeenCalled();
+    }));
+
+    it('sets up the aria-expanded attribute', inject(function ($document) {
+      expect(el.attr('aria-expanded')).toBe('false');
+      openSelect(el);
+      expect(el.attr('aria-expanded')).toBe('true');
+
+      var selectMenu = $document.find('md-select-menu');
+      pressKey(selectMenu, 27);
       waitForSelectClose();
+      expect(el.attr('aria-expanded')).toBe('false');
+    }));
+    it('sets up the aria-multiselectable attribute', inject(function ($document, $rootScope) {
+      $rootScope.model = [1, 3];
+      var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
 
-      expect(called).toBe(true);
+      expect(el.attr('aria-multiselectable')).toBe('true');
+    }));
+    it('sets up the aria-selected attribute', inject(function ($rootScope) {
+      var el = setup('ng-model="$root.model"', [1, 2, 3]);
+      var options = el.find('md-option');
+      expect(options.eq(2).attr('aria-selected')).toBe('false');
+      el.triggerHandler({
+        type: 'click',
+        target: el.find('md-option')[2]
+      });
+      expect(options.eq(2).attr('aria-selected')).toBe('true');
+    }));
+  });
+
+  describe('keyboard controls', function () {
+
+
+    afterEach(inject(function ($document) {
+      var selectMenus = $document.find('md-select-menu');
+      selectMenus.remove();
     }));
 
-    it('restores focus to select when the menu is closed', inject(function($document) {
-        var select = setupSelect('ng-model="val"').find('md-select');
-        openSelect(select);
+    describe('md-select', function () {
+      it('can be opened with a space key', inject(function ($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 32);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
 
-        $document[0].body.appendChild(select[0]);
+      it('can be opened with an enter key', inject(function ($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 13);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
 
-        var selectMenu = $document.find('md-select-menu');
+      it('can be opened with the up key', inject(function ($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 38);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
+
+      it('can be opened with the down key', inject(function ($document) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 40);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
+
+      it('supports typing an option name', inject(function ($document, $rootScope) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        pressKey(el, 50);
+        expect($rootScope.someModel).toBe(2);
+      }));
+    });
+
+    describe('md-select-menu', function () {
+      it('can be closed with escape', inject(function ($document, $rootScope, $animate) {
+        var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
+        openSelect(el);
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
         pressKey(selectMenu, 27);
         waitForSelectClose();
-
-        expect($document[0].activeElement).toBe(select[0]);
-        select.remove();
-    }));
-
-    describe('input container', function () {
-        it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
-            $rootScope.model = 0;
-            var el = setupSelect('ng-model="$root.model"', [1,2,3] );
-            var select = el.find('md-select');
-            expect(selectedOptions(select).length).toBe(0);
-
-            el.triggerHandler({
-                type: 'click',
-                target: select.find('md-option')[1]
-            });
-
-            expect(el).toHaveClass('md-input-has-value');
-        }));
-
-        it('should set has-value class on container for ng-model input', inject(function($rootScope) {
-            $rootScope.value = 'test';
-            var el = setupSelect('ng-model="$root.value"');
-            expect(el).toHaveClass('md-input-has-value');
-
-            $rootScope.$apply('value = "3"');
-            expect(el).toHaveClass('md-input-has-value');
-
-            $rootScope.$apply('value = null');
-            expect(el).not.toHaveClass('md-input-has-value');
-        }));
-
-        it('should match label to given input id', inject(function($rootScope) {
-            var el = setupSelect('ng-model="$root.value", id="foo"');
-            expect(el.find('label').attr('for')).toBe('foo');
-            expect(el.find('md-select').attr('id')).toBe('foo');
-        }));
-
-        it('should match label to automatic input id', inject(function($rootScope) {
-            var el = setupSelect('ng-model="$root.value"');
-            expect(el.find('md-select').attr('id')).toBeTruthy();
-            expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
-        }));
+        expect($document.find('md-select-menu').length).toBe(0);
+      }));
     });
-
-    describe('label behavior', function() {
-        it('defaults to the placeholder text', function() {
-            var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
-            var label = select.find('md-select-value');
-            expect(label.text()).toBe('Hello world');
-            expect(label.hasClass('md-select-placeholder')).toBe(true);
-        });
-
-        it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
-            $rootScope.val = 2;
-            var select = $compile('<md-input-container>' +
-            '<label>Label</label>' +
-            '<md-select ng-model="val" placeholder="Hello World">' +
-            '<md-option value="1">One</md-option>' +
-            '<md-option value="2">Two</md-option>' +
-            '<md-option value="3">Three</md-option>' +
-            '</md-select>' +
-            '</md-input-container>')($rootScope).find('md-select');
-            var label = select.find('md-select-value');
-            $rootScope.$digest();
-
-            expect(label.text()).toBe('Two');
-            expect(label.hasClass('md-select-placeholder')).toBe(false);
-        }));
-
-        it('supports rendering multiple', inject(function($rootScope, $compile) {
-            $rootScope.val = [1, 3];
-            var select = $compile('<md-input-container>' +
-            '<label>Label</label>' +
-            '<md-select multiple ng-model="val" placeholder="Hello World">' +
-            '<md-option value="1">One</md-option>' +
-            '<md-option value="2">Two</md-option>' +
-            '<md-option value="3">Three</md-option>' +
-            '</md-select>' +
-            '</md-input-container>')($rootScope).find('md-select');
-            var label = select.find('md-select-value');
-            $rootScope.$digest();
-
-            expect(label.text()).toBe('One, Three');
-            expect(label.hasClass('md-select-placeholder')).toBe(false);
-        }));
-    });
-
-    it('auto-infers a value when none specified', inject(function($rootScope) {
-        $rootScope.name = "Hannah";
-        var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
-        '<md-option>Hannah</md-option>');
-        expect(selectedOptions(el).length).toBe(1);
-    }));
-
-    it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
-        expect(function() {
-            setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
-            '<md-option value="a">Goodbye</md-option>');
-        }).toThrow();
-    }));
-
-    it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
-        setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
-        '<md-option ng-value="bar">Goodbye</md-option>');
-        $rootScope.$apply('foo = "a"');
-        expect(function() {
-            $rootScope.$apply('bar = "a"');
-        }).toThrow();
-    }));
-
-    it('watches the collection for changes', inject(function($rootScope) {
-        $rootScope.val = 1;
-        var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
-        var label = select.find('md-select-value')[0];
-        expect(label.textContent).toBe('1');
-        $rootScope.val = 4;
-        $rootScope.$$values = [4, 5, 6];
-        $rootScope.$digest();
-        expect(label.textContent).toBe('4');
-    }));
-
-    describe('non-multiple', function() {
-
-        describe('model->view', function() {
-
-            it('renders initial model value', inject(function($rootScope) {
-                $rootScope.$apply('model = "b"');
-                var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-            }));
-
-            it('renders nothing if no initial value is set', function() {
-                var el = setup('ng-model="$root.model"', ['a','b','c']);
-                expect(selectedOptions(el).length).toBe(0);
-            });
-
-            it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
-                $rootScope.$apply('model = "b"');
-                var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = "c"');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect(selectedOptions(el).length).toBe(1);
-            }));
-
-            it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
-                $rootScope.$apply('model = "b"');
-                var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = "d"');
-                expect(selectedOptions(el).length).toBe(0);
-            }));
-
-            it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
-                $rootScope.$apply('model = "b"');
-                var el = setup('ng-model="$root.model"', ['a','b','c']);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = undefined');
-                expect(selectedOptions(el).length).toBe(0);
-            }));
-
-            it('uses track by if given to compare objects', inject(function($rootScope) {
-                $rootScope.$apply('model = {id:2}');
-                var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-                    [{id:1}, {id:2}, {id:3}]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = {id: 3}');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-            }));
-
-            it('uses uid by default to compare objects', inject(function($rootScope) {
-                var one = {}, two = {}, three = {};
-                $rootScope.model = two;
-                var el = setup('ng-model="$root.model"', [one, two, three]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = {}');
-
-                expect(selectedOptions(el).length).toBe(0);
-            }));
-
-        });
-
-        describe('view->model', function() {
-
-            it('should do nothing if clicking selected option', inject(function($rootScope) {
-                $rootScope.model = 3;
-                var el = setup('ng-model="$root.model"', [1,2,3]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
-                el.triggerHandler({
-                    type: 'click',
-                    target: el.find('md-option')[2]
-                });
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect($rootScope.model).toBe(3);
-            }));
-
-            it('should support the ng-change event', inject(function($rootScope, $document) {
-                var changeCalled = false;
-                $rootScope.changed = function() {
-                    changeCalled = true;
-                };
-
-                var selectEl = setupSelect('ng-model="myModel", ng-change="changed()"', [1, 2, 3] ).find('md-select');
-                openSelect(selectEl);
-
-                var menuEl = $document.find('md-select-menu');
-                menuEl.triggerHandler({
-                    type: 'click',
-                    target: menuEl.find('md-option')[1]
-                });
-                expect(changeCalled).toBe(true);
-            }));
-
-            it('should deselect old and select new on click', inject(function($rootScope) {
-                $rootScope.model = 3;
-                var el = setup('ng-model="$root.model"', [1,2,3]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
-                el.triggerHandler({
-                    type: 'click',
-                    target: el.find('md-option')[1]
-                });
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-                expect($rootScope.model).toBe(2);
-            }));
-
-            it('should keep model value if selected option is removed', inject(function($rootScope) {
-                $rootScope.model = 3;
-                $rootScope.values = [1,2,3];
-                var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('values.pop()');
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect(el.find('md-option').length).toBe(2);
-                expect($rootScope.model).toBe(3);
-            }));
-
-            it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-                $rootScope.model = 4;
-                $rootScope.values = [1,2,3];
-                var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-                expect(selectedOptions(el).length).toBe(0);
-
-                $rootScope.$apply('values.unshift(4)');
-
-                expect(el.find('md-option').length).toBe(4);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(selectedOptions(el).length).toBe(1);
-                expect($rootScope.model).toBe(4);
-            }));
-
-        });
-    });
-
-    describe('multiple', function() {
-
-        describe('model->view', function() {
-
-            it('renders initial model value', inject(function($rootScope) {
-                $rootScope.model = [1,3];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([1,3]);
-            }));
-
-            it('renders nothing if empty array is set', inject(function($rootScope) {
-                $rootScope.model = [];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([]);
-            }));
-
-            it('adding a valid value to the model selects its option', inject(function($rootScope) {
-                $rootScope.model = [];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([]);
-
-                $rootScope.$apply('model.push(2)');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([2]);
-            }));
-
-            it('removing a valid value from the model deselects its option', inject(function($rootScope) {
-                $rootScope.model = [2,3];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect($rootScope.model).toEqual([2,3]);
-
-                $rootScope.$apply('model.shift()');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([3]);
-            }));
-
-            it('deselects all options when setting to an empty model', inject(function($rootScope) {
-                $rootScope.model = [2,3];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect($rootScope.model).toEqual([2,3]);
-
-                $rootScope.$apply('model = []');
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([]);
-            }));
-
-            it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
-                $rootScope.model = [2,3];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect($rootScope.model).toEqual([2,3]);
-
-                $rootScope.$apply('model = model.concat([1,4])');
-
-                expect(selectedOptions(el).length).toBe(4);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(3).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([2,3,1,4]);
-            }));
-
-            it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
-                $rootScope.model = [2,4,5,6];
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
-
-                expect(selectedOptions(el).length).toBe(4);
-                expect($rootScope.model).toEqual([2,4,5,6]);
-
-                $rootScope.$apply('model = [1,2,3]');
-
-                expect(selectedOptions(el).length).toBe(3);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([1,2,3]);
-            }));
-
-            it('does not select any options if the models value does not match an option', inject(function($rootScope) {
-                $rootScope.model = [];
-                $rootScope.obj = {};
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([]);
-
-                $rootScope.$apply('model = ["bar", obj]');
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
-            }));
-
-            it('uses track by if given to compare objects', inject(function($rootScope) {
-                $rootScope.$apply('model = [{id:2}]');
-                var el=setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
-                    [{id:1}, {id:2}, {id:3}]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model.push({id: 3}); model.push({id:1}); model.shift();');
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-            }));
-
-            it('uses uid by default to compare objects', inject(function($rootScope) {
-                var one = {}, two = {}, three = {};
-                $rootScope.model = [two];
-                var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
-
-                $rootScope.$apply('model = [{}]');
-
-                expect(selectedOptions(el).length).toBe(0);
-            }));
-
-            it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
-                $rootScope.model = 'string';
-                var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
-                var ngModelCtrl = el.controller('ngModel');
-
-                expect(ngModelCtrl.$error['md-multiple']).toBe(true);
-
-                $rootScope.$apply('model = []');
-                expect(ngModelCtrl.$valid).toBe(true);
-            }));
-
-        });
-
-        describe('view->model', function() {
-
-            it('should deselect a selected option on click', inject(function($rootScope) {
-                $rootScope.model = [1];
-                var el = setupMultiple('ng-model="$root.model"', [1,2]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect($rootScope.model).toEqual([1]);
-
-                el.triggerHandler({
-                    type: 'click',
-                    target: el.find('md-option')[0]
-                });
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([]);
-            }));
-
-            it('selects a deselected option on click', inject(function($rootScope) {
-                $rootScope.model = [1];
-                var el = setupMultiple('ng-model="$root.model"', [1,2]);
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect($rootScope.model).toEqual([1]);
-
-                el.triggerHandler({
-                    type: 'click',
-                    target: el.find('md-option')[1]
-                });
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect($rootScope.model).toEqual([1,2]);
-            }));
-
-            it('should keep model value if a selected option is removed', inject(function($rootScope) {
-                $rootScope.model = [1];
-                $rootScope.values = [1,2];
-                var el = setupMultiple('ng-model="$root.model"',
-                    '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect($rootScope.model).toEqual([1]);
-
-                $rootScope.$apply('values.shift()');
-
-                expect(selectedOptions(el).length).toBe(0);
-                expect($rootScope.model).toEqual([1]);
-            }));
-
-            it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
-                $rootScope.model = [1,3];
-                $rootScope.values = [1,2];
-                var el = setupMultiple('ng-model="$root.model"',
-                    '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
-
-                expect(selectedOptions(el).length).toBe(1);
-                expect($rootScope.model).toEqual([1,3]);
-
-                $rootScope.$apply('values.push(3)');
-
-                expect(selectedOptions(el).length).toBe(2);
-                expect(el.find('md-option').eq(0).attr('selected')).toBe('selected');
-                expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
-                expect($rootScope.model).toEqual([1,3]);
-            }));
-
-        });
-    });
-
-    describe('aria', function() {
-        var el;
-        beforeEach(inject(function($q, $document) {
-            el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-            var selectMenus = $document.find('md-select-menu');
-            selectMenus.remove();
-        }));
-
-        it('adds an aria-label from placeholder', function() {
-            var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
-            expect(select.attr('aria-label')).toBe('Hello world');
-        });
-
-        it('preserves aria-label on value change', inject(function($rootScope, $compile) {
-            var select = $compile('<md-input-container>' +
-            '<label>Pick</label>' +
-            '<md-select ng-model="val">' +
-            '<md-option value="1">One</md-option>' +
-            '<md-option value="2">Two</md-option>' +
-            '<md-option value="3">Three</md-option>' +
-            '</md-select>' +
-            '</md-input-container>')($rootScope).find('md-select');
-            $rootScope.$apply('model = 1');
-            $rootScope.$digest();
-
-            expect(select.attr('aria-label')).toBe('Pick');
-        }));
-
-        it('preserves existing aria-label', inject(function($rootScope) {
-            var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
-            expect(select.attr('aria-label')).toBe('Hello world');
-        }));
-
-        it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
-            spyOn($log, 'warn');
-            var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
-            $rootScope.$apply();
-            expect($log.warn).toHaveBeenCalled();
-
-            $log.warn.calls.reset();
-            select = setupSelect('ng-model="someVal", aria-label="Hello world"').find('md-select');
-            $rootScope.$apply();
-            expect($log.warn).not.toHaveBeenCalled();
-        }));
-
-        it('sets up the aria-expanded attribute', inject(function($document) {
-            expect(el.attr('aria-expanded')).toBe('false');
-            openSelect(el);
-            expect(el.attr('aria-expanded')).toBe('true');
-
-            var selectMenu = $document.find('md-select-menu');
-            pressKey(selectMenu, 27);
-            waitForSelectClose();
-            expect(el.attr('aria-expanded')).toBe('false');
-        }));
-        it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
-            $rootScope.model = [1,3];
-            var el = setupMultiple('ng-model="$root.model"', [1,2,3]);
-
-            expect(el.attr('aria-multiselectable')).toBe('true');
-        }));
-        it('sets up the aria-selected attribute', inject(function($rootScope) {
-            var el = setup('ng-model="$root.model"', [1,2,3]);
-            var options = el.find('md-option');
-            expect(options.eq(2).attr('aria-selected')).toBe('false');
-            el.triggerHandler({
-                type: 'click',
-                target: el.find('md-option')[2]
-            });
-            expect(options.eq(2).attr('aria-selected')).toBe('true');
-        }));
-    });
-
-    describe('keyboard controls', function() {
-
-
-        afterEach(inject(function($document) {
-            var selectMenus = $document.find('md-select-menu');
-            selectMenus.remove();
-        }));
-
-        describe('md-select', function() {
-            it('can be opened with a space key', inject(function($document) {
-                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-                pressKey(el, 32);
-                waitForSelectOpen();
-                var selectMenu = angular.element($document.find('md-select-menu'));
-                expect(selectMenu.length).toBe(1);
-            }));
-
-            it('can be opened with an enter key', inject(function($document) {
-                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-                pressKey(el, 13);
-                waitForSelectOpen();
-                var selectMenu = angular.element($document.find('md-select-menu'));
-                expect(selectMenu.length).toBe(1);
-            }));
-
-            it('can be opened with the up key', inject(function($document) {
-                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-                pressKey(el, 38);
-                waitForSelectOpen();
-                var selectMenu = angular.element($document.find('md-select-menu'));
-                expect(selectMenu.length).toBe(1);
-            }));
-
-            it('can be opened with the down key', inject(function($document) {
-                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-                pressKey(el, 40);
-                waitForSelectOpen();
-                var selectMenu = angular.element($document.find('md-select-menu'));
-                expect(selectMenu.length).toBe(1);
-            }));
-
-            it('supports typing an option name', inject(function($document, $rootScope) {
-                var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
-                pressKey(el, 50);
-                expect($rootScope.someModel).toBe(2);
-            }));
-        });
-
-        describe('md-select-menu', function() {
-            it('can be closed with escape', inject(function($document, $rootScope, $animate) {
-                var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
-                openSelect(el);
-                var selectMenu = angular.element($document.find('md-select-menu'));
-                expect(selectMenu.length).toBe(1);
-                pressKey(selectMenu, 27);
-                waitForSelectClose();
-                expect($document.find('md-select-menu').length).toBe(0);
-            }));
-        });
-    });
+  });
 });

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1,17 +1,17 @@
-describe('<md-select>', function () {
+describe('<md-select>', function() {
 
   beforeEach(module('material.components.input'));
   beforeEach(module('material.components.select', 'ngAnimateMock'));
 
-  beforeEach(inject(function ($mdUtil, $$q) {
-    $mdUtil.transitionEndPromise = function () {
+  beforeEach(inject(function($mdUtil, $$q) {
+    $mdUtil.transitionEndPromise = function() {
       return $$q.when(true);
     };
   }));
 
   function setupSelect(attrs, options, bNoLabel) {
     var el;
-    inject(function ($compile, $rootScope) {
+    inject(function($compile, $rootScope) {
       var src = '<md-input-container>';
       if (!bNoLabel) {
         src += '<label>Label</label>';
@@ -27,7 +27,7 @@ describe('<md-select>', function () {
 
   function setup(attrs, options) {
     var el;
-    inject(function ($compile, $rootScope) {
+    inject(function($compile, $rootScope) {
       var optionsTpl = optTemplate(options);
       var fullTpl = '<md-select-menu ' + (attrs || '') + '>' + optionsTpl +
         '</md-select-menu>';
@@ -44,7 +44,7 @@ describe('<md-select>', function () {
 
   function optTemplate(options) {
     var optionsTpl = '';
-    inject(function ($rootScope) {
+    inject(function($rootScope) {
       if (angular.isArray(options)) {
         $rootScope.$$values = options;
         optionsTpl = '<md-option ng-repeat="value in $$values" ng-value="value">{{value}}</md-option>';
@@ -63,7 +63,7 @@ describe('<md-select>', function () {
     try {
       el.triggerHandler('click');
       waitForSelectOpen();
-      inject(function ($timeout) {
+      inject(function($timeout) {
         $timeout.flush();
       });
     } catch (e) {
@@ -80,7 +80,7 @@ describe('<md-select>', function () {
 
   function waitForSelectOpen() {
     try {
-      inject(function ($rootScope, $animate) {
+      inject(function($rootScope, $animate) {
         $rootScope.$digest();
         $animate.triggerCallbacks();
       });
@@ -90,7 +90,7 @@ describe('<md-select>', function () {
 
   function waitForSelectClose() {
     try {
-      inject(function ($rootScope, $animate) {
+      inject(function($rootScope, $animate) {
         $rootScope.$apply();
         $animate.triggerCallbacks();
 
@@ -99,26 +99,26 @@ describe('<md-select>', function () {
     }
   }
 
-  it('should preserve tabindex', inject(function ($document) {
+  it('should preserve tabindex', inject(function($document) {
     var select = setupSelect('tabindex="2", ng-model="val"').find('md-select');
     expect(select.attr('tabindex')).toBe('2');
   }));
 
-  it('supports non-disabled state', inject(function ($document) {
+  it('supports non-disabled state', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     expect(select.attr('aria-disabled')).toBe('false');
   }));
 
-  it('supports disabled state', inject(function ($document) {
+  it('supports disabled state', inject(function($document) {
     var select = setupSelect('disabled="disabled", ng-model="val"').find('md-select');
     openSelect(select);
     expect($document.find('md-select-menu').length).toBe(0);
     expect(select.attr('aria-disabled')).toBe('true');
   }));
 
-  it('closes the menu if the element is destroyed', inject(function ($document, $rootScope) {
+  it('closes the menu if the element is destroyed', inject(function($document, $rootScope) {
     var called = false;
-    $rootScope.onClose = function () {
+    $rootScope.onClose = function() {
       called = true;
     };
     var select = setupSelect('ng-model="val", md-on-close="onClose()"', [1, 2, 3]).find('md-select');
@@ -130,7 +130,7 @@ describe('<md-select>', function () {
     expect(called).toBe(true);
   }));
 
-  it('restores focus to select when the menu is closed', inject(function ($document) {
+  it('restores focus to select when the menu is closed', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);
 
@@ -144,8 +144,8 @@ describe('<md-select>', function () {
     select.remove();
   }));
 
-  describe('input container', function () {
-    it('should set has-value class on container for non-ng-model input', inject(function ($rootScope) {
+  describe('input container', function() {
+    it('should set has-value class on container for non-ng-model input', inject(function($rootScope) {
       $rootScope.model = 0;
       var el = setupSelect('ng-model="$root.model"', [1, 2, 3]);
       var select = el.find('md-select');
@@ -159,7 +159,7 @@ describe('<md-select>', function () {
       expect(el).toHaveClass('md-input-has-value');
     }));
 
-    it('should set has-value class on container for ng-model input', inject(function ($rootScope) {
+    it('should set has-value class on container for ng-model input', inject(function($rootScope) {
       $rootScope.value = 'test';
       var el = setupSelect('ng-model="$root.value"');
       expect(el).toHaveClass('md-input-has-value');
@@ -171,28 +171,28 @@ describe('<md-select>', function () {
       expect(el).not.toHaveClass('md-input-has-value');
     }));
 
-    it('should match label to given input id', inject(function ($rootScope) {
+    it('should match label to given input id', inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value", id="foo"');
       expect(el.find('label').attr('for')).toBe('foo');
       expect(el.find('md-select').attr('id')).toBe('foo');
     }));
 
-    it('should match label to automatic input id', inject(function ($rootScope) {
+    it('should match label to automatic input id', inject(function($rootScope) {
       var el = setupSelect('ng-model="$root.value"');
       expect(el.find('md-select').attr('id')).toBeTruthy();
       expect(el.find('label').attr('for')).toBe(el.find('md-select').attr('id'));
     }));
   });
 
-  describe('label behavior', function () {
-    it('defaults to the placeholder text', function () {
+  describe('label behavior', function() {
+    it('defaults to the placeholder text', function() {
       var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
       expect(label.hasClass('md-select-placeholder')).toBe(true);
     });
 
-    it('sets itself to the selected option\'s label', inject(function ($rootScope, $compile) {
+    it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
       $rootScope.val = 2;
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
@@ -209,7 +209,7 @@ describe('<md-select>', function () {
       expect(label.hasClass('md-select-placeholder')).toBe(false);
     }));
 
-    it('supports rendering multiple', inject(function ($rootScope, $compile) {
+    it('supports rendering multiple', inject(function($rootScope, $compile) {
       $rootScope.val = [1, 3];
       var select = $compile('<md-input-container>' +
       '<label>Label</label>' +
@@ -227,30 +227,30 @@ describe('<md-select>', function () {
     }));
   });
 
-  it('auto-infers a value when none specified', inject(function ($rootScope) {
+  it('auto-infers a value when none specified', inject(function($rootScope) {
     $rootScope.name = "Hannah";
     var el = setup('ng-model="name"', '<md-option>Tom</md-option>' +
     '<md-option>Hannah</md-option>');
     expect(selectedOptions(el).length).toBe(1);
   }));
 
-  it('errors for duplicate md-options, non-dynamic value', inject(function ($rootScope) {
-    expect(function () {
+  it('errors for duplicate md-options, non-dynamic value', inject(function($rootScope) {
+    expect(function() {
       setup('ng-model="$root.model"', '<md-option value="a">Hello</md-option>' +
       '<md-option value="a">Goodbye</md-option>');
     }).toThrow();
   }));
 
-  it('errors for duplicate md-options, ng-value', inject(function ($rootScope) {
+  it('errors for duplicate md-options, ng-value', inject(function($rootScope) {
     setup('ng-model="$root.model"', '<md-option ng-value="foo">Hello</md-option>' +
     '<md-option ng-value="bar">Goodbye</md-option>');
     $rootScope.$apply('foo = "a"');
-    expect(function () {
+    expect(function() {
       $rootScope.$apply('bar = "a"');
     }).toThrow();
   }));
 
-  it('watches the collection for changes', inject(function ($rootScope) {
+  it('watches the collection for changes', inject(function($rootScope) {
     $rootScope.val = 1;
     var select = setupSelect('ng-model="val"', [1, 2, 3]).find('md-select');
     var label = select.find('md-select-value')[0];
@@ -261,11 +261,11 @@ describe('<md-select>', function () {
     expect(label.textContent).toBe('4');
   }));
 
-  describe('non-multiple', function () {
+  describe('non-multiple', function() {
 
-    describe('model->view', function () {
+    describe('model->view', function() {
 
-      it('renders initial model value', inject(function ($rootScope) {
+      it('renders initial model value', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
         var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
@@ -273,12 +273,12 @@ describe('<md-select>', function () {
         expect(el.find('md-option').eq(1).attr('selected')).toBe('selected');
       }));
 
-      it('renders nothing if no initial value is set', function () {
+      it('renders nothing if no initial value is set', function() {
         var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
         expect(selectedOptions(el).length).toBe(0);
       });
 
-      it('renders model change by selecting new and deselecting old', inject(function ($rootScope) {
+      it('renders model change by selecting new and deselecting old', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
         var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
@@ -290,7 +290,7 @@ describe('<md-select>', function () {
         expect(selectedOptions(el).length).toBe(1);
       }));
 
-      it('renders invalid model change by deselecting old and selecting nothing', inject(function ($rootScope) {
+      it('renders invalid model change by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
         var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
@@ -301,7 +301,7 @@ describe('<md-select>', function () {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('renders model change to undefined by deselecting old and selecting nothing', inject(function ($rootScope) {
+      it('renders model change to undefined by deselecting old and selecting nothing', inject(function($rootScope) {
         $rootScope.$apply('model = "b"');
         var el = setup('ng-model="$root.model"', ['a', 'b', 'c']);
 
@@ -312,7 +312,7 @@ describe('<md-select>', function () {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('uses track by if given to compare objects', inject(function ($rootScope) {
+      it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = {id:2}');
         var el = setup('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
           [{id: 1}, {id: 2}, {id: 3}]);
@@ -326,7 +326,7 @@ describe('<md-select>', function () {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects', inject(function ($rootScope) {
+      it('uses uid by default to compare objects', inject(function($rootScope) {
         var one = {}, two = {}, three = {};
         $rootScope.model = two;
         var el = setup('ng-model="$root.model"', [one, two, three]);
@@ -341,9 +341,9 @@ describe('<md-select>', function () {
 
     });
 
-    describe('view->model', function () {
+    describe('view->model', function() {
 
-      it('should do nothing if clicking selected option', inject(function ($rootScope) {
+      it('should do nothing if clicking selected option', inject(function($rootScope) {
         $rootScope.model = 3;
         var el = setup('ng-model="$root.model"', [1, 2, 3]);
 
@@ -359,9 +359,9 @@ describe('<md-select>', function () {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should support the ng-change event', inject(function ($rootScope, $document) {
+      it('should support the ng-change event', inject(function($rootScope, $document) {
         var changeCalled = false;
-        $rootScope.changed = function () {
+        $rootScope.changed = function() {
           changeCalled = true;
         };
 
@@ -376,7 +376,7 @@ describe('<md-select>', function () {
         expect(changeCalled).toBe(true);
       }));
 
-      it('should deselect old and select new on click', inject(function ($rootScope) {
+      it('should deselect old and select new on click', inject(function($rootScope) {
         $rootScope.model = 3;
         var el = setup('ng-model="$root.model"', [1, 2, 3]);
 
@@ -392,7 +392,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toBe(2);
       }));
 
-      it('should keep model value if selected option is removed', inject(function ($rootScope) {
+      it('should keep model value if selected option is removed', inject(function($rootScope) {
         $rootScope.model = 3;
         $rootScope.values = [1, 2, 3];
         var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
@@ -407,7 +407,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toBe(3);
       }));
 
-      it('should select an option that was just added matching the modelValue', inject(function ($rootScope) {
+      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
         $rootScope.model = 4;
         $rootScope.values = [1, 2, 3];
         var el = setup('ng-model="$root.model"', '<md-option ng-repeat="v in values" ng-value="v">{{v}}</md-option>');
@@ -425,11 +425,11 @@ describe('<md-select>', function () {
     });
   });
 
-  describe('multiple', function () {
+  describe('multiple', function() {
 
-    describe('model->view', function () {
+    describe('model->view', function() {
 
-      it('renders initial model value', inject(function ($rootScope) {
+      it('renders initial model value', inject(function($rootScope) {
         $rootScope.model = [1, 3];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -439,7 +439,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([1, 3]);
       }));
 
-      it('renders nothing if empty array is set', inject(function ($rootScope) {
+      it('renders nothing if empty array is set', inject(function($rootScope) {
         $rootScope.model = [];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -447,7 +447,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding a valid value to the model selects its option', inject(function ($rootScope) {
+      it('adding a valid value to the model selects its option', inject(function($rootScope) {
         $rootScope.model = [];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -461,7 +461,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([2]);
       }));
 
-      it('removing a valid value from the model deselects its option', inject(function ($rootScope) {
+      it('removing a valid value from the model deselects its option', inject(function($rootScope) {
         $rootScope.model = [2, 3];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -475,7 +475,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([3]);
       }));
 
-      it('deselects all options when setting to an empty model', inject(function ($rootScope) {
+      it('deselects all options when setting to an empty model', inject(function($rootScope) {
         $rootScope.model = [2, 3];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -488,7 +488,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('adding multiple valid values to a model selects their options', inject(function ($rootScope) {
+      it('adding multiple valid values to a model selects their options', inject(function($rootScope) {
         $rootScope.model = [2, 3];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4]);
 
@@ -505,7 +505,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([2, 3, 1, 4]);
       }));
 
-      it('correctly selects and deselects options for complete reassignment of model', inject(function ($rootScope) {
+      it('correctly selects and deselects options for complete reassignment of model', inject(function($rootScope) {
         $rootScope.model = [2, 4, 5, 6];
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
 
@@ -521,7 +521,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([1, 2, 3]);
       }));
 
-      it('does not select any options if the models value does not match an option', inject(function ($rootScope) {
+      it('does not select any options if the models value does not match an option', inject(function($rootScope) {
         $rootScope.model = [];
         $rootScope.obj = {};
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3, 4, 5, 6]);
@@ -535,7 +535,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual(["bar", $rootScope.obj]);
       }));
 
-      it('uses track by if given to compare objects', inject(function ($rootScope) {
+      it('uses track by if given to compare objects', inject(function($rootScope) {
         $rootScope.$apply('model = [{id:2}]');
         var el = setupMultiple('ng-model="$root.model" ng-model-options="{trackBy: \'$value.id\'}"',
           [{id: 1}, {id: 2}, {id: 3}]);
@@ -550,7 +550,7 @@ describe('<md-select>', function () {
         expect(el.find('md-option').eq(2).attr('selected')).toBe('selected');
       }));
 
-      it('uses uid by default to compare objects', inject(function ($rootScope) {
+      it('uses uid by default to compare objects', inject(function($rootScope) {
         var one = {}, two = {}, three = {};
         $rootScope.model = [two];
         var el = setupMultiple('ng-model="$root.model"', [one, two, three]);
@@ -563,7 +563,7 @@ describe('<md-select>', function () {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
-      it('errors the model if model value is truthy and not an array', inject(function ($rootScope) {
+      it('errors the model if model value is truthy and not an array', inject(function($rootScope) {
         $rootScope.model = 'string';
         var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
         var ngModelCtrl = el.controller('ngModel');
@@ -576,9 +576,9 @@ describe('<md-select>', function () {
 
     });
 
-    describe('view->model', function () {
+    describe('view->model', function() {
 
-      it('should deselect a selected option on click', inject(function ($rootScope) {
+      it('should deselect a selected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
         var el = setupMultiple('ng-model="$root.model"', [1, 2]);
 
@@ -594,7 +594,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([]);
       }));
 
-      it('selects a deselected option on click', inject(function ($rootScope) {
+      it('selects a deselected option on click', inject(function($rootScope) {
         $rootScope.model = [1];
         var el = setupMultiple('ng-model="$root.model"', [1, 2]);
 
@@ -610,7 +610,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([1, 2]);
       }));
 
-      it('should keep model value if a selected option is removed', inject(function ($rootScope) {
+      it('should keep model value if a selected option is removed', inject(function($rootScope) {
         $rootScope.model = [1];
         $rootScope.values = [1, 2];
         var el = setupMultiple('ng-model="$root.model"',
@@ -625,7 +625,7 @@ describe('<md-select>', function () {
         expect($rootScope.model).toEqual([1]);
       }));
 
-      it('should select an option that was just added matching the modelValue', inject(function ($rootScope) {
+      it('should select an option that was just added matching the modelValue', inject(function($rootScope) {
         $rootScope.model = [1, 3];
         $rootScope.values = [1, 2];
         var el = setupMultiple('ng-model="$root.model"',
@@ -645,20 +645,20 @@ describe('<md-select>', function () {
     });
   });
 
-  describe('aria', function () {
+  describe('aria', function() {
     var el;
-    beforeEach(inject(function ($q, $document) {
+    beforeEach(inject(function($q, $document) {
       el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
       var selectMenus = $document.find('md-select-menu');
       selectMenus.remove();
     }));
 
-    it('adds an aria-label from placeholder', function () {
+    it('adds an aria-label from placeholder', function() {
       var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     });
 
-    it('preserves aria-label on value change', inject(function ($rootScope, $compile) {
+    it('preserves aria-label on value change', inject(function($rootScope, $compile) {
       var select = $compile('<md-input-container>' +
       '<label>Pick</label>' +
       '<md-select ng-model="val">' +
@@ -673,12 +673,12 @@ describe('<md-select>', function () {
       expect(select.attr('aria-label')).toBe('Pick');
     }));
 
-    it('preserves existing aria-label', inject(function ($rootScope) {
+    it('preserves existing aria-label', inject(function($rootScope) {
       var select = setupSelect('ng-model="someVal", aria-label="Hello world", placeholder="Pick"').find('md-select');
       expect(select.attr('aria-label')).toBe('Hello world');
     }));
 
-    it('should expect an aria-label if none is present', inject(function ($compile, $rootScope, $log) {
+    it('should expect an aria-label if none is present', inject(function($compile, $rootScope, $log) {
       spyOn($log, 'warn');
       var select = setupSelect('ng-model="someVal"', null, true).find('md-select');
       $rootScope.$apply();
@@ -690,7 +690,7 @@ describe('<md-select>', function () {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('sets up the aria-expanded attribute', inject(function ($document) {
+    it('sets up the aria-expanded attribute', inject(function($document) {
       expect(el.attr('aria-expanded')).toBe('false');
       openSelect(el);
       expect(el.attr('aria-expanded')).toBe('true');
@@ -700,13 +700,13 @@ describe('<md-select>', function () {
       waitForSelectClose();
       expect(el.attr('aria-expanded')).toBe('false');
     }));
-    it('sets up the aria-multiselectable attribute', inject(function ($document, $rootScope) {
+    it('sets up the aria-multiselectable attribute', inject(function($document, $rootScope) {
       $rootScope.model = [1, 3];
       var el = setupMultiple('ng-model="$root.model"', [1, 2, 3]);
 
       expect(el.attr('aria-multiselectable')).toBe('true');
     }));
-    it('sets up the aria-selected attribute', inject(function ($rootScope) {
+    it('sets up the aria-selected attribute', inject(function($rootScope) {
       var el = setup('ng-model="$root.model"', [1, 2, 3]);
       var options = el.find('md-option');
       expect(options.eq(2).attr('aria-selected')).toBe('false');
@@ -718,16 +718,16 @@ describe('<md-select>', function () {
     }));
   });
 
-  describe('keyboard controls', function () {
+  describe('keyboard controls', function() {
 
 
-    afterEach(inject(function ($document) {
+    afterEach(inject(function($document) {
       var selectMenus = $document.find('md-select-menu');
       selectMenus.remove();
     }));
 
-    describe('md-select', function () {
-      it('can be opened with a space key', inject(function ($document) {
+    describe('md-select', function() {
+      it('can be opened with a space key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 32);
         waitForSelectOpen();
@@ -735,7 +735,7 @@ describe('<md-select>', function () {
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with an enter key', inject(function ($document) {
+      it('can be opened with an enter key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 13);
         waitForSelectOpen();
@@ -743,7 +743,7 @@ describe('<md-select>', function () {
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the up key', inject(function ($document) {
+      it('can be opened with the up key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 38);
         waitForSelectOpen();
@@ -751,7 +751,7 @@ describe('<md-select>', function () {
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('can be opened with the down key', inject(function ($document) {
+      it('can be opened with the down key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 40);
         waitForSelectOpen();
@@ -759,15 +759,15 @@ describe('<md-select>', function () {
         expect(selectMenu.length).toBe(1);
       }));
 
-      it('supports typing an option name', inject(function ($document, $rootScope) {
+      it('supports typing an option name', inject(function($document, $rootScope) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 50);
         expect($rootScope.someModel).toBe(2);
       }));
     });
 
-    describe('md-select-menu', function () {
-      it('can be closed with escape', inject(function ($document, $rootScope, $animate) {
+    describe('md-select-menu', function() {
+      it('can be closed with escape', inject(function($document, $rootScope, $animate) {
         var el = setupSelect('ng-model="someVal"', [1, 2, 3]).find('md-select');
         openSelect(el);
         var selectMenu = angular.element($document.find('md-select-menu'));


### PR DESCRIPTION
Adds required md-input-container to md-select. 
Replaces md-select-label with md-select-value
Adjusts scss to make label transition the same way as with md-input-container/md-input
Removed md-select blacklist from placeholder