### PR TITLE
fix($mdUtil): make "initOptionalProperties" compatible with angular >= 1.4.1

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -334,15 +334,16 @@ angular.module('material.core')
     },
 
     /**
-     * Give optional properties with no value a boolean true by default
+     * Give optional properties with no value a boolean true if attr provided or false otherwise
      */
     initOptionalProperties: function (scope, attr, defaults ) {
        defaults = defaults || { };
        angular.forEach(scope.$$isolateBindings, function (binding, key) {
+         var normalizedAttrName = attr.$normalize(binding.attrName);
          if (binding.optional && angular.isUndefined(scope[key])) {
-           var hasKey = attr.hasOwnProperty(attr.$normalize(binding.attrName));
+           var attrIsDefined = normalizedAttrName in attr &&  !angular.isUndefined(attr[normalizedAttrName]);
 
-           scope[key] = angular.isDefined(defaults[key]) ? defaults[key] : hasKey;
+           scope[key] = angular.isDefined(defaults[key]) ? defaults[key] : attrIsDefined;
          }
        });
     }

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -339,10 +339,8 @@ angular.module('material.core')
     initOptionalProperties: function (scope, attr, defaults ) {
        defaults = defaults || { };
        angular.forEach(scope.$$isolateBindings, function (binding, key) {
-         var normalizedAttrName = attr.$normalize(binding.attrName);
          if (binding.optional && angular.isUndefined(scope[key])) {
-           var attrIsDefined = normalizedAttrName in attr &&  !angular.isUndefined(attr[normalizedAttrName]);
-
+           var attrIsDefined = angular.isDefined(attr[binding.attrName]);
            scope[key] = angular.isDefined(defaults[key]) ? defaults[key] : attrIsDefined;
          }
        });


### PR DESCRIPTION
starting form angular 1.4.1 attrs defined in directive isolated scope are always present in $attrs

Closes #3315