### PR TITLE
Autocomplete: Stop Event propagation for Key.ESC 

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -350,7 +350,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $timeout, $
         ctrl.matches = [];
         ctrl.hidden = true;
         ctrl.index = getDefaultIndex();
-        event.preventDefault();
+        event.stopPropagation();
         break;
       default:
     }

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -350,6 +350,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $timeout, $
         ctrl.matches = [];
         ctrl.hidden = true;
         ctrl.index = getDefaultIndex();
+        event.preventDefault();
         break;
       default:
     }

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -506,7 +506,7 @@ function MdDialogProvider($$interimElementProvider) {
               $timeout($mdDialog.cancel);
             }
           };
-          $rootElement.on('keyup', options.rootElementKeyupCallback);
+          $rootElement.on('keydown', options.rootElementKeyupCallback);
         }
 
         if (options.clickOutsideToClose) {

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -236,7 +236,7 @@ describe('$mdDialog', function() {
 
       expect(parent.find('md-dialog').length).toBe(1);
 
-      $rootElement.triggerHandler({type: 'keyup',
+      $rootElement.triggerHandler({type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
 
@@ -261,7 +261,7 @@ describe('$mdDialog', function() {
 
       expect(parent.find('md-dialog').length).toBe(1);
 
-      $rootElement.triggerHandler({ type: 'keyup', keyCode: $mdConstant.KEY_CODE.ESCAPE });
+      $rootElement.triggerHandler({ type: 'keydown', keyCode: $mdConstant.KEY_CODE.ESCAPE });
 
       $timeout.flush();
       $animate.triggerCallbacks();


### PR DESCRIPTION
1 line change to stop event propagation if ESC was pressed.
Reason: I use an autocomplete field in a dialog, so ESC closes the dialog too.