### PR TITLE
slider demo uses alternative theme for matching RGB

### DIFF
--- a/src/components/slider/demoBasicUsage/index.html
+++ b/src/components/slider/demoBasicUsage/index.html
@@ -10,7 +10,7 @@
       <div flex="10" layout layout-align="center center">
         <span class="md-body-1">R</span>
       </div>
-      <md-slider flex min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider" class="">
+      <md-slider flex min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider" class="md-warn">
       </md-slider>
       <div flex="20" layout layout-align="center center">
         <input type="number" ng-model="color.red" aria-label="red" aria-controls="red-slider">

--- a/src/components/slider/demoBasicUsage/script.js
+++ b/src/components/slider/demoBasicUsage/script.js
@@ -1,6 +1,14 @@
 
 angular.module('sliderDemo1', ['ngMaterial'])
 
+.config(function($mdThemingProvider) {
+  $mdThemingProvider.theme('altTheme')
+    .primaryPalette('blue')
+    .accentPalette('green')
+    .warnPalette('red');
+  $mdThemingProvider.setDefaultTheme('altTheme');
+})
+
 .controller('AppCtrl', function($scope) {
 
   $scope.color = {
@@ -15,5 +23,4 @@ angular.module('sliderDemo1', ['ngMaterial'])
 
   $scope.disabled1 = 0;
   $scope.disabled2 = 70;
-
 });


### PR DESCRIPTION
I've modified the demo in the way that it uses an alternative theme, so that the RGB matches the warn, accent and primary colors of the alternative theme.

![screen shot 2015-06-23 at 5 24 57 pm](https://cloud.githubusercontent.com/assets/5065940/8320217/d22e66b2-19cc-11e5-82ea-ab825b48a5f5.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3429)
<!-- Reviewable:end -->
