### PR TITLE
Wip/css layouts

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -76,14 +76,13 @@ md-menu-item {
     height: 100%;
     padding-left: 2*$baseline-grid;
     padding-right: 2*$baseline-grid;
-    display: flex;
-    flex-direction: row;
+    display: inline-block;
     md-icon {
       margin: auto 2*$baseline-grid auto 0;
     }
     p {
       margin: auto;
-      flex: 1;
+      width:100%;
     }
     span {
       margin-top: auto;

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -11,11 +11,9 @@
 
 [layout] {
   box-sizing: border-box;
-  display: -webkit-box;
   display: -webkit-flex;
-  display: -moz-box;
   display: -moz-flex;
-  display: -ms-flexbox;
+  display: -ms-flex;
   display: flex;
 }
 
@@ -105,11 +103,10 @@
 @mixin layout-for-name($name) {
   [layout-#{$name}] {
     box-sizing: border-box;
-    display: -webkit-box;
     display: -webkit-flex;
-    display: -moz-box;
     display: -moz-flex;
-    display: -ms-flexbox;
+    display: -moz-flex;
+    display: -ms-flex;
     display: flex;
   }
   [layout-#{$name}=column] {
@@ -153,37 +150,43 @@
   // (0-20) * 5 = 0-100%
   @for $i from 0 through 20 {
     [#{$flexName}="#{$i * 5}"] {
-      flex: 0 0 #{$i * 5 + '%'};
+      flex: #{($i * 5)/100};
     }
     [layout="row"] > [#{$flexName}="#{$i * 5}"] {
       max-width: #{$i * 5 + '%'};
+      min-width: #{$i * 5 + '%'};
     }
     [layout="column"] > [#{$flexName}="#{$i * 5}"] {
       max-height: #{$i * 5 + '%'};
+      min-height: #{$i * 5 + '%'};
     }
   }
 
   [#{$flexName}="33"], [#{$flexName}="34"] {
-    flex: 0 0 33.33%;
+    flex: 0.33;
   }
   [#{$flexName}="66"], [#{$flexName}="67"] {
-    flex: 0 0 66.66%;
+    flex: 0.66;
   }
 
   [layout="row"] {
     > [#{$flexName}="33"], > [#{$flexName}="34"] {
       max-width: 33.33%;
+      min-width: 33.33%;
     }
     > [#{$flexName}="66"], > [#{$flexName}="67"] {
       max-width: 66.66%;
+      min-width: 66.66%;
     }
   }
   [layout="column"] {
     > [#{$flexName}="33"], > [#{$flexName}="34"] {
       max-height: 33.33%;
+      min-height: 33.33%;
     }
     > [#{$flexName}="66"], > [#{$flexName}="67"] {
       max-height: 66.66%;
+      min-height: 66.66%;
     }
   }
 }


### PR DESCRIPTION
Updates to support nested flex containers with `flex="<percentage value>"`.
Updates to md-list buttons to use inline-block mode.

Fixes #3436. Fixes #3439.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3443)
<!-- Reviewable:end -->
