### PR TITLE
Fixing md-tooltip on Firefox issues #3047, #3250 and #3430

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -129,7 +129,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     function bindEvents () {
       var mouseActive = false;
       var enterHandler = function() {
-        if (!hasComputedStyleValue('pointer-events','none')) {
+        if (!hasComputedStyleValue('pointer-events','block')) {
           setVisible(true);
         }
       };


### PR DESCRIPTION
var computedStyles = $window.getComputedStyle(element[0]);

console.log(computedStyles['pointer-events'] ); // Firefox returns 'none' as string
console.log(computedStyles['pointer-events'] ); // Chrome returns an empty string ''

The problem is that hasComputedStyleValue('pointer-events','none') always returns true on Firefox and setVisible(true); is not being called.

All the tests are still passing and now the Tooltip works fine on Chrome and Firefox again.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3447)
<!-- Reviewable:end -->
