### PR TITLE
fix($mdUtil): disableBodyScroll() no longer forces scrollbar

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -116,7 +116,7 @@ angular.module('material.core')
           applyStyles(body, {
             position: 'fixed',
             width: '100%',
-            overflowY: 'scroll',
+            overflowY: 'auto',
             top: -scrollOffset + 'px'
           });
 


### PR DESCRIPTION
The disableScrollAround() as used by mdSelect and mdAutocomplete
would force a scrollbar by setting `overflow-y: scroll` on `<body>`.
This change sets it to `auto` so the browser can decide if a scrollbar
is needed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3457)
<!-- Reviewable:end -->
