### PR TITLE
fix(mdTooltip): fix regression that broke tooltips on Firefox

### DIFF
--- a/gulp/tasks/karma-fast.js
+++ b/gulp/tasks/karma-fast.js
@@ -4,7 +4,7 @@ var util = require('../util');
 var ROOT = require('../const').ROOT;
 var args = util.args;
 
-// NOTE: `karma-fas` does NOT pre-make a full build of JS and CSS
+// NOTE: `karma-fast` does NOT pre-make a full build of JS and CSS
 // exports.dependencies = ['build'];
 
 exports.task = function (done) {
@@ -19,6 +19,7 @@ exports.task = function (done) {
   if ( args.browsers ) {
     karmaConfig.browsers = args.browsers.trim().split(',');
   }
+  // NOTE: `karma-fast` does NOT test Firefox by default.
 
   gutil.log('Running unit tests on unminified source.');
   karma.start(karmaConfig, captureError(clearEnv,clearEnv));

--- a/gulp/tasks/karma.js
+++ b/gulp/tasks/karma.js
@@ -39,6 +39,8 @@ exports.task = function (done) {
 
   if ( args.browsers ) {
     karmaConfig.browsers = args.browsers.trim().split(',');
+  } else {
+    karmaConfig.browsers = ['Firefox', 'PhantomJS'];
   }
 
   gutil.log('Running unit tests on unminified source.');

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -129,9 +129,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     function bindEvents () {
       var mouseActive = false;
       var enterHandler = function() {
-        if (!hasComputedStyleValue('pointer-events','none')) {
           setVisible(true);
-        }
       };
       var leaveHandler = function () {
         var autohide = scope.hasOwnProperty('autohide') ? scope.autohide : attr.hasOwnProperty('mdAutohide');

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -170,7 +170,7 @@ describe('<md-tooltip> directive', function() {
             'Tooltip' +
           '</md-tooltip>' +
         '</md-button>'
-      )
+      );
 
       // this focus is needed to set `$document.activeElement`
       // and wouldn't be required if `document.activeElement` was settable.


### PR DESCRIPTION
Remove check for pointer-events not equal to none to resolve non-visible tooltips on Firefox.
Add Chrome & Firefox as default test runners in karma task to avoid regressions like this in the future.

Closes #3047, #3250 and #3430

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3467)
<!-- Reviewable:end -->
