### PR TITLE
feat(interimElement): add onRemoving event

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -344,6 +344,8 @@ function MdDialogDirective($$rAF, $mdTheming) {
  *     to the root element of the application.
  *   - `onComplete` `{function=}`: Callback function used to announce when the show() action is
  *     finished.
+ *   - `onRemoving` `{function=}`: Callback function used to announce when the dialog has begun
+ *     closing.
  *
  * @returns {promise} A promise that can be resolved with `$mdDialog.hide()` or
  * rejected with `$mdDialog.cancel()`.

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -401,6 +401,10 @@ function InterimElementProvider() {
             self.cancelTimeout();
             return removeDone = $q.when(showDone).then(function() {
               var ret = element ? options.onRemove(options.scope, element, options) : true;
+              if (ret) {
+                  // Issue onRemoving callback when `remove()` is called and is not canceled.
+                  (options.onRemoving || angular.noop)(options.scope, element, options);
+              }
               return $q.when(ret).then(function() {
                 if (!options.preserveScope) options.scope.$destroy();
                 removeDone = true;

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -344,6 +344,26 @@ describe('$$interimElement service', function() {
         }
       }));
 
+      it('calls onRemoving', inject(function($rootScope, $animate) {
+        var onRemovingCalled = false;
+        Service.show({
+          template: '<some-element />',
+          isPassingOptions: true,
+          onRemoving: onRemoving
+        });
+        $rootScope.$digest();
+        $animate.triggerCallbacks();
+        Service.hide();
+        $rootScope.$digest();
+        expect(onRemovingCalled).toBe(true);
+
+        function onRemoving(scope, el, options) {
+          onRemovingCalled = true;
+          expect(options.isPassingOptions).toBe(true);
+          expect(el[0]).toBeTruthy();
+        }
+      }));
+
       it('returns a promise', inject(function($$interimElement) {
         expect(typeof Service.show().then).toBe('function');
       }));


### PR DESCRIPTION
This event allows you to perform an action when e.g., a dialog starts to
close as opposed to when it has finished closing.

Fixes #3403.

Example use:

```javascript
viewport.classList.add('blurred');
$mdDialog.show({
  controller: 'MyDialogController',
  clickOutsideToClose: true,
  onRemoving: () => viewport.classList.remove('blurred'), // <---
  template: myTemplate,
  parent: angular.element(document.body),
  targetEvent: event
});
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/3503)
<!-- Reviewable:end -->
