### PR TITLE
Adds support for textarea's "rows" attribute and makes autogrow optional

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -141,6 +141,10 @@ md-input-container {
       outline: none;
       box-shadow: none;
     }
+
+    &.md-no-flex {
+      flex: none !important;
+    }
   }
 
   ng-messages, data-ng-messages, x-ng-messages,


### PR DESCRIPTION
Replaces corrupted PR #2899.

Makes textarea autogrow optional, partly resolves #1209
Fixes textarea auto grow inside scrollable container (resolves #2007 and possibly others)
Adds support for textarea auto grow based on rows attribute (resolves #2006)
Avoid "rows" attribute unintended overwrite by default value