### PR TITLE
fix(toast): replace cancel with hide on hideDelay

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -55,7 +55,7 @@ function MdToastDirective() {
 /**
  * @ngdoc method
  * @name $mdToast#showSimple
- * 
+ *
  * @description
  * Convenience method which builds and shows a simple toast.
  *
@@ -83,7 +83,7 @@ function MdToastDirective() {
 /**
  * @ngdoc method
  * @name $mdToast#updateContent
- * 
+ *
  * @description
  * Updates the content of an existing toast. Useful for updating things like counts, etc.
  *

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -25,8 +25,8 @@ describe('$mdToast service', function() {
           theme: 'some-theme',
           capsule: true
         })
-      ).catch(function() {
-        rejected = true;
+      ).then(function() {
+        resolved = true;
       });
       $rootScope.$digest();
       expect(parent.find('span').text()).toBe('Do something');
@@ -35,7 +35,7 @@ describe('$mdToast service', function() {
       $animate.triggerCallbacks();
       $timeout.flush();
       $animate.triggerCallbacks();
-      expect(rejected).toBe(true);
+      expect(resolved).toBe(true);
     }));
 
     it('supports dynamicly updating the content', inject(function($mdToast, $rootScope, $rootElement) {

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -339,7 +339,7 @@ function InterimElementProvider() {
           show: function() {
             var compilePromise;
             if (options.skipCompile) {
-              compilePromise = $q(function(resolve) { 
+              compilePromise = $q(function(resolve) {
                 resolve({
                   locals: {},
                   link: function() { return options.element; }
@@ -386,7 +386,7 @@ function InterimElementProvider() {
 
               function startHideTimeout() {
                 if (options.hideDelay) {
-                  hideTimeout = $timeout(service.cancel, options.hideDelay) ;
+                  hideTimeout = $timeout(service.hide, options.hideDelay);
                 }
               }
             },

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -16,7 +16,7 @@ describe('$$interimElement service', function() {
         expect(interimTest.show).toBeOfType('function');
 
         var builder = interimTest.build();
-        [ 'controller', 'controllerAs', 'onRemove', 'onShow', 'resolve', 
+        [ 'controller', 'controllerAs', 'onRemove', 'onShow', 'resolve',
           'template', 'templateUrl', 'themable', 'transformTemplate', 'parent'
         ].forEach(function(methodName) {
           expect(builder[methodName]).toBeOfType('function');
@@ -226,7 +226,7 @@ describe('$$interimElement service', function() {
         flush();
         expect($compilerSpy.calls.mostRecent().args[0].key).toBe('newValue');
         expect($compilerSpy.calls.mostRecent().args[0].key2).toBe('newValue2');
-        
+
         $compilerSpy.calls.reset();
         flush();
         flush();
@@ -277,7 +277,7 @@ describe('$$interimElement service', function() {
       }));
 
       it('calls hide after hideDelay', inject(function($animate, $timeout, $rootScope) {
-        var hideSpy = spyOn(Service, 'cancel').and.callThrough();
+        var hideSpy = spyOn(Service, 'hide').and.callThrough();
         Service.show({hideDelay: 1000});
         expect(hideSpy).toHaveBeenCalled();
       }));
@@ -540,4 +540,3 @@ describe('$$interimElement service', function() {
   }
 
 });
-


### PR DESCRIPTION
This replaces the `cancel()` with `hide()` in a toast with the option `hideDelay`.

What it changes is, that the promise get resolved instead of rejected what makes more sense to me.