### PR TITLE
mdSelect: Attributes are always strings.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -644,7 +644,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     if (angular.isDefined(attr.ngValue)) {
       scope.$watch(attr.ngValue, setOptionValue);
     } else if (angular.isDefined(attr.value)) {
-      setOptionValue(attr.value);
+      setOptionValue(isNaN(attr.value) ? attr.value : Number(attr.value));
     } else {
       scope.$watch(function() { return element.text(); }, setOptionValue);
     }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -155,6 +155,15 @@ describe('<md-select>', function() {
 
     select.remove();
   }));
+  
+  it('should not convert numbers to strings', inject(function($compile, $rootScope) {
+    $rootScope.value = 1;
+    $compile('<md-select ng-model="value">' +
+      '<md-option ng-repeat="value in [1, 2, 3]" value="{{value}}">{{value}}</md-option>' +
+    '</md-select>')($rootScope);
+    $rootScope.$digest();
+    expect($rootScope.value).toBe(1);
+  }));
 
   describe('input container', function() {
     beforeEach(inject(function($document) {


### PR DESCRIPTION
Attributes are always strings, this results in unexpected `ng-change` or `$scope.watch` events firing when using numbers.