### PR TITLE
Use button padding value specified by material

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,5 +1,5 @@
 $button-line-height: rem(3.60) !default;
-$button-padding: 0 rem(0.600) !default;
+$button-padding: 0 rem(0.800) !default;
 $button-margin: rem(0.600) rem(0.800) !default;
 $button-min-width: rem(8.800) !default;
 


### PR DESCRIPTION
https://www.google.com/design/spec/components/buttons.html#buttons-usage

```
Button
Height: 36dp
Minimum width: 64dp
Touch target height: 48dp
Horizontal margin: 8dp
Horizontal padding: 8dp
```