### PR TITLE
Check for possible step calculation

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -184,6 +184,10 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     var tickCanvas, tickCtx;
     function redrawTicks() {
       if (!angular.isDefined(attr.mdDiscrete)) return;
+      
+      if (0 >= step) {
+        throw new Error('Step must be greater than zero when in discrete mode');
+      }
 
       var numSteps = Math.floor( (max - min) / step );
       if (!tickCanvas) {


### PR DESCRIPTION
Currently, if you set md-discrete and step 0 in sliders, it will still try to calculate the numSteps, causing the entire application to fail.