### PR TITLE
fix(dialog): Scroll bar issues and broken dialogs on IE

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -31,7 +31,7 @@ md-dialog {
   max-width: 80%;
   max-height: 80%;
   position: relative;
-  overflow: hidden; // stop content from leaking out of dialog parent
+  overflow: auto; // stop content from leaking out of dialog parent and fix IE
 
   box-shadow: $whiteframe-shadow-z5;
 


### PR DESCRIPTION
Change from overflow hidden to overflow auto to preserve the border-radius fix in #1015 and fix dialogs in IE 11.

Fixes #3480. Fixes #3187. Fixes #3005. Fixes #2934.