### PR TITLE
feat(core) create mdResolve service

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -69,7 +69,7 @@ function mdCompilerService($q, $http, $compile, $controller, $templateCache, $md
     var controller = options.controller;
     var controllerAs = options.controllerAs;
     var resolve = angular.copy(options.resolve || {});
-    var locals = angular.copy(options.locals || {});
+    var locals = options.locals;
     var transformTemplate = options.transformTemplate || angular.identity;
     var bindToController = options.bindToController;
 

--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -1,7 +1,7 @@
 angular.module('material.core')
   .service('$mdCompiler', mdCompilerService);
 
-function mdCompilerService($q, $http, $injector, $compile, $controller, $templateCache) {
+function mdCompilerService($q, $http, $compile, $controller, $templateCache, $mdResolve) {
   /* jshint validthis: true */
 
   /*
@@ -73,20 +73,6 @@ function mdCompilerService($q, $http, $injector, $compile, $controller, $templat
     var transformTemplate = options.transformTemplate || angular.identity;
     var bindToController = options.bindToController;
 
-    // Take resolve values and invoke them.  
-    // Resolves can either be a string (value: 'MyRegisteredAngularConst'),
-    // or an invokable 'factory' of sorts: (value: function ValueGetter($dependency) {})
-    angular.forEach(resolve, function(value, key) {
-      if (angular.isString(value)) {
-        resolve[key] = $injector.get(value);
-      } else {
-        resolve[key] = $injector.invoke(value);
-      }
-    });
-    //Add the locals, which are just straight values to inject
-    //eg locals: { three: 3 }, will inject three into the controller
-    angular.extend(resolve, locals);
-
     if (templateUrl) {
       resolve.$template = $http.get(templateUrl, {cache: $templateCache})
         .then(function(response) {
@@ -96,9 +82,8 @@ function mdCompilerService($q, $http, $injector, $compile, $controller, $templat
       resolve.$template = $q.when(template);
     }
 
-    // Wait for all the resolves to finish if they are promises
-    return $q.all(resolve).then(function(locals) {
-
+    // Wait for $mdResolve
+    return $mdResolve(resolve, locals).then(function (locals) {
       var template = transformTemplate(locals.$template);
       var element = options.element || angular.element('<div>').html(template.trim()).contents();
       var linkFn = $compile(element);

--- a/src/core/services/resolve/resolve.js
+++ b/src/core/services/resolve/resolve.js
@@ -39,7 +39,7 @@ function ResolveService($q, $injector) {
    * @returns {object=} promise A promise, which will be resolved with a `resolved` object.
    */
   return function mdResolve(resolve, locals) {
-    var resolved = angular.extend({}, locals);
+    var resolved = angular.isObject(locals) ? angular.copy(locals) : {};
 
     if (angular.isObject(resolve)) {
       for (var name in resolve) {

--- a/src/core/services/resolve/resolve.js
+++ b/src/core/services/resolve/resolve.js
@@ -41,8 +41,11 @@ function ResolveService($q, $injector) {
   return function mdResolve(resolve, locals) {
     var resolved = angular.extend({}, locals);
 
-    for (var name in resolve) {
-      invoke(name, resolve, resolved);
+    if (angular.isObject(resolve)) {
+      for (var name in resolve) {
+        if (!resolve.hasOwnProperty(name)) continue;
+        invoke(name, resolve, resolved);
+      }
     }
 
     return $q.all(resolved);

--- a/src/core/services/resolve/resolve.js
+++ b/src/core/services/resolve/resolve.js
@@ -39,7 +39,7 @@ function ResolveService($q, $injector) {
    * @returns {object=} promise A promise, which will be resolved with a `resolved` object.
    */
   return function mdResolve(resolve, locals) {
-    var resolved = angular.isObject(locals) ? angular.copy(locals) : {};
+    var resolved = angular.extend({}, locals);
 
     if (angular.isObject(resolve)) {
       for (var name in resolve) {

--- a/src/core/services/resolve/resolve.js
+++ b/src/core/services/resolve/resolve.js
@@ -1,0 +1,86 @@
+angular.module('material.core')
+  .service('$mdResolve', ResolveService);
+
+/*
+ * @ngdoc service
+ * @name $mdResolve
+ * @module material.core
+ *
+ * @description
+ * The $mdResolve service helps to resolve acyclic dependencies.
+ * Used internally in $mdCompiler service.
+ *
+ * ```js
+ * var locals = {
+ *   value: 'my value'
+ * };
+ * var resolve = {
+ *   asyncService: function(value, $q) {
+ *     return $q.when(value);
+ *   },
+ *   service: function(value, asyncService) {
+ *     return value == asyncService;
+ *   }
+ * };
+ * $mdResolve(resolve, locals).then(function(resolved) {
+ *   assert(resolved.value == 'my value');
+ *   assert(resolved.asyncService == 'my value');
+ *   assert(resolved.service === true);
+ * });
+ * ```
+ */
+
+/* @ngInject */
+function ResolveService($q, $injector) {
+  /**
+   * Resolve dependencies
+   * @param {object} [resolve] hash of values that have to be resolved
+   * @param {object} [locals] locals
+   * @returns {object=} promise A promise, which will be resolved with a `resolved` object.
+   */
+  return function mdResolve(resolve, locals) {
+    var resolved = angular.extend({}, locals);
+
+    for (var name in resolve) {
+      invoke(name, resolve, resolved);
+    }
+
+    return $q.all(resolved);
+  };
+
+  /**
+   * Take resolve value by name and invoke it.
+   * Value can either be a string (value: 'MyRegisteredAngularConst'),
+   * or an invokable 'factory' of sorts: (value: function ValueGetter($dependency) {}),
+   * or Promise (value: $http.get(url).then(...)).
+   */
+  function invoke(name, resolve, resolved) {
+    if (resolved.hasOwnProperty(name)) return resolved[name];
+    if (!resolve.hasOwnProperty(name)) return;
+
+    var value = resolve[name];
+
+    if (angular.isString(value)) {
+      resolved[name] = $injector.get(value);
+    } else if (isPromise(value)) {
+      resolved[name] = value;
+    } else {
+      var promises = {};
+      $injector.annotate(value).forEach(function (name) {
+        var value = invoke(name, resolve, resolved);
+        if (!angular.isUndefined(value)) promises[name] = value;
+      });
+
+      resolved[name] = $q.all(promises).then(angular.bind($injector, $injector.invoke, value, null));
+    }
+
+    return resolved[name];
+  }
+
+  /**
+   * Check is value Promise.
+   */
+  function isPromise(value) {
+    return angular.isObject(value) && angular.isFunction(value.then);
+  }
+}

--- a/src/core/services/resolve/resolve.spec.js
+++ b/src/core/services/resolve/resolve.spec.js
@@ -1,0 +1,125 @@
+describe('$mdResolve service', function () {
+  beforeEach(module('material.core'));
+
+  function mdResolve(resolve, locals) {
+    var resolved;
+    inject(function ($mdResolve, $rootScope) {
+      $mdResolve(resolve, locals).then(function (locals) {
+        resolved = locals;
+      });
+      $rootScope.$apply();
+    });
+    return resolved;
+  }
+
+  describe('resolve', function () {
+    beforeEach(function () {
+      module(function ($provide) {
+        $provide.constant('ONE', 'one');
+        $provide.constant('TWO', 'two');
+        $provide.constant('THREE', 'three');
+        $provide.constant('FOUR', 'four');
+        $provide.constant('FIVE', 'five');
+        $provide.constant('SIX', 'six');
+      });
+    });
+
+    it('should resolve', inject(function ($q) {
+      var resolve = {
+        one: function () {
+          return 'one';
+        },
+        two: function () {
+          return $q.when('two');
+        },
+        three: 'THREE',
+        four: $q.when('four')
+      };
+
+      var resolved = mdResolve(resolve);
+
+      expect(resolved.one).toBe('one');
+      expect(resolved.two).toBe('two');
+      expect(resolved.three).toBe('three');
+      expect(resolved.four).toBe('four');
+    }));
+
+    it('should locals', inject(function () {
+      var locals = {
+        one: 'one',
+        two: 'TWO'
+      };
+
+      var resolved = mdResolve(null, locals);
+
+      expect(resolved.one).toBe('one');
+      expect(resolved.two).toBe('TWO');
+    }));
+
+    it('should resolve dependencies', inject(function ($q) {
+      var locals = {
+        one: 'one'
+      };
+
+      var resolve = {
+        two: function (TWO) {
+          return $q.when(TWO);
+        },
+        three: function (one, two, THREE) {
+          return one == 'one' && two == 'two' && THREE;
+        },
+        four: 'FOUR',
+        five: $q.when('five'),
+        six: function (one, two, three, four, five, SIX) {
+          return one == 'one' && two == 'two' && three == 'three' && four == 'four' && five == 'five' && SIX;
+        }
+      };
+
+      var resolved = mdResolve(resolve, locals);
+
+      expect(resolved.one).toBe('one');
+      expect(resolved.two).toBe('two');
+      expect(resolved.three).toBe('three');
+      expect(resolved.four).toBe('four');
+      expect(resolved.five).toBe('five');
+      expect(resolved.six).toBe('six');
+    }));
+
+    it('should replace global', inject(function () {
+      var locals = {
+        ONE: 'locals one'
+      };
+
+      var resolve = {
+        TWO: function () {
+          return 'resolve two';
+        }
+      };
+
+      var resolved = mdResolve(resolve, locals);
+
+      expect(resolved.ONE).toBe('locals one');
+      expect(resolved.TWO).toBe('resolve two');
+    }));
+
+    it('should not overwrite the original values', function () {
+      var locals = {
+        one: 'one'
+      };
+
+      var resolve = {
+        two: function () {
+          return 'two'
+        }
+      };
+
+      var localsCopy = angular.copy(locals);
+      var resolveCopy = angular.copy(resolve);
+
+      mdResolve(resolve, locals);
+
+      expect(locals).toEqual(localsCopy);
+      expect(resolve).toEqual(resolveCopy);
+    });
+  });
+});

--- a/src/core/services/resolve/resolve.spec.js
+++ b/src/core/services/resolve/resolve.spec.js
@@ -1,121 +1,168 @@
 describe('$mdResolve service', function () {
   beforeEach(module('material.core'));
 
-  function mdResolve(resolve, locals) {
-    var resolved;
-    inject(function ($mdResolve, $rootScope) {
-      $mdResolve(resolve, locals).then(function (locals) {
-        resolved = locals;
-      });
-      $rootScope.$apply();
-    });
-    return resolved;
+  function isPromise(value) {
+    return angular.isObject(value) && angular.isFunction(value.then);
   }
 
   describe('resolve', function () {
-    beforeEach(function () {
-      module(function ($provide) {
-        $provide.constant('ONE', 'one');
-        $provide.constant('TWO', 'two');
-        $provide.constant('THREE', 'three');
-        $provide.constant('FOUR', 'four');
-        $provide.constant('FIVE', 'five');
-        $provide.constant('SIX', 'six');
+    function mdResolve(resolve, locals) {
+      var resolved;
+      inject(function ($mdResolve, $rootScope) {
+        $mdResolve(resolve, locals).then(function (locals) {
+          resolved = locals;
+        });
+        $rootScope.$apply();
       });
-    });
+      return resolved;
+    }
 
-    it('should resolve', inject(function ($q) {
-      var resolve = {
-        one: function () {
-          return 'one';
-        },
-        two: function () {
-          return $q.when('two');
-        },
-        three: 'THREE',
-        four: $q.when('four')
-      };
-
-      var resolved = mdResolve(resolve);
-
-      expect(resolved.one).toBe('one');
-      expect(resolved.two).toBe('two');
-      expect(resolved.three).toBe('three');
-      expect(resolved.four).toBe('four');
-    }));
-
-    it('should locals', inject(function () {
-      var locals = {
-        one: 'one',
-        two: 'TWO'
-      };
-
-      var resolved = mdResolve(null, locals);
-
-      expect(resolved.one).toBe('one');
-      expect(resolved.two).toBe('TWO');
-    }));
-
-    it('should resolve if resole & locals are not defined', inject(function () {
+    it('should resolve without arguments', inject(function () {
       var resolved = mdResolve();
 
       expect(resolved).toEqual({});
     }));
 
-    it('should resolve dependencies', inject(function ($q) {
-      var locals = {
-        one: 'one'
-      };
+    it('should resolve', module(function ($provide) {
+      $provide.constant('VALUE', 'value');
+      $provide.service('PROMISE', function ($q) {
+        return $q.when('promise');
+      });
 
-      var resolve = {
-        two: function (TWO) {
-          return $q.when(TWO);
-        },
-        three: function (one, two, THREE) {
-          return one == 'one' && two == 'two' && THREE;
-        },
-        four: 'FOUR',
-        five: $q.when('five'),
-        six: function (one, two, three, four, five, SIX) {
-          return one == 'one' && two == 'two' && three == 'three' && four == 'four' && five == 'five' && SIX;
-        }
-      };
+      inject(function ($q, VALUE, PROMISE) {
+        var resolve = {
+          first: function () {
+            return 'first';
+          },
+          second: function () {
+            return $q.when('second');
+          },
+          third: $q.when('third'),
+          providerValue: 'VALUE',
+          providerPromise: 'PROMISE'
+        };
 
-      var resolved = mdResolve(resolve, locals);
+        var resolved = mdResolve(resolve);
 
-      expect(resolved.one).toBe('one');
-      expect(resolved.two).toBe('two');
-      expect(resolved.three).toBe('three');
-      expect(resolved.four).toBe('four');
-      expect(resolved.five).toBe('five');
-      expect(resolved.six).toBe('six');
+        expect(resolved.first).toBe('first');
+        expect(isPromise(resolved.second)).toBe(false);
+        expect(resolved.second).toBe('second');
+        expect(isPromise(resolved.third)).toBe(false);
+        expect(resolved.third).toBe('third');
+        expect(resolved.providerValue).toBe(VALUE);
+        expect(isPromise(resolved.providerPromise)).toBe(true);
+        expect(resolved.providerPromise).toBe(PROMISE);
+      });
     }));
 
-    it('should replace global', inject(function () {
+    it('should resolve locals', inject(function ($q) {
+      var value = 'value';
+      var promise = $q.when('promise');
+
       var locals = {
-        ONE: 'locals one'
+        value: value,
+        promise: promise
       };
 
-      var resolve = {
-        TWO: function () {
-          return 'resolve two';
-        }
-      };
+      var resolved = mdResolve(null, locals);
 
-      var resolved = mdResolve(resolve, locals);
+      expect(resolved.value).toBe(value);
+      expect(isPromise(resolved.promise)).toBe(true);
+      expect(resolved.promise).toBe(promise);
+    }));
 
-      expect(resolved.ONE).toBe('locals one');
-      expect(resolved.TWO).toBe('resolve two');
+    it('should resolve dependencies', module(function ($provide) {
+      $provide.constant('PR_VALUE', 'VALUE');
+      $provide.service('PR_PROMISE', function ($q) {
+        return $q.when('PROMISE');
+      });
+
+      inject(function ($q, PR_VALUE, PR_PROMISE) {
+        var VALUE = PR_VALUE;
+        var PROMISE = PR_PROMISE;
+        var value = 'value';
+        var promise = $q.when('promise');
+
+        var locals = {
+          locValue: value,
+          locPromise: promise
+        };
+
+        var resolve = {
+          resValue: 'PR_VALUE',
+          resPromise: 'PR_PROMISE',
+          resolved: $q.when('resolved'),
+          first: function ($q, PR_VALUE, PR_PROMISE, locValue, locPromise, resValue, resPromise, resolved) {
+            return $q.when(PR_VALUE == VALUE && isPromise(PR_PROMISE) && PR_PROMISE == PROMISE &&
+              locValue == value && isPromise(locPromise) && locPromise == promise &&
+              resValue == VALUE && isPromise(resPromise) && resPromise == PROMISE && !isPromise(resolved) && resolved == 'resolved' &&
+              'first');
+          },
+          second: function (PR_VALUE, PR_PROMISE, locValue, locPromise, resValue, resPromise, resolved, first) {
+            return PR_VALUE == VALUE && isPromise(PR_PROMISE) && PR_PROMISE == PROMISE &&
+              locValue == value && isPromise(locPromise) && locPromise == promise &&
+              resValue == VALUE && isPromise(resPromise) && resPromise == PROMISE && !isPromise(resolved) && resolved == 'resolved' && !isPromise(first) && 'second'
+          }
+        };
+
+        var resolved = mdResolve(resolve, locals);
+
+        expect(resolved.locValue).toBe(value);
+        expect(isPromise(resolved.locPromise)).toBe(true);
+        expect(resolved.locPromise).toBe(promise);
+        expect(resolved.resValue).toBe(VALUE);
+        expect(isPromise(resolved.resPromise)).toBe(true);
+        expect(resolved.resPromise).toBe(PROMISE);
+        expect(isPromise(resolved.resolved)).toBe(false);
+        expect(resolved.resolved).toBe('resolved');
+        expect(isPromise(resolved.first)).toBe(false);
+        expect(resolved.first).toBe('first');
+        expect(resolved.second).toBe('second');
+      });
+    }));
+
+    it('should priority', module(function ($provide) {
+      $provide.constant('first', false);
+      $provide.constant('third', true);
+
+      inject(function () {
+        var locals = {
+          first: true,
+          second: true
+        };
+
+        var resolve = {
+          second: function () {
+            return false;
+          },
+          _first: 'first',
+          _second: 'second',
+          _third: function (first, _first, second, _second, third) {
+            return first && _first &&
+              second && _second &&
+              third;
+          }
+        };
+
+        var resolved = mdResolve(resolve, locals);
+
+        expect(resolved.first).toBe(true);
+        expect(resolved._first).toBe(true);
+        expect(resolved.second).toBe(true);
+        expect(resolved._second).toBe(true);
+        expect(resolved.third).toBe(true);
+        expect(resolved._third).toBe(true);
+      });
     }));
 
     it('should not overwrite the original values', function () {
       var locals = {
-        one: 'one'
+        first: true
       };
 
       var resolve = {
-        two: function () {
-          return 'two'
+        second: function () {
+          return true;
         }
       };
 

--- a/src/core/services/resolve/resolve.spec.js
+++ b/src/core/services/resolve/resolve.spec.js
@@ -56,6 +56,12 @@ describe('$mdResolve service', function () {
       expect(resolved.two).toBe('TWO');
     }));
 
+    it('should resolve if resole & locals are not defined', inject(function () {
+      var resolved = mdResolve();
+
+      expect(resolved).toEqual({});
+    }));
+
     it('should resolve dependencies', inject(function ($q) {
       var locals = {
         one: 'one'

--- a/src/core/services/resolve/resolve.spec.js
+++ b/src/core/services/resolve/resolve.spec.js
@@ -127,5 +127,17 @@ describe('$mdResolve service', function () {
       expect(locals).toEqual(localsCopy);
       expect(resolve).toEqual(resolveCopy);
     });
+
+    it('should pass locals by reference', inject(function () {
+      var value = {};
+
+      var locals = {
+        value: value
+      };
+
+      var resolved = mdResolve(null, locals);
+
+      expect(resolved.value).toBe(value);
+    }));
   });
 });


### PR DESCRIPTION
The $mdResolve service helps to resolve acyclic dependencies (ui.router like resolve).
Used internally in $mdCompiler service.

Now you can do this:

```js
$mdCompiler.compile({
  locals: {
    value: 'value'
  },
  resolve: {
    asyncService: function(value, $q) {
      return $q.when(value);
    },
    service: function(value, asyncService ) {
     return value == asyncService;
    }
  },
  ...
});
```