### PR TITLE
fix(select): issue #3062 controller.$name error

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -169,7 +169,11 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $interpolate, 
 
       if (attr.name && formCtrl) {
         var selectEl = element.parent()[0].querySelector('select[name=".' + attr.name + '"]');
-        formCtrl.$removeControl(angular.element(selectEl).controller());
+        var controller = angular.element(selectEl).controller();
+        
+        if (controller) {
+          formCtrl.$removeControl(controller);
+        }
       }
 
 


### PR DESCRIPTION
If no `ng-controller` parent exists for an `md-select`, an error is thrown when
the $removeControl method is called on the form controller.

http://codepen.io/karlhorky/pen/OVZOqy

Closes angular/material#3062