### PR TITLE
docs(dialog): demo will use it's cancel function

### DIFF
--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -4,7 +4,7 @@
     <div class="md-toolbar-tools">
       <h2>Mango (Fruit)</h2>
       <span flex></span>
-      <md-button class="md-icon-button" ng-click="answer('not applicable')">
+      <md-button class="md-icon-button" ng-click="cancel()">
         <md-icon md-svg-src="img/icons/ic_close_24px.svg" aria-label="Close dialog"></md-icon>
       </md-button>
     </div>


### PR DESCRIPTION
Change the `ng-click` event of the dialog's close button to use the cancel function.

Otherwise the `cancel` function was dead code. I think calling the `answer` function with an arbitrary parameter is a poor example of how to close a dialog.