### PR TITLE
fix(tabs): Use correct variable for md-center-tabs

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -41,7 +41,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   ctrl.lastSelectedIndex = null;
   ctrl.hasFocus = false;
   ctrl.lastClick = true;
-  ctrl.shouldCenterTabs = shouldCenterTabs();
+  ctrl.centerTabs = shouldCenterTabs();
 
   //-- define public methods
   ctrl.updatePagination = $mdUtil.debounce(updatePagination, 100);
@@ -162,7 +162,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function handleShouldPaginate (newValue, oldValue) {
     if (newValue !== oldValue) {
       ctrl.maxTabWidth = getMaxTabWidth();
-      ctrl.shouldCenterTabs = shouldCenterTabs();
+      ctrl.centerTabs = shouldCenterTabs();
       $mdUtil.nextTick(function () {
         ctrl.maxTabWidth = getMaxTabWidth();
         adjustOffset(ctrl.selectedIndex);
@@ -183,7 +183,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @param left
    */
   function handleOffsetChange (left) {
-    var newValue = ctrl.shouldCenterTabs ? '' : '-' + left + 'px';
+    var newValue = ctrl.centerTabs ? '' : '-' + left + 'px';
     angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate3d(' + newValue + ', 0, 0)');
     $scope.$broadcast('$mdTabsPaginationChanged');
   }
@@ -561,7 +561,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function adjustOffset (index) {
     if (!elements.tabs[index]) return;
-    if (ctrl.shouldCenterTabs) return;
+    if (ctrl.centerTabs) return;
     if (index == null) index = ctrl.focusIndex;
     var tab = elements.tabs[index],
         left = tab.offsetLeft,
@@ -640,7 +640,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         left = tab.offsetLeft,
         right = totalWidth - left - tab.offsetWidth,
         tabWidth;
-    if (ctrl.shouldCenterTabs) {
+    if (ctrl.centerTabs) {
       tabWidth = Array.prototype.slice.call(elements.tabs).reduce(function (value, element) {
         return value + element.offsetWidth;
       }, 0);

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -124,12 +124,12 @@ function MdTabs ($mdTheming, $mdUtil, $compile) {
               ng-focus="$mdTabsCtrl.redirectFocus()"\
               ng-class="{\
                   \'md-paginated\': $mdTabsCtrl.shouldPaginate,\
-                  \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs\
+                  \'md-center-tabs\': $mdTabsCtrl.centerTabs\
               }"\
               ng-keydown="$mdTabsCtrl.keydown($event)"\
               role="tablist">\
             <md-pagination-wrapper\
-                ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs }"\
+                ng-class="{ \'md-center-tabs\': $mdTabsCtrl.centerTabs }"\
                 md-tab-scroll="$mdTabsCtrl.scroll($event)">\
               <md-tab-item\
                   tabindex="-1"\


### PR DESCRIPTION
It was using `shouldCenterTabs` instead of `centerTabs` which `shouldCenterTabs()` to always return false as `shouldCenterTabs` was always undefined.

Fixes #2450