### PR TITLE
fix(docs): style tables w/ css class instead of element.

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -12,7 +12,8 @@ body {
   max-width: 100%;
   max-height: 100%;
 }
-table {
+
+.md-api-table {
   margin-bottom: 8px;
   max-width: 100%;
   width: 100%;
@@ -76,26 +77,29 @@ p {
 strong {
   font-weight: 500;
 }
-td, th {
+
+.md-api-table td,
+.md-api-table th {
   padding: 12px 16px;
   text-align: left;
 }
-td {
+
+.md-api-table td {
   vertical-align: top;
 }
-td.description *:first-child {
+.md-api-table td.description *:first-child {
   margin-top: 0;
 }
-td.description *:last-child {
+.md-api-table td.description *:last-child {
   margin-bottom: 0;
 }
-tr:nth-child(odd) td {
+.md-api-table tr:nth-child(odd) td {
   background-color: #E3ECF5;
 }
-tr:nth-child(even) td {
+.md-api-table tr:nth-child(even) td {
   background-color: #D1DEEC;
 }
-th {
+.md-api-table th {
   background-color: #4C9EF0;
   color: white;
 }

--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -8,7 +8,7 @@
 
     <p><code>layout="column" layout-align="center end"</code> would make
     children align along the center vertically and along the end (right) horizontally.</p>
-  <table>
+  <table class="md-api-table">
     <tr>
       <td>layout-align</td>
       <td>Sets child alignment.</td>

--- a/docs/app/partials/layout-options.tmpl.html
+++ b/docs/app/partials/layout-options.tmpl.html
@@ -21,7 +21,7 @@
     other <code>layout</code> attributes available:
   </p>
 
-  <table>
+  <table class="md-api-table">
     <tr>
       <td>layout</td>
       <td>Sets the default layout on all devices.</td>
@@ -113,7 +113,7 @@
     of flex and offset attributes.
   </p>
 
-  <table>
+  <table class="md-api-table">
     <tr>
       <td>flex</td>
       <td>Sets flex.</td>
@@ -159,7 +159,7 @@
     </demo-file>
   </docs-demo>
   <br/>
-  <table>
+  <table class="md-api-table">
     <tr>
       <td>hide</td>
       <td><code>display: none</code></td>

--- a/docs/config/template/ngdoc/api/componentGroup.template.html
+++ b/docs/config/template/ngdoc/api/componentGroup.template.html
@@ -13,7 +13,7 @@
 
 <div class="component-breakdown">
   <div>
-    <table class="definition-table">
+    <table class="definition-table md-api-table">
       <tr>
         <th>Name</th>
         <th>Description</th>

--- a/docs/config/template/ngdoc/lib/macros.html
+++ b/docs/config/template/ngdoc/lib/macros.html
@@ -39,7 +39,7 @@
 {% endmacro -%}
 
 {%- macro paramTable(params) %}
-<table class="no-style">
+<table class="md-api-table">
   <thead>
     <tr>
       <th>Parameter</th>
@@ -82,7 +82,7 @@
 {% endmacro -%}
 
 {%- macro returnTable(fn) -%}
-<table class="no-style">
+<table class="md-api-table">
   <thead>
   <tr>
     <th>Returns</th>


### PR DESCRIPTION
This is necessary in order to enable components that use a `<table>` element (e.g., date-picker).