### PR TITLE
mdMenu: fix memory leak on component destroy

### DIFF
--- a/src/components/menu/_menu.js
+++ b/src/components/menu/_menu.js
@@ -167,8 +167,8 @@ function MenuDirective($mdMenu) {
     mdMenuCtrl.init(menuContainer);
 
     scope.$on('$destroy', function() {
+      menuContainer.remove();
       if (mdMenuCtrl.isOpen) {
-        menuContainer.remove();
         mdMenuCtrl.close();
       }
     });


### PR DESCRIPTION
In a recent project, we found out the mdMenu doesn't release the HTML node(and in jqlite.cache) when the mdMenu is destroyed. Moving the remove() call outside of the mdMenuCtrl.isOpen check fixes the memory leak problem.