### PR TITLE
don't allow undefined objects in md-chips items list

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -412,7 +412,7 @@ function InterimElementProvider() {
           },
           remove: function() {
             self.cancelTimeout();
-            return removeDone = $q.when(showDone).then(function() {
+            return removeDone = $q.when(showDone).finally(function() {
               var ret = element ? options.onRemove(options.scope, element, options) : true;
 
               // Trigger onRemoving callback *before* the remove operation starts


### PR DESCRIPTION
There is no easy way to eliminate invalid chips before insertion. By adding a simple check for undefined before items are pushed to the items' array we get a simple way to filter chips that we don't want to be shown in the chips list.
This feature gives the option to filter unwanted items on md-on-append by returning undefined.