### PR TITLE
fix(select): text-align:end is not supported in IE

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -104,7 +104,7 @@ md-select {
 
   .md-select-icon {
     align-items: flex-end;
-    text-align: right;
+    @include rtl(text-align, right, left);
     width: 3 * $baseline-grid;
     margin: 0 .5 * $baseline-grid;
     transform: translate3d(0, 1px, 0);

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -103,7 +103,7 @@ md-select {
   }
 
   .md-select-icon {
-    align-items: flex-end;
+    @include rtl(align-items, flex-end, flex-start);
     @include rtl(text-align, right, left);
     width: 3 * $baseline-grid;
     margin: 0 .5 * $baseline-grid;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -104,7 +104,7 @@ md-select {
 
   .md-select-icon {
     align-items: flex-end;
-    text-align: end;
+    text-align: right;
     width: 3 * $baseline-grid;
     margin: 0 .5 * $baseline-grid;
     transform: translate3d(0, 1px, 0);


### PR DESCRIPTION
`text-align: end` is not supported by some browsers. This can cause improper positioning of the md-select-icon

https://developer.mozilla.org/en-US/docs/Web/CSS/text-align

Fixes #2213