### PR TITLE
fix(mdChipRemove): center vertically on Firefox

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -94,6 +94,7 @@ $contact-chip-name-width: rem(12) !default;
       box-shadow: none;
       margin: 0;
       position: relative;
+      vertical-align: middle;
       md-icon {
         height: $chip-delete-icon-size;
         width: $chip-delete-icon-size;


### PR DESCRIPTION
Hi,

mdChip's remove button is oddly placed on Firefox (tested on 39 & 41 — see below). This simple fix resolves this.

Cheers!

![mdChipRemove](https://cloud.githubusercontent.com/assets/838867/8831035/f0a3b004-309f-11e5-865a-45e0a0824b82.png)
