### PR TITLE
autocomplete: bugfix - ensures item selection doesn't trigger handleQuery() with autocomplete having minLength=0

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -223,7 +223,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * When the mouse button is released, send focus back to the input field.
    */
   function onMouseup () {
-    elements.input.focus();
+    $mdUtil.nextTick(elements.input.focus);
   }
 
   /**


### PR DESCRIPTION
ensures item selection doesn't trigger handleQuery() with autocomplete having minLength=0

resolves issue #3885

The onMouseup handler is fired after the user selects an item from the drop down before the click event is fired to actually select the item.

Focus performs a query if the min length is zero, in doing so it potentially replaces all the items and destroys their event handlers so the event is never fired.

by placing the call to focus from onMouseUp on the nextTick, we eliminate this bug.

Normal focus remains untouched and will still perform initial search.