### PR TITLE
Remove unnecessary ellipses

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -74,7 +74,7 @@ $contact-chip-name-width: rem(12) !default;
       white-space: nowrap;
       max-width: calc(100% - 31px);
       overflow: hidden;
-      text-overflow: ellipsis;
+      /* text-overflow: ellipsis; */
       &:focus {
         outline: none;
       }


### PR DESCRIPTION
The ellipses only cut off about 3-4 characters that would fit just fine, so they are really unnecessary in most cases.

Fixes #2688 
