### PR TITLE
fix(sidenav): Fix width on mobile devices

### DIFF
--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -109,6 +109,7 @@ md-sidenav {
 @media (max-width: $sidenav-default-width + $sidenav-min-space) {
   md-sidenav {
     width: 85%;
+    min-width:0;
   }
 }
 


### PR DESCRIPTION
Remove the min-width on devices smaller then the default width so that the sidenav will be 84% of the screen instead of locked at $sidenav-default-width

If this isn't a bug Feel free to close this. But it sure seems like one to me.