### PR TITLE
Wip/dialog-centering

### DIFF
--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -19,7 +19,7 @@
 
 angular
   .module('material.components.backdrop', ['material.core'])
-  .directive('mdBackdrop', function BackdropDirective($mdTheming, $animate, $rootElement, $window, $log, $$rAF) {
+  .directive('mdBackdrop', function BackdropDirective($mdTheming, $animate, $rootElement, $window, $log, $$rAF, $document) {
     var ERROR_CSS_POSITION = "<md-backdrop> may not work properly in a scrolled, static-positioned parent container.";
 
     return {
@@ -28,17 +28,28 @@ angular
       };
 
     function postLink(scope, element, attrs) {
+
+        // If body scrolling has been disabled using mdUtil.disableBodyScroll(),
+        // adjust the 'backdrop' height to account for the fixed 'body' top offset
+        var body = $window.getComputedStyle($document[0].body);
+        if ( body.position == 'fixed') {
+          var hViewport = parseInt(body.height,10) + Math.abs(parseInt(body.top,10));
+          element.css({
+            height : hViewport + 'px'
+          });
+        }
+
       // backdrop may be outside the $rootElement, tell ngAnimate to animate regardless
       if( $animate.pin ) $animate.pin(element,$rootElement);
 
       $$rAF(function(){
+
         // Often $animate.enter() is used to append the backDrop element
         // so let's wait until $animate is done...
-
         var parent = element.parent()[0];
         if ( parent ) {
-          var position = $window.getComputedStyle(parent).getPropertyValue('position');
-          if (position == 'static') {
+          var styles = $window.getComputedStyle(parent);
+          if (styles.position == 'static') {
             // backdrop uses position:absolute and will not work properly with parent position:static (default)
             $log.warn( ERROR_CSS_POSITION );
           }
@@ -47,5 +58,6 @@ angular
         $mdTheming.inherit(element, element.parent());
       });
 
-    };
+    }
+
   });

--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -30,7 +30,7 @@ md-backdrop {
   right: 0;
 
   &.md-click-catcher {
-    position: fixed;
+    position: absolute;
   }
 
   &.md-opaque.ng-leave {

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -13,6 +13,7 @@ $dialog-padding: $baseline-grid * 3;
   width: 100%;
   height: 100%;
   z-index: $z-index-dialog;
+  overflow: hidden;
 }
 
 md-dialog {

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -491,14 +491,16 @@ function InterimElementProvider() {
          * Search for parent at insertion time, if not specified
          */
         function findParent(element, options) {
-          var parent = options.parent;
 
           // Search for parent at insertion time, if not specified
-          if (angular.isFunction(parent)) {
-            parent = parent(options.scope, element, options);
-          } else if (angular.isString(parent)) {
-            parent = angular.element($document[0].querySelector(parent));
+          if (angular.isFunction(options.parent)) {
+            parent = options.parent(options.scope, element, options);
+          } else if (angular.isString(options.parent)) {
+            parent = angular.element($document[0].querySelector(options.parent));
+          } else {
+            parent = angular.element(options.parent);
           }
+
 
           // If parent querySelector/getter function fails, or it's just null,
           // find a default.

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -46,6 +46,19 @@ angular.module('material.core')
             return results;
           },
 
+          /**
+           * Calculate the positive scroll offset
+           */
+          scrollTop : function(element) {
+            element = angular.element(element || $document[0].body);
+
+            var body = (element[0] == $document[0].body) ? $document[0].body : undefined;
+            var scrollTop = body ? body.scrollTop + body.parentElement.scrollTop : 0;
+
+             // Calculate the positive scroll offset
+            return scrollTop || Math.abs(element[0].getBoundingClientRect().top);
+          },
+
           // Disables scroll around the passed element.
           disableScrollAround: function (element, parent) {
             $mdUtil.disableScrollAround._count = $mdUtil.disableScrollAround._count || 0;
@@ -109,7 +122,7 @@ angular.module('material.core')
               var htmlNode = body.parentNode;
               var restoreHtmlStyle = htmlNode.getAttribute('style') || '';
               var restoreBodyStyle = body.getAttribute('style') || '';
-              var scrollOffset = body.scrollTop + body.parentElement.scrollTop;
+              var scrollOffset = $mdUtil.scrollTop(body);
               var clientWidth = body.clientWidth;
 
               if (body.scrollHeight > body.clientHeight) {


### PR DESCRIPTION
fix(dialog, backdrop): fill-stretch backdrop to scrolled viewport and center dialog

For scrolled containers and non-body parents,
- the backdrop will now stretch to fill the viewport
- the dialog container resizes to fill the viewPort
- the dialog properly centers within the dialog container

BREAKING CHANGES: md-dialog-container hides overrflow, menu/select click catchers are now positioned absolute.

Previous:

```css
md-backdrop.md-click-catcher {
  position:fixed;
}

.md-dialog-container {
  overflow: auto;
}
```

Updated:

```css
md-backdrop.md-click-catcher {
  position:absolute;
}

.md-dialog-container {
  overflow: hidden;
}
```