### PR TITLE
fix(autocomplete): prevent scroll lock on navigation

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -199,7 +199,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     if (!hidden && oldHidden) {
       positionDropdown();
       if (elements) $mdUtil.nextTick(function () { $mdUtil.disableScrollAround(elements.ul); }, false);
-    } else if (hidden && !oldHidden) {
+    } else if (hidden !== false && !oldHidden) {
       $mdUtil.nextTick(function () { $mdUtil.enableScrolling(); }, false);
     }
   }


### PR DESCRIPTION
Check only for ctrl.hidden being set to false, rather than all falsey values

Closes #3912