### PR TITLE
fix(select): fix incorrect styling of md-select

### DIFF
--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -6,7 +6,7 @@ md-select.md-THEME_NAME-theme {
     border-bottom-color: '{{foreground-4}}';
   }
   &.ng-invalid.ng-dirty {
-    .md-select-label {
+    .md-select-value {
       color: '{{warn-500}}' !important;
       border-bottom-color: '{{warn-500}}' !important;
     }


### PR DESCRIPTION
Change style rule to correctly colour a md-select when its value
is invalid. A rule had been left over with md-select-label instead of the
new md-select-value. This trivial patch fixes it.