### PR TITLE
docs(button): remove duplicate word, differentiate between md-icon and md-icon-button

### DIFF
--- a/docs/content/CSS/button.md
+++ b/docs/content/CSS/button.md
@@ -175,7 +175,7 @@ Add the `.md-fab` class in order to create a floating action button (aka FAB):
 
 ![minibutton](https://cloud.githubusercontent.com/assets/1292882/7273617/1fcca280-e8fe-11e4-9588-231a9e860be1.PNG)
 
-Add add the `.md-mini` class in order to create small, mini-FAB buttons: 
+Add the `.md-mini` class in order to create small, mini-FAB buttons: 
 
 <hljs lang="html">
 <md-button class="md-fab md-mini" aria-label="Eat cake">
@@ -196,7 +196,7 @@ Add add the `.md-mini` class in order to create small, mini-FAB buttons:
 
 ![iconbutton](https://cloud.githubusercontent.com/assets/1292882/7273908/d701bd8a-e900-11e4-84c7-44c580c7372d.PNG)
 
-Create icon buttons by adding the `<md-icon ...>` class:
+Create icon buttons by adding the `.md-icon-button` class and the `<md-icon ...>` component:
 
 <hljs lang="html">
 <md-button class="md-icon-button md-primary" aria-label="Settings">


### PR DESCRIPTION
`<md-icon...` isnt a class, so I added the class `md-icon-button` and called `<md-icon...` a component.