### PR TITLE
Added styling support for md-icon with textarea.

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -238,12 +238,14 @@ md-input-container.md-icon-float {
   > md-icon {
     top: 26px;
     left: 2px;
-    + input {
+    + input,
+    + textarea {
           margin-left: $icon-offset;
     }
   }
 
-  > input {
+  > input,
+  > textarea {
     padding-top : $input-line-height - $input-container-padding;
   }
 


### PR DESCRIPTION
Using md-icon with a textarea does not work as expected:

![image](https://cloud.githubusercontent.com/assets/598803/8985479/a0325150-36a5-11e5-8eb5-660e159593a9.png)


Added the same styling of `input` to `textarea`:

![image](https://cloud.githubusercontent.com/assets/598803/8985512/d0089614-36a5-11e5-8041-610fd03ea522.png)
