### PR TITLE
fix(toast): support parent configurations

### DIFF
--- a/src/components/toast/demoBasicUsage/index.html
+++ b/src/components/toast/demoBasicUsage/index.html
@@ -1,33 +1,43 @@
 <div ng-controller="AppCtrl" layout-fill layout="column" class="inset">
-    <p>Toast can be dismissed with a swipe, a timer, or a button.</p>
+    <p>
+    Toast can be dismissed with a swipe, a timer, or a button.<br/>
+      <span style="font-size:0.8em">Notice the 'Show Custom' toast will not nudge the FABs positions since a custom parent was specified.</span>
+    </p>
+
 
     <div layout="row" layout-sm="column" layout-align="space-around">
       <div style="width:50px"></div>
-      <md-button ng-click="showCustomToast()">
-        Show Custom
-      </md-button>
       <md-button ng-click="showSimpleToast()">
         Show Simple
       </md-button>
       <md-button class="md-raised" ng-click="showActionToast()">
         Show With Action
       </md-button>
+      <md-button ng-click="showCustomToast()">
+        Show Custom
+      </md-button>
       <div style="width:50px"></div>
     </div>
 
-    <div>
-      <br/>
-      <b>Toast Position: "{{getToastPosition()}}"</b>
-      <br/>
-      <md-checkbox ng-repeat="(name, isSelected) in toastPosition"
-        ng-model="toastPosition[name]">
-        {{name}}
-      </md-checkbox>
+    <div layout="row" id="toastBounds">
+
+      <div>
+        <br/>
+        <b>Toast Position: "{{getToastPosition()}}"</b>
+        <br/>
+        <md-checkbox ng-repeat="(name, isSelected) in toastPosition"
+          ng-model="toastPosition[name]">
+          {{name}}
+        </md-checkbox>
+      </div>
+    </div>
+    <div layout="row">
       <md-button class="md-primary md-fab md-fab-bottom-right">
         FAB
       </md-button>
       <md-button class="md-accent md-fab md-fab-top-right">
         FAB
       </md-button>
+
     </div>
 </div>

--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -1,25 +1,40 @@
 
 angular.module('toastDemo1', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdToast, $animate) {
+.controller('AppCtrl', function($scope, $mdToast, $document) {
+  var last = {
+      bottom: false,
+      top: true,
+      left: false,
+      right: true
+    };
 
-  $scope.toastPosition = {
-    bottom: false,
-    top: true,
-    left: false,
-    right: true
-  };
+  $scope.toastPosition = angular.extend({},last);
 
   $scope.getToastPosition = function() {
+    sanitizePosition();
+
     return Object.keys($scope.toastPosition)
       .filter(function(pos) { return $scope.toastPosition[pos]; })
       .join(' ');
   };
 
+  function sanitizePosition() {
+    var current = $scope.toastPosition;
+
+    if ( current.bottom && last.top ) current.top = false;
+    if ( current.top && last.bottom ) current.bottom = false;
+    if ( current.right && last.left ) current.left = false;
+    if ( current.left && last.right ) current.right = false;
+
+    last = angular.extend({},current);
+  }
+
   $scope.showCustomToast = function() {
     $mdToast.show({
       controller: 'ToastCtrl',
       templateUrl: 'toast-template.html',
+      parent : $document[0].querySelector('#toastBounds'),
       hideDelay: 6000,
       position: $scope.getToastPosition()
     });

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -179,7 +179,7 @@ function MdToastProvider($$interimElementProvider) {
   var activeToastContent;
   var $mdToast = $$interimElementProvider('$mdToast')
     .setDefaults({
-      methods: ['position', 'hideDelay', 'capsule' ],
+      methods: ['position', 'hideDelay', 'capsule', 'parent' ],
       options: toastDefaultOptions
     })
     .addPreset('simple', {


### PR DESCRIPTION
update toast to support custom `parent`; as specified in API docs

*  update demo
  *  bottom/top position options are mutually exclusive
  *  left/right position options are mutually exclusive
  *  showCustom action will specify custom toast parent

Fixes #2526