### PR TITLE
fix(gridlist): md-row-height="fit" results in tile height being 0

### DIFF
--- a/src/components/gridList/gridList.js
+++ b/src/components/gridList/gridList.js
@@ -179,6 +179,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
       var performance =
         $mdGridLayout(props.colCount, props.tileSpans, tiles)
           .map(function(tilePositions, rowCount) {
+            props.rowCount = rowCount;
             return {
               grid: {
                 element: element,


### PR DESCRIPTION
It fixes [issue 2741](https://github.com/angular/material/issues/2741)