### PR TITLE
docs(layout-grid): fix typo and hidden text

### DIFF
--- a/docs/app/css/layout-demo.css
+++ b/docs/app/css/layout-demo.css
@@ -20,6 +20,9 @@ demo-include {
 .layout-content demo-include [layout] > div:nth-child(4) {
   background-color: #8bc34a;
 }
+.layout-content demo-include [layout] > div:nth-child(5) {
+  background-color: #009688;
+}
 .layout-content md-divider {
   margin-top: 16px;
 }

--- a/docs/app/partials/layout-grid.tmpl.html
+++ b/docs/app/partials/layout-grid.tmpl.html
@@ -38,10 +38,10 @@
           [flex]
         </div>
         <div flex="66">
-          [flex]
+          [flex="66"]
         </div>
         <div flex="33">
-          [flex]
+          [flex="33"]
         </div>
       </div>
     </demo-file>
@@ -124,7 +124,7 @@
   </docs-demo>
   <p>
     Add the <code>offset</code> attribute to a layout child to set its
-    offset percentage within the layout. Values must be multiples 
+    offset percentage within the layout. Values must be multiples
     of <code>5</code>, or <code>33</code>, <code>34</code>, <code>66</code>, <code>67</code>.
   </p>
   <table>
@@ -158,4 +158,3 @@
     </tr>
   </table>
 </div>
-


### PR DESCRIPTION
- Missing flex percentages description caused confusion.
- Couldn't read white text on white background.