### PR TITLE
fix(fabToolbar): fix toolbar height to use variables

### DIFF
--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -11,8 +11,8 @@ md-fab-toolbar {
     position: relative;
     overflow: hidden;
 
-    // Account for the size of the trigger (5.6rem) plus it's margin/shadow (0.6rem * 2)
-    height: 6.8rem;
+    // Account for the size of the trigger plus it's margin/shadow
+    height: $button-fab-width + ($icon-button-margin * 2);
   }
 
   md-fab-trigger {


### PR DESCRIPTION
Fab Toolbar incorrectly used 6.8rem instead of the rem(6.8) SCSS function.
Also updated it to use button.scss variables instead of hard-coded values.

closes #3384