### PR TITLE
fix(dialog): md-actions left padding has to be same as dialog

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -86,7 +86,7 @@ md-dialog {
     justify-content: flex-end;
     margin-bottom: 0;
     padding-right: $baseline-grid;
-    padding-left: $baseline-grid * 2;
+    padding-left: $dialog-padding;
     min-height: $baseline-grid * 6.5;
     overflow: hidden;
 


### PR DESCRIPTION
<img width="384" alt="screen shot 2015-08-04 at 14 37 01" src="https://cloud.githubusercontent.com/assets/539546/9060756/00685e38-3ab7-11e5-9497-994c785773b6.png">

the left padding of the actions container has to be 24, the same as the padding in the dialog content