### PR TITLE
fix(dialog): use foreground-1 text color

### DIFF
--- a/src/components/dialog/dialog-theme.scss
+++ b/src/components/dialog/dialog-theme.scss
@@ -2,6 +2,7 @@ $dialog-border-radius: 4px !default;
 
 md-dialog.md-THEME_NAME-theme {
   border-radius: $dialog-border-radius;
+  color: '{{foreground-1}}';
   background-color: '{{background-color}}';
 
   &.md-content-overflow .md-actions {


### PR DESCRIPTION
This makes the dialog content better readable when using a dark theme.