### PR TITLE
fix(fabSpeedDial/Toolbar): Refactor default click/hover behavior.

### DIFF
--- a/src/components/fabActions/fabActions.js
+++ b/src/components/fabActions/fabActions.js
@@ -47,14 +47,13 @@
           // Grab whichever parent controller is used
           var controller = controllers[0] || controllers[1];
 
-          // Make the children open/close their parent directive
+          // Make the children close their parent directive
           if (controller) {
             angular.forEach(element.children(), function(child) {
-              // Attach listeners to the `md-fab-action-item`
+              // Attach listeners to the child of each `md-fab-action-item`
               child = angular.element(child).children()[0];
 
-              angular.element(child).on('focus', controller.open);
-              angular.element(child).on('blur', controller.close);
+              angular.element(child).on('click', controller.close);
             });
           }
         }

--- a/src/components/fabSpeedDial/demoMoreOptions/index.html
+++ b/src/components/fabSpeedDial/demoMoreOptions/index.html
@@ -6,7 +6,9 @@
     </p>
 
     <div class="lock-size" layout="row" layout-align="center center">
-      <md-fab-speed-dial ng-hide="demo.hidden" md-direction="down" class="md-fling">
+      <md-fab-speed-dial ng-hide="demo.hidden" md-direction="down" class="md-fling"
+                         md-open="demo.isOpen"
+                         ng-mouseenter="demo.isOpen=true" ng-mouseleave="demo.isOpen=false">
         <md-fab-trigger>
           <md-button aria-label="menu" class="md-fab md-warn">
             <md-tooltip md-direction="top">Menu</md-tooltip>
@@ -71,6 +73,22 @@
       </p>
     </div>
   </md-content>
+
+  <md-content class="md-padding" layout="row">
+    <div flex="50">
+      <h3>Hovering</h3>
+
+      <p>
+        You can also easily setup the speed dial to open on hover using the
+        <code>ng-mouseenter</code> and <code>ng-mouseleave</code> attributes.
+      </p>
+
+      <p>
+        See the example code for more information.
+      </p>
+    </div>
+  </md-content>
+
 
   <script type="text/ng-template" id="dialog.html">
     <md-dialog>

--- a/src/components/fabSpeedDial/fabSpeedDial.spec.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.spec.js
@@ -28,57 +28,13 @@ describe('<md-fab-speed-dial> directive', function () {
     expect(element.hasClass('md-right')).toBe(true);
   }));
 
-  it('opens when the trigger element is focused', inject(function () {
-    build(
-      '<md-fab-speed-dial><md-fab-trigger><button></button></md-fab-trigger></md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('opens when the speed dial elements are focused', inject(function () {
-    build(
-      '<md-fab-speed-dial><md-fab-actions><button></button></md-fab-actions></md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('closes when the speed dial elements are blurred', inject(function () {
-    build(
-      '<md-fab-speed-dial>'+
-      ' <md-fab-trigger>' +
-      '   <button>Show Actions</button>' +
-      ' </md-fab-trigger>' +
-      ' </md-fab-actions>' +
-      ' <md-fab-actions>' +
-      '   <button>Action 1</button>' +
-      ' </md-fab-actions>' +
-      '</md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(true);
-
-    var actionBtn = element.find('md-fab-actions').find('button');
-    actionBtn.triggerHandler('focus');
-    pageScope.$digest();
-    actionBtn.triggerHandler('blur');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(false);
-  }));
-
   it('allows programmatic opening through the md-open attribute', inject(function () {
     build(
-      '<md-fab-speed-dial md-open="isOpen"></md-fab-speed-dial>'
+      '<md-fab-speed-dial md-open="isOpen">' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '</md-fab-speed-dial>'
     );
 
     // By default, it should be closed

--- a/src/components/fabToolbar/fabToolbar.spec.js
+++ b/src/components/fabToolbar/fabToolbar.spec.js
@@ -22,29 +22,6 @@ describe('<md-fab-toolbar> directive', function() {
     expect(element.find('md-fab-trigger').find('button').attr('tabindex')).toBe('-1');
   }));
 
-
-  it('opens when the toolbar elements are focused', inject(function() {
-    build(
-      '<md-fab-toolbar><md-fab-trigger><a></a></md-fab-trigger>' +
-      '<md-fab-actions><button></button></md-fab-actions></md-fab-toolbar>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('closes when the toolbar elements are blurred', inject(function() {
-    build(
-      '<md-fab-toolbar><md-fab-actions><button></button></md-fab-actions></md-fab-toolbar>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    expect(controller.isOpen).toBe(true);
-
-    element.find('button').triggerHandler('blur');
-    expect(controller.isOpen).toBe(false);
-  }));
-
   it('allows programmatic opening through the md-open attribute', inject(function() {
     build(
       '<md-fab-toolbar md-open="isOpen"></md-fab-toolbar>'
@@ -66,7 +43,7 @@ describe('<md-fab-toolbar> directive', function() {
     build(
       '<md-fab-toolbar md-open="isOpen">' +
       '  <md-fab-trigger><button></button></md-fab-trigger>' +
-      '  <md-fab-actions><button></button></md-fab-actions>' +
+      '  <md-fab-actions><md-toolbar><button></button></md-toolbar></md-fab-actions>' +
       '</md-fab-toolbar>'
     );
 

--- a/src/components/fabTrigger/fabTrigger.js
+++ b/src/components/fabTrigger/fabTrigger.js
@@ -30,11 +30,9 @@
         // Grab whichever parent controller is used
         var controller = controllers[0] || controllers[1];
 
-        // Make the children open/close their parent directive
         if (controller) {
           angular.forEach(element.children(), function(child) {
-            angular.element(child).on('focus', controller.open);
-            angular.element(child).on('blur', controller.close);
+            angular.element(child).on('click', controller.toggle);
           });
         }
       }

--- a/src/components/fabTrigger/fabTrigger.spec.js
+++ b/src/components/fabTrigger/fabTrigger.spec.js
@@ -1,0 +1,70 @@
+describe('<md-fab-trigger> directive', function() {
+
+  beforeEach(module('material.components.fabSpeedDial'));
+  beforeEach(module('material.components.fabToolbar'));
+
+  var pageScope, element, controller;
+
+  function compileAndLink(template) {
+    inject(function($compile, $rootScope) {
+      pageScope = $rootScope.$new();
+      element = $compile(template)(pageScope);
+
+      pageScope.$apply();
+    });
+  }
+
+  it('toggles the parent fab speed dial isOpen state when clicked', inject(function() {
+    compileAndLink(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '</md-fab-speed-dial>'
+    );
+
+    controller = element.controller('mdFabSpeedDial');
+
+    // Click to open
+    element.find('md-button').triggerHandler('click');
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(true);
+
+    // Click to close
+    element.find('md-button').triggerHandler('click');
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(false);
+  }));
+
+  it('toggles the parent fab toolbar isOpen state when clicked', inject(function() {
+    compileAndLink(
+      '<md-fab-toolbar>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '  <md-fab-actions>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-actions>' +
+      '</md-fab-toolbar>'
+    );
+
+    var button = angular.element(element.find('md-button')[0]);
+
+    controller = element.controller('mdFabToolbar');
+
+    // Click to open
+    button.triggerHandler('click');
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(true);
+
+    // Click to close
+    button.triggerHandler('click');
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(false);
+  }));
+
+});


### PR DESCRIPTION
Multiple users have requested a configurable way to open the speed dial
and toolbar on hover instead of it being automatic. This PR greatly simplifies
the existing code to be more standard.

BREAKING CHANGE: The FAB Speed Dial/Toolbar no longer automatically
adds the hover effect. The demo has been updated with example code
which utilizes `ng-mouseenter` and `ng-mouseleave` instead.

BREAKING CHANGE: The FAB Speed Dial/Toolbar no longer automatically
opens when receiving keyboard focus via the tab key. You must now
activate the trigger to open the component. This allows you to
skip all of the children if you are attempting to tab to another
element.

This also provides better support for iOS devices (and presumably
other mobile devices too).

fixes #3925, fixes #3214