### PR TITLE
fix(font): use Roboto font instead of RobotoDraft

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -7,7 +7,7 @@
 </title>
 <link rel="icon" type="image/x-icon" href="favicon.ico" />
 <meta name="viewport" content="initial-scale=1" />
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=RobotoDraft:300,400,500,700,400italic">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
 <link rel="stylesheet" href="angular-material.min.css">
 <link rel="stylesheet" href="docs.css">
 </head>

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -7,7 +7,7 @@
 
 // Typography
 // ------------------------------
-$font-family: RobotoDraft, Roboto, 'Helvetica Neue', sans-serif !default;
+$font-family: Roboto, 'Helvetica Neue', sans-serif !default;
 $font-size:   10px;
 
 $display-4-font-size-base: rem(11.20) !default;


### PR DESCRIPTION
RobotoDraft was temporary until the new version of Roboto was
released to Google Web Fonts. Now that Roboto has been updated
as of January 2015, RobotoDraft is considered deprecated.

Closes #4063