### PR TITLE
fix(fabSpeedDial/Toolbar): Improve hover/click/keyboard/aria support.

### DIFF
--- a/src/components/fabActions/fabActions.js
+++ b/src/components/fabActions/fabActions.js
@@ -42,22 +42,6 @@
           // Wrap every child in a new div and add a class that we can scale/fling independently
           children.wrap('<div class="md-fab-action-item">');
         }
-
-        return function postLink(scope, element, attributes, controllers) {
-          // Grab whichever parent controller is used
-          var controller = controllers[0] || controllers[1];
-
-          // Make the children open/close their parent directive
-          if (controller) {
-            angular.forEach(element.children(), function(child) {
-              // Attach listeners to the `md-fab-action-item`
-              child = angular.element(child).children()[0];
-
-              angular.element(child).on('focus', controller.open);
-              angular.element(child).on('blur', controller.close);
-            });
-          }
-        }
       }
     }
   }

--- a/src/components/fabSpeedDial/demoBasicUsage/index.html
+++ b/src/components/fabSpeedDial/demoBasicUsage/index.html
@@ -15,14 +15,14 @@
         </md-fab-trigger>
 
         <md-fab-actions>
-          <md-button aria-label="twitter" class="md-fab md-raised md-mini">
-            <md-icon md-svg-src="img/icons/twitter.svg"></md-icon>
+          <md-button aria-label="Twitter" class="md-fab md-raised md-mini">
+            <md-icon md-svg-src="img/icons/twitter.svg" aria-label="Twitter"></md-icon>
           </md-button>
-          <md-button aria-label="facebook" class="md-fab md-raised md-mini">
-            <md-icon md-svg-src="img/icons/facebook.svg"></md-icon>
+          <md-button aria-label="Facebook" class="md-fab md-raised md-mini">
+            <md-icon md-svg-src="img/icons/facebook.svg" aria-label="Facebook"></md-icon>
           </md-button>
           <md-button aria-label="Google Hangout" class="md-fab md-raised md-mini">
-            <md-icon md-svg-src="img/icons/hangout.svg"></md-icon>
+            <md-icon md-svg-src="img/icons/hangout.svg" aria-label="Google Hangout"></md-icon>
           </md-button>
         </md-fab-actions>
       </md-fab-speed-dial>

--- a/src/components/fabSpeedDial/demoMoreOptions/index.html
+++ b/src/components/fabSpeedDial/demoMoreOptions/index.html
@@ -6,11 +6,13 @@
     </p>
 
     <div class="lock-size" layout="row" layout-align="center center">
-      <md-fab-speed-dial ng-hide="demo.hidden" md-direction="down" class="md-fling">
+      <md-fab-speed-dial ng-hide="demo.hidden" md-direction="down" class="md-fling"
+                         md-open="demo.isOpen"
+                         ng-mouseenter="demo.isOpen=true" ng-mouseleave="demo.isOpen=false">
         <md-fab-trigger>
           <md-button aria-label="menu" class="md-fab md-warn">
             <md-tooltip md-direction="top">Menu</md-tooltip>
-            <md-icon md-svg-src="img/icons/menu.svg"></md-icon>
+            <md-icon md-svg-src="img/icons/menu.svg" aria-label="menu"></md-icon>
           </md-button>
         </md-fab-trigger>
 
@@ -19,7 +21,7 @@
             <md-button aria-label="{{item.name}}" class="md-fab md-raised md-mini"
                        ng-click="demo.openDialog($event, item)">
               <md-tooltip md-direction="{{item.direction}}">{{item.name}}</md-tooltip>
-              <md-icon md-svg-src="{{item.icon}}"></md-icon>
+              <md-icon md-svg-src="{{item.icon}}" aria-label="{{item.name}}"></md-icon>
             </md-button>
           </div>
         </md-fab-actions>
@@ -71,6 +73,22 @@
       </p>
     </div>
   </md-content>
+
+  <md-content class="md-padding" layout="row">
+    <div flex="50">
+      <h3>Hovering</h3>
+
+      <p>
+        You can also easily setup the speed dial to open on hover using the
+        <code>ng-mouseenter</code> and <code>ng-mouseleave</code> attributes.
+      </p>
+
+      <p>
+        See the example code for more information.
+      </p>
+    </div>
+  </md-content>
+
 
   <script type="text/ng-template" id="dialog.html">
     <md-dialog>

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -1,0 +1,326 @@
+(function() {
+  'use strict';
+
+  angular.module('material.components.fabShared', ['material.core'])
+    .controller('FabController', FabController);
+
+  function FabController($scope, $element, $animate, $mdUtil, $mdConstant) {
+    var vm = this;
+
+    // NOTE: We use async evals below to avoid conflicts with any existing digest loops
+
+    vm.open = function() {
+      $scope.$evalAsync("vm.isOpen = true");
+    };
+
+    vm.close = function() {
+      // Async eval to avoid conflicts with existing digest loops
+      $scope.$evalAsync("vm.isOpen = false");
+
+      // Focus the trigger when the element closes so users can still tab to the next item
+      $element.find('md-fab-trigger')[0].focus();
+    };
+
+    // Toggle the open/close state when the trigger is clicked
+    vm.toggle = function() {
+      $scope.$evalAsync("vm.isOpen = !vm.isOpen");
+    };
+
+    setupDefaults();
+    setupListeners();
+    setupWatchers();
+    fireInitialAnimations();
+
+    function setupDefaults() {
+      // Set the default direction to 'down' if none is specified
+      vm.direction = vm.direction || 'down';
+
+      // Set the default to be closed
+      vm.isOpen = vm.isOpen || false;
+
+      // Start the keyboard interaction at the first action
+      resetActionIndex();
+    }
+
+    var events = [];
+
+    function setupListeners() {
+      var eventTypes = [
+        'mousedown', 'mouseup', 'click', 'touchstart', 'touchend', 'focusin', 'focusout'
+      ];
+
+      // Add our listeners
+      angular.forEach(eventTypes, function(eventType) {
+        $element.on(eventType, parseEvents);
+      });
+
+      // Remove our listeners when destroyed
+      $scope.$on('$destroy', function() {
+        angular.forEach(eventTypes, function(eventType) {
+          $element.off(eventType, parseEvents);
+        });
+      });
+    }
+
+    function resetEvents() {
+      events = [];
+    }
+
+    function equalsEvents(toCheck) {
+      var isEqual, strippedCheck, moreToCheck;
+
+      // Quick check to make sure we don't get stuck in an infinite loop
+      var numTests = 0;
+
+      do {
+        // Strip out the question mark
+        strippedCheck = toCheck.map(function(event) {
+          return event.replace('?', '')
+        });
+
+        // Check if they are equal
+        isEqual = angular.equals(events, strippedCheck);
+
+        // If not, check to see if removing an optional event makes them equal
+        if (!isEqual) {
+          toCheck = removeOptionalEvent(toCheck);
+          moreToCheck = (toCheck.length >= events.length && toCheck.length !== strippedCheck.length);
+        }
+      }
+      while (numTests < 10 && !isEqual && moreToCheck);
+
+      return isEqual;
+    }
+
+    function removeOptionalEvent(events) {
+      var foundOptional = false;
+
+      return events.filter(function(event) {
+        // If we have not found an optional one, keep searching
+        if (!foundOptional && event.indexOf('?') !== -1) {
+          foundOptional = true;
+
+          // If we find an optional one, remove only that one and keep going
+          return false;
+        }
+
+        return true;
+      });
+    }
+
+    function parseEvents(latestEvent) {
+      events.push(latestEvent.type);
+
+      // Handle desktop click
+      if (equalsEvents(['mousedown', 'focusout?', 'focusin?', 'mouseup', 'click'])) {
+        handleItemClick(latestEvent);
+        resetEvents();
+        return;
+      }
+
+      // Handle mobile click/tap (and keyboard enter)
+      if (equalsEvents(['touchstart?', 'touchend?', 'click'])) {
+        handleItemClick(latestEvent);
+        resetEvents();
+        return;
+      }
+
+      // Handle tab keys (focusin)
+      if (equalsEvents(['focusin'])) {
+        vm.open();
+        resetEvents();
+        return;
+      }
+
+      // Handle tab keys (focusout)
+      if (equalsEvents(['focusout'])) {
+        vm.close();
+        resetEvents();
+        return;
+      }
+
+      eventUnhandled();
+    }
+
+    /*
+     * No event was handled, so setup a timeout to clear the events
+     *
+     * TODO: Use $mdUtil.debounce()?
+     */
+    var resetEventsTimeout;
+
+    function eventUnhandled() {
+      if (resetEventsTimeout) {
+        window.clearTimeout(resetEventsTimeout);
+      }
+
+      resetEventsTimeout = window.setTimeout(function() {
+        resetEvents();
+      }, 250);
+    }
+
+    function resetActionIndex() {
+      vm.currentActionIndex = -1;
+    }
+
+    function setupWatchers() {
+      // Watch for changes to the direction and update classes/attributes
+      $scope.$watch('vm.direction', function(newDir, oldDir) {
+        // Add the appropriate classes so we can target the direction in the CSS
+        $animate.removeClass($element, 'md-' + oldDir);
+        $animate.addClass($element, 'md-' + newDir);
+
+        // Reset the action index since it may have changed
+        resetActionIndex();
+      });
+
+      var trigger, actions;
+
+      // Watch for changes to md-open
+      $scope.$watch('vm.isOpen', function(isOpen) {
+        // Reset the action index since it may have changed
+        resetActionIndex();
+
+        // We can't get the trigger/actions outside of the watch because the component hasn't been
+        // linked yet, so we wait until the first watch fires to cache them.
+        if (!trigger || !actions) {
+          trigger = getTriggerElement();
+          actions = getActionsElement();
+        }
+
+        if (isOpen) {
+          enableKeyboard();
+        } else {
+          disableKeyboard();
+        }
+
+        var toAdd = isOpen ? 'md-is-open' : '';
+        var toRemove = isOpen ? '' : 'md-is-open';
+
+        // Set the proper ARIA attributes
+        trigger.attr('aria-haspopup', true);
+        trigger.attr('aria-expanded', isOpen);
+        actions.attr('aria-hidden', !isOpen);
+
+        // Animate the CSS classes
+        $animate.setClass($element, toAdd, toRemove);
+      });
+    }
+
+    // Fire the animations once in a separate digest loop to initialize them
+    function fireInitialAnimations() {
+      $mdUtil.nextTick(function() {
+        $animate.addClass($element, 'md-noop');
+      });
+    }
+
+    function enableKeyboard() {
+      angular.element(document).on('keydown', keyPressed);
+    }
+
+    function disableKeyboard() {
+      angular.element(document).off('keydown', keyPressed);
+    }
+
+    function keyPressed(event) {
+      switch (event.which) {
+        case $mdConstant.KEY_CODE.SPACE: event.preventDefault(); return false;
+        case $mdConstant.KEY_CODE.ESCAPE: vm.close(); event.preventDefault(); return false;
+        case $mdConstant.KEY_CODE.LEFT_ARROW: doKeyLeft(event); return false;
+        case $mdConstant.KEY_CODE.UP_ARROW: doKeyUp(event); return false;
+        case $mdConstant.KEY_CODE.RIGHT_ARROW: doKeyRight(event); return false;
+        case $mdConstant.KEY_CODE.DOWN_ARROW: doKeyDown(event); return false;
+      }
+    }
+
+    function doActionPrev(event) {
+      focusAction(event, -1);
+    }
+
+    function doActionNext(event) {
+      focusAction(event, 1);
+    }
+
+    function focusAction(event, direction) {
+      // Grab all of the actions
+      var actions = getActionsElement()[0].querySelectorAll('.md-fab-action-item');
+
+      // Disable all other actions for tabbing
+      angular.forEach(actions, function(action) {
+        angular.element(angular.element(action).children()[0]).attr('tabindex', -1);
+      });
+
+      // Increment/decrement the counter with restrictions
+      vm.currentActionIndex = vm.currentActionIndex + direction;
+      vm.currentActionIndex = Math.min(actions.length - 1, vm.currentActionIndex);
+      vm.currentActionIndex = Math.max(0, vm.currentActionIndex);
+
+      // Focus the element
+      var focusElement =  angular.element(actions[vm.currentActionIndex]).children()[0];
+      angular.element(focusElement).attr('tabindex', 0);
+      focusElement.focus();
+
+      // Make sure the event doesn't bubble and cause something else
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+
+    function doKeyLeft(event) {
+      if (vm.direction === 'left') {
+        doActionNext(event);
+      } else {
+        doActionPrev(event);
+      }
+    }
+
+    function doKeyUp(event) {
+      if (vm.direction === 'down') {
+        doActionPrev(event);
+      } else {
+        doActionNext(event);
+      }
+    }
+
+    function doKeyRight(event) {
+      if (vm.direction === 'left') {
+        doActionPrev(event);
+      } else {
+        doActionNext(event);
+      }
+    }
+
+    function doKeyDown(event) {
+      if (vm.direction === 'up') {
+        doActionPrev(event);
+      } else {
+        doActionNext(event);
+      }
+    }
+
+    function isTrigger(element) {
+      return $mdUtil.getClosest(element, 'md-fab-trigger');
+    }
+
+    function isAction(element) {
+      return $mdUtil.getClosest(element, 'md-fab-actions');
+    }
+
+    function handleItemClick(event) {
+      if (isTrigger(event.target)) {
+        vm.toggle();
+      }
+
+      if (isAction(event.target)) {
+        vm.close();
+      }
+    }
+
+    function getTriggerElement() {
+      return $element.find('md-fab-trigger');
+    }
+
+    function getActionsElement() {
+      return $element.find('md-fab-actions');
+    }
+  }
+})();

--- a/src/components/fabSpeedDial/fabSpeedDial.spec.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.spec.js
@@ -1,16 +1,16 @@
-describe('<md-fab-speed-dial> directive', function () {
+describe('<md-fab-speed-dial> directive', function() {
 
   var pageScope, element, controller;
   var $rootScope, $animate, $timeout;
 
   beforeEach(module('material.components.fabSpeedDial'));
-  beforeEach(inject(function (_$rootScope_, _$animate_, _$timeout_) {
+  beforeEach(inject(function(_$rootScope_, _$animate_, _$timeout_) {
     $rootScope = _$rootScope_;
     $animate = _$animate_;
     $timeout = _$timeout_;
   }));
 
-  it('applies a class for each direction', inject(function () {
+  it('applies a class for each direction', inject(function() {
     build(
       '<md-fab-speed-dial md-direction="{{direction}}"></md-fab-speed-dial>'
     );
@@ -28,57 +28,13 @@ describe('<md-fab-speed-dial> directive', function () {
     expect(element.hasClass('md-right')).toBe(true);
   }));
 
-  it('opens when the trigger element is focused', inject(function () {
+  it('allows programmatic opening through the md-open attribute', inject(function() {
     build(
-      '<md-fab-speed-dial><md-fab-trigger><button></button></md-fab-trigger></md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('opens when the speed dial elements are focused', inject(function () {
-    build(
-      '<md-fab-speed-dial><md-fab-actions><button></button></md-fab-actions></md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('closes when the speed dial elements are blurred', inject(function () {
-    build(
-      '<md-fab-speed-dial>'+
-      ' <md-fab-trigger>' +
-      '   <button>Show Actions</button>' +
-      ' </md-fab-trigger>' +
-      ' </md-fab-actions>' +
-      ' <md-fab-actions>' +
-      '   <button>Action 1</button>' +
-      ' </md-fab-actions>' +
+      '<md-fab-speed-dial md-open="isOpen">' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
       '</md-fab-speed-dial>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(true);
-
-    var actionBtn = element.find('md-fab-actions').find('button');
-    actionBtn.triggerHandler('focus');
-    pageScope.$digest();
-    actionBtn.triggerHandler('blur');
-    pageScope.$digest();
-
-    expect(controller.isOpen).toBe(false);
-  }));
-
-  it('allows programmatic opening through the md-open attribute', inject(function () {
-    build(
-      '<md-fab-speed-dial md-open="isOpen"></md-fab-speed-dial>'
     );
 
     // By default, it should be closed
@@ -93,7 +49,110 @@ describe('<md-fab-speed-dial> directive', function () {
     expect(controller.isOpen).toBe(false);
   }));
 
-  it('properly finishes the fling animation', inject(function (mdFabSpeedDialFlingAnimation) {
+  it('toggles the menu when the trigger clicked', inject(function() {
+    build(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '</md-fab-speed-dial>'
+    );
+
+    // Click to open
+    var clickEvent = {
+      type: 'click',
+      target: element.find('md-button')
+    };
+    element.triggerHandler(clickEvent);
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(true);
+
+    // Click to close
+    element.triggerHandler(clickEvent);
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(false);
+  }));
+
+
+  it('closes the menu when an action is clicked', inject(function() {
+    build(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '  <md-fab-actions>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-actions>' +
+      '</md-fab-speed-dial>'
+    );
+
+    var clickEvent = {
+      type: 'click',
+      target: element.find('md-fab-actions').find('md-button')
+    };
+
+    // Set the menu to be open
+    controller.isOpen = true;
+    pageScope.$digest();
+
+    // Click the action to close
+    element.triggerHandler(clickEvent);
+    pageScope.$digest();
+
+    expect(controller.isOpen).toBe(false);
+  }));
+
+  it('opens the menu when the trigger is focused', inject(function() {
+    build(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '</md-fab-speed-dial>'
+    );
+
+    var focusEvent = {
+      type: 'focusin',
+      target: element.find('md-fab-trigger').find('md-button')
+    };
+
+    element.triggerHandler(focusEvent);
+    pageScope.$digest();
+    expect(controller.isOpen).toBe(true);
+  }));
+
+  it('closes the menu when the trigger is blurred', inject(function() {
+    build(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-trigger>' +
+      '    <md-button></md-button>' +
+      '  </md-fab-trigger>' +
+      '</md-fab-speed-dial>'
+    );
+
+    var focusInEvent = {
+      type: 'focusin',
+      target: element.find('md-fab-trigger').find('md-button')
+    };
+
+    var focusOutEvent = {
+      type: 'focusout',
+      target: element.find('md-fab-trigger').find('md-button')
+    };
+
+    element.triggerHandler(focusInEvent);
+    pageScope.$digest();
+    expect(controller.isOpen).toBe(true);
+
+    element.triggerHandler(focusOutEvent);
+    pageScope.$digest();
+    expect(controller.isOpen).toBe(false);
+  }));
+
+
+  it('properly finishes the fling animation', inject(function(mdFabSpeedDialFlingAnimation) {
     build(
       '<md-fab-speed-dial md-open="isOpen" class="md-fling">' +
       '  <md-fab-trigger><button></button></md-fab-trigger>' +
@@ -111,7 +170,7 @@ describe('<md-fab-speed-dial> directive', function () {
     expect(removeDone).toHaveBeenCalled();
   }));
 
-  it('properly finishes the scale animation', inject(function (mdFabSpeedDialScaleAnimation) {
+  it('properly finishes the scale animation', inject(function(mdFabSpeedDialScaleAnimation) {
     build(
       '<md-fab-speed-dial md-open="isOpen" class="md-fling">' +
       '  <md-fab-trigger><button></button></md-fab-trigger>' +
@@ -130,7 +189,7 @@ describe('<md-fab-speed-dial> directive', function () {
   }));
 
   function build(template) {
-    inject(function ($compile) {
+    inject(function($compile) {
       pageScope = $rootScope.$new();
       element = $compile(template)(pageScope);
       controller = element.controller('mdFabSpeedDial');

--- a/src/components/fabToolbar/demoBasicUsage/index.html
+++ b/src/components/fabToolbar/demoBasicUsage/index.html
@@ -5,14 +5,14 @@
     </p>
 
     <p>
-      You may use the <code>md-open</code> attribute to programmatically
-      control whether or not the control is open, and you may add a class
-      of <code>md-left</code> or <code>md-right</code> to control the
-      position of the trigger and toolbar tools.
+      You may use the <code>md-open</code> attribute to programmatically control whether or not the
+      control is open, and you may set the direction that the toolbar appears using the
+      <code>md-direction</code> attribute. This component currently supports the <code>left</code>
+      and <code>right</code> options.
     </p>
   </md-content>
 
-  <md-fab-toolbar md-open="demo.isOpen" count="demo.count" ng-class="demo.selectedAlignment">
+  <md-fab-toolbar md-open="demo.isOpen" count="demo.count" md-direction="demo.selectedDirection">
     <md-fab-trigger class="align-with-text">
       <md-button aria-label="menu" class="md-fab md-primary">
         <md-icon md-svg-src="img/icons/menu.svg"></md-icon>
@@ -46,11 +46,11 @@
       </div>
 
       <div layout="column">
-        <b>Alignment</b>
+        <b>Direction</b>
 
-        <md-radio-group ng-model="demo.selectedAlignment">
-          <md-radio-button ng-value="'md-left'">Left</md-radio-button>
-          <md-radio-button ng-value="'md-right'">Right</md-radio-button>
+        <md-radio-group ng-model="demo.selectedDirection">
+          <md-radio-button ng-value="'left'">Left</md-radio-button>
+          <md-radio-button ng-value="'right'">Right</md-radio-button>
         </md-radio-group>
       </div>
     </div>

--- a/src/components/fabToolbar/demoBasicUsage/script.js
+++ b/src/components/fabToolbar/demoBasicUsage/script.js
@@ -8,7 +8,7 @@
       $scope.demo = {
         isOpen: false,
         count: 0,
-        selectedAlignment: 'md-left'
+        selectedDirection: 'left'
       };
     });
 })();

--- a/src/components/fabToolbar/demoBasicUsage/style.scss
+++ b/src/components/fabToolbar/demoBasicUsage/style.scss
@@ -1,5 +1,5 @@
 md-fab-toolbar {
-  &.md-left {
+  &.md-right {
     md-fab-trigger.align-with-text {
       // Make sure the FAB lines up with the text for the demo
       left: 7px;

--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -48,16 +48,6 @@ md-fab-toolbar {
 
   &.md-left {
     md-fab-trigger {
-      left: 0;
-    }
-
-    .md-toolbar-tools {
-      flex-direction: row;
-    }
-  }
-
-  &.md-right {
-    md-fab-trigger {
       right: 0;
     }
 
@@ -65,11 +55,11 @@ md-fab-toolbar {
       flex-direction: row-reverse;
 
       > .md-button:first-child {
-        margin-left: 0.6rem;
+        margin-right: 0.6rem;
       }
 
       > .md-button:first-child {
-        margin-right: -0.8rem;
+        margin-left: -0.8rem;
       }
 
 
@@ -77,6 +67,16 @@ md-fab-toolbar {
         margin-right: 8px;
       }
 
+    }
+  }
+
+  &.md-right {
+    md-fab-trigger {
+      left: 0;
+    }
+
+    .md-toolbar-tools {
+      flex-direction: row;
     }
   }
 

--- a/src/components/fabToolbar/fabToolbar.spec.js
+++ b/src/components/fabToolbar/fabToolbar.spec.js
@@ -14,37 +14,6 @@ describe('<md-fab-toolbar> directive', function() {
     });
   }
 
-  it('disables tabbing to the trigger (go straight to first element instead)', inject(function() {
-    build(
-      '<md-fab-toolbar><md-fab-trigger><button></button></md-fab-trigger></md-fab-toolbar>'
-    );
-
-    expect(element.find('md-fab-trigger').find('button').attr('tabindex')).toBe('-1');
-  }));
-
-
-  it('opens when the toolbar elements are focused', inject(function() {
-    build(
-      '<md-fab-toolbar><md-fab-trigger><a></a></md-fab-trigger>' +
-      '<md-fab-actions><button></button></md-fab-actions></md-fab-toolbar>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    expect(controller.isOpen).toBe(true);
-  }));
-
-  it('closes when the toolbar elements are blurred', inject(function() {
-    build(
-      '<md-fab-toolbar><md-fab-actions><button></button></md-fab-actions></md-fab-toolbar>'
-    );
-
-    element.find('button').triggerHandler('focus');
-    expect(controller.isOpen).toBe(true);
-
-    element.find('button').triggerHandler('blur');
-    expect(controller.isOpen).toBe(false);
-  }));
-
   it('allows programmatic opening through the md-open attribute', inject(function() {
     build(
       '<md-fab-toolbar md-open="isOpen"></md-fab-toolbar>'
@@ -66,7 +35,7 @@ describe('<md-fab-toolbar> directive', function() {
     build(
       '<md-fab-toolbar md-open="isOpen">' +
       '  <md-fab-trigger><button></button></md-fab-trigger>' +
-      '  <md-fab-actions><button></button></md-fab-actions>' +
+      '  <md-fab-actions><md-toolbar><button></button></md-toolbar></md-fab-actions>' +
       '</md-fab-toolbar>'
     );
 

--- a/src/components/fabTrigger/fabTrigger.js
+++ b/src/components/fabTrigger/fabTrigger.js
@@ -2,7 +2,7 @@
   'use strict';
 
   angular
-    .module('material.components.fabTrigger', [ 'material.core' ])
+    .module('material.components.fabTrigger', ['material.core'])
     .directive('mdFabTrigger', MdFabTriggerDirective);
 
   /**
@@ -21,24 +21,12 @@
    * See the `<md-fab-speed-dial>` or `<md-fab-toolbar>` directives for example usage.
    */
   function MdFabTriggerDirective() {
+    // TODO: Remove this completely?
     return {
       restrict: 'E',
 
-      require: ['^?mdFabSpeedDial', '^?mdFabToolbar'],
-
-      link: function(scope, element, attributes, controllers) {
-        // Grab whichever parent controller is used
-        var controller = controllers[0] || controllers[1];
-
-        // Make the children open/close their parent directive
-        if (controller) {
-          angular.forEach(element.children(), function(child) {
-            angular.element(child).on('focus', controller.open);
-            angular.element(child).on('blur', controller.close);
-          });
-        }
-      }
-    }
+      require: ['^?mdFabSpeedDial', '^?mdFabToolbar']
+    };
   }
 })();
 


### PR DESCRIPTION
Update components with shared controller that provides better
hover, click, keyboard and ARIA support for improved interaction
on desktop and mobile.

This also provides better support for iOS devices (and presumably
other mobile devices too).

Ideally, these will be refactored into a single component before 1.0.

BREAKING CHANGE: The FAB Speed Dial/Toolbar no longer automatically
adds the hover effect. The demo has been updated with example code
which utilizes `ng-mouseenter` and `ng-mouseleave`.

BREAKING CHANGE - Fab Toolbar now requires the use of the `md-direction`
attribute instead of just setting the `md-left` and `md-right`  CSS class.
This is due to the shared controller and keyboard support.

fixes #3925, fixes #3214, fixes #3231