### PR TITLE
inject $index into the chip template scope. Fixes #3679

### DIFF
--- a/src/components/chips/demoBasicUsage/index.html
+++ b/src/components/chips/demoBasicUsage/index.html
@@ -28,12 +28,13 @@
 
     <br/>
     <h2 class="md-title">Display an ordered set of objects as chips (with custom template).</h2>
+    <p>Note: the variables <code>$chip</code> and <code>$index</code> are available in custom chip templates.</p>
 
     <md-chips class="custom-chips" ng-model="ctrl.vegObjs" readonly="ctrl.readonly"
         md-on-append="ctrl.newVeg($chip)">
       <md-chip-template>
         <span>
-          <strong>{{$chip.name}}</strong>
+          <strong>[{{$index}}] {{$chip.name}}</strong>
           <em>({{$chip.type}})</em>
         </span>
       </md-chip-template>

--- a/src/components/chips/js/chipTranscludeDirective.js
+++ b/src/components/chips/js/chipTranscludeDirective.js
@@ -14,6 +14,7 @@ function MdChipTransclude ($compile, $mdUtil) {
         newScope = ctrl.parent.$new(false, ctrl.parent);
     newScope.$$replacedScope = scope;
     newScope.$chip = scope.$chip;
+    newScope.$index = scope.$index;
     newScope.$mdChipsCtrl = ctrl;
     element.html(ctrl.$scope.$eval(attr.mdChipTransclude));
     $compile(element.contents())(newScope);


### PR DESCRIPTION
Adds `$index` to the variables grafted onto the new scope in chip-transclude