### PR TITLE
fix(chips): interaction with Autocomplete

### DIFF
--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -7,7 +7,7 @@
         md-contact-name="name"
         md-contact-image="image"
         md-contact-email="email"
-        md-require-match
+        md-require-match="true"
         filter-selected="ctrl.filterSelected"
         placeholder="To">
     </md-contact-chips>

--- a/src/components/chips/demoCustomInputs/index.html
+++ b/src/components/chips/demoCustomInputs/index.html
@@ -15,7 +15,7 @@
     <br/>
     <h2 class="md-title">Use <code>md-autocomplete</code>  to build an ordered set of chips.</h2>
 
-    <md-chips ng-model="ctrl.selectedVegetables" md-autocomplete-snap md-require-match>
+    <md-chips ng-model="ctrl.selectedVegetables" md-autocomplete-snap md-require-match="true">
       <md-autocomplete
           md-selected-item="ctrl.selectedItem"
           md-search-text="ctrl.searchText"

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -47,6 +47,9 @@ function MdChipsCtrl ($scope, $mdConstant, $log, $element, $timeout) {
   /** @type {number} */
   this.selectedChip = -1;
 
+  /** @type {boolean} */
+  this.hasAutocomplete = false;
+
 
   /**
    * Hidden hint text for how to delete a chip. Used to give context to screen readers.
@@ -84,7 +87,7 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
   var chipBuffer = this.getChipBuffer();
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.ENTER:
-      if (this.$scope.requireMatch || !chipBuffer) break;
+      if ((this.hasAutocomplete && this.requireMatch) || !chipBuffer) break;
       event.preventDefault();
       this.appendChip(chipBuffer);
       this.resetChipBuffer();
@@ -343,7 +346,7 @@ MdChipsCtrl.prototype.configureUserInput = function(inputElement) {
 };
 
 MdChipsCtrl.prototype.configureAutocomplete = function(ctrl) {
-
+  this.hasAutocomplete = true;
   ctrl.registerSelectedItemWatcher(angular.bind(this, function (item) {
     if (item) {
       this.appendChip(item);


### PR DESCRIPTION
Properly set require-match=true in demos so that the value is correct in the components.
Check for requiredMatch on the controller instead of on the scope.

fixes #3475