### PR TITLE
fix(tabs): update inkBar to not show when tab does not exist

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -648,7 +648,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function updateInkBarStyles () {
     if (!elements.tabs[ ctrl.selectedIndex ]) {
-      angular.element(elements.inkBar).css({ left: 'auto' });
+      angular.element(elements.inkBar).css({ left: 'auto', right 'auto' });
       return;
     }
     if (!ctrl.tabs.length) return queue.push(ctrl.updateInkBarStyles);

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -648,7 +648,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function updateInkBarStyles () {
     if (!elements.tabs[ ctrl.selectedIndex ]) {
-      angular.element(elements.inkBar).css({ left: 'auto', right 'auto' });
+      angular.element(elements.inkBar).css({ left: 'auto', right: 'auto' });
       return;
     }
     if (!ctrl.tabs.length) return queue.push(ctrl.updateInkBarStyles);

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -647,7 +647,10 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @returns {*}
    */
   function updateInkBarStyles () {
-    if (!elements.tabs[ ctrl.selectedIndex ]) return;
+    if (!elements.tabs[ ctrl.selectedIndex ]) {
+      angular.element(elements.inkBar).css({ left: 'auto' });
+      return;
+    }
     if (!ctrl.tabs.length) return queue.push(ctrl.updateInkBarStyles);
     // if the element is not visible, we will not be able to calculate sizes until it is
     // we should treat that as a resize event rather than just updating the ink bar


### PR DESCRIPTION
When setting the slectedIndex to -1 the inkBar will still be visible below the last selected tab. This commit fixes that by setting the inkBar css left property to 'auto' thus hiding it.