### PR TITLE
fix(mdContactChips): trigger $setViewValue on model update

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -193,6 +193,8 @@ MdChipsCtrl.prototype.appendChip = function(newChip) {
   }
   if (this.items.indexOf(newChip) + 1) return;
   this.items.push(newChip);
+
+  this.ngModelCtrl.$setViewValue(angular.copy(this.items));
 };
 
 /**
@@ -268,6 +270,8 @@ MdChipsCtrl.prototype.removeChip = function(index) {
   if (removed && removed.length && this.useOnRemove && this.onRemove) {
     this.onRemove({ '$chip': removed[0], '$index': index });
   }
+
+  this.ngModelCtrl.$setViewValue(angular.copy(this.items));
 };
 
 MdChipsCtrl.prototype.removeChipAndFocusInput = function (index) {

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -100,6 +100,7 @@
       },
       restrict: 'E',
       controller: 'MdContactChipsCtrl',
+      require: '?ngModel',
       controllerAs: '$mdContactChipsCtrl',
       bindToController: true,
       compile: compile,
@@ -116,10 +117,12 @@
     };
 
     function compile(element, attr) {
-      return function postLink(scope, element, attrs, controllers) {
+      return function postLink(scope, element, attrs, ngModelCtrl) {
 
         $mdUtil.initOptionalProperties(scope, attr);
         $mdTheming(element);
+        scope.$mdContactChipsCtrl.$setViewValue = ngModelCtrl ?
+          ngModelCtrl.$setViewValue : angular.noop;
 
         element.attr('tabindex', '-1');
       };


### PR DESCRIPTION
  * Fixes #3857
  * Avoids having to use $scope.$watch in order to get notified for changes
  * Allows use of <md-contact-chips ng-change="ctrl.doStuff()">