### PR TITLE
docs(input): fix typo in demo

### DIFF
--- a/src/components/input/demoErrors/index.html
+++ b/src/components/input/demoErrors/index.html
@@ -31,7 +31,7 @@
         <div ng-messages="projectForm.rate.$error">
           <div ng-message="required">You've got to charge something! You can't just <b>give away</b> a Missile Defense System.</div>
           <div ng-message="min">You should charge at least $800 an hour. This job is a big deal... if you mess up, everyone dies!</div>
-          <div ng-message="max">$5,000 an hour? That's a little ridiculous. I doubt event Bill Clinton could afford that.</div>
+          <div ng-message="max">$5,000 an hour? That's a little ridiculous. I doubt even Bill Clinton could afford that.</div>
         </div>
       </md-input-container>
     </form>


### PR DESCRIPTION
Fixes a typo in the input demo.

fixes #2556 