### PR TITLE
fix(subheader): Fix thrown error when using md-subheader with ng-if and ng-repeat.

### DIFF
--- a/src/components/subheader/demoBasicUsage/index.html
+++ b/src/components/subheader/demoBasicUsage/index.html
@@ -1,6 +1,7 @@
 
 <div ng-controller="SubheaderAppCtrl" layout="column" flex layout-fill>
   <md-content style="height: 600px;" md-theme="altTheme">
+
     <section>
       <md-subheader class="md-primary">Unread Messages</md-subheader>
       <md-list layout-padding>
@@ -16,6 +17,7 @@
         </md-list-item>
       </md-list>
     </section>
+
     <section>
       <md-subheader class="md-warn">Late Messages</md-subheader>
       <md-list layout="column" layout-padding>
@@ -31,6 +33,7 @@
         </md-list-item>
       </md-list>
     </section>
+
     <section>
       <md-subheader>Read Messages</md-subheader>
       <md-list layout="column" layout-padding>
@@ -46,6 +49,7 @@
         </md-list-item>
       </md-list>
     </section>
+
     <section>
       <md-subheader class="md-accent">Archived messages</md-subheader>
       <md-list layout="column" layout-padding>
@@ -61,5 +65,6 @@
         </md-list-item>
       </md-list>
     </section>
+
   </md-content>
 </div>

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -40,42 +40,48 @@ angular.module('material.components.subheader', [
  * </hljs>
  */
 
-function MdSubheaderDirective($mdSticky, $compile, $mdTheming) {
+function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
   return {
     restrict: 'E',
     replace: true,
     transclude: true,
-    template: 
-      '<h2 class="md-subheader">' +
-        '<div class="md-subheader-inner">' +
-          '<span class="md-subheader-content"></span>' +
-        '</div>' +
-      '</h2>',
-    compile: function(element, attr, transclude) {
-      return function postLink(scope, element, attr) {
-        $mdTheming(element);
-        var outerHTML = element[0].outerHTML;
+    template: (
+    '<h2 class="md-subheader">' +
+    '  <div class="md-subheader-inner">' +
+    '    <span class="md-subheader-content"></span>' +
+    '  </div>' +
+    '</h2>'
+    ),
+    link: function postLink(scope, element, attr, controllers, transclude) {
+      $mdTheming(element);
+      var outerHTML = element[0].outerHTML;
 
-        function getContent(el) {
-          return angular.element(el[0].querySelector('.md-subheader-content'));
-        }
+      function getContent(el) {
+        return angular.element(el[0].querySelector('.md-subheader-content'));
+      }
 
-        // Transclude the user-given contents of the subheader
-        // the conventional way.
+      // Transclude the user-given contents of the subheader
+      // the conventional way.
+      transclude(scope, function(clone) {
+        getContent(element).append(clone);
+      });
+
+      // Create another clone, that uses the outer and inner contents
+      // of the element, that will be 'stickied' as the user scrolls.
+      if (!element.hasClass('md-no-sticky')) {
         transclude(scope, function(clone) {
-          getContent(element).append(clone);
-        });
+          var wrapperHtml = '<div class="md-subheader-wrapper">' + outerHTML + '</div>';
+          var stickyClone = $compile(wrapperHtml)(scope);
 
-        // Create another clone, that uses the outer and inner contents
-        // of the element, that will be 'stickied' as the user scrolls.
-        if (!element.hasClass('md-no-sticky')) {
-          transclude(scope, function(clone) {
-            var stickyClone = $compile(angular.element(outerHTML))(scope);
+          // Append the sticky
+          $mdSticky(scope, element, stickyClone);
+
+          // Wait until the next tick when the
+          $mdUtil.nextTick(function() {
             getContent(stickyClone).append(clone);
-            $mdSticky(scope, element, stickyClone);
           });
-        }
-      };
+        });
+      }
     }
-  };
+  }
 }

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -23,6 +23,39 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   }
 }
 
+.md-subheader-wrapper {
+
+  &:not(.md-sticky-no-effect) {
+    .md-subheader {
+      margin: 0;
+    }
+
+    .md-subheader:after {
+      position: absolute;
+      left: 0;
+      bottom: 0;
+      top: 0;
+      right: -$subheader-margin-right;
+      content: '';
+    }
+
+    transition: 0.2s ease-out margin;
+
+    &.md-sticky-clone {
+      z-index: 2;
+    }
+
+    &[sticky-state="active"] {
+      margin-top: -2px;
+    }
+
+    &:not(.md-sticky-clone)[sticky-prev-state="active"] .md-subheader-inner:after {
+      animation: subheaderStickyHoverOut 0.3s ease-out both;
+    }
+  }
+
+}
+
 .md-subheader {
   display: block;
   font-size: $subheader-font-size;
@@ -34,28 +67,6 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
 
   .md-subheader-inner {
     padding: $subheader-padding;
-  }
-
-  &:not(.md-sticky-no-effect) {
-    &:after {
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      top: 0;
-      right: -$subheader-margin-right;
-      content: '';
-    }
-
-    transition: 0.2s ease-out margin;
-    &.md-sticky-clone {
-      z-index: 2;
-    }
-    &[sticky-state="active"] {
-      margin-top: -2px;
-    }
-    &:not(.md-sticky-clone)[sticky-prev-state="active"] .md-subheader-inner:after {
-      animation: subheaderStickyHoverOut 0.3s ease-out both;
-    }
   }
 
   .md-subheader-content {

--- a/src/components/subheader/subheader.spec.js
+++ b/src/components/subheader/subheader.spec.js
@@ -1,6 +1,9 @@
 describe('mdSubheader', function() {
   var $mdStickyMock,
-      basicHtml = '<md-subheader>Hello world!</md-header>';
+      basicHtml = '<md-subheader>Hello world!</md-header>',
+      pageScope, element, controller;
+
+  var $rootScope, $timeout, $exceptionHandler;
 
   beforeEach(module('material.components.subheader', function($provide) {
     $mdStickyMock = function() {
@@ -9,28 +12,77 @@ describe('mdSubheader', function() {
     $provide.value('$mdSticky', $mdStickyMock);
   }));
 
-
-  it('should preserve content', inject(function($compile, $rootScope) {
-    var $scope = $rootScope.$new();
-    $scope.to = 'world';
-    var $el = $compile('<div><md-subheader>Hello {{ to }}!</md-subheader></div>')($scope);
-    $scope.$digest();
-    var $subHeader = $el.children();
-    expect($subHeader.text()).toEqual('Hello world!');
+  beforeEach(inject(function(_$rootScope_, _$timeout_, _$exceptionHandler_) {
+    $rootScope = _$rootScope_;
+    $timeout = _$timeout_;
+    $exceptionHandler = _$exceptionHandler_;
   }));
 
-  it('should implement $mdSticky', inject(function($compile, $rootScope) {
-    var scope = $rootScope.$new();
-    var $el = $compile(basicHtml)(scope);
-    expect($mdStickyMock.args[0]).toBe(scope);
-  }));
+  it('preserves content', function() {
+    build('<div><md-subheader>Hello {{ to }}!</md-subheader></div>');
+    pageScope.to = 'world';
+    pageScope.$digest();
 
-  it('should apply the theme to the header and clone', inject(function($compile, $rootScope) {
-    var scope = $rootScope.$new();
-    $compile('<div md-theme="somethingElse">' + basicHtml + '</div>')(scope);
+    var subHeader = element.children();
+
+    expect(subHeader.text().trim()).toEqual('Hello world!');
+  });
+
+  it('implements $mdSticky', function() {
+    build(basicHtml);
+
+    expect($mdStickyMock.args[0]).toBe(pageScope);
+  });
+
+  it('applies the theme to the header and clone', function() {
+    build('<div md-theme="somethingElse">' + basicHtml + '</div>');
+
+    // Grab the real element
     var element = $mdStickyMock.args[1];
-    var clone = $mdStickyMock.args[2];
+
+    // The subheader now wraps the clone in a DIV in case of ng-if usage, so we have to search for
+    // the proper element.
+    var clone = angular.element($mdStickyMock.args[2][0].querySelector('.md-subheader'));
+
     expect(element.hasClass('md-somethingElse-theme')).toBe(true);
     expect(clone.hasClass('md-somethingElse-theme')).toBe(true);
-  }));
+  });
+
+  it('applies the proper scope to the clone', function() {
+    build('<div><md-subheader>Hello {{ to }}!</md-subheader></div>');
+
+    pageScope.to = 'world';
+    pageScope.$apply();
+
+    var element = $mdStickyMock.args[1];
+    var clone = $mdStickyMock.args[2];
+
+    expect(element.text().trim()).toEqual('Hello world!');
+    expect(clone.text().trim()).toEqual('Hello world!');
+  });
+
+  it('supports ng-if', function() {
+    build('<div><md-subheader ng-if="true">test</md-subheader></div>');
+
+    expect($exceptionHandler.errors).toEqual([]);
+    expect(element[0].querySelectorAll('.md-subheader').length).toEqual(1);
+  });
+
+  it('supports ng-repeat', function() {
+    build('<div><md-subheader ng-repeat="i in [1,2,3]">Test {{i}}</md-subheader></div>');
+
+    expect($exceptionHandler.errors).toEqual([]);
+    expect(element[0].querySelectorAll('.md-subheader').length).toEqual(3);
+  });
+
+  function build(template) {
+    inject(function($compile) {
+      pageScope = $rootScope.$new();
+      element = $compile(template)(pageScope);
+      controller = element.controller('mdSubheader');
+
+      pageScope.$apply();
+      $timeout.flush();
+    });
+  }
 });


### PR DESCRIPTION
When used with `ng-if` or `ng-repeat`, the `md-subheader` was not able to properly
clone itself when creating a sticky because it only had a comment tag. Delay
initialization until after the `ng-if`/`ng-repeat` has finished before attempting
to create the clone.

fixes #2650, fixes #2980 