### PR TITLE
fix(fabToolbar): Fix md-direction attribute to be string instead of expression.

### DIFF
--- a/src/components/fabToolbar/demoBasicUsage/index.html
+++ b/src/components/fabToolbar/demoBasicUsage/index.html
@@ -12,7 +12,8 @@
     </p>
   </md-content>
 
-  <md-fab-toolbar md-open="demo.isOpen" count="demo.count" md-direction="demo.selectedDirection">
+  <md-fab-toolbar md-open="demo.isOpen" count="demo.count"
+                  md-direction="{{demo.selectedDirection}}">
     <md-fab-trigger class="align-with-text">
       <md-button aria-label="menu" class="md-fab md-primary">
         <md-icon md-svg-src="img/icons/menu.svg"></md-icon>

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -79,7 +79,7 @@
       '</div>',
 
       scope: {
-        direction: '=?mdDirection',
+        direction: '@?mdDirection',
         isOpen: '=?mdOpen'
       },
 

--- a/src/components/fabToolbar/fabToolbar.spec.js
+++ b/src/components/fabToolbar/fabToolbar.spec.js
@@ -14,6 +14,26 @@ describe('<md-fab-toolbar> directive', function() {
     });
   }
 
+  it('applies a class for each direction', inject(function() {
+    build(
+      '<md-fab-toolbar md-direction="{{direction}}"></md-fab-toolbar>'
+    );
+
+    pageScope.$apply('direction = "left"');
+    expect(element.hasClass('md-left')).toBe(true);
+
+    pageScope.$apply('direction = "right"');
+    expect(element.hasClass('md-right')).toBe(true);
+  }));
+
+  it('accepts a string for md-direction', inject(function() {
+    build(
+      '<md-fab-toolbar md-direction="right"></md-fab-toolbar>'
+    );
+
+    expect(element.hasClass('md-right')).toBe(true);
+  }));
+
   it('allows programmatic opening through the md-open attribute', inject(function() {
     build(
       '<md-fab-toolbar md-open="isOpen"></md-fab-toolbar>'


### PR DESCRIPTION
The fabSpeedDial treats the `md-direction` attribute as a string as does the shared fabController. However, the fabToolbar treated it as an expression.

Update the code to make it a string instead.

fixes #3390 