### PR TITLE
docs(fabSpeedDial/Toolbar): Update docs with many fixes.

### DIFF
--- a/src/components/fabActions/fabActions.js
+++ b/src/components/fabActions/fabActions.js
@@ -1,6 +1,10 @@
 (function() {
   'use strict';
 
+  /**
+   * @ngdoc module
+   * @name material.components.fabActions
+   */
   angular
     .module('material.components.fabActions', ['material.core'])
     .directive('mdFabActions', MdFabActionsDirective);

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -1,6 +1,10 @@
 (function() {
   'use strict';
 
+  /**
+   * @ngdoc module
+   * @name material.components.fabSpeedDial
+   */
   angular
     // Declare our module
     .module('material.components.fabSpeedDial', [
@@ -39,9 +43,19 @@
    *    appropriate positions.
    *  - `md-scale` - The speed dial items appear in their proper places by scaling from 0% to 100%.
    *
+   * You may also easily position the trigger by applying one one of the following classes to the
+   * `<md-fab-speed-dial>` element:
+   *  - `md-fab-top-left`
+   *  - `md-fab-top-right`
+   *  - `md-fab-bottom-left`
+   *  - `md-fab-bottom-right`
+   *
+   * These CSS classes use `position: absolute`, so you need to ensure that the container element
+   * also uses `position: absolute` or `position: relative` in order for them to work.
+   *
    * @usage
    * <hljs lang="html">
-   * <md-fab-speed-dial direction="up" class="md-fling">
+   * <md-fab-speed-dial md-direction="up" class="md-fling">
    *   <md-fab-trigger>
    *     <md-button aria-label="Add..."><md-icon icon="/img/icons/plus.svg"></md-icon></md-button>
    *   </md-fab-trigger>

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -1,6 +1,10 @@
 (function() {
   'use strict';
 
+  /**
+   * @ngdoc module
+   * @name material.components.fabToolbar
+   */
   angular
     // Declare our module
     .module('material.components.fabToolbar', [
@@ -32,10 +36,20 @@
    * for quick access to common actions when a floating action button is activated (via click or
    * keyboard navigation).
    *
+   * You may also easily position the trigger by applying one one of the following classes to the
+   * `<md-fab-toolbar>` element:
+   *  - `md-fab-top-left`
+   *  - `md-fab-top-right`
+   *  - `md-fab-bottom-left`
+   *  - `md-fab-bottom-right`
+   *
+   * These CSS classes use `position: absolute`, so you need to ensure that the container element
+   * also uses `position: absolute` or `position: relative` in order for them to work.
+   *
    * @usage
    *
    * <hljs lang="html">
-   * <md-fab-toolbar>
+   * <md-fab-toolbar md-direction='left'>
    *   <md-fab-trigger>
    *     <md-button aria-label="Add..."><md-icon icon="/img/icons/plus.svg"></md-icon></md-button>
    *   </md-fab-trigger>

--- a/src/components/fabTrigger/fabTrigger.js
+++ b/src/components/fabTrigger/fabTrigger.js
@@ -1,6 +1,10 @@
 (function() {
   'use strict';
 
+  /**
+   * @ngdoc module
+   * @name material.components.fabTrigger
+   */
   angular
     .module('material.components.fabTrigger', ['material.core'])
     .directive('mdFabTrigger', MdFabTriggerDirective);


### PR DESCRIPTION
Many updates/fixes to the fabSpeedDial and fabToolbar docs:

 * update docs so they actually appear in the directive API section
 * add info about `md-fab-*` CSS classes for positioning
 * fix some errors in the `@usage` sections

fixes #4183