### PR TITLE
avoid pushing undefined chip to chips list

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -191,7 +191,7 @@ MdChipsCtrl.prototype.appendChip = function(newChip) {
   if (this.useOnAppend && this.onAppend) {
     newChip = this.onAppend({'$chip': newChip});
   }
-  if (this.items.indexOf(newChip) + 1) return;
+  if (!newChip || this.items.indexOf(newChip) + 1) return;
   this.items.push(newChip);
 };
 


### PR DESCRIPTION
fix for #4193 
undefined chip pushed into the items array while using md-on-append 

![ud](https://cloud.githubusercontent.com/assets/2281169/9295578/05f95e2e-447b-11e5-9523-7c3bbcb32523.jpg)
