### PR TITLE
docs(mdChips): Fix optional attributes.

### DIFF
--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -66,9 +66,9 @@
    *    the input and delete buttons
    * @param {expression} md-on-append An expression expected to convert the input string into an
    *    object when adding a chip.
-   * @param {expression} md-on-remove An expression which will be called when a chip has been
+   * @param {expression=} md-on-remove An expression which will be called when a chip has been
    *    removed.
-   * @param {expression} md-on-select An expression which will be called when a chip is selected.
+   * @param {expression=} md-on-select An expression which will be called when a chip is selected.
    * @param {string=} delete-hint A string read by screen readers instructing users that pressing
    *    the delete key will remove the chip.
    * @param {string=} delete-button-label A label for the delete button. Also hidden and read by


### PR DESCRIPTION
The `md-on-remove` and `md-on-select` attributes were incorrectly labeled as being required.