### PR TITLE
Fixed CSS issue with dialog and z-index

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -12,7 +12,7 @@ $dialog-padding: $baseline-grid * 3;
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: $z-index-dialog;
+  z-index: $z-index-menu;
   overflow: hidden;
 }
 


### PR DESCRIPTION
md-backdrop had a z-index value superior md-dialog-container preventing the buttons inside a confirm dialog to be clickable