### PR TITLE
fix(css): remove styles that could apply to user-controlled elements.

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -57,11 +57,6 @@ $icon-button-margin: rem(0.600) !default;
   transition: box-shadow $swift-ease-out-duration $swift-ease-out-timing-function,
               background-color $swift-ease-out-duration $swift-ease-out-timing-function;
 
-  *,
-  *:before,
-  *:after {
-    box-sizing: border-box;
-  }
   &:focus {
     outline: none;
   }

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -46,7 +46,7 @@ angular
  * </hljs>
  *
  */
-function MdCheckboxDirective(inputDirective, $mdInkRipple, $mdAria, $mdConstant, $mdTheming, $mdUtil, $timeout) {
+function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $mdUtil, $timeout) {
   inputDirective = inputDirective[0];
   var CHECKED_CSS = 'md-checked';
 

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -21,12 +21,6 @@ md-checkbox {
   min-width: $checkbox-width;
   min-height: $checkbox-width;
 
-  *,
-  *:before,
-  *:after {
-    box-sizing: border-box;
-  }
-
   &.md-focused:not([disabled]) {
     .md-container:before {
       left: -8px;
@@ -46,13 +40,17 @@ md-checkbox {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+
+    box-sizing: border-box;
     display: inline-block;
+
     width: $checkbox-width;
     height: $checkbox-height;
     @include rtl(left, 0, auto);
     @include rtl(right, auto, 0);
 
     &:before {
+      box-sizing: border-box;
       background-color: transparent;
       border-radius: 50%;
       content: '';
@@ -68,6 +66,7 @@ md-checkbox {
     }
 
     &:after {
+      box-sizing: border-box;
       content: '';
       position: absolute;
       top: -10px;
@@ -94,6 +93,7 @@ md-checkbox {
 
   // unchecked
   .md-icon {
+    box-sizing: border-box;
     transition: 240ms;
     position: absolute;
     top: 0;
@@ -116,6 +116,7 @@ md-checkbox {
 
 
   &.md-checked .md-icon:after {
+    box-sizing: border-box;
     transform: rotate(45deg);
     position: absolute;
     left: $checkbox-width / 3;
@@ -131,6 +132,7 @@ md-checkbox {
   }
 
   .md-label {
+    box-sizing: border-box;
     position: relative;
     display: inline-block;
     vertical-align: middle;

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -11,17 +11,8 @@ md-radio-button,
   white-space: nowrap;
   cursor: pointer;
 
-  *,
-  *:before,
-  *:after {
-    box-sizing: border-box;
-  }
-
-  input {
-    display: none;
-  }
-
   .md-container {
+    box-sizing: border-box;
     position: relative;
     top: 4px;
     display: inline-block;
@@ -39,6 +30,7 @@ md-radio-button,
     }
 
     &:before {
+      box-sizing: border-box;
       background-color: transparent;
       border-radius: 50%;
       content: '';
@@ -59,6 +51,7 @@ md-radio-button,
    }
 
   .md-off {
+    box-sizing: border-box;
     position: absolute;
     top: 0;
     left: 0;
@@ -71,6 +64,7 @@ md-radio-button,
   }
 
   .md-on {
+    box-sizing: border-box;
     position: absolute;
     top: 0;
     left: 0;
@@ -86,6 +80,7 @@ md-radio-button,
   }
 
   .md-label {
+    box-sizing: border-box;
     position: relative;
     display: inline-block;
 

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -14,12 +14,6 @@ md-sidenav {
   background-color: white;
   overflow: auto;
 
-  *,
-  *:before,
-  *:after {
-    box-sizing: border-box;
-  }
-
   ul {
     list-style: none;
   }


### PR DESCRIPTION
BREAKING CHANGE

@ThomasBurleson @robertmesserle 

Related to #3516

I'm removing style rules that would affect elements that are not created/owned by ng-material. As far as I can tell form looking at the demos after this, everything is still the same on our end. Users that were inadvertently depending on these styles will be affected.