### PR TITLE
fix(docs): Build on Windows results in broken docs site and tests

### DIFF
--- a/src/components/menu/_menu.js
+++ b/src/components/menu/_menu.js
@@ -135,7 +135,7 @@ angular.module('material.components.menu', [
  *
  */
 
-function MenuDirective($mdMenu) {
+function MenuDirective() {
   var INVALID_PREFIX = 'Invalid HTML for md-menu: ';
   return {
     restrict: 'E',
@@ -259,16 +259,16 @@ function MenuController($mdMenu, $attrs, $element, $scope) {
    * the offset of top and left in pixels.
    */
   function offsets() {
-    var offsets = ($attrs.mdOffset || '0 0').split(' ').map(parseFloat);
-    if (offsets.length == 2) {
+    var topLeftOffsets = ($attrs.mdOffset || '0 0').split(' ').map(parseFloat);
+    if (topLeftOffsets.length == 2) {
       return {
-        left: offsets[0],
-        top: offsets[1]
+        left: topLeftOffsets[0],
+        top: topLeftOffsets[1]
       };
-    } else if (offsets.length == 1) {
+    } else if (topLeftOffsets.length == 1) {
       return {
-        top: offsets[0],
-        left: offsets[0]
+        top: topLeftOffsets[0],
+        left: topLeftOffsets[0]
       };
     } else {
       throw Error('Invalid offsets specified. Please follow format <x, y> or <n>');

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -101,7 +101,7 @@
 }
 
 
-/* mixin definition ; sets LTR and RTL within the same style call */
+// mixin definition ; sets LTR and RTL within the same style call
 @mixin rtl($prop, $value, $rtl-value) {
   #{$prop}: $value;
   html[dir=rtl] & {
@@ -109,9 +109,7 @@
   }
 }
 
-/**
- * Position a FAB button.
- */
+// Position a FAB button.
 @mixin fab-position($spot, $top: auto, $right: auto, $bottom: auto, $left: auto) {
   &.md-fab-#{$spot} {
     top: $top;


### PR DESCRIPTION
Multi-line SCSS comments result in ILLEGAL_CHARACTER errors in Chrome when built with Windows.
Removed unused $mdMenu injections in MenuDirective and fixed duplicate offsets variable.

Fixes #4226. Fixes #4079.