### PR TITLE
fix(subheader/sticky): Stick subheader to content instead of parent.

### DIFF
--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -46,11 +46,11 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     replace: true,
     transclude: true,
     template: (
-    '<h2 class="md-subheader">' +
+    '<div class="md-subheader">' +
     '  <div class="md-subheader-inner">' +
     '    <span class="md-subheader-content"></span>' +
     '  </div>' +
-    '</h2>'
+    '</div>'
     ),
     link: function postLink(scope, element, attr, controllers, transclude) {
       $mdTheming(element);

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -30,15 +30,6 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
       margin: 0;
     }
 
-    .md-subheader:after {
-      position: absolute;
-      left: 0;
-      bottom: 0;
-      top: 0;
-      right: -$subheader-margin-right;
-      content: '';
-    }
-
     transition: 0.2s ease-out margin;
 
     &.md-sticky-clone {


### PR DESCRIPTION
The `$mdSticky` service used to stick it's contents to the parent of the `<md-content>` container. This resulted in some odd styling issues and the inability to have two lists with sticky subheaders side-by-side.

This fix appends the subheaders directly to the `<md-content>` to fix this issue.

Also, updated subheaders to use `<div>` tags instead of `<h2>`.

fixes #3535