### PR TITLE
fix(subheader): Set styles to allow click/hover when stickied.

### DIFF
--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -66,10 +66,12 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   position: relative;
 
   .md-subheader-inner {
+    display: block;
     padding: $subheader-padding;
   }
 
   .md-subheader-content {
+    display: block;
     z-index: 1;
     position: relative;
   }


### PR DESCRIPTION
Previously, the inner DIVs of the subheader component were not set to use `display: block`, so you could potentially have contents that were inaccessible.

fixes #3932