### PR TITLE
feat(layouts): convert layout attribute selectors to class selectors 

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -29,10 +29,10 @@ module.exports = {
     'src/core/style/mixins.scss',
     'src/core/style/structure.scss',
     'src/core/style/typography.scss',
-    'src/core/style/layout.scss'
+    'src/core/services/layout/layout.scss'
   ],
   scssStandaloneFiles: [
-    'src/core/style/layout.scss'
+    'src/core/services/layout/layout.scss'
   ],
   paths: 'src/{components,services}/**',
   outputDir: 'dist/',

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -1,15 +1,4 @@
-// Responsive attributes
-// ------------------------------
-
-// hide means hide everywhere
-/* Sizes:
-  0    <= size < 600  Phone
-  600  <= size < 960  Tablet
-  960  <= size < 1200 Tablet-Landscape
-  1200 <= size         PC
-*/
-
-[layout] {
+.layout {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -19,72 +8,64 @@
   display: flex;
 }
 
-[layout=column] {
+.layout-column {
   flex-direction: column;
   -webkit-flex-direction: column;
 }
 
-[layout=row] {
+.layout-row {
   flex-direction: row;
   -webkit-flex-direction: row;
 }
 
-[layout-padding] > [flex-sm],
-[layout-padding] > [flex-lt-md]
+.layout-padding > .flex-sm,
+.layout-padding > .flex-lt-md
 {
   padding: $layout-gutter-width / 4;
 }
-[layout-padding],
-[layout-padding] > [flex],
-[layout-padding] > [flex-gt-sm],
-[layout-padding] > [flex-md],
-[layout-padding] > [flex-lt-lg]
+.layout-padding,
+.layout-padding > .flex,
+.layout-padding > .flex-gt-sm,
+.layout-padding > .flex-md,
+.layout-padding > .flex-lt-lg
 {
   padding: $layout-gutter-width / 2;
 }
-[layout-padding] > [flex-gt-md],
-[layout-padding] > [flex-lg]
+.layout-padding > .flex-gt-md,
+.layout-padding > .flex-lg
 {
   padding: $layout-gutter-width / 1;
 }
 
 
-[layout-margin] > [flex-sm],
-[layout-margin] > [flex-lt-md]
+.layout-margin > .flex-sm,
+.layout-margin > .flex-lt-md
 {
   margin: $layout-gutter-width / 4;
 }
-[layout-margin],
-[layout-margin] > [flex],
-[layout-margin] > [flex-gt-sm],
-[layout-margin] > [flex-md],
-[layout-margin] > [flex-lt-lg] {
+.layout-margin,
+.layout-margin > .flex,
+.layout-margin > .flex-gt-sm,
+.layout-margin > .flex-md,
+.layout-margin > .flex-lt-lg {
   margin: $layout-gutter-width / 2;
 }
-[layout-margin] > [flex-gt-md],
-[layout-margin] > [flex-lg]
+.layout-margin > .flex-gt-md,
+.layout-margin > .flex-lg
 {
   margin: $layout-gutter-width / 1;
 }
 
 
 
-[layout-wrap] {
+.layout-wrap {
   flex-wrap: wrap;
 }
 
-[layout-fill] {
+.layout-fill {
   margin: 0;
   min-height: 100%;
   width: 100%;
-}
-@-moz-document url-prefix() {
-  [layout-fill] {
-    margin: 0;
-    width: 100%;
-    min-height: auto;
-    height: inherit;
-  }
 }
 
 @mixin flex-order-for-name($suffix: null) {
@@ -92,20 +73,20 @@
   @if $suffix != null {
     $selector: 'flex-order-#{$suffix}';
   }
-  [#{$selector}="0"] { order: 0; }
-  [#{$selector}="1"] { order: 1; }
-  [#{$selector}="2"] { order: 2; }
-  [#{$selector}="3"] { order: 3; }
-  [#{$selector}="4"] { order: 4; }
-  [#{$selector}="5"] { order: 5; }
-  [#{$selector}="6"] { order: 6; }
-  [#{$selector}="7"] { order: 7; }
-  [#{$selector}="8"] { order: 8; }
-  [#{$selector}="9"] { order: 9; }
+  .#{$selector}-0 { order: 0; }
+  .#{$selector}-1 { order: 1; }
+  .#{$selector}-2 { order: 2; }
+  .#{$selector}-3 { order: 3; }
+  .#{$selector}-4 { order: 4; }
+  .#{$selector}-5 { order: 5; }
+  .#{$selector}-6 { order: 6; }
+  .#{$selector}-7 { order: 7; }
+  .#{$selector}-8 { order: 8; }
+  .#{$selector}-9 { order: 9; }
 }
 
 @mixin layout-for-name($name) {
-  [layout-#{$name}] {
+  .layout-#{$name} {
     box-sizing: border-box;
     display: -webkit-box;
     display: -webkit-flex;
@@ -114,10 +95,10 @@
     display: -ms-flexbox;
     display: flex;
   }
-  [layout-#{$name}=column] {
+  .layout-#{$name}-column {
     flex-direction: column;
   }
-  [layout-#{$name}=row] {
+  .layout-#{$name}-row {
     flex-direction: row;
   }
 }
@@ -128,14 +109,14 @@
     $offsetName: 'offset-#{$name}';
   }
   @for $i from 1 through 19 {
-    [#{$offsetName}="#{$i * 5}"] {
+    .#{$offsetName}-#{$i * 5} {
       margin-left: #{$i * 5 + '%'};
     }
   }
-  [#{$offsetName}="33"], [#{$offsetName}="34"] {
+  .#{$offsetName}-33, .#{$offsetName}-34 {
     margin-left: 33.33%;
   }
-  [#{$offsetName}="66"], [#{$offsetName}="67"] {
+  .#{$offsetName}-66, .#{$offsetName}-67 {
     margin-left: 66.66%;
   }
 }
@@ -146,7 +127,7 @@
     $flexName: 'flex-#{$name}';
   }
 
-  [#{$flexName}] {
+  .#{$flexName} {
     box-sizing: border-box;
     flex: 1;
   }
@@ -154,37 +135,37 @@
 
   // (0-20) * 5 = 0-100%
   @for $i from 0 through 20 {
-    [#{$flexName}="#{$i * 5}"] {
+    .#{$flexName}-#{$i * 5} {
       flex: 0 0 #{$i * 5 + '%'};
     }
-    [layout="row"] > [#{$flexName}="#{$i * 5}"] {
+    .layout-row > .#{$flexName}-#{$i * 5} {
       max-width: #{$i * 5 + '%'};
     }
-    [layout="column"] > [#{$flexName}="#{$i * 5}"] {
+    .layout-column > .#{$flexName}-#{$i * 5} {
       max-height: #{$i * 5 + '%'};
     }
   }
 
-  [#{$flexName}="33"], [#{$flexName}="34"] {
+  .#{$flexName}-33, .#{$flexName}-34 {
     flex: 0 0 33.33%;
   }
-  [#{$flexName}="66"], [#{$flexName}="67"] {
+  .#{$flexName}-66, .#{$flexName}-67 {
     flex: 0 0 66.66%;
   }
 
-  [layout="row"] {
-    > [#{$flexName}="33"], > [#{$flexName}="34"] {
+  .layout-row {
+    > .#{$flexName}-33, > .#{$flexName}-34 {
       max-width: 33.33%;
     }
-    > [#{$flexName}="66"], > [#{$flexName}="67"] {
+    > .#{$flexName}-66, > .#{$flexName}-67 {
       max-width: 66.66%;
     }
   }
-  [layout="column"] {
-    > [#{$flexName}="33"], > [#{$flexName}="34"] {
+  .layout-column {
+    > .#{$flexName}-33, > .#{$flexName}-34 {
       max-height: 33.33%;
     }
-    > [#{$flexName}="66"], > [#{$flexName}="67"] {
+    > .#{$flexName}-66, > .#{$flexName}-67 {
       max-height: 66.66%;
     }
   }
@@ -203,34 +184,34 @@
   }
 
   // Main Axis Center
-  [#{$name}="center"], //stretch
-  [#{$name}="center center"],
-  [#{$name}="center start"],
-  [#{$name}="center end"] {
+  .#{$name}-center, //stretch
+  .#{$name}-center-center,
+  .#{$name}-center-start,
+  .#{$name}-center-end {
     justify-content: center;
   }
 
   // Main Axis End
-  [#{$name}="end"], //stretch
-  [#{$name}="end center"],
-  [#{$name}="end start"],
-  [#{$name}="end end"] {
+  .#{$name}-end, //stretch
+  .#{$name}-end-center,
+  .#{$name}-end-start,
+  .#{$name}-end-end {
     justify-content: flex-end;
   }
 
   // Main Axis Space Around
-  [#{$name}="space-around"], //stretch
-  [#{$name}="space-around center"],
-  [#{$name}="space-around start"],
-  [#{$name}="space-around end"] {
+  .#{$name}-space-around, //stretch
+  .#{$name}-space-around-center,
+  .#{$name}-space-around-start,
+  .#{$name}-space-around-end {
     justify-content: space-around;
   }
 
   // Main Axis Space Between
-  [#{$name}="space-between"], //stretch
-  [#{$name}="space-between center"],
-  [#{$name}="space-between start"],
-  [#{$name}="space-between end"] {
+  .#{$name}-space-between, //stretch
+  .#{$name}-space-between-center,
+  .#{$name}-space-between-start,
+  .#{$name}-space-between-end {
     justify-content: space-between;
   }
 
@@ -241,29 +222,29 @@
   // ------------------------------
 
   // Cross Axis Center
-  [#{$name}="center center"],
-  [#{$name}="start center"],
-  [#{$name}="end center"],
-  [#{$name}="space-between center"],
-  [#{$name}="space-around center"] {
+  .#{$name}-center-center,
+  .#{$name}-start-center,
+  .#{$name}-end-center,
+  .#{$name}-space-between-center,
+  .#{$name}-space-around-center {
     align-items: center;
   }
 
   // Cross Axis Start
-  [#{$name}="center start"],
-  [#{$name}="start start"],
-  [#{$name}="end start"],
-  [#{$name}="space-between start"],
-  [#{$name}="space-around start"] {
+  .#{$name}-center-start,
+  .#{$name}-start-start,
+  .#{$name}-end-start,
+  .#{$name}-space-between-start,
+  .#{$name}-space-around-start {
     align-items: flex-start;
   }
 
   // Cross Axis End
-  [#{$name}="center end"],
-  [#{$name}="start end"],
-  [#{$name}="end end"],
-  [#{$name}="space-between end"],
-  [#{$name}="space-around end"] {
+  .#{$name}-center-end,
+  .#{$name}-start-end,
+  .#{$name}-end-end,
+  .#{$name}-space-between-end,
+  .#{$name}-space-around-end {
     align-items: flex-end;
   }
 

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -1,3 +1,14 @@
+// Responsive attributes
+// ------------------------------
+
+// hide means hide everywhere
+/* Sizes:
+  0    <= size < 600  Phone
+  600  <= size < 960  Tablet
+  960  <= size < 1200 Tablet-Landscape
+  1200 <= size         PC
+*/
+
 .layout {
   box-sizing: border-box;
   display: -webkit-box;
@@ -66,6 +77,14 @@
   margin: 0;
   min-height: 100%;
   width: 100%;
+}
+@-moz-document url-prefix() {
+  .layout-fill {
+    margin: 0;
+    width: 100%;
+    min-height: auto;
+    height: inherit;
+  }
 }
 
 @mixin flex-order-for-name($suffix: null) {
@@ -266,8 +285,8 @@
 
 // SMALL SCREEN
 @media (max-width: $layout-breakpoint-sm - 1) {
-  [hide-sm], [hide] {
-    &:not([show-sm]):not([show]) {
+  .hide-sm, .hide {
+    &:not(.show-sm):not(.show) {
       display: none;
     }
   }
@@ -290,12 +309,12 @@
 
 // MEDIUM SCREEN
 @media (min-width: $layout-breakpoint-sm) and (max-width: $layout-breakpoint-md - 1) {
-  [hide], [hide-gt-sm] {
-    &:not([show-gt-sm]):not([show-md]):not([show]) {
+  .hide, .hide-gt-sm {
+    &:not(.show-gt-sm):not(.show-md):not(.show) {
       display: none;
     }
   }
-  [hide-md]:not([show-md]):not([show]) {
+  .hide-md:not(.show-md):not(.show) {
     display: none;
   }
 
@@ -317,12 +336,12 @@
 
 // LARGE SCREEN
 @media (min-width: $layout-breakpoint-md) and (max-width: $layout-breakpoint-lg - 1) {
-  [hide], [hide-gt-sm], [hide-gt-md] {
-    &:not([show-gt-sm]):not([show-gt-md]):not([show-lg]):not([show]) {
+  .hide, .hide-gt-sm, .hide-gt-md {
+    &:not(.show-gt-sm):not(.show-gt-md):not(.show-lg):not(.show) {
       display: none;
     }
   }
-  [hide-lg]:not([show-lg]):not([show]) {
+  .hide-lg:not(.show-lg):not(.show) {
     display: none;
   }
 
@@ -335,8 +354,8 @@
 
 // BIGGER THAN LARGE SCREEN
 @media (min-width: $layout-breakpoint-lg) {
-  [hide-gt-sm], [hide-gt-md], [hide-gt-lg], [hide] {
-    &:not([show-gt-sm]):not([show-gt-md]):not([show-gt-lg]):not([show]) {
+  .hide-gt-sm, .hide-gt-md, .hide-gt-lg, .hide {
+    &:not(.show-gt-sm):not(.show-gt-md):not(.show-gt-lg):not(.show) {
       display: none;
     }
   }

--- a/src/core/services/layout/layouts.js
+++ b/src/core/services/layout/layouts.js
@@ -1,0 +1,108 @@
+(function () {
+
+  'use strict';
+
+  angular.module('material.layouts', ['material.core'])
+
+      // Attribute directives with optional value(s)
+
+      .directive('layout'              , attribute_withValue('layout'      , true)  )
+      .directive('layoutSm'            , attribute_withValue('layout-sm'   , true)  )
+      .directive('layoutGtSm'          , attribute_withValue('layout-gt-sm', true)  )
+      .directive('layoutMd'            , attribute_withValue('layout-md'   , true)  )
+      .directive('layoutGtMd'          , attribute_withValue('layout-gt-md', true)  )
+      .directive('layoutLg'            , attribute_withValue('layout-lg'   , true)  )
+      .directive('layoutGtLg'          , attribute_withValue('layout-gt-lg', true)  )
+
+      .directive('flex'                , attribute_withValue('flex'        , true)  )
+      .directive('flexSm'              , attribute_withValue('flex-sm'     , true)  )
+      .directive('flexGtSm'            , attribute_withValue('flex-gt-sm'  , true)  )
+      .directive('flexMd'              , attribute_withValue('flex-md'     , true)  )
+      .directive('flexGtMd'            , attribute_withValue('flex-gt-md'  , true)  )
+      .directive('flexLg'              , attribute_withValue('flex-lg'     , true)  )
+      .directive('flexGtLg'            , attribute_withValue('flex-gt-lg'  , true)  )
+
+      // Attribute directives with optional value(s) but directiveName is NOT added as a class
+
+      .directive('layoutAlign'         , attribute_withValue('layout-align')        )
+      .directive('layoutAlignSm'       , attribute_withValue('layout-align-sm')     )
+      .directive('layoutAlignGtSm'     , attribute_withValue('layout-align-gt-sm')  )
+      .directive('layoutAlignMd'       , attribute_withValue('layout-align-md')     )
+      .directive('layoutAlignGtMd'     , attribute_withValue('layout-align-gt-md')  )
+      .directive('layoutAlignLg'       , attribute_withValue('layout-align-lg')     )
+      .directive('layoutAlignGtLg'     , attribute_withValue('layout-align-gt-lg')  )
+
+      .directive('flexOrder'           , attribute_withValue('flex-order')          )
+      .directive('flexOrderSm'         , attribute_withValue('flex-order-sm')       )
+      .directive('flexOrderGtSm'       , attribute_withValue('flex-order-gt-sm')    )
+      .directive('flexOrderMd'         , attribute_withValue('flex-order-md')       )
+      .directive('flexOrderGtMd'       , attribute_withValue('flex-order-gt-md')    )
+      .directive('flexOrderLg'         , attribute_withValue('flex-order-lg')       )
+      .directive('flexOrderGtLg'       , attribute_withValue('flex-order-gt-lg')    )
+
+      .directive('offset'              , attribute_withValue('offset')              )
+      .directive('offsetSm'            , attribute_withValue('offset-sm')           )
+      .directive('offsetGtSm'          , attribute_withValue('offset-gt-sm')        )
+      .directive('offsetMd'            , attribute_withValue('offset-md')           )
+      .directive('offsetGtMd'          , attribute_withValue('offset-gt-md')        )
+      .directive('offsetLg'            , attribute_withValue('offset-lg')           )
+      .directive('offsetGtLg'          , attribute_withValue('offset-gt-lg')        )
+
+      // Attribute directives with no value(s )
+
+      .directive('layoutMargin'        , attribute_noValue('layout-margin')         )
+      .directive('layoutPadding'       , attribute_noValue('layout-padding')        )
+      .directive('layoutWrap'          , attribute_noValue('layout-wrap')           )
+      .directive('layoutFill'          , attribute_noValue('layout-fill')           )
+
+      .directive('hide'                , attribute_noValue('hide')                  )
+      .directive('hideSm'              , attribute_noValue('hide-sm')               )
+      .directive('hideGtSm'            , attribute_noValue('hide-gt-sm')            )
+      .directive('hideMd'              , attribute_noValue('hide-md')               )
+      .directive('hideGtMd'            , attribute_noValue('hide-gt-md')            )
+      .directive('hideLg'              , attribute_noValue('hide-lg')               )
+      .directive('hideGtLg'            , attribute_noValue('hide-gt-lg')            )
+      .directive('show'                , attribute_noValue('show')                  )
+      .directive('showSm'              , attribute_noValue('show-sm')               )
+      .directive('showGtSm'            , attribute_noValue('show-gt-sm')            )
+      .directive('showMd'              , attribute_noValue('show-md')               )
+      .directive('showGtMd'            , attribute_noValue('show-gt-md')            )
+      .directive('showLg'              , attribute_noValue('show-lg')               )
+      .directive('showGtLg'            , attribute_noValue('show-gt-lg')            );
+
+    /**
+     * Creates a registration function with Directive postLink function
+     * for ngMaterial Layout attribute directive
+     *
+     * Note: This provides easy translation to switch ngMaterial
+     * attribute selectors to CLASS selectors and directives.
+     *
+     * !! This is important for IE Browser performance
+     *
+     * @param classname String like flex-gt-md
+     * @param addDirectiveAsClass Boolean
+     */
+    function attribute_withValue(className, addDirectiveAsClass) {
+        return [function() {
+            return {
+                link: function(link, element, attrs) {
+                    var directive = attrs.$normalize(className);
+                    if (addDirectiveAsClass)  element.addClass(className);
+                    if (attrs[directive])
+                        element.addClass(className + "-" + attrs[directive].replace(/\s+/g, "-"));
+                }
+            };
+        }];
+    }
+
+    function attribute_noValue(className) {
+        return [function() {
+            return {
+                link: function(link, element, attrs) {
+                    element.addClass(className);
+                }
+            };
+        }];
+    }
+
+})();

--- a/src/core/services/layout/layouts.spec.js
+++ b/src/core/services/layout/layouts.spec.js
@@ -1,0 +1,87 @@
+describe('layouts service', function () {
+    beforeEach(module('material.layouts'));
+
+    describe('expecting layout classes', function () {
+
+        var suffixes = ['sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg'];
+
+        var directionValues = ['row', 'column'];
+        var flexValues = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 33, 34, 66, 67];
+        var alignmentValues = ['center', 'center center', 'center start', 'center end',
+                           'end', 'end-center', 'end start', 'end end',
+                           'space-around', 'space-around center', 'space-around start', 'space-around end',
+                           'space-between', 'space-between center', 'space-between start', 'space-between end',
+                           'center center', 'start center', 'end center', 'space-between center', 'space-around center',
+                           'center start', 'start start', 'end start', 'space-between start', 'space-around start',
+                           'center end', 'start end', 'end end', 'space-between end', 'space-around end'];
+        var flexOrderValues = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        var offsetValues = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 33, 34, 66, 67];
+
+        var mappings = [{ attribute: 'layout', suffixes: suffixes, values: directionValues, testStandAlone: true, addDirectiveAsClass: true },
+                        { attribute: 'flex', suffixes: suffixes, values: flexValues, testStandAlone: true, addDirectiveAsClass: true },
+                        { attribute: 'layout-align', suffixes: suffixes, values: alignmentValues },
+                        { attribute: 'flex-order', suffixes: suffixes, values: flexOrderValues },
+                        { attribute: 'offset', suffixes: suffixes, values: offsetValues },
+                        { attribute: 'layout-padding', testStandAlone: true },
+                        { attribute: 'layout-margin', testStandAlone: true },
+                        { attribute: 'layout-wrap', testStandAlone: true },
+                        { attribute: 'layout-fill', testStandAlone: true },
+                        { attribute: 'hide', suffixes: suffixes, testStandAlone: true },
+                        { attribute: 'show', suffixes: suffixes, testStandAlone: true }];
+
+        function testMapping(attribute, expectedClass) {
+            it('should fail if the class ' + expectedClass + ' was not added for attribute ' + attribute, inject(function ($compile, $rootScope) {
+                var element = $compile('<div ' + attribute + '>Layout</div>')($rootScope);
+                expect(element.hasClass(expectedClass)).toBe(true);
+            }));
+        }
+
+        function testWithSuffix(attribute, suffixes, values, testStandAlone, addDirectiveAsClass) {
+            for (var j = 0; j < suffixes.length; j++) {
+                var suffix = suffixes[j];
+                // Add the suffix to the attribute.
+                var attributeWithValue = attribute + '-' + suffix;
+                // Add the suffix to the expected class.
+                var expectedClass = attribute + '-' + suffix;
+                // Run the test.
+                if (testStandAlone)
+                    testMapping(attributeWithValue, expectedClass);
+                // Add suffixes with values.
+                if (values)
+                    testWithSuffixAndValue(attribute, values, suffix, addDirectiveAsClass);
+            };
+        }
+
+        function testWithSuffixAndValue(attribute, values, suffix, addDirectiveAsClass) {
+            for (var j = 0; j < values.length; j++) {
+                var attributeValue = values[j].toString();
+                // If there was a suffix passed in, add it first.
+                var attributeWithValue = suffix ? attribute + '-' + suffix : attribute;
+                // Add the value.
+                attributeWithValue += '="' + attributeValue + '"';
+                // The expected class always starts with the attribute name, add the suffix if any.
+                var expectedClass = suffix ? attribute + '-' + suffix : attribute;
+                // Add the class if necessary.
+                if (addDirectiveAsClass)
+                    expectedClass += ' ' + expectedClass;
+                // Add the attribute and suffix to the expected class and replace the spaces with a dash.                
+                expectedClass += '-' + attributeValue.replace(/\s+/g, "-");
+                // Run the test.
+                testMapping(attributeWithValue, expectedClass);
+            };
+        }
+
+        for (var i = 0; i < mappings.length; i++) {
+            var mapping = mappings[i];
+            // First test the mapping without any suffixes or values.
+            if (mapping.testStandAlone)
+                testMapping(mapping.attribute, mapping.attribute);
+            // Check for suffixes.
+            if (mapping.suffixes)
+                testWithSuffix(mapping.attribute, mapping.suffixes, mapping.values, mapping.testStandAlone, mapping.addDirectiveAsClass);
+            // Check for values.
+            if (mapping.values)
+                testWithSuffixAndValue(mapping.attribute, mapping.values, undefined, mapping.addDirectiveAsClass);
+        }
+    });
+});


### PR DESCRIPTION
Created directives to add CSS classes to elements which appears to help IE's selector engine.

Fixes #1771. Closes #4282.