### PR TITLE
chore(layout): style changes for layout code

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -45,69 +45,69 @@
 
       // Attribute directives with optional value(s)
 
-      .directive('layout'              , attribute_withValue('layout'      , true)  )
-      .directive('layoutSm'            , attribute_withValue('layout-sm'   , true)  )
-      .directive('layoutGtSm'          , attribute_withValue('layout-gt-sm', true)  )
-      .directive('layoutMd'            , attribute_withValue('layout-md'   , true)  )
-      .directive('layoutGtMd'          , attribute_withValue('layout-gt-md', true)  )
-      .directive('layoutLg'            , attribute_withValue('layout-lg'   , true)  )
-      .directive('layoutGtLg'          , attribute_withValue('layout-gt-lg', true)  )
+      .directive('layout'              , attributeWithValue('layout'      , true)  )
+      .directive('layoutSm'            , attributeWithValue('layout-sm'   , true)  )
+      .directive('layoutGtSm'          , attributeWithValue('layout-gt-sm', true)  )
+      .directive('layoutMd'            , attributeWithValue('layout-md'   , true)  )
+      .directive('layoutGtMd'          , attributeWithValue('layout-gt-md', true)  )
+      .directive('layoutLg'            , attributeWithValue('layout-lg'   , true)  )
+      .directive('layoutGtLg'          , attributeWithValue('layout-gt-lg', true)  )
 
-      .directive('flex'                , attribute_withValue('flex'        , true)  )
-      .directive('flexSm'              , attribute_withValue('flex-sm'     , true)  )
-      .directive('flexGtSm'            , attribute_withValue('flex-gt-sm'  , true)  )
-      .directive('flexMd'              , attribute_withValue('flex-md'     , true)  )
-      .directive('flexGtMd'            , attribute_withValue('flex-gt-md'  , true)  )
-      .directive('flexLg'              , attribute_withValue('flex-lg'     , true)  )
-      .directive('flexGtLg'            , attribute_withValue('flex-gt-lg'  , true)  )
+      .directive('flex'                , attributeWithValue('flex'        , true)  )
+      .directive('flexSm'              , attributeWithValue('flex-sm'     , true)  )
+      .directive('flexGtSm'            , attributeWithValue('flex-gt-sm'  , true)  )
+      .directive('flexMd'              , attributeWithValue('flex-md'     , true)  )
+      .directive('flexGtMd'            , attributeWithValue('flex-gt-md'  , true)  )
+      .directive('flexLg'              , attributeWithValue('flex-lg'     , true)  )
+      .directive('flexGtLg'            , attributeWithValue('flex-gt-lg'  , true)  )
 
       // Attribute directives with optional value(s) but directiveName is NOT added as a class
 
-      .directive('layoutAlign'         , attribute_withValue('layout-align')        )
-      .directive('layoutAlignSm'       , attribute_withValue('layout-align-sm')     )
-      .directive('layoutAlignGtSm'     , attribute_withValue('layout-align-gt-sm')  )
-      .directive('layoutAlignMd'       , attribute_withValue('layout-align-md')     )
-      .directive('layoutAlignGtMd'     , attribute_withValue('layout-align-gt-md')  )
-      .directive('layoutAlignLg'       , attribute_withValue('layout-align-lg')     )
-      .directive('layoutAlignGtLg'     , attribute_withValue('layout-align-gt-lg')  )
+      .directive('layoutAlign'         , attributeWithValue('layout-align')        )
+      .directive('layoutAlignSm'       , attributeWithValue('layout-align-sm')     )
+      .directive('layoutAlignGtSm'     , attributeWithValue('layout-align-gt-sm')  )
+      .directive('layoutAlignMd'       , attributeWithValue('layout-align-md')     )
+      .directive('layoutAlignGtMd'     , attributeWithValue('layout-align-gt-md')  )
+      .directive('layoutAlignLg'       , attributeWithValue('layout-align-lg')     )
+      .directive('layoutAlignGtLg'     , attributeWithValue('layout-align-gt-lg')  )
 
-      .directive('flexOrder'           , attribute_withValue('flex-order')          )
-      .directive('flexOrderSm'         , attribute_withValue('flex-order-sm')       )
-      .directive('flexOrderGtSm'       , attribute_withValue('flex-order-gt-sm')    )
-      .directive('flexOrderMd'         , attribute_withValue('flex-order-md')       )
-      .directive('flexOrderGtMd'       , attribute_withValue('flex-order-gt-md')    )
-      .directive('flexOrderLg'         , attribute_withValue('flex-order-lg')       )
-      .directive('flexOrderGtLg'       , attribute_withValue('flex-order-gt-lg')    )
+      .directive('flexOrder'           , attributeWithValue('flex-order')          )
+      .directive('flexOrderSm'         , attributeWithValue('flex-order-sm')       )
+      .directive('flexOrderGtSm'       , attributeWithValue('flex-order-gt-sm')    )
+      .directive('flexOrderMd'         , attributeWithValue('flex-order-md')       )
+      .directive('flexOrderGtMd'       , attributeWithValue('flex-order-gt-md')    )
+      .directive('flexOrderLg'         , attributeWithValue('flex-order-lg')       )
+      .directive('flexOrderGtLg'       , attributeWithValue('flex-order-gt-lg')    )
 
-      .directive('offset'              , attribute_withValue('offset')              )
-      .directive('offsetSm'            , attribute_withValue('offset-sm')           )
-      .directive('offsetGtSm'          , attribute_withValue('offset-gt-sm')        )
-      .directive('offsetMd'            , attribute_withValue('offset-md')           )
-      .directive('offsetGtMd'          , attribute_withValue('offset-gt-md')        )
-      .directive('offsetLg'            , attribute_withValue('offset-lg')           )
-      .directive('offsetGtLg'          , attribute_withValue('offset-gt-lg')        )
+      .directive('offset'              , attributeWithValue('offset')              )
+      .directive('offsetSm'            , attributeWithValue('offset-sm')           )
+      .directive('offsetGtSm'          , attributeWithValue('offset-gt-sm')        )
+      .directive('offsetMd'            , attributeWithValue('offset-md')           )
+      .directive('offsetGtMd'          , attributeWithValue('offset-gt-md')        )
+      .directive('offsetLg'            , attributeWithValue('offset-lg')           )
+      .directive('offsetGtLg'          , attributeWithValue('offset-gt-lg')        )
 
-      // Attribute directives with no value(s )
+      // Attribute directives with no value(s)
 
-      .directive('layoutMargin'        , attribute_noValue('layout-margin')         )
-      .directive('layoutPadding'       , attribute_noValue('layout-padding')        )
-      .directive('layoutWrap'          , attribute_noValue('layout-wrap')           )
-      .directive('layoutFill'          , attribute_noValue('layout-fill')           )
+      .directive('layoutMargin'        , attributeWithoutValue('layout-margin')         )
+      .directive('layoutPadding'       , attributeWithoutValue('layout-padding')        )
+      .directive('layoutWrap'          , attributeWithoutValue('layout-wrap')           )
+      .directive('layoutFill'          , attributeWithoutValue('layout-fill')           )
 
-      .directive('hide'                , attribute_noValue('hide')                  )
-      .directive('hideSm'              , attribute_noValue('hide-sm')               )
-      .directive('hideGtSm'            , attribute_noValue('hide-gt-sm')            )
-      .directive('hideMd'              , attribute_noValue('hide-md')               )
-      .directive('hideGtMd'            , attribute_noValue('hide-gt-md')            )
-      .directive('hideLg'              , attribute_noValue('hide-lg')               )
-      .directive('hideGtLg'            , attribute_noValue('hide-gt-lg')            )
-      .directive('show'                , attribute_noValue('show')                  )
-      .directive('showSm'              , attribute_noValue('show-sm')               )
-      .directive('showGtSm'            , attribute_noValue('show-gt-sm')            )
-      .directive('showMd'              , attribute_noValue('show-md')               )
-      .directive('showGtMd'            , attribute_noValue('show-gt-md')            )
-      .directive('showLg'              , attribute_noValue('show-lg')               )
-      .directive('showGtLg'            , attribute_noValue('show-gt-lg')            );
+      .directive('hide'                , attributeWithoutValue('hide')                  )
+      .directive('hideSm'              , attributeWithoutValue('hide-sm')               )
+      .directive('hideGtSm'            , attributeWithoutValue('hide-gt-sm')            )
+      .directive('hideMd'              , attributeWithoutValue('hide-md')               )
+      .directive('hideGtMd'            , attributeWithoutValue('hide-gt-md')            )
+      .directive('hideLg'              , attributeWithoutValue('hide-lg')               )
+      .directive('hideGtLg'            , attributeWithoutValue('hide-gt-lg')            )
+      .directive('show'                , attributeWithoutValue('show')                  )
+      .directive('showSm'              , attributeWithoutValue('show-sm')               )
+      .directive('showGtSm'            , attributeWithoutValue('show-gt-sm')            )
+      .directive('showMd'              , attributeWithoutValue('show-md')               )
+      .directive('showGtMd'            , attributeWithoutValue('show-gt-md')            )
+      .directive('showLg'              , attributeWithoutValue('show-lg')               )
+      .directive('showGtLg'            , attributeWithoutValue('show-gt-lg')            );
 
     /**
      * Creates a registration function with for ngMaterial Layout attribute directive
@@ -115,39 +115,41 @@
      * Note: This provides easy translation to switch ngMaterial
      * attribute selectors to CLASS selectors and directives.
      *
-     * !! This is important for IE Browser performance
+     * *This is important for IE Browser performance*
      *
-     * @param classname String attribute name; eg `layout-gt-md` with value ="row"
-     * @param addDirectiveAsClass Boolean
+     * @param {string} className attribute name; eg `layout-gt-md` with value ="row"
+     * @param {boolean=} addDirectiveAsClass
      */
-    function attribute_withValue(className, addDirectiveAsClass) {
-        return [function() {
-            return {
-                compile : function (element, attr) {
-                  attributeValueToClass(null, element, attr);
+    function attributeWithValue(className, addDirectiveAsClass) {
+      return function() {
+        return {
+            compile: function(element, attr) {
+              attributeValueToClass(null, element, attr);
 
-                  // !! use for postLink to account for transforms after ng-transclude
-                  return attributeValueToClass;
-                }
-            };
-        }];
+              // Use for postLink to account for transforms after ng-transclude.
+              return attributeValueToClass;
+            }
+        };
+      };
 
-        /**
-         * Add as transformed class selector(s), then
-         * remove the deprecated attribute selector
-         */
-        function attributeValueToClass(scope, element, attr) {
-          var directive = attr.$normalize(className);
+      /**
+       * Add as transformed class selector(s), then
+       * remove the deprecated attribute selector
+       */
+      function attributeValueToClass(scope, element, attr) {
+        var directive = attr.$normalize(className);
 
-          // Add transformed class selector(s)
-          if (addDirectiveAsClass)  element.addClass(className);
-          if (attr[directive])
-              element.addClass(className + "-" + attr[directive].replace(/\s+/g, "-"));
-
-          try {
-            element.removeAttr(className);
-          } catch(e) { }
+        // Add transformed class selector(s)
+        if (addDirectiveAsClass) {
+          element.addClass(className);
         }
+
+        if (attr[directive]) {
+          element.addClass(className + "-" + attr[directive].replace(/\s+/g, "-"));
+        }
+
+        element.removeAttr(className);
+      }
     }
 
     /**
@@ -155,28 +157,25 @@
      *
      * Simple transpose of attribute usage to class usage
      */
-    function attribute_noValue(className) {
-        return [function() {
-            return {
-              compile : function (element, attr) {
-                  attributeToClass(null, element);
+    function attributeWithoutValue(className) {
+      return function() {
+        return {
+          compile: function(element, attr) {
+            attributeToClass(null, element);
 
-                  // !! use for postLink to account for transforms after ng-transclude
-                  return attributeToClass;
-                }
-            };
-        }];
+            // Use for postLink to account for transforms after ng-transclude.
+            return attributeToClass;
+          }
+        };
+      };
 
-      /**
-       * Add as transformed class selector, then
-       * remove the deprecated attribute selector
-       */
-      function attributeToClass(scope, element) {
-        element.addClass(className);
-        try {
-          element.removeAttr(className);
-        } catch(e) { }
-      }
+    /**
+     * Add as transformed class selector, then
+     * remove the deprecated attribute selector
+     */
+    function attributeToClass(scope, element) {
+      element.addClass(className);
+      element.removeAttr(className);
     }
-
+  }
 })();

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -1,5 +1,4 @@
 describe('layout directives', function() {
-
   beforeEach(module('material.core', 'material.layout'));
 
   describe('expecting layout classes', function() {
@@ -10,27 +9,27 @@ describe('layout directives', function() {
     var flexValues = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 33, 34, 66, 67];
     var offsetValues = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 33, 34, 66, 67];
     var alignmentValues = [
-          'center', 'center center', 'center start', 'center end',
-          'end', 'end-center', 'end start', 'end end',
-          'space-around', 'space-around center', 'space-around start', 'space-around end',
-          'space-between', 'space-between center', 'space-between start', 'space-between end',
-          'center center', 'start center', 'end center', 'space-between center', 'space-around center',
-          'center start', 'start start', 'end start', 'space-between start', 'space-around start',
-          'center end', 'start end', 'end end', 'space-between end', 'space-around end'
-        ];
+      'center', 'center center', 'center start', 'center end',
+      'end', 'end-center', 'end start', 'end end',
+      'space-around', 'space-around center', 'space-around start', 'space-around end',
+      'space-between', 'space-between center', 'space-between start', 'space-between end',
+      'center center', 'start center', 'end center', 'space-between center', 'space-around center',
+      'center start', 'start start', 'end start', 'space-between start', 'space-around start',
+      'center end', 'start end', 'end end', 'space-between end', 'space-around end'
+    ];
     var mappings = [
-            { attribute: 'flex',           suffixes: suffixes, values: flexValues, addDirectiveAsClass: true, testStandAlone: true},
-            { attribute: 'flex-order',     suffixes: suffixes, values: flexOrderValues },
-            { attribute: 'offset',         suffixes: suffixes, values: offsetValues },
-            { attribute: 'hide',           suffixes: suffixes, testStandAlone: true },
-            { attribute: 'show',           suffixes: suffixes, testStandAlone: true },
-            { attribute: 'layout',         suffixes: suffixes, values: directionValues, addDirectiveAsClass: true, testStandAlone: true },
-            { attribute: 'layout-align',   suffixes: suffixes, values: alignmentValues },
-            { attribute: 'layout-padding', testStandAlone: true },
-            { attribute: 'layout-margin',  testStandAlone: true },
-            { attribute: 'layout-wrap',    testStandAlone: true },
-            { attribute: 'layout-fill',    testStandAlone: true }
-        ];
+      { attribute: 'flex',           suffixes: suffixes, values: flexValues, addDirectiveAsClass: true, testStandAlone: true},
+      { attribute: 'flex-order',     suffixes: suffixes, values: flexOrderValues },
+      { attribute: 'offset',         suffixes: suffixes, values: offsetValues },
+      { attribute: 'hide',           suffixes: suffixes, testStandAlone: true },
+      { attribute: 'show',           suffixes: suffixes, testStandAlone: true },
+      { attribute: 'layout',         suffixes: suffixes, values: directionValues, addDirectiveAsClass: true, testStandAlone: true },
+      { attribute: 'layout-align',   suffixes: suffixes, values: alignmentValues },
+      { attribute: 'layout-padding', testStandAlone: true },
+      { attribute: 'layout-margin',  testStandAlone: true },
+      { attribute: 'layout-wrap',    testStandAlone: true },
+      { attribute: 'layout-fill',    testStandAlone: true }
+    ];
 
     // Run all the tests; iterating the mappings...
 
@@ -42,22 +41,18 @@ describe('layout directives', function() {
       if (map.suffixes)       testWithSuffix(map.attribute, map.suffixes, map.values, map.testStandAlone, map.addDirectiveAsClass);
     }
 
-    /**
-     * Test a simple layout directive to validate that the layout class is added.
-     */
+    /** Test a simple layout directive to validate that the layout class is added. */
     function testSimpleDirective(attribute, expectedClass) {
       // default fallback is attribute as class...
       expectedClass = expectedClass || attribute;
 
       it('should fail if the class ' + expectedClass + ' was not added for attribute ' + attribute, inject(function($compile, $rootScope) {
-        var element = $compile('<div ' + attribute + '>Layout</div>')($rootScope);
+        var element = $compile('<div ' + attribute + '>Layout</div>')($rootScope.$new());
         expect(element.hasClass(expectedClass)).toBe(true);
       }));
     }
 
-    /**
-     * Test directives with 'sm', 'gt-sm', 'md', 'gt-md', 'lg', and 'gt-lg' suffixes
-     */
+    /** Test directives with 'sm', 'gt-sm', 'md', 'gt-md', 'lg', and 'gt-lg' suffixes */
     function testWithSuffixAndValue(attribute, values, suffix, addDirectiveAsClass) {
 
       for (var j = 0; j < values.length; j++) {
@@ -72,15 +67,14 @@ describe('layout directives', function() {
       }
 
       /**
-       * Build string of expected classes that should be added to the
-       * DOM element.
+       * Build string of expected classes that should be added to the DOM element.
        *
        * Convert directive with value to classes
        *
-       * @param attrClass String full attribute name; eg 'layout-gt-lg'
-       * @param attrValue String HTML directive; eg "column"
+       * @param {string} attrClass Full attribute name; eg 'layout-gt-lg'
+       * @param {string} attrValue HTML directive; eg "column"
        *
-       * @returns String to be used with element.addClass(...); eg  `layout-gt-lg layout-gt-lg-column`
+       * @returns {string} Class name(s) to be added; e.g., `layout-gt-lg layout-gt-lg-column`.
        */
       function buildExpectedClass(attrClass, attrValue) {
         if (addDirectiveAsClass) attrClass += ' ' + attrClass;
@@ -92,19 +86,19 @@ describe('layout directives', function() {
        * Note: The expected class always starts with the
        *     attribute name, add the suffix if any.
        *
-       * @param attrClass String full attribute name; eg 'layout-gt-lg'
-       * @param attrValue String HTML directive; eg "column"
+       * @param {string} attrClass Full attribute name; eg 'layout-gt-lg'
+       * @param {string} attrValue HTML directive; eg "column"
        *
-       * @returns String like `layout-gt-lg="column"`
+       * @returns {string} Attribute with value, e.g., `layout-gt-lg="column"`
        */
-      function buildAttributeWithValue(attr, value) {
-        return attr + '="' + value + '"';
+      function buildAttributeWithValue(attrClass, attrValue) {
+        return attrClass + '="' + attrValue + '"';
       }
     }
 
     /**
      * Test directive as simple with media suffix and with associated values.
-     * e.g.  layout-gt-md="row"
+     * E.g., layout-gt-md="row"
      */
     function testWithSuffix(attribute, suffixes, values, testStandAlone, addDirectiveAsClass) {
       for (var j = 0; j < suffixes.length; j++) {


### PR DESCRIPTION
@ThomasBurleson Looked through the layout code and figured this was the easiest way to give feedback.

* Removed underscores from functions names to follow Google JS style guide.
* Fixed JsDoc syntax
* Remove `try-catch` blocks. `removeAttr` is a no-op if the attribute isn't present, and using a `try-catch` block forces V8 to go into unoptimized mode, potentially having a very negative performance impact.
* Changed inconsistent indentation.