### PR TITLE
fix(mdTabs): Fix 0-height animation on iOS devices.

### DIFF
--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -31,9 +31,6 @@ md-tabs {
   overflow: hidden;
   position: relative;
   flex-shrink: 0;
-  &.ng-animate {
-    transition: height $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
-  }
   &:not(.md-no-tab-content):not(.md-dynamic-height) {
     min-height: 200 + $tabs-header-height;
   }


### PR DESCRIPTION
On iOS devices, when switching between tabs, the height would jump
to 0, then animate to the proper place causing a bad glitch.

Fixes #4339