### PR TITLE
fix(autoComplete):  dynamic changing  ng-required not working

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -136,7 +136,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function configureWatchers () {
     var wait = parseInt($scope.delay, 10) || 0;
     $attrs.$observe('disabled', function (value) { ctrl.isDisabled = value; });
-    $attrs.$observe('required', function (value) { ctrl.isRequired = value !== null; });
+    $attrs.$observe('required', function (value) { ctrl.isRequired = value === null ? false : value ; });
     $scope.$watch('searchText', wait ? $mdUtil.debounce(handleSearchText, wait) : handleSearchText);
     $scope.$watch('selectedItem', selectedItemChange);
     angular.element($window).on('resize', positionDropdown);


### PR DESCRIPTION
Setting the <autocomplete ng-required="var" to false doesn't update the input field ng-required="$mdAutocompleteCtrl.isRequired"  $mdAutocompleteCtrl.isRequired remains true