### PR TITLE
Fix scrolling behavior of sidenav when popped out

### DIFF
--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -73,11 +73,25 @@ md-sidenav {
     min-width: $sidenav-default-width;
     transform: translate3d(0%, 0, 0);
   }
+  
+  &:not(.md-closed):not(.md-locked-open) {
+    position: fixed;
+    top: 0;
+    left: 0;
+  }
 
   @extend .md-sidenav-left;
 }
-.md-sidenav-backdrop.md-locked-open {
-  display: none;
+.md-sidenav-backdrop {
+  &.md-locked-open {
+    display: none;
+  }
+  
+  &:not(.md-locked-open) {
+    position: fixed;
+    top: 0;
+    left: 0;
+  }
 }
 
 .md-sidenav-left {


### PR DESCRIPTION
Add `position: fixed;` to sidenav and backdrop when open but not locked, so that it is not possible to scroll below the backdrop (previously possible when body content is longer than the current screen height, which is ugly).