### PR TITLE
fix(layout): Set the initial height to inherit the parent.

### DIFF
--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -20,7 +20,3 @@ section .md-button {
   font-size: 14px;
   opacity: 0.54;
 }
-
-.launch {
-  padding-top:12px;
-}

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -17,6 +17,7 @@
   display: -moz-flex;
   display: -ms-flexbox;
   display: flex;
+  height: inherit;
 }
 
 .layout-column {


### PR DESCRIPTION
In some cases, browsers have issues with rendering flex layouts
when the height of an element is not set. This simply forces each
layout element (which is the most common case when using flex) to
the height it would normally be.

Also fixes random icon padding in demo causing the icon to be
mis-aligned.

Fixes #4022. References #3901. Fixes #4130.