### PR TITLE
fix(mdSelect): Close menu on hitting Enter key

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1058,7 +1058,7 @@ function SelectProvider($$interimElementProvider) {
                 });
                 ev.preventDefault();
               }
-              checkCloseMenu();
+              checkCloseMenu(ev);
               break;
             case keyCodes.TAB:
             case keyCodes.ESCAPE:


### PR DESCRIPTION
`checkCloseMenu` is being called without an event in `onMenuKeyDown`, which causes a `Uncaught TypeError: Cannot read property 'currentTarget' of undefined` error.

Fixes #4377.