### PR TITLE
fix(mdToolbar): Allow md-scroll-shrink usage with ng-if.

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -56,19 +56,22 @@ angular.module('material.components.toolbar', [
  * at one fourth the rate at which the user scrolls down. Default 0.5.
  */
 
-function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate ) {
-  var translateY = angular.bind(null, $mdUtil.supplant, 'translate3d(0,{0}px,0)' );
+function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
+  var translateY = angular.bind(null, $mdUtil.supplant, 'translate3d(0,{0}px,0)');
 
   return {
     restrict: 'E',
+    template: '<div ng-transclude></div>',
+    transclude: true,
     controller: angular.noop,
+    scope: {
+      scrollShrink: '=?mdScrollShrink'
+    },
     link: function(scope, element, attr) {
 
       $mdTheming(element);
 
-      if (angular.isDefined(attr.mdScrollShrink)) {
-        setupScrollShrink();
-      }
+      setupScrollShrink();
 
       function setupScrollShrink() {
         // Current "y" position of scroll
@@ -84,24 +87,68 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate ) 
         var debouncedContentScroll = $$rAF.throttle(onContentScroll);
         var debouncedUpdateHeight = $mdUtil.debounce(updateToolbarHeight, 5 * 1000);
 
+        var disableScrollShrink;
+
         // Wait for $mdContentLoaded event from mdContent directive.
         // If the mdContent element is a sibling of our toolbar, hook it up
         // to scroll events.
         scope.$on('$mdContentLoaded', onMdContentLoad);
 
+        // If the toolbar is used inside an ng-if statement, we may miss the
+        // $mdContentLoaded event, so we attempt to fake it if we have a
+        // md-content close enough.
+        scope.$watch('scrollShrink', onChangeScrollShrink);
+
+        // If the scope is destroyed (which could happen with ng-if), make sure
+        // to disable scroll shrinking again
+        scope.$on('$destroy', function() {
+          disableScrollShrink();
+        });
+
+        function onChangeScrollShrink(scrollShrink) {
+          var closestContent = element.parent().find('md-content');
+
+          // If we have a content element, fake the call; this might still fail
+          // if the content element isn't a sibling of the toolbar
+          if (!contentElement && closestContent.length) {
+            onMdContentLoad(null, closestContent);
+          }
+
+          if (contentElement) {
+            // Disable only if the attribute's expression evaluates to false
+            if (scrollShrink === false) {
+              disableScrollShrink();
+            } else {
+              enableScrollShrink();
+            }
+          }
+        }
+
+        function enableScrollShrink() {
+          contentElement.on('scroll', debouncedContentScroll);
+          contentElement.attr('scroll-shrink', 'true');
+
+          $$rAF(updateToolbarHeight);
+
+          return function disableScrollShrink() {
+            contentElement.off('scroll', debouncedContentScroll);
+            contentElement.attr('scroll-shrink', 'false');
+
+            $$rAF(updateToolbarHeight);
+          }
+        }
+
+
         function onMdContentLoad($event, newContentEl) {
           // Toolbar and content must be siblings
-          if (element.parent()[0] === newContentEl.parent()[0]) {
+          if (newContentEl && element.parent()[0] === newContentEl.parent()[0]) {
             // unhook old content event listener if exists
             if (contentElement) {
               contentElement.off('scroll', debouncedContentScroll);
             }
 
-            newContentEl.on('scroll', debouncedContentScroll);
-            newContentEl.attr('scroll-shrink', 'true');
-
             contentElement = newContentEl;
-            $$rAF(updateToolbarHeight);
+            disableScrollShrink = enableScrollShrink();
           }
         }
 
@@ -113,9 +160,12 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate ) 
           //
           // As the user scrolls down, the content will be transformed up slowly
           // to put the content underneath where the toolbar was.
-          var margin =  (-toolbarHeight * shrinkSpeedFactor) + 'px';
-          contentElement.css('margin-top', margin);
-          contentElement.css('margin-bottom', margin);
+          var margin = (-toolbarHeight * shrinkSpeedFactor) + 'px';
+
+          contentElement.css({
+            "margin-top": margin,
+            "margin-bottom": margin
+          });
 
           onContentScroll();
         }
@@ -130,17 +180,17 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate ) 
             Math.max(0, y + scrollTop - prevScrollTop)
           );
 
-          element.css( $mdConstant.CSS.TRANSFORM, translateY([-y * shrinkSpeedFactor]) );
-          contentElement.css( $mdConstant.CSS.TRANSFORM, translateY([(toolbarHeight - y) * shrinkSpeedFactor]) );
+          element.css($mdConstant.CSS.TRANSFORM, translateY([-y * shrinkSpeedFactor]));
+          contentElement.css($mdConstant.CSS.TRANSFORM, translateY([(toolbarHeight - y) * shrinkSpeedFactor]));
 
           prevScrollTop = scrollTop;
 
-          $mdUtil.nextTick(function () {
+          $mdUtil.nextTick(function() {
             var hasWhiteFrame = element.hasClass('md-whiteframe-z1');
 
-            if ( hasWhiteFrame && !y) {
+            if (hasWhiteFrame && !y) {
               $animate.removeClass(element, 'md-whiteframe-z1');
-            } else if ( !hasWhiteFrame && y ) {
+            } else if (!hasWhiteFrame && y) {
               $animate.addClass(element, 'md-whiteframe-z1');
             }
           });


### PR DESCRIPTION
Previously, the toolbar would fail to enable scroll shrinking
if the developer used an `ng-if` statement on the `md-toolbar`.

This commit allows usage of `ng-if` as well as watching the
`md-scroll-shrink` for changes so they can enable/disable
scroll shrinking.

Fixes #2751.