### PR TITLE
Ripple containers within menu buttons need to inherit border radius

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -91,6 +91,9 @@ md-menu-item {
       margin-top: auto;
       margin-bottom: auto;
     }
+    .md-ripple-container {
+      border-radius: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
The official site must have styles that override this but if you open a Codepen for the menu component, you'll notice that the ripple container has a 3px border radius due to this rule,

```css
.md-button .md-ripple-container {
    border-radius: 3px;
}
```

which does not match the 0px border radius of the menu button.