### PR TITLE
fix(subheader): Remove 16px right margin.

### DIFF
--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -1,9 +1,8 @@
 $subheader-line-height: 1em !default;
 $subheader-font-size: rem(1.4) !default;
-$subheader-padding: ($baseline-grid * 2) 0px ($baseline-grid * 2) ($baseline-grid * 2) !default;
+$subheader-padding: ($baseline-grid * 2) !default;
 $subheader-font-weight: 500 !default;
 $subheader-margin: 0 0 0 0 !default;
-$subheader-margin-right: 16px !default;
 $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
 
 @keyframes subheaderStickyHoverIn {
@@ -53,7 +52,6 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   font-weight: $subheader-font-weight;
   line-height: $subheader-line-height;
   margin: $subheader-margin;
-  margin-right: $subheader-margin-right;
   position: relative;
 
   .md-subheader-inner {


### PR DESCRIPTION
Previously, the subheader had a 16px right margin that would be
visible and particularly odd if you changed the subheader
background. After recent changes with the subheader now being
stickied to the `<md-content>` instead of the parent, this can
now be removed.

Fixes #4389.