### PR TITLE
fix(md-tooltip): removed watcher for performance

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -82,10 +82,12 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
 
     function configureWatchers () {
       scope.$on('$destroy', function() {
-        scope.visible = false;
+        if (scope.visible !== false) {
+          scope.visible = false;
+          $mdUtil.nextTick(checkVisibility);
+        }
         element.remove();
         angular.element($window).off('resize', debouncedOnResize);
-        checkVisibility();
       });
     }
     
@@ -184,14 +186,18 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         if (value) {
           setVisible.queued = true;
           $timeout(function() {
-            scope.visible = setVisible.value;
+            if (scope.visible !== setVisible.value) {
+              scope.visible = setVisible.value;
+              $mdUtil.nextTick(checkVisibility);
+            }
             setVisible.queued = false;
-            checkVisibility();
           }, scope.delay);
         } else {
           $mdUtil.nextTick(function() { 
-              scope.visible = false; 
-              checkVisibility();
+              if (scope.visible !== false) {
+                scope.visible = false; 
+                checkVisibility();
+              }
           });
         }
       }
@@ -205,9 +211,11 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       // Check if we should display it or not.
       // This handles hide-* and show-* along with any user defined css
       if ( hasComputedStyleValue('display','none') ) {
-        scope.visible = false;
+        if (scope.visible !== false) {
+          scope.visible = false;
+          $mdUtil.nextTick(checkVisibility);
+        }
         element.detach();
-        checkVisibility();
         return;
       }
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -84,11 +84,15 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         scope.visible = false;
         element.remove();
         angular.element($window).off('resize', debouncedOnResize);
+        checkVisibility();
       });
-      scope.$watch('visible', function (isVisible) {
-        if (isVisible) showTooltip();
-        else hideTooltip();
-      });
+    }
+    
+    function checkVisibility () {
+      if (scope.visible)
+        showTooltip();
+      else
+        hideTooltip();
     }
 
     function addAriaLabel () {
@@ -181,9 +185,13 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
           $timeout(function() {
             scope.visible = setVisible.value;
             setVisible.queued = false;
+            checkVisibility();
           }, scope.delay);
         } else {
-          $mdUtil.nextTick(function() { scope.visible = false; });
+          $mdUtil.nextTick(function() { 
+              scope.visible = false; 
+              checkVisibility();
+          });
         }
       }
     }
@@ -198,6 +206,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       if ( hasComputedStyleValue('display','none') ) {
         scope.visible = false;
         element.detach();
+        checkVisibility();
         return;
       }
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -73,7 +73,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     bindEvents();
     configureWatchers();
     addAriaLabel();
-    checkVisibility();
+    $mdUtil.nextTick(checkVisibility);
 
 
     function setDefaults () {

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -73,6 +73,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     bindEvents();
     configureWatchers();
     addAriaLabel();
+    checkVisibility();
 
 
     function setDefaults () {


### PR DESCRIPTION
md-tooltip uses a watcher per tooltip. The watcher is just to watch if scope.visible changes. This variable only changes internally so there's no reason to need a watcher when the changes could be tracked manually.

fixes https://github.com/angular/material/issues/4033