### PR TITLE
fix(progressLinear): sync logic, perf upgrades, fix animations

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -71,15 +71,14 @@ md-autocomplete {
     &.md-menu-showing {
       z-index: $z-index-backdrop + 1;
     }
-    md-progress-linear[md-mode=indeterminate] {
+    md-progress-linear .md-mode-indeterminate {
       position: absolute;
-      bottom: 0; left: 0; width: 100%;
+      top: 20px; left: 0; width: 100%;
       height: 3px;
       transition: none;
 
       .md-container {
         transition: none;
-        top: auto;
         height: 3px;
       }
       &.ng-enter {

--- a/src/components/progressCircular/demoBasicUsage/index.html
+++ b/src/components/progressCircular/demoBasicUsage/index.html
@@ -26,9 +26,12 @@
       <md-progress-circular md-mode="{{vm.modes[4]}}" md-diameter="96"></md-progress-circular>
     </div>
 
+
+    <hr ng-class="{'visible' : vm.activated}">
+
     <div layout="row" id="loaders">
 
-      <p style="margin-right: 20px">Show Progress Circular Indicators: </p>
+      <p>Progress Circular Indicators: </p>
 
       <h5>Off</h5>
       <md-switch
@@ -39,5 +42,9 @@
       </md-switch>
     </div>
 
+  <p class="small">
+    Note: With above switch -- that simply clears the md-mode in each <code>&lt;md-progress-linear md-mode=""&gt;</code> element --
+    developers can easily disable the animations and hide their progress indicators.
+  </p>
 
 </div>

--- a/src/components/progressCircular/demoBasicUsage/style.css
+++ b/src/components/progressCircular/demoBasicUsage/style.css
@@ -20,3 +20,29 @@ md-progress-circular {
 #loaders > h5 {
     padding-top: 8px;
 }
+
+#loaders > p {
+    margin-right: 20px;
+}
+
+
+p.small {
+  font-size: 0.8em;
+  margin-top: -18px;
+}
+
+
+hr {
+  width: 100%;
+  margin-top: 20px;
+  border-color: rgba(221, 221, 177, 0.1);
+}
+
+p.small > code {
+    font-size: 0.8em;
+}
+
+
+.visible  {
+    border-color: rgba(221, 221, 177, 0);
+}

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -7,62 +7,71 @@ $progress-border-width : 10px;
 $progress-circular-size : 10 * $progress-border-width !default;
 
 md-progress-circular {
-  width: $progress-circular-size;
-  height: $progress-circular-size;
   display: block;
   position: relative;
+
+  width: $progress-circular-size;
+  height: $progress-circular-size;
+
   padding-top: 0 !important;
   margin-bottom: 0 !important;
-  overflow: hidden;
+
   transform: scale(0.5);
 
-  .md-inner {
-    width: $progress-circular-size;
-    height: $progress-circular-size;
+  .md-spinner-wrapper {
+    display:block;
     position: relative;
-    .md-gap {
-      position: absolute;
-      left: $progress-circular-size * 0.5 - 1;
-      right: $progress-circular-size * 0.5 - 1;
-      top: 0;
-      bottom: 0;
-      border-top-width: $progress-border-width;
-      border-top-style: solid;
-      box-sizing: border-box;
-    }
-    .md-left, .md-right {
-      position: absolute;
-      top: 0;
-      height: $progress-circular-size;
-      width: $progress-circular-size * 0.50;
-      overflow: hidden;
-      .md-half-circle {
-        position: absolute;
-        top: 0;
-        width: $progress-circular-size;
-        height: $progress-circular-size;
-        box-sizing: border-box;
-        border-width: $progress-border-width;
-        border-style: solid;
-        border-bottom-color: transparent;
-        border-radius: 50%;
-      }
-    }
-    .md-left {
-      left: 0;
-      .md-half-circle {
-        left: 0;
-        border-right-color: transparent;
-      }
-    }
-    .md-right {
-      right: 0;
-      .md-half-circle {
-        right: 0;
-        border-left-color: transparent;
-      }
-    }
+    overflow: hidden;
+
+    .md-inner {
+       width: $progress-circular-size;
+       height: $progress-circular-size;
+       position: relative;
+       .md-gap {
+         position: absolute;
+         left: $progress-circular-size * 0.5 - 1;
+         right: $progress-circular-size * 0.5 - 1;
+         top: 0;
+         bottom: 0;
+         border-top-width: $progress-border-width;
+         border-top-style: solid;
+         box-sizing: border-box;
+       }
+       .md-left, .md-right {
+         position: absolute;
+         top: 0;
+         height: $progress-circular-size;
+         width: $progress-circular-size * 0.50;
+         overflow: hidden;
+         .md-half-circle {
+           position: absolute;
+           top: 0;
+           width: $progress-circular-size;
+           height: $progress-circular-size;
+           box-sizing: border-box;
+           border-width: $progress-border-width;
+           border-style: solid;
+           border-bottom-color: transparent;
+           border-radius: 50%;
+         }
+       }
+       .md-left {
+         left: 0;
+         .md-half-circle {
+           left: 0;
+           border-right-color: transparent;
+         }
+       }
+       .md-right {
+         right: 0;
+         .md-half-circle {
+           right: 0;
+           border-left-color: transparent;
+         }
+       }
+     }
   }
+
 
   .md-spinner-wrapper.md-mode-indeterminate  {
     animation: outer-rotate $progress-circular-outer-duration linear infinite;
@@ -88,7 +97,7 @@ md-progress-circular {
     }
   }
 
-  .ng-hide md-progress-circular, md-progress-circular.ng-hide {
+  md-progress-circular.ng-hide {
     .md-spinner-wrapper  {
       animation: none;
       .md-inner {

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -11,6 +11,36 @@ describe('mdProgressCircular', function() {
     element.remove();
   });
 
+  it('should auto-set the md-mode to "indeterminate" if not specified', inject(function($compile, $rootScope, $mdConstant) {
+    element = $compile('<div>' +
+          '<md-progress-circular></md-progress-circular>' +
+          '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    var progress = element.find('md-progress-circular');
+    expect(progress.attr('md-mode')).toEqual('indeterminate');
+  }));
+
+  it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
+    var element = $compile('<div>' +
+      '<md-progress-circular value="{{progress}}"></md-progress-circular>' +
+      '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    var progress = element.find('md-progress-circular');
+    expect(progress.attr('md-mode')).toEqual('determinate');
+  }));
+
+
+
   it('should update aria-valuenow', inject(function($compile, $rootScope) {
     element = $compile('<div>' +
       '<md-progress-circular value="{{progress}}">' +

--- a/src/components/progressLinear/demoBasicUsage/index.html
+++ b/src/components/progressLinear/demoBasicUsage/index.html
@@ -1,15 +1,56 @@
-<div ng-controller="AppCtrl" layout="column" layout-margin style="padding:25px;">
+<div ng-controller="AppCtrl as vm" layout="column" layout-margin style="padding:25px;">
 
   <h2 class="md-title">Determinate</h2>
-  <p>For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.</p>
-  <md-progress-linear md-mode="determinate" value="{{determinateValue}}"></md-progress-linear>
-  <p>Buffer indicates loading from the server</p>
-  <md-progress-linear class="md-warn" md-mode="buffer" value="{{determinateValue}}" md-buffer-value="{{determinateValue2}}"></md-progress-linear>
+
+  <p>
+    For operations where the percentage of the operation completed can be determined, use a <b>determinate</b> indicator.
+    They give users a quick sense of how long an operation will take.
+  </p>
+  <md-progress-linear md-mode="determinate" value="{{vm.determinateValue}}"></md-progress-linear>
 
   <h4 class="md-title">Indeterminate</h4>
-  <p>For operations where the user is asked to wait a moment while something finishes up, and it's not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.</p>
+  <p>
+    For operations where the user is asked to wait a moment while something finishes up, and it's not
+    necessary to expose what's happening behind the scenes and how long it will take, use an
+    <b>indeterminate</b> indicator:
+  </p>
   <md-progress-linear md-mode="indeterminate"></md-progress-linear>
-  <p>Query indicates pre-loading situation until the loading can actually be made</p>
-  <md-progress-linear md-mode="query"></md-progress-linear>
+
+  <h4 class="md-title">Buffer</h4>
+  <p>
+    For operations where the user wants to indicate some activity or loading from the server, use the <b>buffer</b> indicator:
+  </p>
+  <md-progress-linear class="md-warn" md-mode="{{vm.modes[0]}}" value="{{vm.determinateValue}}"
+                      md-buffer-value="{{vm.determinateValue2}}"></md-progress-linear>
+
+  <h4 class="md-title">Query</h4>
+  <p>
+    For situations where the user wants to indicate pre-loading (until the loading can actually be made), use the <b>query</b> indicator:
+  </p>
+  <div class="container" ng-class="{'visible' : !vm.activated}">
+      <md-progress-linear md-mode="{{vm.modes[1]}}"></md-progress-linear>
+    <div class="bottom-block">
+        <span>Loading application libraries...</span>
+    </div>
+  </div>
+
+  <hr ng-class="{'visible' : vm.activated}">
+
+  <div layout="row" id="loaders">
+
+    <p>Query and Buffer progress linear indicators: </p>
+
+    <h5>Off</h5>
+    <md-switch
+          ng-model="vm.activated"
+          ng-change="vm.toggleActivation()"
+          aria-label="Enable Indicators">
+      <h5>On</h5>
+    </md-switch>
+  </div>
+
+  <p class="small">
+    Note: With the above switch -- which simply clears the md-mode in each <code>&lt;md-progress-linear md-mode=""&gt;</code> element --
+    developers now easily disable the animations and hide their progress indicators.</p>
 
 </div>

--- a/src/components/progressLinear/demoBasicUsage/script.js
+++ b/src/components/progressLinear/demoBasicUsage/script.js
@@ -2,20 +2,44 @@ angular.module('progressLinearDemo1', ['ngMaterial'])
   .config(function($mdThemingProvider) {
   })
   .controller('AppCtrl', ['$scope', '$interval', function($scope, $interval) {
-    $scope.mode = 'query';
-    $scope.determinateValue = 30;
-    $scope.determinateValue2 = 30;
+    var self = this, j= 0, counter = 0;
+
+    self.mode = 'query';
+    self.activated = true;
+    self.determinateValue = 30;
+    self.determinateValue2 = 30;
+
+    self.modes = [ ];
+
+    /**
+     * Turn off or on the 5 themed loaders
+     */
+    self.toggleActivation = function() {
+        if ( !self.activated ) self.modes = [ ];
+        if (  self.activated ) j = counter = 0;
+    };
 
     $interval(function() {
-      $scope.determinateValue += 1;
-      $scope.determinateValue2 += 1.5;
-      if ($scope.determinateValue > 100) {
-        $scope.determinateValue = 30;
-        $scope.determinateValue2 = 30;
-      }
+      self.determinateValue += 1;
+      self.determinateValue2 += 1.5;
+
+      if (self.determinateValue > 100) self.determinateValue = 30;
+      if (self.determinateValue2 > 100) self.determinateValue2 = 30;
+
+        // Incrementally start animation the five (5) Indeterminate,
+        // themed progress circular bars
+
+        if ( (j < 2) && !self.modes[j] && self.activated ) {
+          self.modes[j] = (j==0) ? 'buffer' : 'query';
+        }
+        if ( counter++ % 4 == 0 ) j++;
+
+        // Show the indicator in the "Used within Containers" after 200ms delay
+        if ( j == 2 ) self.contained = "indeterminate";
+
     }, 100, 0, true);
 
     $interval(function() {
-      $scope.mode = ($scope.mode == 'query' ? 'determinate' : 'query');
+      self.mode = (self.mode == 'query' ? 'determinate' : 'query');
     }, 7200, 0, true);
   }]);

--- a/src/components/progressLinear/demoBasicUsage/style.css
+++ b/src/components/progressLinear/demoBasicUsage/style.css
@@ -7,6 +7,68 @@ h4 {
 }
 
 md-progress-linear {
-  padding-top:10px;
-  margin-bottom:20px;
+  padding-top: 10px;
+  margin-bottom: 20px;
+}
+
+#loaders > md-switch {
+  margin: 0;
+  margin-left: 10px;
+  margin-top: -10px;
+}
+
+#loaders > h5 {
+  padding-top: 4px;
+}
+
+#loaders > p {
+  margin-right: 20px;
+  font-size: 0.90em;
+}
+
+p.small {
+  font-size: 0.8em;
+  margin-top: -18px;
+}
+
+hr {
+  width: 100%;
+  margin-top: 20px;
+  border-color: rgba(221, 221, 177, 0.1);
+}
+
+
+p.small > code {
+    font-size: 0.8em;
+}
+
+.visible  {
+    opacity: 0;
+    border: 2px solid white !important;
+}
+
+
+.container {
+  display: block;
+  position: relative;
+  height: 100%;
+  width: 100%;
+  border: 2px solid rgb(170,209,249);
+  transition: opacity  0.1s linear;
+  border-top: 0px;
+}
+
+.bottom-block {
+  display: block;
+  position: relative;
+  background-color: rgba(255, 235, 169, 0.25);
+  height: 85px;
+  width: 100%;
+}
+
+.bottom-block > span {
+  display: inline-block;
+  margin-top:10px;
+  padding:25px;
+  font-size: 0.9em;
 }

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -15,15 +15,33 @@ angular.module('material.components.progressLinear', [
  * @restrict E
  *
  * @description
- * The linear progress directive is used to make loading content in your app as delightful and painless as possible by minimizing the amount of visual change a user sees before they can view and interact with content. Each operation should only be represented by one activity indicator—for example, one refresh operation should not display both a refresh bar and an activity circle.
+ * The linear progress directive is used to make loading content
+ * in your app as delightful and painless as possible by minimizing
+ * the amount of visual change a user sees before they can view
+ * and interact with content.
  *
- * For operations where the percentage of the operation completed can be determined, use a determinate indicator. They give users a quick sense of how long an operation will take.
+ * Each operation should only be represented by one activity indicator
+ * For example: one refresh operation should not display both a
+ * refresh bar and an activity circle.
  *
- * For operations where the user is asked to wait a moment while something finishes up, and it’s not necessary to expose what's happening behind the scenes and how long it will take, use an indeterminate indicator.
+ * For operations where the percentage of the operation completed
+ * can be determined, use a determinate indicator. They give users
+ * a quick sense of how long an operation will take.
+ *
+ * For operations where the user is asked to wait a moment while
+ * something finishes up, and it’s not necessary to expose what's
+ * happening behind the scenes and how long it will take, use an
+ * indeterminate indicator.
  *
  * @param {string} md-mode Select from one of four modes: determinate, indeterminate, buffer or query.
+ *
+ * Note: if the `md-mode` value is set as undefined or specified as 1 of the four (4) valid modes, then `.ng-hide`
+ * will be auto-applied as a style to the component.
+ *
+ * Note: if not configured, the `md-mode="indeterminate"` will be auto injected as an attribute. If `value=""` is also specified, however,
+ * then `md-mode="determinate"` would be auto-injected instead.
  * @param {number=} value In determinate and buffer modes, this number represents the percentage of the primary progress bar. Default: 0
- * @param {number=} md-buffer-value In the buffer mode, this number represents the precentage of the secondary progress bar. Default: 0
+ * @param {number=} md-buffer-value In the buffer mode, this number represents the percentage of the secondary progress bar. Default: 0
  *
  * @usage
  * <hljs lang="html">
@@ -38,7 +56,11 @@ angular.module('material.components.progressLinear', [
  * <md-progress-linear md-mode="query"></md-progress-linear>
  * </hljs>
  */
-function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
+function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
+  var MODE_DETERMINATE = "determinate",
+      MODE_INDETERMINATE = "indeterminate",
+      MODE_BUFFER = "buffer",
+      MODE_QUERY = "query";
 
   return {
     restrict: 'E',
@@ -59,57 +81,104 @@ function MdProgressLinearDirective($$rAF, $mdConstant, $mdTheming) {
   }
   function postLink(scope, element, attr) {
     $mdTheming(element);
-    var bar1Style = element[0].querySelector('.md-bar1').style,
-      bar2Style = element[0].querySelector('.md-bar2').style,
-      container = angular.element(element[0].querySelector('.md-container'));
+    var lastMode, toVendorCSS = $mdUtil.dom.animator.toCss;
+    var bar1 = angular.element(element[0].querySelector('.md-bar1')),
+        bar2 = angular.element(element[0].querySelector('.md-bar2')),
+        container = angular.element(element[0].querySelector('.md-container'));
 
-    attr.$observe('value', function(value) {
-      if (attr.mdMode == 'query') {
-        return;
+    validateMode();
+    watchAttributes();
+
+    /**
+     * Watch the value, md-buffer-value, and md-mode attributes
+     */
+    function watchAttributes() {
+      attr.$observe('value', function(value) {
+        var percentValue = clamp(value);
+        element.attr('aria-valuenow', percentValue);
+
+        if (mode() != MODE_QUERY) animateIndicator(bar2, percentValue);
+      });
+
+      attr.$observe('mdBufferValue', function(value) {
+        animateIndicator(bar1, clamp(value));
+      });
+
+      attr.$observe('mdMode',function(mode){
+        switch( mode ) {
+          case MODE_QUERY:
+          case MODE_BUFFER:
+          case MODE_DETERMINATE:
+          case MODE_INDETERMINATE:
+            container.removeClass('ng-hide');
+            container.removeClass( lastMode );
+            container.addClass( lastMode = "md-mode-" + mode );
+            break;
+          default:
+            container.removeClass( lastMode );
+            container.addClass('ng-hide');
+            lastMode = undefined;
+            break;
+        }
+      });
+    }
+
+    /**
+     * Auto-defaults the mode to either `determinate` or `indeterminate` mode; if not specified
+     */
+    function validateMode() {
+      if ( angular.isUndefined(attr.mdMode) ) {
+        var hasValue = angular.isDefined(attr.value);
+        var mode = hasValue ? MODE_DETERMINATE : MODE_INDETERMINATE;
+        var info = "Auto-adding the missing md-mode='{0}' to the ProgressLinear element";
+
+        $log.debug( $mdUtil.supplant(info, [mode]) );
+
+        element.attr("md-mode",mode);
+        attr['mdMode'] = mode;
       }
+    }
 
-      var clamped = clamp(value);
-      element.attr('aria-valuenow', clamped);
-      bar2Style[$mdConstant.CSS.TRANSFORM] = transforms[clamped];
-    });
+    /**
+     * Is the md-mode a valid option?
+     */
+    function mode() {
+      var value = attr.mdMode;
+      if ( value ) {
+        switch(value) {
+          case MODE_DETERMINATE:
+          case MODE_INDETERMINATE:
+          case MODE_BUFFER:
+          case MODE_QUERY:
+            break;
+          default:
+            value = undefined;
+            break;
+        }
+      }
+      return value;
+    }
 
-    attr.$observe('mdBufferValue', function(value) {
-      bar1Style[$mdConstant.CSS.TRANSFORM] = transforms[clamp(value)];
-    });
+    /**
+     * Manually set CSS to animate the Determinate indicator based on the specified
+     * percentage value (0-100).
+     */
+    function animateIndicator(target, value) {
+      if ( !mode() ) return;
 
-    $$rAF(function() {
-      container.addClass('md-ready');
-    });
+      var to = $mdUtil.supplant("translateX({0}%) scale({1},1)", [ (value-100)/2, value/100 ]);
+      var styles = toVendorCSS({ transform : to });
+      angular.element(target).css( styles );
+    }
   }
 
+  /**
+   * Clamps the value to be between 0 and 100.
+   * @param {number} value The value to clamp.
+   * @returns {number}
+   */
   function clamp(value) {
-    if (value > 100) {
-      return 100;
-    }
-
-    if (value < 0) {
-      return 0;
-    }
-
-    return Math.ceil(value || 0);
+    return Math.max(0, Math.min(value || 0, 100));
   }
 }
 
-
-// **********************************************************
-// Private Methods
-// **********************************************************
-var transforms = (function() {
-  var values = new Array(101);
-  for(var i = 0; i < 101; i++){
-    values[i] = makeTransform(i);
-  }
-
-  return values;
-
-  function makeTransform(value){
-    var scale = value/100;
-    var translateX = (value-100)/2;
-    return 'translateX(' + translateX.toString() + '%) scale(' + scale.toString() + ', 1)';
-  }
-})();

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -1,92 +1,110 @@
 $progress-linear-bar-height: 5px !default;
 
-md-progress-linear:not([md-mode="indeterminate"]) {
+md-progress-linear {
   display: block;
+  position: relative;
   width: 100%;
   height: $progress-linear-bar-height;
 
+  padding-top: 0 !important;
+  margin-bottom: 0 !important;
+
   .md-container {
-    overflow: hidden;
+    display:block;
     position: relative;
+    overflow: hidden;
+
+    width:100%;
     height: $progress-linear-bar-height;
-    top: $progress-linear-bar-height;
-    transform: translate(0, 5px) scale(1, 0);
-    transition: all .3s linear;
-  }
 
-  .md-container.md-ready {
-    transform: translate(0, 0) scale(1, 1);
-  }
+    transform: translate(0, 0) scale(1, 1);;
 
-  .md-bar {
-    height: $progress-linear-bar-height;
-    position: absolute;
-    width: 100%;
-  }
+    .md-bar {
+      position: absolute;
 
-  .md-bar1, .md-bar2 {
-    transition: all 0.2s linear;
-  }
+      left: 0;
+      top: 0;
+      bottom: 0;
 
-  &[md-mode=determinate] {
-    .md-bar1 {
-      display: none;
-    }
-  }
-
-  &[md-mode=buffer] {
-    .md-container {
-      background-color: transparent !important;
+      width: 100%;
+      height: $progress-linear-bar-height;
     }
 
     .md-dashed:before {
       content: "";
-      display: block;
+      display: none;
+      position: absolute;
+
+      margin-top: 0;
       height: $progress-linear-bar-height;
       width: 100%;
-      margin-top: 0;
-      position: absolute;
+
       background-color: transparent;
       background-size: 10px 10px !important;
       background-position: 0px -23px;
+    }
+
+    .md-bar1, .md-bar2 {
+
+      // Just set the transition information here.
+      // Note: the actual transform values are calculated in JS
+
+      transition: transform 0.2s linear;
+    }
+
+    // ************************************************************
+    // Animations for modes: Determinate, InDeterminate, and Query
+    // ************************************************************
+
+    &.md-mode-query {
+        .md-bar1 {
+          display: none;
+        }
+        .md-bar2 {
+          transition: all 0.2s linear;
+          animation: query .8s infinite cubic-bezier(0.390, 0.575, 0.565, 1.000);
+        }
+      }
+
+    &.md-mode-determinate {
+      .md-bar1 {
+        display: none;
+      }
+    }
+
+    &.md-mode-indeterminate {
+      .md-bar1 {
+        animation: md-progress-linear-indeterminate-scale-1 4s infinite,
+                   md-progress-linear-indeterminate-1 4s infinite;
+      }
+      .md-bar2 {
+        animation: md-progress-linear-indeterminate-scale-2 4s infinite,
+                   md-progress-linear-indeterminate-2 4s infinite;
+      }
+    }
+
+    &.ng-hide {
+      animation: none;
+
+      .md-bar1 {
+        animation-name: none;
+      }
+      .md-bar2 {
+        animation-name: none;
+      }
+    }
+  }
+
+  // Special animations for the `buffer` mode
+
+  .md-container.md-mode-buffer {
+    background-color: transparent !important;
+
+    transition: all 0.2s linear;
+
+    .md-dashed:before {
+      display: block;
       animation: buffer 3s infinite linear;
-    }
-  }
-
-  &[md-mode=query] {
-    .md-bar2 {
-      animation: query .8s infinite cubic-bezier(0.390, 0.575, 0.565, 1.000);
-    }
-  }
-}
-
-md-progress-linear[md-mode="indeterminate"] {
-  display: block;
-  width: 100%;
-  height: $progress-linear-bar-height;
-  position: relative;
-  .md-container {
-    width: 100%;
-    overflow: hidden;
-    position: relative;
-    height: $progress-linear-bar-height;
-    top: $progress-linear-bar-height;
-    transition: all .3s linear;
-    .md-bar {
-      height: $progress-linear-bar-height;
-      left: 0;
-      width: 288 * 100% / 360;
-      position: absolute;
-      top: 0;
-      bottom: 0;
-    }
-    .md-bar1 {
-      animation: md-progress-linear-indeterminate-scale-1 4s infinite,
-                 md-progress-linear-indeterminate-1 4s infinite;
-    }
-    .md-bar2 {
-      animation: md-progress-linear-indeterminate-scale-2 4s infinite,
-                 md-progress-linear-indeterminate-2 4s infinite;
     }
   }
 }
@@ -101,7 +119,6 @@ md-progress-linear[md-mode="indeterminate"] {
     transform: translateX(-50%) scale(0, 1);
   }
 }
-
 @keyframes buffer {
   0% {
     opacity: 1;
@@ -115,7 +132,6 @@ md-progress-linear[md-mode="indeterminate"] {
     background-position: -200px -23px;
   }
 }
-
 @keyframes md-progress-linear-indeterminate-scale-1 {
   0% {
     transform: scaleX(0.1);
@@ -133,7 +149,6 @@ md-progress-linear[md-mode="indeterminate"] {
     transform: scaleX(0.1);
   }
 }
-
 @keyframes md-progress-linear-indeterminate-1 {
   0% {
     left: -378.6 * 100% / 360;
@@ -151,7 +166,6 @@ md-progress-linear[md-mode="indeterminate"] {
     left: 343.6 * 100% / 360;
   }
 }
-
 @keyframes md-progress-linear-indeterminate-scale-2 {
   0% {
     transform: scaleX(0.1);
@@ -169,7 +183,6 @@ md-progress-linear[md-mode="indeterminate"] {
     transform: scaleX(0.1);
   }
 }
-
 @keyframes md-progress-linear-indeterminate-2 {
   0% {
     left: -197.6 * 100% / 360;
@@ -187,3 +200,5 @@ md-progress-linear[md-mode="indeterminate"] {
     left: 422.6 * 100% / 360;
   }
 }
+
+

--- a/src/components/progressLinear/progress-linear.spec.js
+++ b/src/components/progressLinear/progress-linear.spec.js
@@ -2,9 +2,54 @@ describe('mdProgressLinear', function() {
 
   beforeEach(module('material.components.progressLinear'));
 
+  it('should auto-set the md-mode to "indeterminate" if not specified', inject(function($compile, $rootScope, $mdConstant) {
+    var element = $compile('<div>' +
+      '<md-progress-linear></md-progress-linear>' +
+      '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    var progress = element.find('md-progress-linear');
+    expect(progress.attr('md-mode')).toEqual('indeterminate');
+  }));
+
+  it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
+    var element = $compile('<div>' +
+      '<md-progress-linear value="{{progress}}"></md-progress-linear>' +
+      '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    var progress = element.find('md-progress-linear');
+    expect(progress.attr('md-mode')).toEqual('determinate');
+  }));
+
+  it('should set not transform if mode is undefined', inject(function($compile, $rootScope, $mdConstant) {
+    var element = $compile('<div>' +
+      '<md-progress-linear value="{{progress}}" md-mode="{{mode}}">' +
+      '</md-progress-linear>' +
+      '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    var progress = element.find('md-progress-linear'),
+      bar2 = angular.element(progress[0].querySelectorAll('.md-bar2'))[0];
+
+    expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toEqual('');
+  }));
+
   it('should set transform based on value', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}">' +
+      '<md-progress-linear value="{{progress}}" md-mode="determinate">' +
       '</md-progress-linear>' +
       '</div>')($rootScope);
 
@@ -35,7 +80,7 @@ describe('mdProgressLinear', function() {
 
   it('should set transform based on buffer value', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}" md-buffer-value="{{progress2}}">' +
+      '<md-progress-linear value="{{progress}}" md-buffer-value="{{progress2}}" md-mode="buffer">' +
       '</md-progress-linear>' +
       '</div>')($rootScope);
 
@@ -45,7 +90,7 @@ describe('mdProgressLinear', function() {
     });
 
     var progress = element.find('md-progress-linear'),
-      bar1 = angular.element(progress[0].querySelectorAll('.md-bar1'))[0];
+        bar1 = angular.element(progress[0].querySelectorAll('.md-bar1'))[0];
 
     expect(bar1.style[$mdConstant.CSS.TRANSFORM]).toEqual('translateX(-12.5%) scale(0.75, 1)');
   }));

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -97,12 +97,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $rootElement, 
     if (attr.mdOnOpen) {
 
       // Show progress indicator while loading async
+      // Use ng-hide for `display:none` so the indicator does not interfere with the options list
       element
         .find('md-content')
         .prepend(angular.element(
           '<div>' +
-          ' <md-progress-circular md-mode="indeterminate" ng-hide="$$loadingAsyncDone">' +
-          ' </md-progress-circular>' +
+          ' <md-progress-circular md-mode="{{progressMode}}" ng-hide="$$loadingAsyncDone"></md-progress-circular>' +
           '</div>'
         ));
 
@@ -988,10 +988,12 @@ function SelectProvider($$interimElementProvider) {
       function watchAsyncLoad() {
         if (opts.loadingAsync && !opts.isRemoved) {
           scope.$$loadingAsyncDone = false;
+          scope.progressMode = 'indeterminate';
 
           $q.when(opts.loadingAsync)
             .then(function() {
               scope.$$loadingAsyncDone = true;
+              scope.progressMode = '';
               delete opts.loadingAsync;
             }).then(function() {
               $$rAF(positionAndFocusMenu);


### PR DESCRIPTION
synchronize progressLinear with similar logic used in progressCircular.

* improve animation performances
* watch md-mode for changes
* refactor animation SCSS
* enable hiding and no-animations with undefined/empty md-mode attributes
* for both indicators, use `display:inline-block;`
* update demos with enable switch
* fix query mode
* update Select to use enhanced progressCircular component
* fix autocomplete styling of progress-linear.md-mode-indeterminate

BREAKING-CHANGES

Before:

```css
md-progress-linear {
  display: block;
}
md-progress-circular {
   // display not set
   // position not set
}
```

```css
md-progress-linear {
  display: inline-block;
  position: relative;
}
md-progress-circular {
  display: inline-block;
  position: relative;
}
```

Fixes #4421. Fixes #4409. Fixes #2540. Fixes #2364. Fixes #1926. Fixes #3802.