### PR TITLE
fix(md-chips): appendChip disallows identical objects

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -218,6 +218,30 @@ describe('<md-chips>', function() {
         expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
       });
 
+      it('should disallow identical object chips', function() {
+        var element = buildChips(CHIP_APPEND_TEMPLATE);
+        var ctrl = element.controller('mdChips');
+
+        ctrl.items = [{name: 'Apple', uppername: 'APPLE'}];
+
+        var chipObj = function(chip) {
+          return {
+            name: chip,
+            uppername: chip.toUpperCase()
+          };
+        };
+        scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
+
+        element.scope().$apply(function() {
+          ctrl.chipBuffer = 'Apple';
+          simulateInputEnterKey(ctrl);
+        });
+
+        expect(ctrl.items.length).toBe(1);
+        expect(scope.appendChip).toHaveBeenCalled();
+        expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
+      });
+
       it('should prevent the default when backspace is pressed', inject(function($mdConstant) {
         var element = buildChips(BASIC_CHIP_TEMPLATE);
         var ctrl = element.controller('mdChips');

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -192,13 +192,19 @@ MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
  * call out to the md-on-append method, if provided
  * @param newChip
  */
-MdChipsCtrl.prototype.appendChip = function(newChip) {
-  if (this.useOnAppend && this.onAppend) {
-    newChip = this.onAppend({'$chip': newChip});
-  }
-  if (this.items.indexOf(newChip) + 1) return;
-  this.items.push(newChip);
-};
+ MdChipsCtrl.prototype.appendChip = function(newChip) {
+   if (this.useOnAppend && this.onAppend) {
+     newChip = this.onAppend({'$chip': newChip});
+   }
+   if(typeof newChip === 'object'){
+     var identical = this.items.filter(function(item){
+       return angular.equals(newChip, item);
+     });
+     if(identical.length > 0) return;
+   }
+   if (this.items.indexOf(newChip) + 1) return;
+   this.items.push(newChip);
+ };
 
 /**
  * Sets whether to use the md-on-append expression. This expression is

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -197,10 +197,10 @@ MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
      newChip = this.onAppend({'$chip': newChip});
    }
    if(typeof newChip === 'object'){
-     var identical = this.items.filter(function(item){
+     var identical = this.items.some(function(item){
        return angular.equals(newChip, item);
      });
-     if(identical.length > 0) return;
+     if(identical) return;
    }
    if (this.items.indexOf(newChip) + 1) return;
    this.items.push(newChip);

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -193,16 +193,24 @@ MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
  * @param newChip
  */
  MdChipsCtrl.prototype.appendChip = function(newChip) {
+
+   // If useOnAppend and onAppend function is provided call it.
    if (this.useOnAppend && this.onAppend) {
      newChip = this.onAppend({'$chip': newChip});
    }
-   if(typeof newChip === 'object'){
+
+   // If items contains identical object to newChip do not append
+   if(angular.isObject(newChip)){
      var identical = this.items.some(function(item){
        return angular.equals(newChip, item);
      });
      if(identical) return;
    }
+
+   // If items contains newChip do not append
    if (this.items.indexOf(newChip) + 1) return;
+
+   //add newChip to items
    this.items.push(newChip);
  };
 


### PR DESCRIPTION
md-chips' appendChip disallows appending an identical string or an exact object (duplicate object) more than once. It now disallows identical objects from being appended.

fixes angular/material#4466