### PR TITLE
docs: fix typo in demos > Menu > Menu Position Modes

### DIFF
--- a/src/components/menu/demoMenuPositionModes/index.html
+++ b/src/components/menu/demoMenuPositionModes/index.html
@@ -1,6 +1,6 @@
 <div class="md-menu-demo" ng-controller="PositionDemoCtrl as ctrl">
   <div class="menu-demo-container" layout-align="center center" layout="column">
-    <h2 class="md-title">Positon Mode Demos</h2>
+    <h2 class="md-title">Position Mode Demos</h2>
     <p>The <code>md-position-mode</code> attribute can be used to specify the positioning along the <code>x</code> and <code>y</code> axis.</p>
     <hr/>
     <h3 class="md-subhead">Target-Based Position Modes</h3>


### PR DESCRIPTION
Fixes a typo ('Positon' -> 'Position') in the Demos > Menu > Menu Position Modes docs