### PR TITLE
docs: fix codepen buttons not working in Demos > Menu

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -79,7 +79,6 @@
       var processors = [
         applyAngularAttributesToParentElement,
         insertTemplatesAsScriptTags,
-        htmlEscapeAmpersand,
         htmlEscapeAmpersand
       ];
 
@@ -113,7 +112,7 @@
 
       // Grab only the DIV for the demo...
       angular.forEach(angular.element(html), function(it,key){
-        if ((it.nodeName != "SCRIPT") || (it.nodeName != "#text")) {
+        if ((it.nodeName != "SCRIPT") && (it.nodeName != "#text")) {
           tmp = angular.element(it);
         }
       });


### PR DESCRIPTION
Fixes Codepen buttons not working in Menu Position Modes & Menu Width demos & removes duplicate call to htmlEscapeAmpersand() function in codepen.js

Fixes #4514