### PR TITLE
fix(datepicker): handle DST incocnsistency encountered in some timezones. Fixes #4215

### DIFF
--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -154,7 +154,23 @@
        * @returns {string}
        */
       function defaultFormatDate(date) {
-        return date ? date.toLocaleDateString() : '';
+        if (!date) {
+          return '';
+        }
+
+        // All of the dates created through ng-material *should* be set to midnight.
+        // If we encounter a date where the localeTime shows at 11pm instead of midnight,
+        // we have run into an issue with DST where we need to increment the hour by one:
+        // var d = new Date(1992, 9, 8, 0, 0, 0);
+        // d.toLocaleString(); // == "10/7/1992, 11:00:00 PM"
+        var localeTime = date.toLocaleTimeString();
+        var formatDate = date;
+        if (date.getHours() == 0 &&
+            (localeTime.indexOf('11:') !== -1 || localeTime.indexOf('23:') !== -1)) {
+          formatDate = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 1, 0, 0);
+        }
+
+        return formatDate.toLocaleDateString();
       }
 
       /**


### PR DESCRIPTION
I'm well aware that this is a pretty hacky solution, but I haven't been able to think of something cleaner. 

It's also not something that I can see how to write a unit test for, since it depends on a specific timezone being set for the _operating system_.

All of this only comes into play when users use the default parsing/formatting instead of something like moment (like they're supposed to).

@ThomasBurleson @robertmesserle for review