### PR TITLE
perf($mdSticky): Fix performance issue when sticky is emulated.

### DIFF
--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -296,7 +296,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil) {
     element.on('scroll touchmove', function() {
       if (!isScrolling) {
         isScrolling = true;
-        $$rAF(loopScrollEvent);
+        $$rAF.throttle(loopScrollEvent);
         element.triggerHandler('$scrollstart');
       }
       element.triggerHandler('$scroll');
@@ -309,7 +309,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil) {
         element.triggerHandler('$scrollend');
       } else {
         element.triggerHandler('$scroll');
-        $$rAF(loopScrollEvent);
+        $$rAF.throttle(loopScrollEvent);
       }
     }
   }


### PR DESCRIPTION
When the browser is not naitively capable of handling sticky elements, we fake it by watching for scroll changes and manually triggering certain events. These use `$$rAF`, but were not throttling the call.

Fix: use `$$rAF.throttle()` when calling our loop function.

Fixes #4523. Fixes #4459.