### PR TITLE
fix: inverted logic in md-switch dragging

### DIFF
--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -136,7 +136,7 @@ function MdSwitch(mdCheckboxDirective, $mdTheming, $mdUtil, $document, $mdConsta
 
         // We changed if there is no distance (this is a click a click),
         // or if the drag distance is >50% of the total.
-        var isChanged = ngModel.$viewValue ? drag.translate < 0.5 : drag.translate > 0.5;
+        var isChanged = ngModel.$viewValue ? drag.translate > 0.5 : drag.translate < 0.5;
         if (isChanged) {
           applyModelValue(!ngModel.$viewValue);
         }


### PR DESCRIPTION
md-switch was being toggled when the user dragged less than half the way and didn't toggle when dragged more than half the way.
Invert this logic.

Fixes #4549