### PR TITLE
fix(button): remove md-focused class on mouseleave

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -118,6 +118,9 @@ function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
       .on('focus', function() {
         if (scope.mouseActive === false) { element.addClass('md-focused'); }
       })
+      .on('mouseleave', function() {
+        element.removeClass('md-focused');
+      })
       .on('blur', function() { element.removeClass('md-focused'); });
   }
 


### PR DESCRIPTION
md-button was retaining focus on mouseleave, this was especially visible on buttons with tooltips that get focused on hover (see #4249).

Fixes #4249 #4329