### PR TITLE
fix(dialog): disallow tabbing into a aira-hidden regions created when…

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -751,8 +751,8 @@ function MdDialogProvider($$interimElementProvider) {
       };
 
       /**
-       * Walk DOM to apply or remove aria-hidden on sibling nodes
-       * and parent sibling nodes
+       * Walk DOM to apply or remove aria-hidden and set tabindex appropriately
+       * based on aria-hidden value on sibling nodes and parent sibling nodes
        *
        */
       function walkDOM(element) {
@@ -760,12 +760,37 @@ function MdDialogProvider($$interimElementProvider) {
           if (element === document.body) {
             return;
           }
-          var children = element.parentNode.children;
+          var children = element.parentNode.children,
+            attrToSet = 'md-saved-tabindex',
+            attrToDefault = 'tabindex',
+            tabModifierSelector = '[md-saved-tabindex]:not([md-saved-tabindex="-1"])';
+
+          if (isHidden) {
+            attrToSet = 'tabindex';
+            attrToDefault = 'md-saved-tabindex';
+            tabModifierSelector = 'button:not([tabindex="-1"]),\
+              a[href]:not([tabindex="-1"]),\
+              input:not([tabindex="-1"]),\
+              textarea:not([tabindex="-1"]),\
+              select:not([tabindex="-1"]),\
+              [tabindex]:not([tabindex="-1"])';
+          }
+
           for (var i = 0; i < children.length; i++) {
             // skip over child if it is an ascendant of the dialog
             // or a script or style tag
             if (element !== children[i] && !isNodeOneOf(children[i], ['SCRIPT', 'STYLE'])) {
+              var tabbables = children[i].querySelectorAll(tabModifierSelector);
+
               children[i].setAttribute('aria-hidden', isHidden);
+
+              for (var j = 0; j < tabbables.length; j++) {
+                var tabbable = tabbables[j],
+                  attrToSetValue = tabbable.getAttribute(attrToSet) || '0',
+                  attrToDefaultValue = tabbable.getAttribute(attrToDefault) || '-1';
+                tabbable.setAttribute(attrToDefault, attrToSetValue);
+                tabbable.setAttribute(attrToSet, attrToDefaultValue);
+              }
             }
           }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -469,6 +469,26 @@ function MdDialogProvider($$interimElementProvider) {
       }
     };
 
+
+    function ariaFocus(ev) {
+      var dialog = document.querySelector('md-dialog');
+
+      if (isHidden(ev.target)) {
+        ev.stopImmediatePropagation();
+        dialog.focus();
+      }
+
+      function isHidden(element) {
+        while (element) {
+          if (element.getAttribute('aria-hidden') === 'true') {
+            return true;
+          }
+          element = element.parentElement;
+        }
+        return false;
+      }
+    }
+
     /**
      * Show method for dialogs
      */
@@ -480,6 +500,8 @@ function MdDialogProvider($$interimElementProvider) {
       captureSourceAndParent(element, options);
       configureAria(element.find('md-dialog'), options);
       showBackdrop(scope, element, options);
+
+      document.addEventListener('focus', ariaFocus, true);
 
       return dialogPopIn(element, options)
         .then(function() {
@@ -541,6 +563,8 @@ function MdDialogProvider($$interimElementProvider) {
       options.deactivateListeners();
       options.unlockScreenReader();
       options.hideBackdrop(options.$destroy);
+
+      document.removeEventListener('focus', ariaFocus, true);
 
       // For navigation $destroy events, do a quick, non-animated removal,
       // but for normal closes (from clicks, etc) animate the removal

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -751,8 +751,8 @@ function MdDialogProvider($$interimElementProvider) {
       };
 
       /**
-       * Walk DOM to apply or remove aria-hidden and set tabindex appropriately
-       * based on aria-hidden value on sibling nodes and parent sibling nodes
+       * Walk DOM to apply or remove aria-hidden on sibling nodes
+       * and parent sibling nodes
        *
        */
       function walkDOM(element) {
@@ -760,37 +760,12 @@ function MdDialogProvider($$interimElementProvider) {
           if (element === document.body) {
             return;
           }
-          var children = element.parentNode.children,
-            attrToSet = 'md-saved-tabindex',
-            attrToDefault = 'tabindex',
-            tabModifierSelector = '[md-saved-tabindex]:not([md-saved-tabindex="-1"])';
-
-          if (isHidden) {
-            attrToSet = 'tabindex';
-            attrToDefault = 'md-saved-tabindex';
-            tabModifierSelector = 'button:not([tabindex="-1"]),\
-              a[href]:not([tabindex="-1"]),\
-              input:not([tabindex="-1"]),\
-              textarea:not([tabindex="-1"]),\
-              select:not([tabindex="-1"]),\
-              [tabindex]:not([tabindex="-1"])';
-          }
-
+          var children = element.parentNode.children;
           for (var i = 0; i < children.length; i++) {
             // skip over child if it is an ascendant of the dialog
             // or a script or style tag
             if (element !== children[i] && !isNodeOneOf(children[i], ['SCRIPT', 'STYLE'])) {
-              var tabbables = children[i].querySelectorAll(tabModifierSelector);
-
               children[i].setAttribute('aria-hidden', isHidden);
-
-              for (var j = 0; j < tabbables.length; j++) {
-                var tabbable = tabbables[j],
-                  attrToSetValue = tabbable.getAttribute(attrToSet) || '0',
-                  attrToDefaultValue = tabbable.getAttribute(attrToDefault) || '-1';
-                tabbable.setAttribute(attrToDefault, attrToSetValue);
-                tabbable.setAttribute(attrToSet, attrToDefaultValue);
-              }
             }
           }
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -907,6 +907,68 @@ describe('$mdDialog', function() {
       var sibling = angular.element(parent[0].querySelector('.sibling'));
       expect(sibling.attr('aria-hidden')).toBe('true');
     }));
+
+    it('should set tabindex of to sibling\'s tabbable nodes to -1', inject(function($mdDialog, $rootScope, $timeout) {
+
+      var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
+      var parent = angular.element('<a href="a">');
+      parent.append('<div class="sibling">\
+          <button></button>\
+          <a href="b"></a>\
+          <span tabindex="0"></span>\
+          <input/>\
+          <textarea></textarea>\
+          <select></select>\
+        </div>');
+
+      $mdDialog.show({
+        template: template,
+        parent: parent
+      });
+
+      runAnimation();
+
+      var dialog = angular.element(parent.find('md-dialog'));
+      expect(dialog.parent().attr('tabindex')).toBe(undefined);
+
+      var siblingTabbables = angular.element(parent[0].querySelectorAll('.sibling [tabindex="-1"]'));      
+      expect(siblingTabbables.length).toEqual(6);
+    }));
+
+    it('should set tabindex of sibling\'s tabbables to the original value', inject(function($mdDialog, $mdConstant, $rootScope, $timeout) {
+
+      var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
+      var parent = angular.element('<div>');
+      var expectedIndex = [ -1, 0, 1, 0, 3, 0 ];
+      parent.append('<div class="sibling">\
+          <button tabindex="-1"></button>\
+          <a href="b"></a>\
+          <span tabindex="1"></span>\
+          <input/>\
+          <textarea tabindex="3"></textarea>\
+          <select></select>\
+        </div>');
+
+      $mdDialog.show({
+        template: template,
+        parent: parent,
+        escapeToClose: true
+      });
+
+      runAnimation();
+
+      parent.triggerHandler({
+        type: 'keyup',
+        keyCode: $mdConstant.KEY_CODE.ESCAPE
+      });
+
+      runAnimation();
+      
+      var siblingTabbables = angular.element(parent[0].querySelectorAll('.sibling [tabindex]'));
+      for (var i = 0; i < 6; i ++) {
+        expect(siblingTabbables[i].tabIndex).toBe(expectedIndex[i]);
+      }
+     }));
   });
 
   function hasConfigurationMethods(preset, methods) {

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -907,68 +907,6 @@ describe('$mdDialog', function() {
       var sibling = angular.element(parent[0].querySelector('.sibling'));
       expect(sibling.attr('aria-hidden')).toBe('true');
     }));
-
-    it('should set tabindex of to sibling\'s tabbable nodes to -1', inject(function($mdDialog, $rootScope, $timeout) {
-
-      var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
-      var parent = angular.element('<a href="a">');
-      parent.append('<div class="sibling">\
-          <button></button>\
-          <a href="b"></a>\
-          <span tabindex="0"></span>\
-          <input/>\
-          <textarea></textarea>\
-          <select></select>\
-        </div>');
-
-      $mdDialog.show({
-        template: template,
-        parent: parent
-      });
-
-      runAnimation();
-
-      var dialog = angular.element(parent.find('md-dialog'));
-      expect(dialog.parent().attr('tabindex')).toBe(undefined);
-
-      var siblingTabbables = angular.element(parent[0].querySelectorAll('.sibling [tabindex="-1"]'));      
-      expect(siblingTabbables.length).toEqual(6);
-    }));
-
-    it('should set tabindex of sibling\'s tabbables to the original value', inject(function($mdDialog, $mdConstant, $rootScope, $timeout) {
-
-      var template = '<md-dialog aria-label="Some Other Thing">Hello</md-dialog>';
-      var parent = angular.element('<div>');
-      var expectedIndex = [ -1, 0, 1, 0, 3, 0 ];
-      parent.append('<div class="sibling">\
-          <button tabindex="-1"></button>\
-          <a href="b"></a>\
-          <span tabindex="1"></span>\
-          <input/>\
-          <textarea tabindex="3"></textarea>\
-          <select></select>\
-        </div>');
-
-      $mdDialog.show({
-        template: template,
-        parent: parent,
-        escapeToClose: true
-      });
-
-      runAnimation();
-
-      parent.triggerHandler({
-        type: 'keyup',
-        keyCode: $mdConstant.KEY_CODE.ESCAPE
-      });
-
-      runAnimation();
-      
-      var siblingTabbables = angular.element(parent[0].querySelectorAll('.sibling [tabindex]'));
-      for (var i = 0; i < 6; i ++) {
-        expect(siblingTabbables[i].tabIndex).toBe(expectedIndex[i]);
-      }
-     }));
   });
 
   function hasConfigurationMethods(preset, methods) {


### PR DESCRIPTION
aria-hidden="true" does not prevent elements inside the hidden region from being tabbed to. Because the element is still within an aria-hidden="true" region, screen readers will not read the content of the tabbed element. I think this can cause a great deal of confusion. Therefore, I set the tabindex of all tabbable elements that I am aware of within the aria-hidden="true" regions that are set with the walkDOM function to -1, and set them back when walkDOM is used to show set aria-hidden to false.

Also, http://www.w3.org/TR/wai-aria-practices/#modal_dialog suggests trapping focus in the dialog entirely, but I thought that might be going a bit too far as you may want to tab out of the page/application, and into the address bar or something else.