### PR TITLE
bug: Keyboard handlers not removed if speed-dial is removed from DOM, breaks spacebar

### DIFF
--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -59,6 +59,9 @@
         angular.forEach(eventTypes, function(eventType) {
           $element.off(eventType, parseEvents);
         });
+        // remove any attached keyboard handlers in case element is removed while
+        // speed dial is open
+        disableKeyboard();
       });
     }
 


### PR DESCRIPTION
Our project uses a speed dial where clicking on the actions actually causes the containing block to be removed from the dom (due to an ng-if). The result is the document still has a global keydown handler that causes all spacebar presses to be ignored! Seems like the keyboard handlers should be removed if the element is removed from the DOM.

As an aside, a global keydown handler that disables spacebar seems like a dangerous choice. What if I have a speed dial open but want to enter text somewhere else on the page.... I can't use a space bar anymore? That doesn't seem like a good idea.