### PR TITLE
fix(layout): updates to flexbox styles, directives

### DIFF
--- a/config/build.config.js
+++ b/config/build.config.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var versionFile = __dirname + '/../dist/commit';
 
 module.exports = {
-  ngVersion: '1.4.4',
+  ngVersion: '1.4.6',
   version: pkg.version,
   repository: pkg.repository.url
     .replace(/^git/,'https')

--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -1,13 +1,20 @@
 var gulp = require('gulp');
 var webserver = require('gulp-webserver');
 var LR_PORT = require('../const').LR_PORT;
+var util = require('../util');
 
 exports.task = function() {
-  return gulp.src('.')
+    var openUrl = false;
+    if (typeof util.args.o === 'string' ||
+        typeof util.args.o === 'boolean') {
+        openUrl = util.args.o;
+    }
+    return gulp.src('.')
       .pipe(webserver({
-        host: '0.0.0.0',
-        livereload: true,
-        port: LR_PORT,
-        directoryListing: true
-      }));
+            host: '0.0.0.0',
+            livereload: true,
+            port: LR_PORT,
+            directoryListing: true,
+            open: openUrl
+        }));
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
   "name": "angular-material-source",
   "version": "0.11.0",
+  "description": "The Angular Material project is an implementation of Material Design in Angular.js. This project provides a set of reusable, well-tested, and accessible UI components based on the Material Design system. Similar to the Polymer project's Paper elements collection, Angular Material is supported internally at Google by the Angular.js, Material Design UX and other product teams.",
+  "keywords": "client-side, browser, material, material-design, design, angular, css, components, google",
+  "homepage": "https://material.angularjs.org",
+  "bugs": "https://github.com/angular/material/issues",
+  "license": "MIT",
   "repository": {
+    "type" : "git",
     "url": "git://github.com/angular/material.git"
   },
   "devDependencies": {
@@ -59,6 +65,7 @@
     "through2": "^0.6.3"
   },
   "scripts": {
+    "watch": "gulp watch site --dev",
     "prom": "git pull --rebase origin master",
     "current-branch": "git rev-parse --abbrev-ref HEAD",
     "merge-base": "git merge-base $(npm run -s current-branch) origin/master",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
     "url": "git://github.com/angular/material.git"
   },
   "devDependencies": {
-    "angular": "1.4.4",
-    "angular-animate": "1.4.4",
-    "angular-aria": "1.4.4",
-    "angular-messages": "1.4.4",
-    "angular-mocks": "1.4.4",
-    "angular-route": "1.4.4",
+    "angular": "1.4.6",
+    "angular-animate": "1.4.6",
+    "angular-aria": "1.4.6",
+    "angular-messages": "1.4.6",
+    "angular-mocks": "1.4.6",
+    "angular-route": "1.4.6",
     "angularytics": "^0.3.0",
     "canonical-path": "0.0.2",
     "cli-color": "^1.0.0",

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -44,15 +44,14 @@ describe('<md-autocomplete>', function () {
     // Using md-item-size would reduce this to a single flush, but given that
     // autocomplete allows for custom row templates, it's better to measure
     // rather than assuming a given size.
-    inject(function ($$rAF) {
-      $$rAF.flush();
-      element.scope().$apply();
-      $$rAF.flush();
+    inject(function ($material, $timeout) {
+      $material.flushOutstandingAnimations();
+      $timeout.flush();
     });
   }
 
   describe('basic functionality', function () {
-    it('should update selected item and search text', inject(function ($timeout, $mdConstant) {
+    it('should update selected item and search text', inject(function ($timeout, $mdConstant, $material) {
       var scope    = createScope();
       var template = '\
           <md-autocomplete\
@@ -67,11 +66,12 @@ describe('<md-autocomplete>', function () {
       var ctrl     = element.controller('mdAutocomplete');
       var ul       = element.find('ul');
 
+      $material.flushInterimElement();
+
       expect(scope.searchText).toBe('');
       expect(scope.selectedItem).toBe(null);
 
       element.scope().searchText = 'fo';
-      $timeout.flush();
       waitForVirtualRepeat(element);
 
       expect(scope.searchText).toBe('fo');
@@ -160,7 +160,7 @@ describe('<md-autocomplete>', function () {
   });
 
   describe('basic functionality with template', function () {
-    it('should update selected item and search text', inject(function ($timeout, $mdConstant) {
+    it('should update selected item and search text', inject(function ($timeout, $material, $mdConstant) {
       var scope    = createScope();
       var template = '\
           <md-autocomplete\
@@ -180,8 +180,9 @@ describe('<md-autocomplete>', function () {
       expect(scope.searchText).toBe('');
       expect(scope.selectedItem).toBe(null);
 
+      $material.flushInterimElement();
+
       element.scope().searchText = 'fo';
-      $timeout.flush();
       waitForVirtualRepeat(element);
 
       expect(scope.searchText).toBe('fo');
@@ -190,6 +191,7 @@ describe('<md-autocomplete>', function () {
 
       ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
       ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+
       $timeout.flush();
 
       expect(scope.searchText).toBe('foo');
@@ -198,7 +200,7 @@ describe('<md-autocomplete>', function () {
       element.remove();
     }));
 
-    it('should compile the template against the parent scope', inject(function ($timeout) {
+    it('should compile the template against the parent scope', inject(function ($timeout, $material) {
       var scope    = createScope(null, { bang: 'boom' });
       var template = '\
           <md-autocomplete\
@@ -216,6 +218,8 @@ describe('<md-autocomplete>', function () {
       var element  = compile(template, scope);
       var ctrl     = element.controller('mdAutocomplete');
       var ul       = element.find('ul');
+
+      $material.flushOutstandingAnimations();
 
       expect(scope.bang).toBe('boom');
 
@@ -242,7 +246,7 @@ describe('<md-autocomplete>', function () {
   });
 
   describe('xss prevention', function () {
-    it('should not allow html to slip through', inject(function($timeout) {
+    it('should not allow html to slip through', inject(function($timeout, $material) {
       var html = 'foo <img src="img" onerror="alert(1)" />';
       var scope = createScope([ { display: html } ]);
       var template = '\
@@ -257,6 +261,8 @@ describe('<md-autocomplete>', function () {
           </md-autocomplete>';
       var element  = compile(template, scope);
       var ul       = element.find('ul');
+
+      $material.flushOutstandingAnimations();
 
       expect(scope.searchText).toBe('');
       expect(scope.selectedItem).toBe(null);

--- a/src/components/autocomplete/js/autocompleteParentScopeDirective.js
+++ b/src/components/autocomplete/js/autocompleteParentScopeDirective.js
@@ -10,17 +10,13 @@ function MdAutocompleteItemScopeDirective($compile, $mdUtil) {
   };
 
   function postLink(scope, element, attr) {
-    var newScope = scope.$mdAutocompleteCtrl.parent.$new();
-    var relevantVariables = ['item', '$index'];
+    var ctrl     = scope.$mdAutocompleteCtrl;
+    var newScope = ctrl.parent.$new();
+    var itemName = ctrl.itemName;
 
     // Watch for changes to our scope's variables and copy them to the new scope
-    angular.forEach(relevantVariables, function(variable){
-      scope.$watch(variable, function(value) {
-        $mdUtil.nextTick(function() {
-          newScope[variable] = value;
-        });
-      });
-    });
+    watchVariable('$index', '$index');
+    watchVariable('item', itemName);
 
     // Recompile the contents with the new/modified scope
     $compile(element.contents())(newScope);
@@ -29,6 +25,18 @@ function MdAutocompleteItemScopeDirective($compile, $mdUtil) {
     if (attr.hasOwnProperty('mdAutocompleteReplace')) {
       element.after(element.contents());
       element.remove();
+    }
+
+    /**
+     * Creates a watcher for variables that are copied from the parent scope
+     * @param variable
+     * @param alias
+     */
+    function watchVariable (variable, alias) {
+      $mdUtil.nextTick(function () {
+        newScope[alias] = scope[variable];
+        scope.$watch(variable, function (value) { newScope[alias] = value; });
+      });
     }
   }
 }

--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -12,9 +12,17 @@ angular
   .directive('mdBottomSheet', MdBottomSheetDirective)
   .provider('$mdBottomSheet', MdBottomSheetProvider);
 
-function MdBottomSheetDirective() {
+/* @ngInject */
+function MdBottomSheetDirective($mdBottomSheet) {
   return {
-    restrict: 'E'
+    restrict: 'E',
+    link : function postLink(scope, element, attr) {
+      // When navigation force destroys an interimElement, then
+      // listen and $destroy() that interim instance...
+      scope.$on('$destroy', function() {
+        $mdBottomSheet.destroy();
+      });
+    }
   };
 }
 

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -2,16 +2,15 @@ describe('$mdBottomSheet service', function() {
   beforeEach(module('material.components.bottomSheet'));
 
   describe('#build()', function() {
-    it('should close when `escapeToClose == true`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+    it('should close when `escapeToClose == true`', inject(function($mdBottomSheet, $rootElement, $material, $mdConstant) {
       var parent = angular.element('<div>');
       $mdBottomSheet.show({
         template: '<md-bottom-sheet>',
         parent: parent,
         escapeToClose: true
       });
-      $rootScope.$apply();
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
 
       expect(parent.find('md-bottom-sheet').length).toBe(1);
 
@@ -20,7 +19,7 @@ describe('$mdBottomSheet service', function() {
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
 
-      $timeout.flush();
+      $material.flushInterimElement();
       expect(parent.find('md-bottom-sheet').length).toBe(0);
     }));
 
@@ -33,8 +32,6 @@ describe('$mdBottomSheet service', function() {
       });
       $rootScope.$apply();
 
-      $animate.triggerCallbacks();
-
       expect(parent.find('md-bottom-sheet').length).toBe(1);
 
       $rootElement.triggerHandler({type: 'keyup', keyCode: $mdConstant.KEY_CODE.ESCAPE});
@@ -42,7 +39,7 @@ describe('$mdBottomSheet service', function() {
       expect(parent.find('md-bottom-sheet').length).toBe(1);
     }));
 
-    it('should close when navigation fires `scope.$destroy()`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+    it('should close when navigation fires `scope.$destroy()`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $material, $mdConstant) {
           var parent = angular.element('<div>');
           $mdBottomSheet.show({
             template: '<md-bottom-sheet>',
@@ -51,11 +48,12 @@ describe('$mdBottomSheet service', function() {
           });
 
           $rootScope.$apply();
-          $animate.triggerCallbacks();
+          $material.flushOutstandingAnimations();
 
           expect(parent.find('md-bottom-sheet').length).toBe(1);
 
           $rootScope.$destroy();
+          $material.flushInterimElement();
           expect(parent.find('md-bottom-sheet').length).toBe(0);
         }));
 
@@ -78,7 +76,6 @@ describe('$mdBottomSheet service', function() {
         escapeToClose: false
       });
       $rootScope.$apply();
-      $animate.triggerCallbacks();
 
       var sheet = parent.find('md-bottom-sheet');
       expect(sheet.length).toBe(1);

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -2,7 +2,7 @@ describe('$mdBottomSheet service', function() {
   beforeEach(module('material.components.bottomSheet'));
 
   describe('#build()', function() {
-    it('should escapeToClose == true', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+    it('should close when `escapeToClose == true`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
       var parent = angular.element('<div>');
       $mdBottomSheet.show({
         template: '<md-bottom-sheet>',
@@ -24,7 +24,7 @@ describe('$mdBottomSheet service', function() {
       expect(parent.find('md-bottom-sheet').length).toBe(0);
     }));
 
-    it('should escapeToClose == false', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+    it('should not close when `escapeToClose == false`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
       var parent = angular.element('<div>');
       $mdBottomSheet.show({
         template: '<md-bottom-sheet>',
@@ -41,6 +41,23 @@ describe('$mdBottomSheet service', function() {
 
       expect(parent.find('md-bottom-sheet').length).toBe(1);
     }));
+
+    it('should close when navigation fires `scope.$destroy()`', inject(function($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+          var parent = angular.element('<div>');
+          $mdBottomSheet.show({
+            template: '<md-bottom-sheet>',
+            parent: parent,
+            escapeToClose: false
+          });
+
+          $rootScope.$apply();
+          $animate.triggerCallbacks();
+
+          expect(parent.find('md-bottom-sheet').length).toBe(1);
+
+          $rootScope.$destroy();
+          expect(parent.find('md-bottom-sheet').length).toBe(0);
+        }));
 
     it('should focus child with md-autofocus', inject(function($rootScope, $animate, $document, $mdBottomSheet) {
       jasmine.mockElementFocus(this);

--- a/src/components/bottomSheet/demoBasicUsage/script.js
+++ b/src/components/bottomSheet/demoBasicUsage/script.js
@@ -22,7 +22,7 @@ angular.module('bottomSheetDemo1', ['ngMaterial'])
       controller: 'ListBottomSheetCtrl',
       targetEvent: $event
     }).then(function(clickedItem) {
-      $scope.alert = clickedItem.name + ' clicked!';
+      $scope.alert = clickedItem['name'] + ' clicked!';
     });
   };
 
@@ -35,7 +35,7 @@ angular.module('bottomSheetDemo1', ['ngMaterial'])
     }).then(function(clickedItem) {
       $mdToast.show(
             $mdToast.simple()
-              .content(clickedItem.name + ' clicked!')
+              .content(clickedItem['name'] + ' clicked!')
               .position('top right')
               .hideDelay(1500)
           );

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,5 +1,5 @@
 $card-padding: 16px !default;
-$card-box-shadow: $whiteframe-shadow-z1 !default;
+$card-box-shadow: $whiteframe-shadow-1dp !default;
 
 md-card {
   box-sizing: border-box;

--- a/src/components/datepicker/calendar-theme.scss
+++ b/src/components/datepicker/calendar-theme.scss
@@ -1,7 +1,7 @@
 /** Theme styles for mdCalendar. */
 
 .md-calendar.md-THEME_NAME-theme {
-  color: '{{foreground-2}}';
+  color: '{{foreground-1}}';
 
   tr:last-child td {
     border-bottom-color: '{{background-200}}';
@@ -10,12 +10,15 @@
 .md-THEME_NAME-theme {
 
   .md-calendar-day-header {
-    background: '{{background-200}}'; // grey-200
-    color: '{{foreground-2}}'; // grey-700
+    background: '{{background-hue-1}}';
+    color: '{{foreground-1}}';
   }
 
   .md-calendar-date.md-calendar-date-today {
-    color: '{{primary-500}}'; // blue-500
+
+    .md-calendar-date-selection-indicator {
+      border: 1px solid '{{primary-500}}'; // blue-500
+    }
 
     &.md-calendar-date-disabled {
       color: '{{primary-500-0.6}}';
@@ -26,12 +29,12 @@
   // (the root md-calendar holds browser focus).
   .md-calendar-date.md-focus {
     .md-calendar-date-selection-indicator {
-      background: '{{background-300}}'; // grey-300
+      background: '{{background-hue-1}}';
     }
   }
 
   .md-calendar-date-selection-indicator:hover {
-    background: '{{background-300}}'; // grey-300
+    background: '{{background-hue-1}}';
   }
 
   // Selected style goes after hover and focus so that it takes priority.
@@ -40,11 +43,12 @@
     .md-calendar-date-selection-indicator {
       background: '{{primary-500}}'; // blue-500
       color: '{{primary-500-contrast}}'; // white
+      border-color: transparent;
     }
   }
 
   .md-calendar-date-disabled,
   .md-calendar-month-label-disabled {
-    color: '{{background-400}}'; // grey-400
+    color: '{{foreground-3}}';
   }
 }

--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -6,7 +6,7 @@ $md-calendar-side-padding: 16px !default;
 $md-calendar-weeks-to-show: 7 !default;
 
 $md-calendar-month-label-padding: 8px !default;
-$md-calendar-month-label-font-size: 13px !default;
+$md-calendar-month-label-font-size: 14px !default;
 
 $md-calendar-scroll-cue-shadow-radius: 6px;
 
@@ -122,6 +122,7 @@ md-calendar {
 .md-calendar-month-label {
   height: $md-calendar-cell-size;
   font-size: $md-calendar-month-label-font-size;
+  font-weight: 500; // Roboto Medium
   padding: 0 0 0 $md-calendar-side-padding + $md-calendar-month-label-padding;
 }
 

--- a/src/components/datepicker/calendar.spec.js
+++ b/src/components/datepicker/calendar.spec.js
@@ -5,7 +5,7 @@ describe('md-calendar', function() {
   var JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9,
       NOV = 10, DEC = 11;
 
-  var ngElement, element, scope, pageScope, controller, $animate, $compile, $$rAF;
+  var ngElement, element, scope, pageScope, controller, $material, $compile, $$rAF;
   var $rootScope, dateLocale, $mdUtil, keyCodes, dateUtil;
 
   // List of calendar elements added to the DOM so we can remove them after every test.
@@ -17,8 +17,7 @@ describe('md-calendar', function() {
    */
   function applyDateChange() {
     pageScope.$apply();
-    $animate.triggerCallbacks();
-    $$rAF.flush();
+    $material.flushOutstandingAnimations();
 
     // Internally, the calendar sets scrollTop to scroll to the month for a change.
     // The handler for that scroll won't be invoked unless we manually trigger it.
@@ -139,7 +138,7 @@ describe('md-calendar', function() {
       }
     });
 
-    $animate = $injector.get('$animate');
+    $material = $injector.get('$material');
     $compile = $injector.get('$compile');
     $rootScope = $injector.get('$rootScope');
     $$rAF = $injector.get('$$rAF');
@@ -474,7 +473,7 @@ describe('md-calendar', function() {
     controller.changeDisplayDate(laterDate);
     expect(controller.displayDate).toBeSameDayAs(earlierDate);
 
-    $animate.triggerCallbacks();
+    $material.flushOutstandingAnimations();
     controller.changeDisplayDate(laterDate);
     expect(controller.displayDate).toBeSameDayAs(laterDate);
   });

--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -1,10 +1,15 @@
 /** Theme styles for mdDatepicker. */
 
 md-datepicker.md-THEME_NAME-theme {
-  background: white;
+  background: '{{background-color}}';
 }
 
 .md-THEME_NAME-theme {
+
+  .md-datepicker-input {
+    color: '{{background-contrast}}';
+    background: '{{background-color}}';
+  }
 
   .md-datepicker-input-container {
     border-bottom-color: '{{background-300}}';
@@ -23,6 +28,10 @@ md-datepicker.md-THEME_NAME-theme {
   }
 
   .md-datepicker-triangle-button {
+    .md-datepicker-expand-triangle {
+      border-top-color: '{{foreground-3}}';
+    }
+
     &:hover .md-datepicker-expand-triangle {
       border-top-color: '{{foreground-2}}';
     }
@@ -35,7 +44,8 @@ md-datepicker.md-THEME_NAME-theme {
     }
   }
 
-  .md-datepicker-calendar {
-    background: white;
+  .md-datepicker-calendar,
+  .md-datepicker-input-mask-opaque {
+    background: '{{background-color}}';
   }
 }

--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -7,6 +7,7 @@ md-datepicker.md-THEME_NAME-theme {
 .md-THEME_NAME-theme {
 
   .md-datepicker-input {
+    @include input-placeholder-color('{{foreground-3}}');
     color: '{{background-contrast}}';
     background: '{{background-color}}';
   }

--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -331,7 +331,11 @@
     var parsedDate = this.dateLocale.parseDate(inputString);
     this.dateUtil.setDateTimeToMidnight(parsedDate);
 
-    if (this.dateUtil.isValidDate(parsedDate) &&
+    if (inputString === '') {
+      this.ngModelCtrl.$setViewValue(null);
+      this.date = null;
+      this.inputContainer.classList.remove(INVALID_CLASS);
+    } else if (this.dateUtil.isValidDate(parsedDate) &&
         this.dateLocale.isDateComplete(inputString) &&
         this.dateUtil.isDateWithinRange(parsedDate, this.minDate, this.maxDate)) {
       this.ngModelCtrl.$setViewValue(parsedDate);

--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -294,9 +294,13 @@
     if (this.$attrs['ngDisabled']) {
       // The expression is to be evaluated against the directive element's scope and not
       // the directive's isolate scope.
-      this.$element.scope().$watch(this.$attrs['ngDisabled'], function(isDisabled) {
-        self.setDisabled(isDisabled);
-      });
+      var scope = this.$mdUtil.validateScope(this.$element) ? this.$element.scope() : null;
+
+      if ( scope ) {
+        scope.$watch(this.$attrs['ngDisabled'], function(isDisabled) {
+          self.setDisabled(isDisabled);
+        });
+      }
     }
 
     Object.defineProperty(this, 'placeholder', {

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -174,9 +174,9 @@ md-datepicker[disabled] {
 // view while the pane is opening. This is done as a cue to users that the calendar is scrollable.
 .md-datepicker-calendar-pane {
   .md-calendar {
-    transform: translateY(150px);
-    transition: transform 0.4s $swift-ease-out-timing-function;
-    transition-delay: 0.1s;
+    transform: translateY(-85px);
+    transition: transform 0.65s $swift-ease-out-timing-function;
+    transition-delay: 0.125s;
   }
 
   &.md-pane-open .md-calendar {

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -77,7 +77,6 @@ md-datepicker {
   position: absolute;
   right: 0;
   left: 120px;
-  background: white;
 
   height: 100%;
 }
@@ -115,7 +114,7 @@ $md-date-arrow-size: 5px;
   height: 0;
   border-left: $md-date-arrow-size solid transparent;
   border-right: $md-date-arrow-size solid transparent;
-  border-top: $md-date-arrow-size solid rgba(black, 0.20);
+  border-top: $md-date-arrow-size solid;
 }
 
 // Button containing the down "disclosure" triangle/arrow.

--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -50,6 +50,14 @@ describe('md-date-picker', function() {
     expect(controller.inputElement.value).toBe(dateLocale.formatDate(initialDate));
   });
 
+  it('should set the ngModel value to null when the text input is emptied', function() {
+    controller.inputElement.value = '';
+    controller.ngInputElement.triggerHandler('input');
+    $timeout.flush();
+
+    expect(pageScope.myDate).toBeNull();
+  });
+
   it('should open and close the floating calendar pane element', function() {
     // We can asset that the calendarPane is in the DOM by checking if it has a height.
     expect(controller.calendarPane.offsetHeight).toBe(0);

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -5,10 +5,10 @@
     <md-datepicker ng-model="myDate" md-placeholder="Enter date"></md-datepicker>
 
     <h4>Disabled date-picker</h4>
-    <md-datepicker ng-model="myDate" placeholder="Enter date" disabled></md-datepicker>
+    <md-datepicker ng-model="myDate" md-placeholder="Enter date" disabled></md-datepicker>
 
     <h4>Date-picker with min date and max date</h4>
-    <md-datepicker ng-model="myDate" placeholder="Enter date"
+    <md-datepicker ng-model="myDate" md-placeholder="Enter date"
         md-min-date="minDate" md-max-date="maxDate"></md-datepicker>
   </md-content>
 </div>

--- a/src/components/dialog/demoBasicUsage/index.html
+++ b/src/components/dialog/demoBasicUsage/index.html
@@ -16,10 +16,14 @@
     </md-button>
   </div>
 
+  <p class="footer">Note: The <b>Confirm</b> dialog does not use <code>$mdDialog.clickOutsideToClose(true)</code>.</p>
+
   <div ng-if="status">
     <br/>
     <b layout="row" layout-align="center center" class="md-padding">
       {{status}}
     </b>
   </div>
+
+
 </div>

--- a/src/components/dialog/demoBasicUsage/style.css
+++ b/src/components/dialog/demoBasicUsage/style.css
@@ -7,3 +7,14 @@
     color:blue;
     text-decoration: underline;
 }
+
+.footer {
+    width:100%;
+    text-align: center;
+    margin-left:20px;
+}
+ .footer, .footer > code {
+    font-size: 0.8em;
+    margin-top:50px;
+}
+

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -570,7 +570,7 @@ function MdDialogProvider($$interimElementProvider) {
       // the DOM element.
       if ( angular.isString(options.parent) ) {
         var simpleSelector = options.parent,
-            container = $document[0].querySelectorAll(selector);
+            container = $document[0].querySelectorAll(simpleSelector);
         options.parent = container.length ? container[0] : null;
       }
       // If we have a reference to a raw dom element, always wrap it in jqLite

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -10,7 +10,7 @@ angular
   .directive('mdDialog', MdDialogDirective)
   .provider('$mdDialog', MdDialogProvider);
 
-function MdDialogDirective($$rAF, $mdTheming) {
+function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
   return {
     restrict: 'E',
     link: function(scope, element, attr) {
@@ -25,9 +25,19 @@ function MdDialogDirective($$rAF, $mdTheming) {
           //-- delayed image loading may impact scroll height, check after images are loaded
           angular.element(images).on('load', addOverflowClass);
         }
+
+        scope.$on('$destroy', function() {
+          $mdDialog.destroy();
+        });
+
+        /**
+         *
+         */
         function addOverflowClass() {
           element.toggleClass('md-content-overflow', content.scrollHeight > content.clientHeight);
         }
+
+
       });
     }
   };
@@ -530,16 +540,30 @@ function MdDialogProvider($$interimElementProvider) {
     function onRemove(scope, element, options) {
       options.deactivateListeners();
       options.unlockScreenReader();
+      options.hideBackdrop(options.$destroy);
 
-      options.hideBackdrop();
+      // For navigation $destroy events, do a quick, non-animated removal,
+      // but for normal closes (from clicks, etc) animate the removal
 
-      return dialogPopOut(element, options)
-        .finally(function() {
-          angular.element($document[0].body).removeClass('md-dialog-is-showing');
-          element.remove();
+      return !!options.$destroy ? detachAndClean() : animateRemoval().then( detachAndClean );
 
-          options.origin.focus();
-        });
+      /**
+       * For normal closes, animate the removal.
+       * For forced closes (like $destroy events), skip the animations
+       */
+      function animateRemoval() {
+        return dialogPopOut(element, options);
+      }
+
+      /**
+       * Detach the element
+       */
+      function detachAndClean() {
+        angular.element($document[0].body).removeClass('md-dialog-is-showing');
+        element.remove();
+
+        if (!options.$destroy) options.origin.focus();
+      }
     }
 
     /**
@@ -661,10 +685,12 @@ function MdDialogProvider($$interimElementProvider) {
       /**
        * Hide modal backdrop element...
        */
-      options.hideBackdrop = function hideBackdrop() {
+      options.hideBackdrop = function hideBackdrop($destroy) {
         if (options.backdrop) {
-          $animate.leave(options.backdrop);
+          if ( !!$destroy ) options.backdrop.remove();
+          else              $animate.leave(options.backdrop);
         }
+
         if (options.disableParentScroll) {
           options.restoreScroll();
           delete options.restoreScroll;
@@ -755,7 +781,6 @@ function MdDialogProvider($$interimElementProvider) {
 
       var isFixed = $window.getComputedStyle($document[0].body).position == 'fixed';
       var backdrop = options.backdrop ? $window.getComputedStyle(options.backdrop[0]) : null;
-
       var height = backdrop ? Math.min($document[0].body.clientHeight, Math.ceil(Math.abs(parseInt(backdrop.height, 10)))) : 0;
 
       container.css({

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -755,10 +755,11 @@ function MdDialogProvider($$interimElementProvider) {
 
       var isFixed = $window.getComputedStyle($document[0].body).position == 'fixed';
       var backdrop = options.backdrop ? $window.getComputedStyle(options.backdrop[0]) : null;
-      var height = backdrop ? Math.ceil(Math.abs(parseInt(backdrop.height, 10))) : 0;
+
+      var height = backdrop ? Math.min($document[0].body.clientHeight, Math.ceil(Math.abs(parseInt(backdrop.height, 10)))) : 0;
 
       container.css({
-        top: (isFixed ? $mdUtil.scrollTop(options.parent) / 2 : 0) + 'px',
+        top: (isFixed ? $mdUtil.scrollTop(options.parent) : 0) + 'px',
         height: height ? height + 'px' : '100%'
       });
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -402,11 +402,11 @@ function MdDialogProvider($$interimElementProvider) {
       options: dialogDefaultOptions
     })
     .addPreset('alert', {
-      methods: ['title', 'content', 'ariaLabel', 'ok', 'theme'],
+      methods: ['title', 'content', 'ariaLabel', 'ok', 'theme', 'css'],
       options: advancedDialogOptions
     })
     .addPreset('confirm', {
-      methods: ['title', 'content', 'ariaLabel', 'ok', 'cancel', 'theme'],
+      methods: ['title', 'content', 'ariaLabel', 'ok', 'cancel', 'theme', 'css'],
       options: advancedDialogOptions
     });
 
@@ -414,7 +414,7 @@ function MdDialogProvider($$interimElementProvider) {
   function advancedDialogOptions($mdDialog, $mdTheming) {
     return {
       template: [
-        '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}">',
+        '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" class="{{ dialog.css }}">',
         ' <md-dialog-content role="document" tabIndex="-1">',
         '   <h2 class="md-title">{{ dialog.title }}</h2>',
         '   <div class="md-dialog-content-body" md-template="::dialog.content"></div>',

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -606,12 +606,16 @@ function MdDialogProvider($$interimElementProvider) {
      * Listen for escape keys and outside clicks to auto close
      */
     function activateListeners(element, options) {
+      var window = angular.element($window);
+      var onWindowResize = $mdUtil.debounce(function(){
+        stretchDialogContainerToViewport(element, options);
+      }, 60);
+
       var removeListeners = [];
       var smartClose = function() {
         // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
         // cancel or fallback to hide.
         var closeFn = ( options.$type == 'alert' ) ? $mdDialog.hide : $mdDialog.cancel;
-
         $mdUtil.nextTick(closeFn, true);
       };
 
@@ -629,11 +633,15 @@ function MdDialogProvider($$interimElementProvider) {
         // Add keyup listeners
         element.on('keyup', keyHandlerFn);
         target.on('keyup', keyHandlerFn);
+        window.on('resize', onWindowResize);
 
         // Queue remove listeners function
         removeListeners.push(function() {
+
           element.off('keyup', keyHandlerFn);
           target.off('keyup', keyHandlerFn);
+          window.off('resize', onWindowResize);
+
         });
       }
       if (options.clickOutsideToClose) {
@@ -810,6 +818,9 @@ function MdDialogProvider($$interimElementProvider) {
       return animator
         .translate3d(dialogEl, from, to, translateOptions)
         .then(function(animateReversal) {
+
+
+
           // Build a reversal translate function synched to this translation...
           options.reverseAnimate = function() {
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -569,7 +569,7 @@ function MdDialogProvider($$interimElementProvider) {
       // If the parent specifier is a simple string selector, then query for
       // the DOM element.
       if ( angular.isString(options.parent) ) {
-        var simpleSelector = options.parent;
+        var simpleSelector = options.parent,
             container = $document[0].querySelectorAll(selector);
         options.parent = container.length ? container[0] : null;
       }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -36,7 +36,7 @@ md-dialog {
   position: relative;
   overflow: auto; // stop content from leaking out of dialog parent and fix IE
 
-  box-shadow: $whiteframe-shadow-z5;
+  box-shadow: $whiteframe-shadow-13dp;
 
   display: flex;
   flex-direction: column;

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -13,14 +13,10 @@ describe('$mdDialog', function() {
       return $$q.when();
     });
   }));
-  beforeEach(inject(function($rootScope, $timeout, $$rAF, $animate) {
-
+  beforeEach(inject(function($material) {
     runAnimation = function() {
-      $timeout.flush(); // flush to start animations
-      $$rAF.flush();    // flush animations
-      $animate.triggerCallbacks();
-      $timeout.flush(); // flush responses after animation completions
-    }
+      $material.flushInterimElement();
+    };
   }));
 
   describe('#alert()', function() {
@@ -144,7 +140,7 @@ describe('$mdDialog', function() {
         })
       );
 
-      runAnimation(parent.find('md-dialog'));
+      runAnimation();
 
       container = angular.element(parent[0].querySelector('.md-dialog-container'));
       container.triggerHandler({
@@ -152,7 +148,8 @@ describe('$mdDialog', function() {
         target: container[0]
       });
 
-      runAnimation(parent.find('md-dialog'));
+      $timeout.flush();
+      runAnimation();
 
       container = angular.element(parent[0].querySelector('.md-dialog-container'));
       expect(container.length).toBe(0);
@@ -188,7 +185,7 @@ describe('$mdDialog', function() {
       'ok', 'cancel', 'targetEvent', 'theme'
     ]);
 
-    it('shows a basic confirm dialog with simple text content', inject(function($rootScope, $mdDialog, $animate) {
+    it('shows a basic confirm dialog with simple text content', inject(function($rootScope, $mdDialog, $animate, $timeout) {
       var parent = angular.element('<div>');
       var rejected = false;
       $mdDialog.show(
@@ -285,7 +282,7 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('.dialog-close'));
     }));
 
-    it('should remove `md-dialog-container` after click outside', inject(function($mdDialog, $rootScope, $timeout) {
+    it('should remove `md-dialog-container` after click outside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
 
@@ -309,6 +306,8 @@ describe('$mdDialog', function() {
         type: 'click',
         target: container[0]
       });
+
+      runAnimation();
       runAnimation();
 
       container = angular.element(parent[0].querySelector('.md-dialog-container'));
@@ -342,6 +341,7 @@ describe('$mdDialog', function() {
         type: 'keyup',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
+      runAnimation();
       runAnimation();
 
       container = angular.element(parent[0].querySelector('.md-dialog-container'));
@@ -539,6 +539,7 @@ describe('$mdDialog', function() {
         type: 'click',
         target: container[0]
       });
+      runAnimation();
       runAnimation();
 
       expect(parent.find('md-dialog').length).toBe(0);

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -158,6 +158,28 @@ describe('$mdDialog', function() {
       expect(container.length).toBe(0);
     }));
 
+    it('should remove `md-dialog-container` on scope.$destroy()', inject(function($mdDialog, $rootScope, $timeout) {
+      var container, parent = angular.element('<div>');
+
+      $mdDialog.show(
+        $mdDialog.alert({
+          template: '' +
+            '<md-dialog>' +
+            '  <md-dialog-content tabIndex="0">' +
+            '    <p>Muppets are the best</p>' +
+            '  </md-dialog-content>' +
+            '</md-dialog>',
+          parent: parent
+        })
+      );
+
+      runAnimation(parent.find('md-dialog'));
+        $rootScope.$destroy();
+      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+
+      expect(container.length).toBe(0);
+    }));
+
   });
 
   describe('#confirm()', function() {

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -34,6 +34,7 @@ describe('$mdDialog', function() {
               .confirm()
               .parent(parent)
               .title('')
+              .css('someClass anotherClass')
               .ok('Next')
               .cancel("Back")
           ).then(function() {
@@ -49,9 +50,12 @@ describe('$mdDialog', function() {
           var title = mdContent.find('h2');
           var content = mdContent.find('p');
           var buttons = parent.find('md-button');
+          var css = mdDialog.attr('class').split(' ');
 
           expect(title.text()).toBe('');
           expect(content.text()).toBe('');
+          expect(css).toContain('someClass');
+          expect(css).toContain('anotherClass');
 
           buttons.eq(0).triggerHandler('click');
 
@@ -72,6 +76,7 @@ describe('$mdDialog', function() {
           .title('Title')
           .content('Hello world')
           .theme('some-theme')
+          .css('someClass anotherClass')
           .ok('Next')
       ).then(function() {
           resolved = true;
@@ -87,12 +92,15 @@ describe('$mdDialog', function() {
       var content = mdContent.find('p');
       var buttons = parent.find('md-button');
       var theme = mdDialog.attr('md-theme');
+      var css = mdDialog.attr('class').split(' ');
 
       expect(title.text()).toBe('Title');
       expect(content.text()).toBe('Hello world');
       expect(buttons.length).toBe(1);
       expect(buttons.eq(0).text()).toBe('Next');
       expect(theme).toBe('some-theme');
+      expect(css).toContain('someClass');
+      expect(css).toContain('anotherClass');
       expect(mdDialog.attr('role')).toBe('alertdialog');
 
       buttons.eq(0).triggerHandler('click');

--- a/src/components/input/demoBasicUsage/index.html
+++ b/src/components/input/demoBasicUsage/index.html
@@ -53,7 +53,7 @@
         </md-input-container>
         <md-input-container flex>
           <label>Postal Code</label>
-          <input ng-model="user.postalCode">
+          <input ng-model="user.postalCode" placeholder="12345">
         </md-input-container>
       </div>
 

--- a/src/components/input/demoErrors/index.html
+++ b/src/components/input/demoErrors/index.html
@@ -26,12 +26,41 @@
       </md-input-container>
 
       <md-input-container>
+        <label>Client Email</label>
+        <input required type="email" name="clientEmail" ng-model="project.clientEmail"
+               minlength="10" maxlength="100" ng-pattern="/^.+@.+\..+$/" />
+
+        <div ng-messages="projectForm.clientEmail.$error" role="alert">
+          <div ng-message-exp="['required', 'minlength', 'maxlength', 'pattern']">
+            Your email must be between 10 and 100 characters long and look like an e-mail address.
+          </div>
+        </div>
+      </md-input-container>
+
+      <md-input-container>
         <label>Hourly Rate (USD)</label>
-        <input required type="number" step="any" name="rate" ng-model="project.rate" min="800" max="4999">
-        <div ng-messages="projectForm.rate.$error">
-          <div ng-message="required">You've got to charge something! You can't just <b>give away</b> a Missile Defense System.</div>
-          <div ng-message="min">You should charge at least $800 an hour. This job is a big deal... if you mess up, everyone dies!</div>
-          <div ng-message="max">$5,000 an hour? That's a little ridiculous. I doubt event Bill Clinton could afford that.</div>
+        <input required type="number" step="any" name="rate" ng-model="project.rate" min="800"
+               max="4999" ng-pattern="/^1234$/">
+
+        <div ng-messages="projectForm.rate.$error" multiple>
+          <div ng-message="required">
+            You've got to charge something! You can't just <b>give away</b> a Missile Defense
+            System.
+          </div>
+
+          <div ng-message="min">
+            You should charge at least $800 an hour. This job is a big deal... if you mess up,
+            everyone dies!
+          </div>
+
+          <div ng-message="pattern">
+            You should charge exactly $1,234.
+          </div>
+
+          <div ng-message="max">
+            {{projectForm.rate.$viewValue | currency:"$":0}} an hour? That's a little ridiculous. I
+            doubt event Bill Clinton could afford that.
+          </div>
         </div>
       </md-input-container>
     </form>

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -16,11 +16,12 @@ md-input-container.md-THEME_NAME-theme {
     color: '{{foreground-3}}';
   }
 
-  ng-messages,
-  [ng-message], [data-ng-message], [x-ng-message] {
-    color: '{{warn-500}}'
+  ng-messages, [ng-messages],
+  ng-message, data-ng-message, x-ng-message,
+  [ng-message], [data-ng-message], [x-ng-message],
+  [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
+    color: '{{warn-500}}';
   }
-
 
   &:not(.md-input-invalid) {
     &.md-input-has-value {
@@ -65,6 +66,7 @@ md-input-container.md-THEME_NAME-theme {
     }
     ng-message, data-ng-message, x-ng-message,
     [ng-message], [data-ng-message], [x-ng-message],
+    [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
     .md-char-counter {
       color: '{{warn-500}}';
     }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -27,8 +27,10 @@ angular.module('material.components.input', [
  * Input and textarea elements will not behave properly unless the md-input-container
  * parent is provided.
  *
- * @param md-is-error {expression=} When the given expression evaluates to true, the input container will go into error state. Defaults to erroring if the input has been touched and is invalid.
- * @param md-no-float {boolean=} When present, placeholders will not be converted to floating labels
+ * @param md-is-error {expression=} When the given expression evaluates to true, the input container
+ *   will go into error state. Defaults to erroring if the input has been touched and is invalid.
+ * @param md-no-float {boolean=} When present, placeholders will not be converted to floating
+ *   labels.
  *
  * @usage
  * <hljs lang="html">
@@ -55,6 +57,7 @@ function mdInputContainerDirective($mdTheming, $parse) {
   function postLink(scope, element, attr) {
     $mdTheming(element);
   }
+
   function ContainerCtrl($scope, $element, $attrs) {
     var self = this;
 
@@ -72,6 +75,9 @@ function mdInputContainerDirective($mdTheming, $parse) {
     };
     self.setHasMessages = function(hasMessages) {
       $element.toggleClass('md-input-has-messages', !!hasMessages);
+    };
+    self.setHasPlaceholder = function(hasPlaceholder) {
+      $element.toggleClass('md-input-has-placeholder', !!hasPlaceholder);
     };
     self.setInvalid = function(isInvalid) {
       $element.toggleClass('md-input-invalid', !!isInvalid);
@@ -110,10 +116,15 @@ function labelDirective() {
  * @description
  * Use the `<input>` or the  `<textarea>` as a child of an `<md-input-container>`.
  *
- * @param {number=} md-maxlength The maximum number of characters allowed in this input. If this is specified, a character counter will be shown underneath the input.<br/><br/>
- * The purpose of **`md-maxlength`** is exactly to show the max length counter text. If you don't want the counter text and only need "plain" validation, you can use the "simple" `ng-maxlength` or maxlength attributes.
- * @param {string=} aria-label Aria-label is required when no label is present.  A warning message will be logged in the console if not present.
- * @param {string=} placeholder An alternative approach to using aria-label when the label is not present.  The placeholder text is copied to the aria-label attribute.
+ * @param {number=} md-maxlength The maximum number of characters allowed in this input. If this is
+ *   specified, a character counter will be shown underneath the input.<br/><br/>
+ *   The purpose of **`md-maxlength`** is exactly to show the max length counter text. If you don't
+ *   want the counter text and only need "plain" validation, you can use the "simple" `ng-maxlength`
+ *   or maxlength attributes.
+ * @param {string=} aria-label Aria-label is required when no label is present.  A warning message
+ *   will be logged in the console if not present.
+ * @param {string=} placeholder An alternative approach to using aria-label when the label is not
+ *   PRESENT. The placeholder text is copied to the aria-label attribute.
  * @param md-no-autogrow {boolean=} When present, textareas will not grow automatically.
  *
  * @usage
@@ -172,13 +183,13 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
     var isReadonly = angular.isDefined(attr.readonly);
 
-    if ( !containerCtrl ) return;
+    if (!containerCtrl) return;
     if (containerCtrl.input) {
       throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
     }
     containerCtrl.input = element;
 
-    if(!containerCtrl.label) {
+    if (!containerCtrl.label) {
       $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
     }
 
@@ -199,8 +210,8 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-      return ngModelCtrl.$invalid && ngModelCtrl.$touched;
-    };
+        return ngModelCtrl.$invalid && ngModelCtrl.$touched;
+      };
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
@@ -236,14 +247,15 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
       return arg;
     }
+
     function inputCheckValue() {
       // An input's value counts if its length > 0,
       // or if the input's validity state says it has bad input (eg string in a number input)
-      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity||{}).badInput);
+      containerCtrl.setHasValue(element.val().length > 0 || (element[0].validity || {}).badInput);
     }
 
     function setupTextarea() {
-      if(angular.isDefined(element.attr('md-no-autogrow'))) {
+      if (angular.isDefined(element.attr('md-no-autogrow'))) {
         return;
       }
 
@@ -254,7 +266,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       var lineHeight = null;
       // can't check if height was or not explicity set,
       // so rows attribute will take precedence if present
-      if(node.hasAttribute('rows')) {
+      if (node.hasAttribute('rows')) {
         min_rows = parseInt(node.getAttribute('rows'));
       }
 
@@ -273,7 +285,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
       }
       element.on('keydown input', onChangeTextarea);
 
-      if(isNaN(min_rows)) {
+      if (isNaN(min_rows)) {
         element.attr('rows', '1');
 
         element.on('scroll', onScroll);
@@ -292,7 +304,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
         // temporarily disables element's flex so its height 'runs free'
         element.addClass('md-no-flex');
 
-        if(isNaN(min_rows)) {
+        if (isNaN(min_rows)) {
           node.style.height = "auto";
           node.scrollTop = 0;
           var height = getHeight();
@@ -300,7 +312,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
         } else {
           node.setAttribute("rows", 1);
 
-          if(!lineHeight) {
+          if (!lineHeight) {
             node.style.minHeight = '0';
 
             lineHeight = element.prop('clientHeight');
@@ -317,7 +329,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
         container.style.height = 'auto';
       }
 
-      function getHeight () {
+      function getHeight() {
         var line = node.scrollHeight - node.offsetHeight;
         return node.offsetHeight + (line > 0 ? line : 0);
       }
@@ -378,7 +390,7 @@ function mdMaxlengthDirective($animate) {
     };
 
     function renderCharCount(value) {
-      charCountEl.text( ( element.val() || value || '' ).length + '/' + maxlength );
+      charCountEl.text(( element.val() || value || '' ).length + '/' + maxlength);
       return value;
     }
   }
@@ -393,23 +405,29 @@ function placeholderDirective($log) {
   };
 
   function postLink(scope, element, attr, inputContainer) {
+    // If there is no input container, just return
     if (!inputContainer) return;
-    if (angular.isDefined(inputContainer.element.attr('md-no-float'))) return;
 
+    // Add a placeholder class so we can target it in the CSS
+    inputContainer.setHasPlaceholder(true);
+
+    var label = inputContainer.element.find('label');
+    var hasNoFloat = angular.isDefined(inputContainer.element.attr('md-no-float'));
+
+    // If we have a label, or they specify the md-no-float attribute, just return
+    if ((label && label.length) || hasNoFloat) return;
+
+    // Otherwise, grab/remove the placeholder
     var placeholderText = attr.placeholder;
     element.removeAttr('placeholder');
 
-    if ( inputContainer.element.find('label').length == 0 ) {
-      if (inputContainer.input && inputContainer.input[0].nodeName != 'MD-SELECT') {
-        var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
+    // And add the placeholder text as a separate label
+    if (inputContainer.input && inputContainer.input[0].nodeName != 'MD-SELECT') {
+      var placeholder = '<label ng-click="delegateClick()">' + placeholderText + '</label>';
 
-        inputContainer.element.addClass('md-icon-float');
-        inputContainer.element.prepend(placeholder);
-      }
-    } else if (element[0].nodeName != 'MD-SELECT') {
-      $log.warn("The placeholder='" + placeholderText + "' will be ignored since this md-input-container has a child label element.");
+      inputContainer.element.addClass('md-icon-float');
+      inputContainer.element.prepend(placeholder);
     }
-
   }
 }
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -28,6 +28,12 @@ md-input-container {
   padding: $input-container-padding;
   padding-bottom: $input-container-padding + $input-error-height;
 
+  // When we have ng-messages, remove the input error height from our bottom padding, since the
+  // ng-messages wrapper has a min-height of 1 error (so we don't adjust height as often; see below)
+  &.md-input-has-messages {
+    padding-bottom: $input-container-padding;
+  }
+
   > md-icon {
     position: absolute;
     top: 5px;
@@ -143,6 +149,9 @@ md-input-container {
     -ms-flex-preferred-size: $input-line-height; //IE fix
     border-radius: 0;
 
+    // Fix number inputs in Firefox to be full-width
+    width: auto;
+
     &:focus {
       outline: none;
     }
@@ -156,44 +165,65 @@ md-input-container {
     }
   }
 
+  .md-char-counter {
+    position: absolute;
+    right: 0;
+    order: 3;
+  }
+
   ng-messages, data-ng-messages, x-ng-messages,
   [ng-messages], [data-ng-messages], [x-ng-messages] {
-    order: 3;
     position: relative;
+    order: 4;
+    min-height: $input-error-height;
   }
+
   ng-message, data-ng-message, x-ng-message,
   [ng-message], [data-ng-message], [x-ng-message],
+  [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
   .md-char-counter {
+    $input-error-line-height: $input-error-font-size + 2px;
     //-webkit-font-smoothing: antialiased;
-    position: absolute;
     font-size: $input-error-font-size;
-    line-height: $input-error-height;
+    line-height: $input-error-line-height;
+    overflow: hidden;
+
+    // Add some top padding which is equal to half the difference between the expected height
+    // and the actual height
+    $error-padding-top: ($input-error-height - $input-error-line-height) / 2;
+    padding-top: $error-padding-top;
 
     &:not(.md-char-counter) {
-      padding-right: rem(3);
+      padding-right: rem(5);
     }
 
     &.ng-enter {
-      transition: $swift-ease-out;
-      transition-delay: 0.2s;
+      transition: $swift-ease-in;
+
+      // Delay the enter transition so it happens after the leave
+      transition-delay: $swift-ease-in-duration / 1.5;
+
+      // Since we're delaying the transition, we speed up the duration a little bit to compensate
+      transition-duration: $swift-ease-in-duration / 1.5;
     }
     &.ng-leave {
-      transition: $swift-ease-in;
+      transition: $swift-ease-out;
+
+      // Speed up the duration (see enter comment above)
+      transition-duration: $swift-ease-out-duration / 1.5;
     }
     &.ng-enter,
     &.ng-leave.ng-leave-active {
+      // Move the error upwards off the screen and fade it out
+      margin-top: -$input-error-line-height - $error-padding-top;
       opacity: 0;
-      transform: translate3d(0, -20%, 0);
     }
     &.ng-leave,
     &.ng-enter.ng-enter-active {
+      // Move the error down into position and fade it in
+      margin-top: 0;
       opacity: 1;
-      transform: translate3d(0, 0, 0);
     }
-  }
-  .md-char-counter {
-    bottom: $input-container-padding;
-    right: $input-container-padding;
   }
 
   &.md-input-focused,

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -227,9 +227,18 @@ md-input-container {
   }
 
   &.md-input-focused,
+  &.md-input-has-placeholder,
   &.md-input-has-value {
-    label:not(.md-no-float)  {
+    label:not(.md-no-float) {
       transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
+    }
+  }
+
+  // If we have an existing value; don't animate the transform as it happens on page load and
+  // causes erratic/unnecessary animation
+  &.md-input-has-value {
+    label {
+      transition: none;
     }
   }
 

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -7,8 +7,8 @@ describe('md-input-container directive', function() {
     var container;
     inject(function($rootScope, $compile) {
       container = $compile((isForm ? '<form>' : '') +
-                           '<md-input-container><input ' +(attrs||'')+ '><label></label></md-input-container>' +
-                           (isForm ? '<form>' : ''))($rootScope);
+        '<md-input-container><input ' + (attrs || '') + '><label></label></md-input-container>' +
+        (isForm ? '<form>' : ''))($rootScope);
       $rootScope.$apply();
     });
     return container;
@@ -107,10 +107,10 @@ describe('md-input-container directive', function() {
 
     it('should work with a constant', inject(function($rootScope, $compile) {
       var el = $compile('<form name="form">' +
-                        ' <md-input-container>' +
-                        '   <input md-maxlength="5" ng-model="foo" name="foo">' +
-                        ' </md-input-container>' +
-                        '</form>')($rootScope);
+        ' <md-input-container>' +
+        '   <input md-maxlength="5" ng-model="foo" name="foo">' +
+        ' </md-input-container>' +
+        '</form>')($rootScope);
       $rootScope.$apply();
       expect($rootScope.form.foo.$error['md-maxlength']).toBeFalsy();
       expect(getCharCounter(el).text()).toBe('0/5');
@@ -132,10 +132,10 @@ describe('md-input-container directive', function() {
 
     it('should add and remove maxlength element & error with expression', inject(function($rootScope, $compile) {
       var el = $compile('<form name="form">' +
-                        ' <md-input-container>' +
-                        '   <input md-maxlength="max" ng-model="foo" name="foo">' +
-                        ' </md-input-container>' +
-                        '</form>')($rootScope);
+        ' <md-input-container>' +
+        '   <input md-maxlength="max" ng-model="foo" name="foo">' +
+        ' </md-input-container>' +
+        '</form>')($rootScope);
 
       $rootScope.$apply();
       expect($rootScope.form.foo.$error['md-maxlength']).toBeFalsy();
@@ -165,21 +165,26 @@ describe('md-input-container directive', function() {
   }));
 
   it('should ignore placeholder when a label element is present', inject(function($rootScope, $compile) {
-      var el = $compile('<md-input-container><label>Hello</label><input ng-model="foo" placeholder="some placeholder"></md-input-container>')($rootScope);
-      var placeholder = el[0].querySelector('.md-placeholder');
-      var label = el.find('label')[0];
+    var el = $compile(
+      '<md-input-container>' +
+      '  <label>Hello</label>' +
+      '  <input ng-model="foo" placeholder="some placeholder" />' +
+      '</md-input-container>'
+    )($rootScope);
 
-      expect(el.find('input')[0].hasAttribute('placeholder')).toBe(false);
-      expect(label).toBeTruthy();
-      expect(label.textContent).toEqual('Hello');
-    }));
+    var label = el.find('label')[0];
+
+    expect(el.find('input')[0].hasAttribute('placeholder')).toBe(true);
+    expect(label).toBeTruthy();
+    expect(label.textContent).toEqual('Hello');
+  }));
 
   it('should put an aria-label on the input when no label is present', inject(function($rootScope, $compile) {
     var el = $compile('<form name="form">' +
-                      ' <md-input-container md-no-float>' +
-                      '   <input placeholder="baz" md-maxlength="max" ng-model="foo" name="foo">' +
-                      ' </md-input-container>' +
-                      '</form>')($rootScope);
+      ' <md-input-container md-no-float>' +
+      '   <input placeholder="baz" md-maxlength="max" ng-model="foo" name="foo">' +
+      ' </md-input-container>' +
+      '</form>')($rootScope);
 
     $rootScope.$apply();
 
@@ -190,10 +195,10 @@ describe('md-input-container directive', function() {
   it('should put the container in "has value" state when input has a static value', inject(function($rootScope, $compile) {
     var scope = $rootScope.$new();
     var template =
-        '<md-input-container>' +
-          '<label>Name</label>' +
-          '<input value="Larry">' +
-        '</md-input-container>';
+      '<md-input-container>' +
+      '<label>Name</label>' +
+      '<input value="Larry">' +
+      '</md-input-container>';
 
     var element = $compile(template)(scope);
     scope.$apply();

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -64,7 +64,7 @@ function mdListDirective($mdTheming) {
  * </hljs>
  *
  */
-function mdListItemDirective($mdAria, $mdConstant, $timeout) {
+function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
   var proxiedTypes = ['md-checkbox', 'md-switch'];
   return {
     restrict: 'E',
@@ -227,7 +227,8 @@ function mdListItemDirective($mdAria, $mdConstant, $timeout) {
 
         if (proxies.length && firstChild) {
           $element.children().eq(0).on('click', function(e) {
-            if (firstChild.contains(e.target)) {
+            var parentButton = $mdUtil.getClosest(e.target, 'BUTTON');
+            if (!parentButton && firstChild.contains(e.target)) {
               angular.forEach(proxies, function(proxy) {
                 if (e.target !== proxy && !proxy.contains(e.target)) {
                   angular.element(proxy).triggerHandler('click');

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -185,6 +185,9 @@ md-list-item.md-3-line > .md-no-style {
       letter-spacing: 0.010em;
       margin: $list-h3-margin;
       line-height: $list-header-line-height;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
     h4 {
       font-size: $body-font-size-base;
@@ -192,6 +195,9 @@ md-list-item.md-3-line > .md-no-style {
       margin: $list-h4-margin;
       font-weight: $list-h4-font-weight;
       line-height: $list-header-line-height;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
     p {
       font-size: $body-font-size-base;

--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -148,7 +148,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout) {
     if (!skipFocus) {
       var el = self.restoreFocusTo || $element.find('button')[0];
       if (el instanceof angular.element) el = el[0];
-      el.focus();
+      if (el) el.focus();
     }
   };
 

--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -100,7 +100,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout) {
       preserveElement: self.isInMenuBar || self.nestedMenus.length > 0,
       parent: self.isInMenuBar ? $element : 'body'
     });
-  }
+  };
 
   // Expose a open function to the child scope for html to use
   $scope.$mdOpenMenu = this.open;
@@ -133,6 +133,10 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout) {
     this.containerProxy && this.containerProxy(ev);
   };
 
+  this.destroy = function() {
+    return $mdMenu.destroy();
+  };
+
   // Use the $mdMenu interim element service to close the menu contents
   this.close = function closeMenu(skipFocus, closeOpts) {
     if ( !self.isOpen ) return;
@@ -140,12 +144,13 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout) {
 
     $scope.$emit('$mdMenuClose', $element);
     $mdMenu.hide(null, closeOpts);
+
     if (!skipFocus) {
       var el = self.restoreFocusTo || $element.find('button')[0];
       if (el instanceof angular.element) el = el[0];
       el.focus();
     }
-  }
+  };
 
   /**
    * Build a nice object out of our string attribute which specifies the

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -191,8 +191,11 @@ function MenuDirective($mdUtil) {
     mdMenuCtrl.init(menuContainer, { isInMenuBar: isInMenuBar });
 
     scope.$on('$destroy', function() {
-      menuContainer.remove();
-      mdMenuCtrl.close();
+      mdMenuCtrl
+        .destroy()
+        .finally(function(){
+          menuContainer.remove();
+        });
     });
 
   }

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -213,10 +213,14 @@ function MenuProvider($$interimElementProvider) {
         opts.menuContentEl[0].addEventListener('click', captureClickListener, true);
 
         // kick off initial focus in the menu on the first element
-        var focusTarget = opts.menuContentEl[0].querySelector('[md-menu-focus-target]') ||
-          opts.menuContentEl[0].firstElementChild.querySelector('[tabindex]') ||
-          opts.menuContentEl[0].firstElementChild.firstElementChild;
-        focusTarget.focus();
+        var focusTarget = opts.menuContentEl[0].querySelector('[md-menu-focus-target]');
+        if ( !focusTarget && firstChild ) {
+          var firstChild = opts.menuContentEl[0].firstElementChild;
+
+          focusTarget = firstChild.querySelector('[tabindex]') || firstChild.firstElementChild;
+        }
+
+        focusTarget && focusTarget.focus();
 
         return function cleanupInteraction() {
           element.removeClass('md-clickable');

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -17,6 +17,7 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
     margin-top: $baseline-grid / 2;
     margin-bottom: $baseline-grid / 2;
     height: 1px;
+    min-height: 1px;
     width: 100%;
   }
 

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -79,6 +79,10 @@ md-menu-item {
     padding-right: 2*$baseline-grid;
   }
 
+  > a.md-button {
+    display: flex;
+  }
+
   > .md-button {
     border-radius: 0;
     margin: auto 0;

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -17,7 +17,6 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
     margin-top: $baseline-grid / 2;
     margin-bottom: $baseline-grid / 2;
     height: 1px;
-    min-height: 1px;
     width: 100%;
   }
 

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -86,6 +86,7 @@ describe('material.components.menu', function() {
     });
 
     it('closes on backdrop click', inject(function($document) {
+
       openMenu(setup());
 
       expect(getOpenMenuContainer().length).toBe(1);
@@ -96,6 +97,7 @@ describe('material.components.menu', function() {
       expect(getOpenMenuContainer().length).toBe(0);
     }));
 
+
     it('closes on escape', inject(function($document, $mdConstant) {
       openMenu(setup());
       expect(getOpenMenuContainer().length).toBe(1);
@@ -104,6 +106,16 @@ describe('material.components.menu', function() {
 
       pressKey(openMenuEl, $mdConstant.KEY_CODE.ESCAPE);
       waitForMenuClose();
+
+      expect(getOpenMenuContainer().length).toBe(0);
+    }));
+
+    it('closes on $destroy', inject(function($document, $rootScope) {
+      var scope = $rootScope.$new();
+      openMenu( setup(null,false,scope) );
+
+      expect(getOpenMenuContainer().length).toBe(1);
+      scope.$destroy();
 
       expect(getOpenMenuContainer().length).toBe(0);
     }));
@@ -164,7 +176,7 @@ describe('material.components.menu', function() {
       }
     });
 
-    function setup(triggerType, noEvent) {
+    function setup(triggerType, noEvent, scope) {
       var menu,
         template = $mdUtil.supplant('' +
           '<md-menu>' +
@@ -180,7 +192,7 @@ describe('material.components.menu', function() {
         $rootScope.doSomething = function($event) {
           menuActionPerformed = true;
         };
-        menu = $compile(template)($rootScope);
+        menu = $compile(template)(scope || $rootScope);
       });
 
       attachedElements.push(menu);
@@ -192,7 +204,6 @@ describe('material.components.menu', function() {
   // ********************************************
   // Internal methods
   // ********************************************
-
 
   function getOpenMenuContainer() {
     var res;

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -151,7 +151,7 @@ describe('material.components.menu', function() {
         }
 
         function testAttribute(attr) {
-          return inject(function($rootScope, $compile) {
+          return inject(function($rootScope, $compile, $timeout, $browser, $animate) {
             var template = '' +
               '<md-menu>' +
               ' <button ng-click="$mdOpenMenu($event)">Hello World</button>' +
@@ -162,9 +162,12 @@ describe('material.components.menu', function() {
               ' </md-menu-content>' +
               '</md-menu>';
 
+
             openMenu($compile(template)($rootScope));
+
             expect(getOpenMenuContainer().length).toBe(1);
 
+            $timeout.flush();
             var btn = getOpenMenuContainer()[0].querySelector('md-button');
             btn.click();
 
@@ -226,23 +229,14 @@ describe('material.components.menu', function() {
   }
 
   function waitForMenuOpen() {
-    inject(function($rootScope, $$rAF, $timeout) {
-      $rootScope.$digest();
-
-        $$rAF.flush();      // flush $animate.enter(backdrop)
-        $$rAF.flush();      // flush $animateCss
-        $timeout.flush();   // flush response
-
+    inject(function($material) {
+      $material.flushInterimElement();
     });
   }
 
   function waitForMenuClose() {
-    inject(function($rootScope, $$rAF, $timeout) {
-      $rootScope.$digest();
-
-        $$rAF.flush();      // flush $animate.leave(backdrop)
-        $$rAF.flush();      // flush $animateCss
-        $timeout.flush();   // flush response
+    inject(function($material) {
+      $material.flushInterimElement();
     });
   }
 

--- a/src/components/progressCircular/progress-circular.js
+++ b/src/components/progressCircular/progress-circular.js
@@ -95,6 +95,8 @@ function MdProgressCircularDirective($mdTheming, $mdUtil, $log) {
     var spinnerWrapper =  angular.element(element.children()[0]);
     var lastMode, toVendorCSS = $mdUtil.dom.animator.toCss;
 
+    element.attr('md-mode', mode());
+
     updateScale();
     validateMode();
     watchAttributes();
@@ -210,7 +212,7 @@ function MdProgressCircularDirective($mdTheming, $mdUtil, $log) {
      * Is the md-mode a valid option?
      */
     function mode() {
-      var value = attr.mdMode;
+      var value = (attr.mdMode || "").trim();
       if ( value ) {
         switch(value) {
           case MODE_DETERMINATE :

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -25,6 +25,19 @@ describe('mdProgressCircular', function() {
     expect(progress.attr('md-mode')).toEqual('indeterminate');
   }));
 
+  it('should trim the md-mode value', inject(function($compile, $rootScope, $mdConstant) {
+    element = $compile('<div>' +
+          '<md-progress-circular md-mode=" indeterminate"></md-progress-circular>' +
+          '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+    });
+
+    var progress = element.find('md-progress-circular');
+    expect(progress.attr('md-mode')).toEqual('indeterminate');
+  }));
+
   it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
       '<md-progress-circular value="{{progress}}"></md-progress-circular>' +

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -81,10 +81,13 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
   }
   function postLink(scope, element, attr) {
     $mdTheming(element);
+
     var lastMode, toVendorCSS = $mdUtil.dom.animator.toCss;
     var bar1 = angular.element(element[0].querySelector('.md-bar1')),
         bar2 = angular.element(element[0].querySelector('.md-bar2')),
         container = angular.element(element[0].querySelector('.md-container'));
+
+    element.attr('md-mode', mode());
 
     validateMode();
     watchAttributes();
@@ -142,7 +145,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
      * Is the md-mode a valid option?
      */
     function mode() {
-      var value = attr.mdMode;
+      var value = (attr.mdMode || "").trim();
       if ( value ) {
         switch(value) {
           case MODE_DETERMINATE:

--- a/src/components/progressLinear/progress-linear.spec.js
+++ b/src/components/progressLinear/progress-linear.spec.js
@@ -16,6 +16,18 @@ describe('mdProgressLinear', function() {
     expect(progress.attr('md-mode')).toEqual('indeterminate');
   }));
 
+  it('should trim the md-mode value', inject(function($compile, $rootScope, $mdConstant) {
+    element = $compile('<div>' +
+          '<md-progress-linear md-mode=" indeterminate"></md-progress-linear>' +
+          '</div>')($rootScope);
+
+    $rootScope.$apply(function() {
+    });
+
+    var progress = element.find('md-progress-linear');
+    expect(progress.attr('md-mode')).toEqual('indeterminate');
+  }));
+
   it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
     var element = $compile('<div>' +
       '<md-progress-linear value="{{progress}}"></md-progress-linear>' +

--- a/src/components/select/demoBasicUsage/index.html
+++ b/src/components/select/demoBasicUsage/index.html
@@ -2,18 +2,23 @@
   <div>
     <h1 class="md-title">Enter an address</h1>
     <div layout="row">
+
       <md-input-container>
         <label>Street Name</label>
-        <input type="text"/>
+        <input>
       </md-input-container>
+
       <md-input-container>
         <label>City</label>
-        <input type="text"/>
+        <input>
       </md-input-container>
+
       <md-input-container>
         <label>State</label>
         <md-select ng-model="ctrl.userState">
-          <md-option ng-repeat="state in ctrl.states" value="{{state.abbrev}}">{{state.abbrev}}</md-option>
+          <md-option ng-repeat="state in ctrl.states" value="{{state.abbrev}}">
+            {{state.abbrev}}
+          </md-option>
         </md-select>
       </md-input-container>
     </div>

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -1,4 +1,9 @@
 md-select.md-THEME_NAME-theme {
+  &[disabled] .md-select-value {
+    border-bottom-color: transparent;
+    background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
+    background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
+  }
   .md-select-value {
     &.md-select-placeholder {
       color: '{{foreground-3}}';

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -344,7 +344,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $rootElement, 
         selectEl.data('$mdSelectController', mdSelectCtrl);
         selectScope = scope.$new();
         $mdTheming.inherit(selectContainer, element);
-        selectContainer[0].setAttribute('class', selectContainer[0].getAttribute('class') + ' ' + element.attr('md-container-class'));
+        if (element.attr('md-container-class')) {
+          selectContainer[0].setAttribute('class', selectContainer[0].getAttribute('class') + ' ' + element.attr('md-container-class'));
+        }
         selectContainer = $compile(selectContainer)(selectScope);
         selectMenuCtrl = selectContainer.find('md-select-menu').controller('mdSelectMenu');
       }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -144,7 +144,6 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     attr.tabindex = attr.tabindex || '0';
 
     return function postLink(scope, element, attr, ctrls) {
-      var isOpen;
       var isDisabled;
 
       var containerCtrl = ctrls[0];
@@ -316,19 +315,22 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       element.attr(ariaAttrs);
 
       scope.$on('$destroy', function() {
-        if (isOpen) {
-          $mdSelect.hide().finally(function() {
-            selectContainer.remove();
+        $mdSelect
+          .destroy()
+          .finally(function() {
+            if ( selectContainer ) {
+              selectContainer.remove();
+            }
+
+            if (containerCtrl) {
+              containerCtrl.setFocused(false);
+              containerCtrl.setHasValue(false);
+              containerCtrl.input = null;
+            }
           });
-        } else {
-          selectContainer.remove();
-        }
-        if (containerCtrl) {
-          containerCtrl.setFocused(false);
-          containerCtrl.setHasValue(false);
-          containerCtrl.input = null;
-        }
       });
+
+
 
       function inputCheckValue() {
         // The select counts as having a value if one or more options are selected,
@@ -345,7 +347,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         selectScope = scope.$new();
         $mdTheming.inherit(selectContainer, element);
         if (element.attr('md-container-class')) {
-          selectContainer[0].setAttribute('class', selectContainer[0].getAttribute('class') + ' ' + element.attr('md-container-class'));
+          var value = selectContainer[0].getAttribute('class') + ' ' + element.attr('md-container-class');
+          selectContainer[0].setAttribute('class', value);
         }
         selectContainer = $compile(selectContainer)(selectScope);
         selectMenuCtrl = selectContainer.find('md-select-menu').controller('mdSelectMenu');
@@ -374,7 +377,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       }
 
       function openSelect() {
-        scope.$apply('isOpen = true');
+        selectScope.isOpen = true;
 
         $mdSelect.show({
           scope: selectScope,
@@ -385,7 +388,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           hasBackdrop: true,
           loadingAsync: attr.mdOnOpen ? scope.$eval(attr.mdOnOpen) || true : false
         }).then(function() {
-          isOpen = false;
+          selectScope.isOpen = false;
         });
       }
     };
@@ -782,38 +785,42 @@ function SelectProvider($$interimElementProvider) {
      * Interim-element onRemove logic....
      */
     function onRemove(scope, element, opts) {
+      opts = opts || { };
       opts.cleanupInteraction();
       opts.cleanupResizing();
       opts.hideBackdrop();
 
-      return $animateCss(element, {addClass: 'md-leave'})
-         .start()
-         .then(function(response) {
+      // For navigation $destroy events, do a quick, non-animated removal,
+      // but for normal closes (from clicks, etc) animate the removal
 
-           configureAria(opts.target, false);
-           element.removeClass('md-active');
+      return  (opts.$destroy === true) ? detachAndClean() : animateRemoval().then( detachAndClean );
 
-           announceClosed(opts);
-           detachElement(element, opts);
+      /**
+       * For normal closes (eg clicks), animate the removal.
+       * For forced closes (like $destroy events from navigation),
+       * skip the animations
+       */
+      function animateRemoval() {
+        return $animateCss(element, {addClass: 'md-leave'}).start();
+      }
 
-           return response;
-         })
-         .finally(function() {
-           opts.restoreFocus && opts.target.focus();
-         });
+      /**
+       * Detach the element and cleanup prior changes
+       */
+      function detachAndClean() {
+        configureAria(opts.target, false);
 
-      // If we want to ignore leave animations (and remove immediately):
-      //
-      //     configureAria(opts.target, false);
-      //
-      //     element.addClass('md-leave');
-      //     element.removeClass('md-active');
-      //
-      //     announceClosed(opts);
-      //     detachElement(element, opts);
-      //     opts.restoreFocus && opts.target.focus();
-      //
-      //     return $q.when(true);
+        element.attr('opacity', 0);
+        element.removeClass('md-active');
+        detachElement(element, opts);
+
+        announceClosed(opts);
+
+        if (!opts.$destroy && opts.restoreFocus) {
+          opts.target.focus();
+        }
+      }
+
     }
 
     /**
@@ -911,14 +918,10 @@ function SelectProvider($$interimElementProvider) {
          * Hide modal backdrop element...
          */
         return function hideBackdrop() {
-          if (options.backdrop) {
-            // Override duration to immediately remove invisible backdrop
-            $animate.leave(options.backdrop, {duration: 0});
-          }
-          if (options.disableParentScroll) {
-            options.restoreScroll();
-            delete options.restoreScroll;
-          }
+          if (options.backdrop) options.backdrop.remove();
+          if (options.disableParentScroll) options.restoreScroll();
+
+          delete options.restoreScroll;
         }
       }
 
@@ -1164,7 +1167,7 @@ function SelectProvider($$interimElementProvider) {
     }
 
     /**
-     * Use browser to remove this element without triggering a $destory event
+     * Use browser to remove this element without triggering a $destroy event
      */
     function detachElement(element, opts) {
       if (element[0].parentNode === opts.parent[0]) {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -70,7 +70,7 @@ angular.module('material.components.select', [
  *   </md-input-container>
  * </hljs>
  */
-function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $rootElement, $compile, $parse) {
+function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $parse) {
   return {
     restrict: 'E',
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
@@ -281,7 +281,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $rootElement, 
       });
 
       attr.$observe('disabled', function(disabled) {
-        if (typeof disabled == "string") {
+        if (angular.isString(disabled)) {
           disabled = true;
         }
         // Prevent click event being registered twice

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -184,6 +184,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         }
       }
 
+      if (formCtrl) {
+        $mdUtil.nextTick(function() {
+          formCtrl.$setPristine();
+        });
+      }
+
       var originalRender = ngModelCtrl.$render;
       ngModelCtrl.$render = function() {
         originalRender();
@@ -489,6 +495,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         // reference. This allowed the developer to also push and pop from their array.
         $scope.$watchCollection($attrs.ngModel, function(value) {
           if (validateArray(value)) renderMultiple(value);
+          self.ngModel.$setPristine();
         });
       } else {
         delete ngModel.$validators['md-multiple'];

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1124,12 +1124,12 @@ function SelectProvider($$interimElementProvider) {
            */
           function mouseOnScrollbar() {
             var clickOnScrollbar = false;
-            if(ev && (ev.currentTarget.children.length > 0)) {
+            if (ev && (ev.currentTarget.children.length > 0)) {
               var child = ev.currentTarget.children[0];
               var hasScrollbar = child.scrollHeight > child.clientHeight;
               if (hasScrollbar && child.children.length > 0) {
                 var relPosX = ev.pageX - ev.currentTarget.getBoundingClientRect().left;
-                if(relPosX > child.children[0].offsetWidth)
+                if (relPosX > child.querySelector('md-option').offsetWidth)
                   clickOnScrollbar = true;
               }
             }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -153,7 +153,7 @@ md-select-menu {
     }
   }
 
-  box-shadow: $whiteframe-shadow-z1;
+  box-shadow: $whiteframe-shadow-1dp;
   max-height: ($select-option-height * $select-max-visible-options) + 2 * $baseline-grid;
   min-height: $select-option-height;
   overflow-y: hidden;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -54,6 +54,14 @@ md-input-container > md-select {
 md-select {
   display: flex;
   margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
+  &[disabled] .md-select-value {
+    background-position: 0 bottom;
+    // This background-size is coordinated with a linear-gradient set in select-theme.scss
+    // to create a dotted line under the input.
+    background-size: 4px 1px;
+    background-repeat: repeat-x;
+    margin-bottom: -1px; // Shift downward so dotted line is positioned the same as other bottom borders
+  }
   &:focus {
     outline: none;
   }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -53,6 +53,7 @@ describe('<md-select>', function() {
       type: 'click',
       target: angular.element($document.find('md-option')[0])
     });
+
     waitForSelectClose();
 
     expect(called).toBe(true);
@@ -651,7 +652,7 @@ describe('<md-select>', function() {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('sets up the aria-expanded attribute', inject(function($document) {
+    it('sets up the aria-expanded attribute', inject(function($document, $timeout) {
       disableAnimations();
 
       expect(el.attr('aria-expanded')).toBe('false');
@@ -815,34 +816,15 @@ describe('<md-select>', function() {
   }
 
   function waitForSelectOpen() {
-    try {
-      inject(function($rootScope, $timeout, $$rAF) {
-          $rootScope.$digest();
-
-            $$rAF.flush();  // flush $animate.enter(backdrop)
-          $timeout.flush(); // flush response
-            $$rAF.flush();  // flush $animateCss
-          $timeout.flush(); // flush response
-
-          $rootScope.$digest();
-      });
-    } catch(e) { }
+    inject(function($material) {
+      $material.flushInterimElement();
+    });
   }
 
   function waitForSelectClose() {
-    try {
-      inject(function($rootScope, $timeout, $$rAF) {
-          $rootScope.$digest();
-
-          $$rAF.flush();    // flush $animate.leave(backdrop)
-          $timeout.flush(); // flush response
-
-          $rootScope.$digest();
-
-          $$rAF.flush();
-          $rootScope.$digest();
-      });
-    } catch(e) { }
+    inject(function($material) {
+      $material.flushInterimElement();
+    });
   }
 
 });

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -242,9 +242,14 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     };
     var backdrop = $mdUtil.createBackdrop(scope, "md-sidenav-backdrop md-opaque ng-enter");
 
-    element.on('$destroy', sidenavCtrl.destroy);
     $mdTheming.inherit(backdrop, element);
 
+    element.on('$destroy', function() {
+      backdrop.remove();
+      sidenavCtrl.destroy();
+    });
+
+    scope.$on('$destroy', backdrop.remove );
     scope.$watch(isLocked, updateIsLocked);
     scope.$watch('isOpen', updateIsOpen);
 

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -15,25 +15,25 @@ describe('mdSidenav', function() {
 
   describe('directive', function() {
 
-    it('should bind isOpen attribute', inject(function($rootScope, $animate) {
+    it('should bind isOpen attribute', inject(function($rootScope, $material) {
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect(el.hasClass('md-closed')).toBe(false);
       expect(el.parent().find('md-backdrop').length).toBe(1);
 
       $rootScope.$apply('show = false');
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect(el.hasClass('md-closed')).toBe(true);
       expect(el.parent().find('md-backdrop').length).toBe(0);
     }));
 
-    it('should close on escape', inject(function($rootScope, $animate, $mdConstant, $timeout) {
+    it('should close on escape', inject(function($rootScope, $material, $mdConstant, $timeout) {
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       el.parent().triggerHandler({
         type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
@@ -42,26 +42,26 @@ describe('mdSidenav', function() {
       expect($rootScope.show).toBe(false);
     }));
 
-    it('should close on backdrop click', inject(function($rootScope, $animate, $timeout) {
+    it('should close on backdrop click', inject(function($rootScope, $material, $timeout) {
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       el.parent().find('md-backdrop').triggerHandler('click');
       $timeout.flush();
       expect($rootScope.show).toBe(false);
     }));
 
-    it('should focus sidenav on open', inject(function($rootScope, $animate, $document) {
+    it('should focus sidenav on open', inject(function($rootScope, $material, $document) {
       jasmine.mockElementFocus(this);
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect($document.activeElement).toBe(el[0]);
     }));
 
-    it('should focus child with md-sidenav-focus', inject(function($rootScope, $animate, $document, $compile) {
+    it('should focus child with md-sidenav-focus', inject(function($rootScope, $material, $document, $compile) {
       jasmine.mockElementFocus(this);
       var parent = angular.element('<div>');
       var markup = '<md-sidenav md-is-open="show">'+
@@ -75,11 +75,11 @@ describe('mdSidenav', function() {
       $rootScope.$apply('show = true');
 
       var focusEl = sidenavEl.find('input');
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect($document.activeElement).toBe(focusEl[0]);
     }));
 
-    it('should focus child with md-autofocus', inject(function($rootScope, $animate, $document, $compile) {
+    it('should focus child with md-autofocus', inject(function($rootScope, $material, $document, $compile) {
       jasmine.mockElementFocus(this);
       var parent = angular.element('<div>');
       var markup = '<md-sidenav md-is-open="show">'+
@@ -93,12 +93,12 @@ describe('mdSidenav', function() {
       $rootScope.$apply('show = true');
 
       var focusEl = sidenavEl.find('input');
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect($document.activeElement).toBe(focusEl[0]);
     }));
 
 
-    it('should focus on last md-sidenav-focus element', inject(function($rootScope, $animate, $document, $compile) {
+    it('should focus on last md-sidenav-focus element', inject(function($rootScope, $material, $document, $compile) {
       jasmine.mockElementFocus(this);
       var parent = angular.element('<div>');
       var markup = '<md-sidenav md-is-open="show">'+
@@ -112,18 +112,18 @@ describe('mdSidenav', function() {
       $compile(parent)($rootScope);
       $rootScope.$apply('show = true');
 
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       var focusEl = sidenavEl.find('input');
       expect($document.activeElement).toBe(focusEl[0]);
     }));
 
-    it('should lock open when is-locked-open is true', inject(function($rootScope, $animate, $document) {
+    it('should lock open when is-locked-open is true', inject(function($rootScope, $material, $document) {
       var el = setup('md-is-open="show" md-is-locked-open="lock"');
       expect(el.hasClass('md-locked-open')).toBe(false);
       $rootScope.$apply('lock = true');
       expect(el.hasClass('md-locked-open')).toBe(true);
       $rootScope.$apply('show = true');
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       expect(el.parent().find('md-backdrop').hasClass('md-locked-open')).toBe(true);
     }));
 
@@ -174,17 +174,14 @@ describe('mdSidenav', function() {
   });
 
   describe("controller Promise API", function() {
-    var $animate, $rootScope;
+    var $material, $rootScope;
 
-      function flush() {
-        if ( !$rootScope.$$phase) {
-          $rootScope.$apply();
-        }
-        $animate.triggerCallbacks();
-      }
+    function flush() {
+      $material.flushInterimElement();
+    }
 
-    beforeEach( inject(function(_$animate_,_$rootScope_,_$timeout_) {
-        $animate = _$animate_;
+    beforeEach( inject(function(_$material_,_$rootScope_,_$timeout_) {
+        $material = _$material_;
         $rootScope = _$rootScope_;
         $timeout = _$timeout_;
     }));

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -50,22 +50,22 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     scope: {},
     require: '?ngModel',
     template:
-      '<div class="md-slider-wrapper">\
-        <div class="md-track-container">\
-          <div class="md-track"></div>\
-          <div class="md-track md-track-fill"></div>\
-          <div class="md-track-ticks"></div>\
-        </div>\
-        <div class="md-thumb-container">\
-          <div class="md-thumb"></div>\
-          <div class="md-focus-thumb"></div>\
-          <div class="md-focus-ring"></div>\
-          <div class="md-sign">\
-            <span class="md-thumb-text"></span>\
-          </div>\
-          <div class="md-disabled-thumb"></div>\
-        </div>\
-      </div>',
+      '<div class="md-slider-wrapper">' +
+        '<div class="md-track-container">' +
+          '<div class="md-track"></div>' +
+          '<div class="md-track md-track-fill"></div>' +
+          '<div class="md-track-ticks"></div>' +
+        '</div>' +
+        '<div class="md-thumb-container">' +
+          '<div class="md-thumb"></div>' +
+          '<div class="md-focus-thumb"></div>' +
+          '<div class="md-focus-ring"></div>' +
+          '<div class="md-sign">' +
+            '<span class="md-thumb-text"></span>' +
+          '</div>' +
+          '<div class="md-disabled-thumb"></div>' +
+        '</div>' +
+      '</div>',
     compile: compile
   };
 

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -98,10 +98,13 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       $viewChangeListeners: []
     };
 
-    var isDisabledParsed = attr.ngDisabled && $parse(attr.ngDisabled);
-    var isDisabledGetter = isDisabledParsed ?
-      function() { return isDisabledParsed(scope.$parent); } :
-      angular.noop;
+    var isDisabledGetter = angular.noop;
+    if (attr.disabled != null) {
+      isDisabledGetter = function() { return true; };
+    } else if (attr.ngDisabled) {
+      isDisabledGetter = angular.bind(null, $parse(attr.ngDisabled), scope.$parent);
+    }
+
     var thumb = angular.element(element[0].querySelector('.md-thumb'));
     var thumbText = angular.element(element[0].querySelector('.md-thumb-text'));
     var thumbContainer = thumb.parent();
@@ -139,7 +142,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       ngModelRender();
       redrawTicks();
     }
-    setTimeout(updateAll);
+    setTimeout(updateAll, 0);
 
     var debouncedUpdateAll = $$rAF.throttle(updateAll);
     angular.element($window).on('resize', debouncedUpdateAll);
@@ -306,7 +309,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     function onPressDown(ev) {
       if (isDisabledGetter()) return;
 
-      element.addClass('active');
+      element.addClass('md-active');
       element[0].focus();
       refreshSliderDimensions();
 
@@ -320,7 +323,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     function onPressUp(ev) {
       if (isDisabledGetter()) return;
 
-      element.removeClass('dragging active');
+      element.removeClass('md-dragging md-active');
 
       var exactVal = percentToValue( positionToPercent( ev.pointer.x ));
       var closestVal = minMaxValidator( stepValidator(exactVal) );
@@ -334,7 +337,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       isDragging = true;
       ev.stopPropagation();
 
-      element.addClass('dragging');
+      element.addClass('md-dragging');
       setSliderFromEvent(ev);
     }
     function onDrag(ev) {

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -214,7 +214,7 @@ md-slider {
   }
 
   /* Don't animate left/right while panning */
-  &.dragging {
+  &.md-dragging {
     .md-thumb-container,
     .md-track-fill {
       transition: none;
@@ -236,7 +236,7 @@ md-slider {
       }
 
       &:focus,
-      &.active {
+      &.md-active {
         .md-focus-thumb {
           display: block;
         }
@@ -259,7 +259,7 @@ md-slider {
 
     &:not([disabled]) {
       &:focus,
-      &.active {
+      &.md-active {
         .md-sign,
         .md-sign:after {
           opacity: 1;

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -1,101 +1,112 @@
 describe('md-slider', function() {
+  var $compile, $timeout, $log, $mdConstant, pageScope;
 
   beforeEach(module('ngAria'));
   beforeEach(module('material.components.slider'));
 
+  beforeEach(inject(function($injector) {
+    var $rootScope = $injector.get('$rootScope');
+    pageScope = $rootScope.$new();
+
+    $compile = $injector.get('$compile');
+    $timeout = $injector.get('$timeout');
+    $mdConstant = $injector.get('$mdConstant');
+    $log = $injector.get('$log');
+  }));
+
   function setup(attrs, dimensions) {
     var slider;
-    inject(function($compile, $rootScope) { 
-      slider = $compile('<md-slider ' + (attrs || '') + '>')($rootScope);
-      spyOn(
-        slider[0].querySelector('.md-track-container'), 
-        'getBoundingClientRect'
-      ).and.returnValue(angular.extend({
-        width: 100,
-        left: 0,
-        right: 0
-      }, dimensions || {}));
-    });
+
+    slider = $compile('<md-slider ' + (attrs || '') + '>')(pageScope);
+    spyOn(
+      slider[0].querySelector('.md-track-container'),
+      'getBoundingClientRect'
+    ).and.returnValue(angular.extend({
+      width: 100,
+      left: 0,
+      right: 0
+    }, dimensions || {}));
+
     return slider;
   }
 
-  it('should set model on press', inject(function($compile, $rootScope, $timeout) {
+  it('should set model on press', function() {
     var slider = setup('ng-model="value" min="0" max="100"');
-    $rootScope.$apply('value = 50');
+    pageScope.$apply('value = 50');
 
     slider.triggerHandler({type: '$md.pressdown', pointer: { x: 30 }});
     slider.triggerHandler({type: '$md.dragstart', pointer: { x: 30 }});
     $timeout.flush();
-    expect($rootScope.value).toBe(30);
+    expect(pageScope.value).toBe(30);
 
-    //When going past max, it should clamp to max
+    // When going past max, it should clamp to max.
     slider.triggerHandler({type: '$md.drag', pointer: { x: 150 }});
     $timeout.flush();
-    expect($rootScope.value).toBe(100);
+    expect(pageScope.value).toBe(100);
 
     slider.triggerHandler({type: '$md.drag', pointer: { x: 50 }});
     $timeout.flush();
-    expect($rootScope.value).toBe(50);
-  }));
+    expect(pageScope.value).toBe(50);
+  });
 
-  it('should increment model on right arrow', inject(function($compile, $rootScope, $timeout, $mdConstant) {
+  it('should increment model on right arrow', function() {
     var slider = setup('min="100" max="104" step="2" ng-model="model"');
-    $rootScope.$apply('model = 100');
+    pageScope.$apply('model = 100');
 
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(102);
+    expect(pageScope.model).toBe(102);
 
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(104);
+    expect(pageScope.model).toBe(104);
 
-    // Stays at max
+    // Stays at max.
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(104);
-  }));
+    expect(pageScope.model).toBe(104);
+  });
 
-  it('should decrement model on left arrow', inject(function($compile, $rootScope, $timeout, $mdConstant) {
+  it('should decrement model on left arrow', function() {
     var slider = setup('min="100" max="104" step="2" ng-model="model"');
-    $rootScope.$apply('model = 104');
+    pageScope.$apply('model = 104');
 
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.LEFT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(102);
+    expect(pageScope.model).toBe(102);
 
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.LEFT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(100);
+    expect(pageScope.model).toBe(100);
 
-    // Stays at min
+    // Stays at min.
     slider.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.LEFT_ARROW
     });
     $timeout.flush();
-    expect($rootScope.model).toBe(100);
-  }));
+    expect(pageScope.model).toBe(100);
+  });
 
-  it('should update the thumb text', inject(function($compile, $rootScope, $timeout, $mdConstant) {
+  it('should update the thumb text', function() {
     var slider = setup('ng-model="value" md-discrete min="0" max="100" step="1"');
 
-    $rootScope.$apply('value = 30');
+    pageScope.$apply('value = 30');
     expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
     slider.triggerHandler({
@@ -111,38 +122,37 @@ describe('md-slider', function() {
     slider.triggerHandler({type: '$md.dragstart', pointer: { x: 31 }});
     slider.triggerHandler({type: '$md.drag', pointer: { x: 31 }});
     expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('31');
-  }));
+  });
 
-  it('should update the thumb text with the model value when using ng-change', inject(function($compile, $rootScope, $timeout) {
-    $rootScope.stayAt50 = function () {
-      $rootScope.value = 50;
+  it('should update the thumb text with the model value when using ng-change', function() {
+    pageScope.stayAt50 = function () {
+      pageScope.value = 50;
     };
 
     var slider = setup('ng-model="value" min="0" max="100" ng-change="stayAt50()"');
-    var sliderCtrl = slider.controller('mdSlider');
 
     slider.triggerHandler({type: '$md.pressdown', pointer: { x: 30 }});
     $timeout.flush();
-    expect($rootScope.value).toBe(50);
+    expect(pageScope.value).toBe(50);
     expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('50');
-  }));
+  });
 
-  it('should call $log.warn if aria-label isnt provided', inject(function($compile, $rootScope, $timeout, $log) {
+  it('should call $log.warn if aria-label isnt provided', function() {
     spyOn($log, "warn");
-    var element = setup('min="100" max="104" step="2" ng-model="model"');
+    setup('min="100" max="104" step="2" ng-model="model"');
     expect($log.warn).toHaveBeenCalled();
-  }));
+  });
 
-  it('should not call $log.warn if aria-label is provided', inject(function($compile, $rootScope, $timeout, $log) {
+  it('should not call $log.warn if aria-label is provided', function() {
     spyOn($log, "warn");
-    var element = setup('aria-label="banana" min="100" max="104" step="2" ng-model="model"');
+    setup('aria-label="banana" min="100" max="104" step="2" ng-model="model"');
     expect($log.warn).not.toHaveBeenCalled();
-  }));
+  });
 
-  it('should add aria attributes', inject(function($compile, $rootScope, $timeout, $mdConstant){
+  it('should add aria attributes', function() {
     var slider = setup('min="100" max="104" step="2" ng-model="model"');
 
-    $rootScope.$apply('model = 102');
+    pageScope.$apply('model = 102');
 
     expect(slider.attr('role')).toEqual('slider');
     expect(slider.attr('aria-valuemin')).toEqual('100');
@@ -155,10 +165,10 @@ describe('md-slider', function() {
     });
     $timeout.flush();
     expect(slider.attr('aria-valuenow')).toEqual('100');
-  }));
+  });
 
-  it('should ignore pressdown events when disabled', inject(function($compile, $rootScope, $timeout) {
-    $rootScope.isDisabled = true;
+  it('should ignore pressdown events when disabled', function() {
+    pageScope.isDisabled = true;
     var slider = setup('ng-disabled="isDisabled"');
 
     // Doesn't add active class on pressdown when disabled
@@ -166,52 +176,64 @@ describe('md-slider', function() {
       type: '$md.pressdown',
       pointer: {}
     });
-    expect(slider).not.toHaveClass('active');
+    expect(slider).not.toHaveClass('md-active');
 
     // Doesn't remove active class up on pressup when disabled
-    slider.addClass('active');
+    slider.addClass('md-active');
     slider.triggerHandler({
       type: '$md.pressup',
       pointer: {}
     });
-    expect(slider).toHaveClass('active');
-  }));
+    expect(slider).toHaveClass('md-active');
+  });
 
-  it('should add active class on pressdown and remove on pressup', inject(function($rootScope) {
+  it('should disable via the `disabled` attribute', function() {
+    var slider = setup('disabled');
+    
+    // Check for disabled state by triggering the pressdown handler and asserting that
+    // the slider is not active.
+    slider.triggerHandler({
+      type: '$md.pressdown',
+      pointer: {}
+    });
+    expect(slider).not.toHaveClass('md-active');
+  });
+
+  it('should add active class on pressdown and remove on pressup', function() {
     var slider = setup();
 
-    expect(slider).not.toHaveClass('active');
+    expect(slider).not.toHaveClass('md-active');
 
     slider.triggerHandler({
       type: '$md.pressdown',
       pointer: {}
     });
-    expect(slider).toHaveClass('active');
+    expect(slider).toHaveClass('md-active');
 
     slider.triggerHandler({
       type: '$md.pressup',
       pointer: {}
     });
-    expect(slider).not.toHaveClass('active');
-  }));
+    expect(slider).not.toHaveClass('md-active');
+  });
   
-  it('should increment at a predictable step', inject(function($rootScope, $timeout) {
+  it('should increment at a predictable step', function() {
 
     buildSlider(0.1, 1).drag({x:70});
-    expect($rootScope.value).toBe(0.7);
+    expect(pageScope.value).toBe(0.7);
 
     buildSlider(0.25, 1).drag({x:45});
-    expect($rootScope.value).toBe(0.5);
+    expect(pageScope.value).toBe(0.5);
 
     buildSlider(0.25, 1).drag({x:35});
-    expect($rootScope.value).toBe(0.25);
+    expect(pageScope.value).toBe(0.25);
 
     buildSlider(1, 100).drag({x:90});
-    expect($rootScope.value).toBe(90);
+    expect(pageScope.value).toBe(90);
 
     function buildSlider(step, max) {
       var slider = setup('ng-model="value" min="0" max="' + max + '" step="' + step + '"');
-          $rootScope.$apply('value = 0.5');
+          pageScope.$apply('value = 0.5');
 
       return {
         drag : function simulateDrag(drag) {
@@ -224,6 +246,6 @@ describe('md-slider', function() {
       };
     }
 
-  }));
+  });
 
 });

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -47,12 +47,12 @@ angular.module('material.components.switch', [
  *
  * </hljs>
  */
-function MdSwitch(mdCheckboxDirective, $mdTheming, $mdUtil, $document, $mdConstant, $parse, $$rAF, $mdGesture) {
+function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdGesture) {
   var checkboxDirective = mdCheckboxDirective[0];
 
   return {
     restrict: 'E',
-    priority:210, // Run before ngAria
+    priority: 210, // Run before ngAria
     transclude: true,
     template:
       '<div class="md-container">' +
@@ -61,20 +61,26 @@ function MdSwitch(mdCheckboxDirective, $mdTheming, $mdUtil, $document, $mdConsta
           '<div class="md-thumb" md-ink-ripple md-ink-ripple-checkbox></div>' +
         '</div>'+
       '</div>' +
-      '<div ng-transclude class="md-label">' +
-      '</div>',
+      '<div ng-transclude class="md-label"></div>',
     require: '?ngModel',
-    compile: compile
+    compile: mdSwitchCompile
   };
 
-  function compile(element, attr) {
+  function mdSwitchCompile(element, attr) {
     var checkboxLink = checkboxDirective.compile(element, attr);
-    // no transition on initial load
+    // No transition on initial load.
     element.addClass('md-dragging');
 
     return function (scope, element, attr, ngModel) {
       ngModel = ngModel || $mdUtil.fakeNgModel();
-      var disabledGetter = $parse(attr.ngDisabled);
+
+      var disabledGetter = null;
+      if (attr.disabled != null) {
+        disabledGetter = function() { return true; };
+      } else if (attr.ngDisabled) {
+        disabledGetter = $parse(attr.ngDisabled);
+      }
+
       var thumbContainer = angular.element(element[0].querySelector('.md-thumb-container'));
       var switchContainer = angular.element(element[0].querySelector('.md-container'));
 
@@ -85,7 +91,7 @@ function MdSwitch(mdCheckboxDirective, $mdTheming, $mdUtil, $document, $mdConsta
 
       checkboxLink(scope, element, attr, ngModel);
 
-      if (angular.isDefined(attr.ngDisabled)) {
+      if (disabledGetter) {
         scope.$watch(disabledGetter, function(isDisabled) {
           element.attr('tabindex', isDisabled ? -1 : 0);
         });
@@ -100,14 +106,12 @@ function MdSwitch(mdCheckboxDirective, $mdTheming, $mdUtil, $document, $mdConsta
 
       var drag;
       function onDragStart(ev) {
-        // Don't go if ng-disabled===true
-        if (disabledGetter(scope)) return;
+        // Don't go if the switch is disabled.
+        if (disabledGetter && disabledGetter(scope)) return;
         ev.stopPropagation();
 
         element.addClass('md-dragging');
-        drag = {
-          width: thumbContainer.prop('offsetWidth')
-        };
+        drag = {width: thumbContainer.prop('offsetWidth')};
         element.removeClass('transition');
       }
 

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -81,7 +81,7 @@ md-switch {
     height: $switch-thumb-size;
     width: $switch-thumb-size;
     border-radius: 50%;
-    box-shadow: $whiteframe-shadow-z1;
+    box-shadow: $whiteframe-shadow-1dp;
 
     &:before {
       background-color: transparent;

--- a/src/components/switch/switch.spec.js
+++ b/src/components/switch/switch.spec.js
@@ -1,19 +1,28 @@
 describe('<md-switch>', function() {
   var CHECKED_CSS = 'md-checked';
+  var $compile, parentScope;
 
   beforeEach(module('ngAria', 'material.components.switch'));
 
-  it('should set checked css class and aria-checked attributes', inject(function($compile, $rootScope) {
-    var element = $compile('<div>' +
-                             '<md-switch ng-model="blue">' +
-                             '</md-switch>' +
-                             '<md-switch ng-model="green">' +
-                             '</md-switch>' +
-                           '</div>')($rootScope);
+  beforeEach(inject(function($injector) {
+    var $rootScope = $injector.get('$rootScope');
+    parentScope = $rootScope.$new();
 
-    $rootScope.$apply(function(){
-      $rootScope.blue = false;
-      $rootScope.green = true;
+    $compile = $injector.get('$compile');
+  }));
+
+  it('should set checked css class and aria-checked attributes', function() {
+    var template =
+        '<div>' +
+          '<md-switch ng-model="blue"></md-switch>' +
+          '<md-switch ng-model="green"></md-switch>' +
+        '</div>';
+
+    var element = $compile(template)(parentScope);
+
+    parentScope.$apply(function(){
+      parentScope.blue = false;
+      parentScope.green = true;
     });
 
     var switches = angular.element(element[0].querySelectorAll('md-switch'));
@@ -26,9 +35,9 @@ describe('<md-switch>', function() {
     expect(switches.eq(1).attr('aria-checked')).toEqual('true');
     expect(switches.eq(1).attr('role')).toEqual('checkbox');
 
-    $rootScope.$apply(function(){
-      $rootScope.blue = true;
-      $rootScope.green = false;
+    parentScope.$apply(function(){
+      parentScope.blue = true;
+      parentScope.green = false;
     });
 
     expect(switches.eq(1).hasClass(CHECKED_CSS)).toEqual(false);
@@ -36,17 +45,24 @@ describe('<md-switch>', function() {
     expect(switches.eq(1).attr('aria-checked')).toEqual('false');
     expect(switches.eq(0).attr('aria-checked')).toEqual('true');
     expect(switches.eq(1).attr('role')).toEqual('checkbox');
-  }));
+  });
 
-  it('should have tabindex -1 while disabled', inject(function($rootScope, $compile) {
-    $rootScope.value = false;
-    var el = $compile('<md-switch ng-disabled="$root.value">')($rootScope);
+  it('should have tabindex -1 while disabled', function() {
+    parentScope.value = false;
+    var el = $compile('<md-switch ng-disabled="value">')(parentScope);
 
-    $rootScope.$apply();
+    parentScope.$apply();
     expect(el.attr('tabindex')).not.toEqual('-1');
 
-    $rootScope.$apply('value = true');
+    parentScope.$apply('value = true');
     expect(el.attr('tabindex')).toEqual('-1');
-  }));
+  });
 
+  it('should disable via `disabled` attribute', function() {
+    parentScope.value = false;
+    var element = $compile('<md-switch disabled>')(parentScope);
+
+    parentScope.$apply();
+    expect(element.attr('tabindex')).toEqual('-1');
+  });
 });

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -226,18 +226,20 @@ md-tab-content {
 }
 
 md-ink-bar {
+  $duration: $swift-ease-in-out-duration * 0.5;
+  $multiplier: 0.5;
   position: absolute;
   left: auto;
   right: auto;
   bottom: 0;
   height: 2px;
   &.md-left {
-    transition: left ($swift-ease-in-out-duration * 0.45) $swift-ease-in-out-timing-function,
-        right $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
+    transition: left ($duration * $multiplier) $swift-ease-in-out-timing-function,
+        right $duration $swift-ease-in-out-timing-function;
   }
   &.md-right {
-    transition: left $swift-ease-in-out-duration $swift-ease-in-out-timing-function,
-        right ($swift-ease-in-out-duration * 0.45) $swift-ease-in-out-timing-function;
+    transition: left $duration $swift-ease-in-out-timing-function,
+        right ($duration * $multiplier) $swift-ease-in-out-timing-function;
   }
 }
 

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -11,9 +11,17 @@ angular.module('material.components.toast', [
   .directive('mdToast', MdToastDirective)
   .provider('$mdToast', MdToastProvider);
 
-function MdToastDirective() {
+/* @ngInject */
+function MdToastDirective($mdToast) {
   return {
-    restrict: 'E'
+    restrict: 'E',
+    link: function postLink(scope, element, attr) {
+      // When navigation force destroys an interimElement, then
+      // listen and $destroy() that interim instance...
+      scope.$on('$destroy', function() {
+        $mdToast.destroy();
+      });
+    }
   };
 }
 
@@ -254,7 +262,7 @@ function MdToastProvider($$interimElementProvider) {
       element.off(SWIPE_EVENTS, options.onSwipe);
       options.parent.removeClass(options.openClass);
 
-      return $animate.leave(element);
+      return (options.$destroy == true) ? element.remove() : $animate.leave(element);
     }
 
     function toastOpenClass(position) {

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -2,24 +2,16 @@ describe('$mdToast service', function() {
 
   beforeEach(module('material.components.toast'));
 
-  afterEach(inject(function($timeout, $animate) {
-    $animate.triggerCallbacks();
-    $timeout.flush();
+  afterEach(inject(function($material) {
+    $material.flushOutstandingAnimations();
   }));
 
   function setup(options) {
     var promise;
-    inject(function($mdToast, $rootScope, $$rAF, $timeout) {
+    inject(function($mdToast, $material, $timeout) {
       options = options || {};
-
-      $$rAF.flush();
-
       promise = $mdToast.show(options);
-
-      $rootScope.$digest();
-      $$rAF.flush();
-      $timeout.flush();
-
+      $material.flushOutstandingAnimations();
     });
     return promise;
   }
@@ -27,7 +19,7 @@ describe('$mdToast service', function() {
   describe('simple()', function() {
     hasConfigMethods(['content', 'action', 'capsule', 'highlightAction', 'theme']);
 
-    it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $animate) {
+    it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $material, $browser) {
       var openAndclosed = false;
       var parent = angular.element('<div>');
       $mdToast.show(
@@ -38,15 +30,17 @@ describe('$mdToast service', function() {
           capsule: true
         })
       ).then(function() {
-          openAndclosed = true;
+        openAndclosed = true;
       });
-      $rootScope.$digest();
+
+      $material.flushOutstandingAnimations();
+
       expect(parent.find('span').text()).toBe('Do something');
       expect(parent.find('md-toast')).toHaveClass('md-capsule');
       expect(parent.find('md-toast').attr('md-theme')).toBe('some-theme');
-      $animate.triggerCallbacks();
-      $timeout.flush();
-      $animate.triggerCallbacks();
+
+      $material.flushInterimElement();
+
       expect(openAndclosed).toBe(true);
     }));
 
@@ -59,7 +53,7 @@ describe('$mdToast service', function() {
       expect($rootElement.find('span').text()).toBe('Goodbye world');
     }));
 
-    it('supports an action toast', inject(function($mdToast, $rootScope, $animate) {
+    it('supports an action toast', inject(function($mdToast, $rootScope, $material) {
       var resolved = false;
       var parent = angular.element('<div>');
       $mdToast.show(
@@ -72,13 +66,11 @@ describe('$mdToast service', function() {
       ).then(function() {
         resolved = true;
       });
-      $rootScope.$digest();
-      $animate.triggerCallbacks();
+      $material.flushOutstandingAnimations();
       var button = parent.find('button');
       expect(button.text()).toBe('Click me');
       button.triggerHandler('click');
-      $rootScope.$digest();
-      $animate.triggerCallbacks();
+      $material.flushInterimElement();
       expect(resolved).toBe(true);
     }));
 
@@ -173,15 +165,18 @@ describe('$mdToast service', function() {
   describe('lifecycle', function() {
 
     describe('should hide',function() {
-      it('current toast when showing new one', inject(function($rootElement) {
+      it('current toast when showing new one', inject(function($rootElement, $material) {
         disableAnimations();
 
         setup({
           template: '<md-toast class="one">'
         });
+
         expect($rootElement[0].querySelector('md-toast.one')).toBeTruthy();
         expect($rootElement[0].querySelector('md-toast.two')).toBeFalsy();
         expect($rootElement[0].querySelector('md-toast.three')).toBeFalsy();
+
+        $material.flushInterimElement();
 
         setup({
           template: '<md-toast class="two">'
@@ -191,9 +186,14 @@ describe('$mdToast service', function() {
         expect($rootElement[0].querySelector('md-toast.two')).toBeTruthy();
         expect($rootElement[0].querySelector('md-toast.three')).toBeFalsy();
 
+        $material.flushInterimElement();
+
         setup({
           template: '<md-toast class="three">'
         });
+
+        $material.flushOutstandingAnimations();
+
         expect($rootElement[0].querySelector('md-toast.one')).toBeFalsy();
         expect($rootElement[0].querySelector('md-toast.two')).toBeFalsy();
         expect($rootElement[0].querySelector('md-toast.three')).toBeTruthy();
@@ -213,7 +213,7 @@ describe('$mdToast service', function() {
         expect($rootElement.find('md-toast').length).toBe(0);
       }));
 
-      it('and resolve with default `true`', inject(function($timeout, $animate, $mdToast) {
+      it('and resolve with default `true`', inject(function($timeout, $material, $mdToast) {
         disableAnimations();
 
         var hideDelay = 1234, result, fault;
@@ -227,15 +227,14 @@ describe('$mdToast service', function() {
 
         $mdToast.hide();
 
-          $timeout.flush();
-          $animate.triggerCallbacks();
+        $material.flushInterimElement();
 
         expect(result).toBe(true);
         expect(angular.isUndefined(fault)).toBe(true);
 
       }));
 
-      it('and resolve with specified value', inject(function($timeout, $animate, $mdToast) {
+      it('and resolve with specified value', inject(function($timeout, $animate, $material, $mdToast) {
         disableAnimations();
 
         var hideDelay = 1234, result, fault;
@@ -249,15 +248,14 @@ describe('$mdToast service', function() {
 
         $mdToast.hide("secret");
 
-          $timeout.flush();
-          $animate.triggerCallbacks();
+        $material.flushInterimElement();
 
         expect(result).toBe("secret");
         expect(angular.isUndefined(fault)).toBe(true);
 
       }));
 
-      it('and resolve `true` after timeout', inject(function($timeout, $animate) {
+      it('and resolve `true` after timeout', inject(function($timeout, $material) {
         disableAnimations();
 
         var hideDelay = 1234, result, fault;
@@ -269,15 +267,14 @@ describe('$mdToast service', function() {
           function(error){ fault = error;  }
         );
 
-        $timeout.flush();
-        $animate.triggerCallbacks();
+        $material.flushInterimElement();
 
         expect(result).toBe(true);
         expect(angular.isUndefined(fault)).toBe(true);
 
       }));
 
-      it('and resolve `ok` with click on OK button', inject(function($mdToast, $rootScope, $timeout, $animate) {
+      it('and resolve `ok` with click on OK button', inject(function($mdToast, $rootScope, $timeout, $material, $browser) {
         var result, fault;
         var parent = angular.element('<div>');
         var toast = $mdToast.simple({
@@ -291,27 +288,27 @@ describe('$mdToast service', function() {
             function(response){ result = response;  },
             function(error){ fault = error;  }
           );
-        $rootScope.$digest();
-        $animate.triggerCallbacks();
+
+        $material.flushOutstandingAnimations();
 
         parent.find('button').triggerHandler('click');
 
-        $timeout.flush();
-        $animate.triggerCallbacks();
+        $material.flushInterimElement();
 
         expect(result).toBe('ok');
         expect(angular.isUndefined(fault)).toBe(true);
-
       }));
     });
 
-    it('should add class to toastParent', inject(function($rootElement) {
+    it('should add class to toastParent', inject(function($rootElement, $material) {
       disableAnimations();
 
       setup({
         template: '<md-toast>'
       });
       expect($rootElement.hasClass('md-toast-open-bottom')).toBe(true);
+
+      $material.flushInterimElement();
 
       setup({
         template: '<md-toast>',

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -1,13 +1,13 @@
 describe('<md-tooltip> directive', function() {
-  var $compile, $rootScope, $animate, $timeout;
+  var $compile, $rootScope, $material, $timeout;
   var element;
 
   beforeEach(module('material.components.tooltip'));
   beforeEach(module('material.components.button'));
-  beforeEach(inject(function(_$compile_, _$rootScope_, _$animate_, _$timeout_){
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$material_, _$timeout_){
     $compile   = _$compile_;
     $rootScope = _$rootScope_;
-    $animate   = _$animate_;
+    $material  = _$material_;
     $timeout   = _$timeout_;
   }));
   afterEach(function() {
@@ -96,7 +96,6 @@ describe('<md-tooltip> directive', function() {
           '</md-tooltip>' +
         '</md-button>'
       );
-
 
       showTooltip(true);
 
@@ -220,7 +219,7 @@ describe('<md-tooltip> directive', function() {
     $rootScope.testModel = {};
 
     $rootScope.$apply();
-    $animate.triggerCallbacks();
+    $material.flushOutstandingAnimations();
 
     return element;
   }
@@ -229,7 +228,7 @@ describe('<md-tooltip> directive', function() {
     if (angular.isUndefined(isVisible)) isVisible = true;
 
     $rootScope.$apply('testModel.isVisible = ' + (isVisible ? 'true' : 'false') );
-    $animate.triggerCallbacks();
+    $material.flushOutstandingAnimations();
   }
 
   function findTooltip() {

--- a/src/components/virtualRepeat/virtual-repeater.spec.js
+++ b/src/components/virtualRepeat/virtual-repeater.spec.js
@@ -21,11 +21,12 @@ describe('<md-virtual-repeat>', function() {
       HORIZONTAL_PX = 150,
       ITEM_SIZE = 10;
 
-  beforeEach(inject(function(_$$rAF_, _$compile_, _$document_, $rootScope) {
+  beforeEach(inject(function(_$$rAF_, _$compile_, _$document_, $rootScope, _$material_) {
     repeater = angular.element(REPEATER_HTML);
     container = angular.element(CONTAINER_HTML).append(repeater);
     component = null;
     $$rAF = _$$rAF_;
+    $material = _$material_;
     $compile = _$compile_;
     $document = _$document_;
     scope = $rootScope.$new();
@@ -49,6 +50,8 @@ describe('<md-virtual-repeat>', function() {
     scroller  = angular.element(component[0].querySelector('.md-virtual-repeat-scroller'));
     sizer     = angular.element(component[0].querySelector('.md-virtual-repeat-sizer'));
     offsetter = angular.element(component[0].querySelector('.md-virtual-repeat-offsetter'));
+
+    $material.flushOutstandingAnimations();
 
     return component;
   }
@@ -96,9 +99,7 @@ describe('<md-virtual-repeat>', function() {
     repeater.removeAttr('md-item-size');
     createRepeater();
     scope.items = createItems(NUM_ITEMS);
-    scope.$apply();
-    $$rAF.flush();
-    $$rAF.flush();
+    $material.flushInterimElement();
 
     var numItemRenderers = VERTICAL_PX / ITEM_SIZE + VirtualRepeatController.NUM_EXTRA;
 

--- a/src/components/whiteframe/demoBasicUsage/index.html
+++ b/src/components/whiteframe/demoBasicUsage/index.html
@@ -1,23 +1,99 @@
-<div layout="column" layout-fill style="padding-bottom: 32px;">
+<div layout="row" layout-padding layout-wrap layout-fill style="padding-bottom: 32px;">
 
-  <md-whiteframe class="md-whiteframe-z1" layout layout-align="center center">
-    <span>.md-whiteframe-z1</span>
+  <md-whiteframe class="md-whiteframe-1dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-1dp</span>
   </md-whiteframe>
 
-  <md-whiteframe class="md-whiteframe-z2" layout layout-align="center center">
-    <span>.md-whiteframe-z2</span>
+  <md-whiteframe class="md-whiteframe-2dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-2dp</span>
   </md-whiteframe>
 
-  <md-whiteframe class="md-whiteframe-z3" layout layout-align="center center">
-    <span>.md-whiteframe-z3</span>
+  <md-whiteframe class="md-whiteframe-3dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-3dp</span>
   </md-whiteframe>
 
-  <md-whiteframe class="md-whiteframe-z4" layout layout-align="center center">
-    <span>.md-whiteframe-z4</span>
+  <md-whiteframe class="md-whiteframe-4dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-4dp</span>
   </md-whiteframe>
 
-  <md-whiteframe class="md-whiteframe-z5" layout layout-align="center center">
-    <span>.md-whiteframe-z5</span>
+  <md-whiteframe class="md-whiteframe-5dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-5dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-6dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-6dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-7dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-7dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-8dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-8dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-9dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-9dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-10dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-10dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-11dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-11dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-12dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-12dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-13dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-13dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-14dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-14dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-15dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-15dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-16dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-16dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-17dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-17dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-18dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-18dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-19dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-19dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-20dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-20dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-21dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-21dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-22dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-22dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-23dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-23dp</span>
+  </md-whiteframe>
+
+  <md-whiteframe class="md-whiteframe-24dp" flex="25" layout layout-align="center center">
+    <span>.md-whiteframe-24dp</span>
   </md-whiteframe>
 
 </div>

--- a/src/components/whiteframe/demoBasicUsage/style.css
+++ b/src/components/whiteframe/demoBasicUsage/style.css
@@ -1,5 +1,5 @@
 md-whiteframe {
   background: #fff;
-  margin: 20px;
-  padding: 20px;
+  margin: 30px;
+  height: 100px;
 }

--- a/src/components/whiteframe/whiteframe.scss
+++ b/src/components/whiteframe/whiteframe.scss
@@ -1,17 +1,74 @@
-.md-whiteframe-z1 {
-  box-shadow: $whiteframe-shadow-z1;
+.md-whiteframe-1dp, .md-whiteframe-z1 {
+  box-shadow: $whiteframe-shadow-1dp;
 }
-.md-whiteframe-z2 {
-  box-shadow: $whiteframe-shadow-z2;
+.md-whiteframe-2dp {
+  box-shadow: $whiteframe-shadow-2dp;
 }
-.md-whiteframe-z3 {
-  box-shadow: $whiteframe-shadow-z3;
+.md-whiteframe-3dp {
+  box-shadow: $whiteframe-shadow-3dp;
 }
-.md-whiteframe-z4 {
-  box-shadow: $whiteframe-shadow-z4;
+.md-whiteframe-4dp, .md-whiteframe-z2{
+  box-shadow: $whiteframe-shadow-4dp;
 }
-.md-whiteframe-z5 {
-  box-shadow: $whiteframe-shadow-z5;
+.md-whiteframe-5dp {
+  box-shadow: $whiteframe-shadow-5dp;
+}
+.md-whiteframe-6dp {
+  box-shadow: $whiteframe-shadow-6dp;
+}
+.md-whiteframe-7dp, .md-whiteframe-z3 {
+  box-shadow: $whiteframe-shadow-7dp;
+}
+.md-whiteframe-8dp {
+  box-shadow: $whiteframe-shadow-8dp;
+}
+.md-whiteframe-9dp {
+  box-shadow: $whiteframe-shadow-9dp;
+}
+.md-whiteframe-10dp, .md-whiteframe-z4 {
+  box-shadow: $whiteframe-shadow-10dp;
+}
+.md-whiteframe-11dp {
+  box-shadow: $whiteframe-shadow-11dp;
+}
+.md-whiteframe-12dp {
+  box-shadow: $whiteframe-shadow-12dp;
+}
+.md-whiteframe-13dp, .md-whiteframe-z5{
+  box-shadow: $whiteframe-shadow-13dp;
+}
+.md-whiteframe-14dp {
+  box-shadow: $whiteframe-shadow-14dp;
+}
+.md-whiteframe-15dp {
+  box-shadow: $whiteframe-shadow-15dp;
+}
+.md-whiteframe-16dp {
+  box-shadow: $whiteframe-shadow-16dp;
+}
+.md-whiteframe-17dp {
+  box-shadow: $whiteframe-shadow-17dp;
+}
+.md-whiteframe-18dp {
+  box-shadow: $whiteframe-shadow-18dp;
+}
+.md-whiteframe-19dp {
+  box-shadow: $whiteframe-shadow-19dp;
+}
+.md-whiteframe-20dp {
+  box-shadow: $whiteframe-shadow-20dp;
+}
+.md-whiteframe-21dp {
+  box-shadow: $whiteframe-shadow-21dp;
+}
+.md-whiteframe-22dp {
+  box-shadow: $whiteframe-shadow-22dp;
+}
+.md-whiteframe-23dp {
+  box-shadow: $whiteframe-shadow-23dp;
+}
+.md-whiteframe-24dp {
+  box-shadow: $whiteframe-shadow-24dp;
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -410,7 +410,7 @@ function InterimElementProvider() {
                 showAction = showElement(element, options, compiledData.controller)
                   .then(resolve, rejectAll );
 
-              });
+              }, rejectAll);
 
             function rejectAll(fault) {
               // Force the '$md<xxx>.show()' promise to reject
@@ -429,6 +429,10 @@ function InterimElementProvider() {
          * - perform optional clean up scope.
          */
         function transitionOutAndRemove(response, isCancelled, opts) {
+
+          // abort if the show() and compile failed
+          if ( !element ) return $q.when(false);
+
           options = angular.extend(options || {}, opts || {});
           options.cancelAutoHide && options.cancelAutoHide();
           options.element.triggerHandler('$mdInterimElementRemove');
@@ -601,7 +605,6 @@ function InterimElementProvider() {
               // Start transitionIn
               $q.when(options.onShow(options.scope, element, options, controller))
                 .then(function () {
-
                   notifyComplete(options.scope, element, options);
                   startAutoHide();
 

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -116,8 +116,13 @@ function InterimElementProvider() {
       var publicService = {
         hide: interimElementService.hide,
         cancel: interimElementService.cancel,
-        show: showInterimElement
+        show: showInterimElement,
+
+        // Special internal method to destroy an interim element without animations
+        // used when navigation changes causes a $scope.$destroy() action
+        destroy : destroyInterimElement
       };
+
 
       defaultMethods = providerConfig.methods || [];
       // This must be invoked after the publicService is initialized
@@ -178,9 +183,11 @@ function InterimElementProvider() {
           //
           // @example `$mdToast.simple('hello')` // sets options.content to hello
           //                                     // because argOption === 'content'
-          if (arguments.length && definition.argOption && !angular.isObject(arg) &&
-              !angular.isArray(arg)) {
+          if (arguments.length && definition.argOption &&
+              !angular.isObject(arg) && !angular.isArray(arg))  {
+
             return (new Preset())[definition.argOption](arg);
+
           } else {
             return new Preset(arg);
           }
@@ -190,6 +197,9 @@ function InterimElementProvider() {
 
       return publicService;
 
+      /**
+       *
+       */
       function showInterimElement(opts) {
         // opts is either a preset which stores its options on an _options field,
         // or just an object made up of options
@@ -199,6 +209,17 @@ function InterimElementProvider() {
         return interimElementService.show(
           angular.extend({}, defaultOptions, opts)
         );
+      }
+
+      /**
+       *  Special method to hide and destroy an interimElement WITHOUT
+       *  any 'leave` or hide animations ( an immediate force hide/remove )
+       *
+       *  NOTE: This calls the onRemove() subclass method for each component...
+       *  which must have code to respond to `options.$destroy == true`
+       */
+      function destroyInterimElement(opts) {
+          return interimElementService.destroy(opts);
       }
 
       /**
@@ -219,7 +240,7 @@ function InterimElementProvider() {
   }
 
   /* @ngInject */
-  function InterimElementFactory($document, $q, $rootScope, $timeout, $rootElement, $animate,
+  function InterimElementFactory($document, $q, $$q, $rootScope, $timeout, $rootElement, $animate,
                                  $mdUtil, $mdCompiler, $mdTheming, $log ) {
     return function createInterimElementService() {
       var SHOW_CANCELLED = false;
@@ -241,7 +262,8 @@ function InterimElementProvider() {
       return service = {
         show: show,
         hide: hide,
-        cancel: cancel
+        cancel: cancel,
+        destroy : destroy
       };
 
       /*
@@ -259,7 +281,7 @@ function InterimElementProvider() {
        */
       function show(options) {
         options = options || {};
-        var interimElement = new InterimElement(options);
+        var interimElement = new InterimElement(options || {});
         var hideExisting = !options.skipHide && stack.length ? service.hide() : $q.when(true);
 
         // This hide()s only the current interim element before showing the next, new one
@@ -271,7 +293,8 @@ function InterimElementProvider() {
           interimElement
             .show()
             .catch(function( reason ) {
-              // $log.error("InterimElement.show() error: " + reason );
+              //$log.error("InterimElement.show() error: " + reason );
+              return reason;
             });
 
         });
@@ -311,9 +334,10 @@ function InterimElementProvider() {
 
         function closeElement(interim) {
           interim
-            .remove(reason || SHOW_CLOSED, false)
+            .remove(reason || SHOW_CLOSED, false, options || { })
             .catch(function( reason ) {
-              // $log.error("InterimElement.hide() error: " + reason );
+              //$log.error("InterimElement.hide() error: " + reason );
+              return reason;
             });
           return interim.deferred.promise;
         }
@@ -331,17 +355,28 @@ function InterimElementProvider() {
        * @returns Promise that will be resolved after the element has been removed.
        *
        */
-      function cancel(reason) {
+      function cancel(reason, options) {
         var interim = stack.shift();
         if ( !interim ) return $q.when(reason || SHOW_CANCELLED);
 
         interim
-          .remove(reason || SHOW_CANCELLED, true)
+          .remove(reason || SHOW_CANCELLED, true, options || { })
           .catch(function( reason ) {
-            // $log.error("InterimElement.cancel() error: " + reason );
+            //$log.error("InterimElement.cancel() error: " + reason );
+            return reason;
           });
 
         return interim.deferred.promise;
+      }
+
+      /*
+       * Special method to quick-remove the interim element without animations
+       */
+      function destroy() {
+        var interim = stack.shift();
+
+        return interim ? interim.remove(SHOW_CANCELLED, false, {'$destroy':true}) :
+               $q.when(SHOW_CANCELLED);
       }
 
 
@@ -393,39 +428,44 @@ function InterimElementProvider() {
          * - perform the transition-out, and
          * - perform optional clean up scope.
          */
-        function transitionOutAndRemove(response, isCancelled) {
+        function transitionOutAndRemove(response, isCancelled, opts) {
+          options = angular.merge(options || {}, opts || {});
           options.cancelAutoHide && options.cancelAutoHide();
+          options.element.triggerHandler('$mdInterimElementRemove');
 
-          return $q(function(resolve, reject){
+          if ( options.$destroy === true ) {
 
-            $q.when(showAction).finally(function(){
-              options.element.triggerHandler('$mdInterimElementRemove');
-              hideElement(options.element, options).then( function() {
+            return hideElement(options.element, options);
 
-                (isCancelled && rejectAll(response)) || resolveAll();
+          } else {
 
-              }, rejectAll );
+            $q.when(showAction)
+                .finally(function() {
+                  hideElement(options.element, options).then(function() {
 
-            });
+                    (isCancelled && rejectAll(response)) || resolveAll(response);
 
-            function resolveAll() {
-              // The `show()` returns a promise that will be resolved when the interim
-              // element is hidden or cancelled...
-              self.deferred.resolve(response);
+                  }, rejectAll);
+                });
 
-              // Now resolve the `.hide()` promise itself (optional)
-              resolve(response);
-            }
+            return self.deferred.promise;
+          }
 
-            function rejectAll(fault) {
-              // Force the '$md<xxx>.show()' promise to reject
-              self.deferred.reject(fault);
 
-              // Continue rejection propagation
-              reject(fault);
-            }
+          /**
+           * The `show()` returns a promise that will be resolved when the interim
+           * element is hidden or cancelled...
+           */
+          function resolveAll(response) {
+            self.deferred.resolve(response);
+          }
 
-          });
+          /**
+           * Force the '$md<xxx>.show()' promise to reject
+           */
+          function rejectAll(fault) {
+            self.deferred.reject(fault);
+          }
         }
 
         /**
@@ -578,21 +618,32 @@ function InterimElementProvider() {
         function hideElement(element, options) {
           var announceRemoving = options.onRemoving || angular.noop;
 
-          return $q(function (resolve, reject) {
+          return $$q(function (resolve, reject) {
             try {
               // Start transitionIn
-              var action = $q.when(element ? options.onRemove(options.scope, element, options) : true);
+              var action = $$q.when( options.onRemove(options.scope, element, options) || true );
 
               // Trigger callback *before* the remove operation starts
               announceRemoving(element, action);
 
-              // Wait until transition-out is done
-              action.then(function () {
+              if ( options.$destroy == true ) {
 
-                !options.preserveScope && options.scope.$destroy();
+                // For $destroy, onRemove should be synchronous
                 resolve(element);
 
-              }, reject );
+              } else {
+
+                // Wait until transition-out is done
+                action.then(function () {
+
+                  if (!options.preserveScope && options.scope ) {
+                    options.scope.$destroy();
+                  }
+
+                  resolve(element);
+
+                }, reject );
+              }
 
             } catch(e) {
               reject(e.message);

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -429,7 +429,7 @@ function InterimElementProvider() {
          * - perform optional clean up scope.
          */
         function transitionOutAndRemove(response, isCancelled, opts) {
-          options = angular.merge(options || {}, opts || {});
+          options = angular.extend(options || {}, opts || {});
           options.cancelAutoHide && options.cancelAutoHide();
           options.element.triggerHandler('$mdInterimElementRemove');
 

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -2,7 +2,7 @@ describe('$$interimElement service', function() {
 
   beforeEach(module('material.core'));
 
-  var $rootScope, $$rAF, $q, $timeout;
+  var $rootScope, $q, $timeout;
   var $compilerSpy, $themingSpy;
 
   describe('provider', function() {
@@ -46,24 +46,31 @@ describe('$$interimElement service', function() {
     it('should not call onShow or onRemove on failing to load templates', function() {
       createInterimProvider('interimTest');
       inject(function($q, $rootScope, $rootElement, interimTest, $httpBackend) {
+        var templateCompiled = true;
+
         $compilerSpy.and.callFake(function(reason) {
           return $q(function(resolve,reject){
-            reject(reason || false);
+            templateCompiled = false;
+            reject(500 || false);
           });
         });
         $httpBackend.when('GET', '/fail-url.html').respond(500, '');
+
         var onShowCalled = false, onHideCalled = false;
+
         interimTest.show({
           templateUrl: '/fail-url.html',
-          onShow: function(scope, el) { onShowCalled = true; },
+          onShow: function() { onShowCalled = true; },
           onRemove: function() { onHideCalled = true; }
         });
-        $$rAF.flush();
+
+        $material.flushOutstandingAnimations();
         interimTest.cancel();
-        $$rAF.flush();
+        $material.flushOutstandingAnimations();
 
         expect(onShowCalled).toBe(false);
         expect(onHideCalled).toBe(false);
+        expect(templateCompiled).toBe(false);
       });
     });
 
@@ -351,6 +358,7 @@ describe('$$interimElement service', function() {
           });
 
         flush();
+        $timeout.flush();
         expect(autoClosed).toBe(true);
       }));
 
@@ -622,10 +630,10 @@ describe('$$interimElement service', function() {
       $provide.value('$mdCompiler', $mdCompiler);
       $provide.value('$mdTheming', $themingSpy);
     });
-    inject(function($q, $compile, _$rootScope_, _$$rAF_, _$timeout_) {
+    inject(function($q, $compile, _$rootScope_, _$timeout_, _$material_) {
       $rootScope = _$rootScope_;
-      $$rAF = _$$rAF_;
       $timeout = _$timeout_;
+      $material = _$material_;
 
       $compilerSpy.and.callFake(function(opts) {
         var el = $compile(opts.template || "<div></div>");
@@ -652,13 +660,7 @@ describe('$$interimElement service', function() {
   }
 
   function flush() {
-    try {
-      $timeout.flush();
-      $rootScope.$apply();
-      $$rAF.flush();
-    } finally {
-      $timeout.flush();
-    }
+    $material.flushInterimElement();
   }
 
   function tailHook( sourceFn, hookFn ) {

--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  var _$$mdLayout, _$parse;
+  var $$mdLayout, $parse, $interpolate;
 
     /**
      *
@@ -69,20 +69,16 @@
       .directive('layout'              , attributeWithObserve('layout' , true)       )
       .directive('layoutSm'            , attributeWithObserve('layout-sm'   , true)  )
       .directive('layoutGtSm'          , attributeWithObserve('layout-gt-sm', true)  )
-      .directive('layoutLtMd'          , warnAttrNotSupported('layout-lt-md',true)   )
       .directive('layoutMd'            , attributeWithObserve('layout-md'   , true)  )
       .directive('layoutGtMd'          , attributeWithObserve('layout-gt-md', true)  )
-      .directive('layoutLtLg'          , warnAttrNotSupported('layout-lt-lg',true)   )
       .directive('layoutLg'            , attributeWithObserve('layout-lg'   , true)  )
       .directive('layoutGtLg'          , attributeWithObserve('layout-gt-lg', true)  )
 
       .directive('flex'                , attributeWithObserve('flex'        , true)  )
       .directive('flexSm'              , attributeWithObserve('flex-sm'     , true)  )
       .directive('flexGtSm'            , attributeWithObserve('flex-gt-sm'  , true)  )
-      .directive('flexLtMd'            , warnAttrNotSupported('flex-lt-md'  ,true)   )
       .directive('flexMd'              , attributeWithObserve('flex-md'     , true)  )
       .directive('flexGtMd'            , attributeWithObserve('flex-gt-md'  , true)  )
-      .directive('flexLtLg'            , warnAttrNotSupported('flex-lt-lg'  ,true)   )
       .directive('flexLg'              , attributeWithObserve('flex-lg'     , true)  )
       .directive('flexGtLg'            , attributeWithObserve('flex-gt-lg'  , true)  )
 
@@ -91,30 +87,24 @@
       .directive('layoutAlign'         , attributeWithObserve('layout-align')        )
       .directive('layoutAlignSm'       , attributeWithObserve('layout-align-sm')     )
       .directive('layoutAlignGtSm'     , attributeWithObserve('layout-align-gt-sm')  )
-      .directive('layoutAlignLtMd'     , warnAttrNotSupported('layout-align-lt-md')  )
       .directive('layoutAlignMd'       , attributeWithObserve('layout-align-md')     )
       .directive('layoutAlignGtMd'     , attributeWithObserve('layout-align-gt-md')  )
-      .directive('layoutAlignLtLg'     , warnAttrNotSupported('layout-align-lt-lg')  )
       .directive('layoutAlignLg'       , attributeWithObserve('layout-align-lg')     )
       .directive('layoutAlignGtLg'     , attributeWithObserve('layout-align-gt-lg')  )
 
       .directive('flexOrder'           , attributeWithObserve('flex-order')          )
       .directive('flexOrderSm'         , attributeWithObserve('flex-order-sm')       )
       .directive('flexOrderGtSm'       , attributeWithObserve('flex-order-gt-sm')    )
-      .directive('flexOrderLtMd'       , warnAttrNotSupported('flex-order-lt-md')    )
       .directive('flexOrderMd'         , attributeWithObserve('flex-order-md')       )
       .directive('flexOrderGtMd'       , attributeWithObserve('flex-order-gt-md')    )
-      .directive('flexOrderLtLg'       , warnAttrNotSupported('flex-order-lt-lg')    )
       .directive('flexOrderLg'         , attributeWithObserve('flex-order-lg')       )
       .directive('flexOrderGtLg'       , attributeWithObserve('flex-order-gt-lg')    )
 
       .directive('offset'              , attributeWithObserve('offset')              )
       .directive('offsetSm'            , attributeWithObserve('offset-sm')           )
       .directive('offsetGtSm'          , attributeWithObserve('offset-gt-sm')        )
-      .directive('offsetLtMd'          , warnAttrNotSupported('offset-lt-md')        )
       .directive('offsetMd'            , attributeWithObserve('offset-md')           )
       .directive('offsetGtMd'          , attributeWithObserve('offset-gt-md')        )
-      .directive('offsetLtLg'          , warnAttrNotSupported('offset-lt-lg')        )
       .directive('offsetLg'            , attributeWithObserve('offset-lg')           )
       .directive('offsetGtLg'          , attributeWithObserve('offset-gt-lg')        )
 
@@ -128,21 +118,36 @@
       .directive('hide'                , attributeWithoutValue('hide')               )
       .directive('hideSm'              , attributeWithoutValue('hide-sm')            )
       .directive('hideGtSm'            , attributeWithoutValue('hide-gt-sm')         )
-      .directive('hideLtMd'            , warnAttrNotSupported ('hide-lt-md')         )
       .directive('hideMd'              , attributeWithoutValue('hide-md')            )
       .directive('hideGtMd'            , attributeWithoutValue('hide-gt-md')         )
-      .directive('hideLtLg'            , warnAttrNotSupported ('hide-lt-lg')         )
       .directive('hideLg'              , attributeWithoutValue('hide-lg')            )
       .directive('hideGtLg'            , attributeWithoutValue('hide-gt-lg')         )
       .directive('show'                , attributeWithoutValue('show')               )
       .directive('showSm'              , attributeWithoutValue('show-sm')            )
       .directive('showGtSm'            , attributeWithoutValue('show-gt-sm')         )
-      .directive('showLtMd'            , warnAttrNotSupported ('show-lt-md')         )
       .directive('showMd'              , attributeWithoutValue('show-md')            )
       .directive('showGtMd'            , attributeWithoutValue('show-gt-md')         )
-      .directive('showLtLg'            , warnAttrNotSupported ('show-lt-lg')         )
       .directive('showLg'              , attributeWithoutValue('show-lg')            )
-      .directive('showGtLg'            , attributeWithoutValue('show-gt-lg')         );
+      .directive('showGtLg'            , attributeWithoutValue('show-gt-lg')         )
+
+      // !! Deprecated attributes: use the `-lt` (aka less-than) notations
+
+      .directive('layoutLtMd'          , warnAttrNotSupported('layout-lt-md',true)   )
+      .directive('layoutLtLg'          , warnAttrNotSupported('layout-lt-lg',true)   )
+      .directive('flexLtMd'            , warnAttrNotSupported('flex-lt-md'  ,true)   )
+      .directive('flexLtLg'            , warnAttrNotSupported('flex-lt-lg'  ,true)   )
+
+      .directive('layoutAlignLtMd'     , warnAttrNotSupported('layout-align-lt-md')  )
+      .directive('layoutAlignLtLg'     , warnAttrNotSupported('layout-align-lt-lg')  )
+      .directive('flexOrderLtMd'       , warnAttrNotSupported('flex-order-lt-md')    )
+      .directive('flexOrderLtLg'       , warnAttrNotSupported('flex-order-lt-lg')    )
+      .directive('offsetLtMd'          , warnAttrNotSupported('offset-lt-md')        )
+      .directive('offsetLtLg'          , warnAttrNotSupported('offset-lt-lg')        )
+
+      .directive('hideLtMd'            , warnAttrNotSupported ('hide-lt-md')         )
+      .directive('hideLtLg'            , warnAttrNotSupported ('hide-lt-lg')         )
+      .directive('showLtMd'            , warnAttrNotSupported ('show-lt-md')         )
+      .directive('showLtLg'            , warnAttrNotSupported ('show-lt-lg')         );
 
     /**
      * These functions create registration functions for ngMaterial Layout attribute directives
@@ -158,9 +163,11 @@
      * @param {boolean=} addDirectiveAsClass
      */
     function attributeWithObserve(className, addDirectiveAsClass) {
-      return ['$$mdLayout', '$document', '$parse', function($$mdLayout, $document, $parse) {
-        _$$mdLayout = $$mdLayout;
-        _$parse = $parse;
+
+      return ['$$mdLayout', '$document', '$parse', '$interpolate', function(_$$mdLayout_, $document, _$parse_, _$interpolate_) {
+        $$mdLayout = _$$mdLayout_;
+        $parse = _$parse_;
+        $interpolate = _$interpolate_;
 
         return {
             restrict : 'A',
@@ -176,57 +183,64 @@
       }];
 
 
-
       /**
        * Add as transformed class selector(s), then
        * remove the deprecated attribute selector
        */
-      function attributeValueToClass(scope, element, attr) {
-        var directive = attr.$normalize(className);
-        var attrExpression = _$parse( directive[directive] );
+      function attributeValueToClass(scope, element, attrs) {
+        var updateClassFn = updateClassWithValue(element,className, attrs);
+        var normalizedAttr = attrs.$normalize(className);
+        var attrValue = attrs[normalizedAttr] ? attrs[normalizedAttr].replace(/\s+/g, "-") : null;
+        var addImmediate = attrValue ? !needsInterpolation(attrValue) : false;
+        var watchValue   = needsInterpolation(attrValue);
 
         // Add transformed class selector(s)
-        if (addDirectiveAsClass) {
-          element.addClass(className);
-        }
+        if (addDirectiveAsClass) element.addClass(className);
 
-        if ( attr[directive] ) {
-          element.addClass(className + "-" + attr[directive].replace(/\s+/g, "-"));
-
-          if ( _$$mdLayout.removeAttributes ) {
-            element.removeAttr(directive);
-          }
-        }
-
-        if ( scope ) {
-          /**
-           * After link-phase, do NOT remove deprecated layout attribute selector.
-           * Instead watch the attribute so interpolated data-bindings to layout
-           * selectors will continue to be supported.
-           *
-           * $observe() the className and update with new class (after removing the last one)
-           *
-           * e.g. `layout="{{layoutDemo.direction}}"` will update...
-           */
-          var lastClass;
-
-          attr.$observe(function() {
-
-            return attrExpression(scope);
-
-          }, function(newVal) {
-
-            element.removeClass(lastClass);
-
-              lastClass = className + "-" + String(newVal).replace(/\s+/g, "-");
-
-            element.addClass(lastClass);
-
-          });
-
-        }
-
+        if ( addImmediate ) element.addClass(className + "-" + attrValue);
+        if ( watchValue ) attrs.$observe( normalizedAttr, updateClassFn );
+        if ( $$mdLayout.removeAttributes ) element.removeAttr(className);
       }
+
+    }
+
+    /**
+     * See if the original value has interpolation symbols:
+     * e.g.  flex-gt-md="{{triggerPoint}}"
+     */
+    function needsInterpolation(value) {
+      return (value ||"").indexOf($interpolate.startSymbol()) > -1;
+    }
+
+    /**
+     * After link-phase, do NOT remove deprecated layout attribute selector.
+     * Instead watch the attribute so interpolated data-bindings to layout
+     * selectors will continue to be supported.
+     *
+     * $observe() the className and update with new class (after removing the last one)
+     *
+     * e.g. `layout="{{layoutDemo.direction}}"` will update...
+     *
+     * NOTE: The value must match one of the specified styles in the CSS.
+     * For example `flex-gt-md="{{size}}`  where `scope.size == 47` will NOT work since
+     * only breakpoints for 0, 5, 10, 15... 100, 33, 34, 66, 67 are defined.
+     *
+     */
+    function updateClassWithValue(element, className, attr) {
+      var lastClass;
+
+      return function updateClassWithValue(newValue) {
+        var value = String(newValue || "").replace(/\s+/g, "-");
+
+        element.removeClass(lastClass);
+        lastClass = !value ? className : className + "-" + value;
+        element.addClass(lastClass);
+
+        // Conditionally remove the attribute selector in case the browser attempts to
+        // read it and suffers a performance downgrade (IE).
+
+        if ( $$mdLayout.removeAttributes ) element.removeAttr(className);
+      };
     }
 
     /**
@@ -234,11 +248,11 @@
      * This is a `simple` transpose of attribute usage to class usage
      */
     function attributeWithoutValue(className) {
-      return ['$$mdLayout', '$document', function($$mdLayout, $document) {
-        _$$mdLayout = $$mdLayout;
+      return ['$$mdLayout', '$document', function(_$$mdLayout_, $document) {
+        $$mdLayout = _$$mdLayout_;
         return {
           restrict : 'A',
-          compile: function(element, attr) {
+          compile: function(element, attrs) {
             if ( postLinkIsDisabled($document[0]) ) return angular.noop;
 
             attributeToClass(null, element);
@@ -256,7 +270,7 @@
       function attributeToClass(scope, element) {
         element.addClass(className);
 
-        if ( scope && _$$mdLayout.removeAttributes ) {
+        if ( $$mdLayout.removeAttributes ) {
           // After link-phase, remove deprecated layout attribute selector
           element.removeAttr(className);
         }
@@ -289,10 +303,13 @@
      *       }
      *
      * Note: this means that 'md-css-only' will not work for IE (due to performance issues)
-     * In these cases, the Layout translators (directives) should be enabled.
+     * In these cases, the Layout translators (directives) should be enabled and the
+     * `angular-material.[min.]js` must be loaded.
      */
     function postLinkIsDisabled(document) {
-      var disablePostLinks = _$$mdLayout.disablePostLinks;
+      var disablePostLinks = $$mdLayout.disablePostLinks;
+
+      // Perform a read-once (1x) check for the `md-css-only` class on the BODY
 
       if ( angular.isUndefined(disablePostLinks) ) {
         var body = document.querySelectorAll("body")[0];
@@ -301,7 +318,7 @@
         disablePostLinks = styles ? (styles.indexOf('md-css-only') > -1) : false;
       }
 
-      return _$$mdLayout.disablePostLinks = disablePostLinks;
+      return $$mdLayout.disablePostLinks = disablePostLinks;
     }
 
 })();

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -9,7 +9,7 @@
   1200 <= size         PC
 */
 
-.layout {
+.layout, .md-css-only [layout]  {
   box-sizing: border-box;
   display: -webkit-box;
   display: -webkit-flex;
@@ -19,71 +19,90 @@
   display: flex;
 }
 
-.layout-column {
+.layout-column, .md-css-only [layout=column] {
   flex-direction: column;
   -webkit-flex-direction: column;
 }
 
-.layout-row {
+.layout-row, .md-css-only [layout=row] {
   flex-direction: row;
   -webkit-flex-direction: row;
 }
 
 .layout-padding > .flex-sm,
-.layout-padding > .flex-lt-md
+.layout-padding > .flex-lt-md,
+.md-css-only [layout-padding] > [flex-sm],
+.md-css-only [layout-padding] > [flex-lt-md]
 {
   padding: $layout-gutter-width / 4;
 }
+
 .layout-padding,
 .layout-padding > .flex,
 .layout-padding > .flex-gt-sm,
 .layout-padding > .flex-md,
-.layout-padding > .flex-lt-lg
+.layout-padding > .flex-lt-lg,
+.md-css-only [layout-padding],
+.md-css-only [layout-padding] > .md-css-only [flex],
+.md-css-only [layout-padding] > .md-css-only [flex-gt-sm],
+.md-css-only [layout-padding] > .md-css-only [flex-md],
+.md-css-only [layout-padding] > .md-css-only [flex-lt-lg]
 {
   padding: $layout-gutter-width / 2;
 }
 .layout-padding > .flex-gt-md,
-.layout-padding > .flex-lg
+.layout-padding > .flex-lg,
+.md-css-only [layout-padding] > .md-css-only [flex-gt-md],
+.md-css-only [layout-padding] > .md-css-only [flex-lg]
 {
   padding: $layout-gutter-width / 1;
 }
 
-
 .layout-margin > .flex-sm,
-.layout-margin > .flex-lt-md
+.layout-margin > .flex-lt-md,
+.md-css-only [layout-margin] >  .md-css-only [flex-sm],
+.md-css-only [layout-margin] >  .md-css-only [flex-lt-md]
 {
   margin: $layout-gutter-width / 4;
 }
+
 .layout-margin,
 .layout-margin > .flex,
 .layout-margin > .flex-gt-sm,
 .layout-margin > .flex-md,
-.layout-margin > .flex-lt-lg {
+.layout-margin > .flex-lt-lg,
+.md-css-only [layout-margin],
+.md-css-only [layout-margin] >  .md-css-only [flex],
+.md-css-only [layout-margin] >  .md-css-only [flex-gt-sm],
+.md-css-only [layout-margin] >  .md-css-only [flex-md],
+.md-css-only [layout-margin] >  .md-css-only [flex-lt-lg]
+{
   margin: $layout-gutter-width / 2;
 }
+
 .layout-margin > .flex-gt-md,
-.layout-margin > .flex-lg
+.layout-margin > .flex-lg,
+.md-css-only [layout-margin] >  .md-css-only [flex-gt-md],
+.md-css-only [layout-margin] >  .md-css-only [flex-lg]
 {
   margin: $layout-gutter-width / 1;
 }
 
-
-
-.layout-wrap {
+.layout-wrap, .md-css-only [layout-wrap]  {
   flex-wrap: wrap;
 }
 
-.layout-fill {
+.layout-fill, .md-css-only [layout-fill] {
   margin: 0;
   min-height: 100%;
   width: 100%;
 }
 @-moz-document url-prefix() {
-  .layout-fill {
+  .layout-fill, .md-css-only [layout-fill] {
     margin: 0;
     width: 100%;
-    min-height: auto;
-    height: inherit;
+    min-height: 100%;
+    height: 100%;
   }
 }
 
@@ -92,20 +111,20 @@
   @if $suffix != null {
     $selector: 'flex-order-#{$suffix}';
   }
-  .#{$selector}-0 { order: 0; }
-  .#{$selector}-1 { order: 1; }
-  .#{$selector}-2 { order: 2; }
-  .#{$selector}-3 { order: 3; }
-  .#{$selector}-4 { order: 4; }
-  .#{$selector}-5 { order: 5; }
-  .#{$selector}-6 { order: 6; }
-  .#{$selector}-7 { order: 7; }
-  .#{$selector}-8 { order: 8; }
-  .#{$selector}-9 { order: 9; }
+  .md-css-only [#{$selector}="0"] { order: 0; }
+  .md-css-only [#{$selector}="1"] { order: 1; }
+  .md-css-only [#{$selector}="2"] { order: 2; }
+  .md-css-only [#{$selector}="3"] { order: 3; }
+  .md-css-only [#{$selector}="4"] { order: 4; }
+  .md-css-only [#{$selector}="5"] { order: 5; }
+  .md-css-only [#{$selector}="6"] { order: 6; }
+  .md-css-only [#{$selector}="7"] { order: 7; }
+  .md-css-only [#{$selector}="8"] { order: 8; }
+  .md-css-only [#{$selector}="9"] { order: 9; }
 }
 
 @mixin layout-for-name($name) {
-  .layout-#{$name} {
+  .layout-#{$name}, .md-css-only [layout-#{$name}] {
     box-sizing: border-box;
     display: -webkit-box;
     display: -webkit-flex;
@@ -114,11 +133,14 @@
     display: -ms-flexbox;
     display: flex;
   }
-  .layout-#{$name}-column {
+  .layout-#{$name}-column,
+  .md-css-only [layout-#{$name}=column] {
     flex-direction: column;
   }
-  .layout-#{$name}-row {
+  .layout-#{$name}-row,
+  .md-css-only [layout-#{$name}=row] {
     flex-direction: row;
+    flex-wrap: wrap;
   }
 }
 
@@ -128,15 +150,21 @@
     $offsetName: 'offset-#{$name}';
   }
   @for $i from 1 through 19 {
-    .#{$offsetName}-#{$i * 5} {
+    .#{$offsetName}-#{$i * 5},
+    .md-css-only [#{$offsetName}="#{$i * 5}"]
+    {
       margin-left: #{$i * 5 + '%'};
     }
   }
-  .#{$offsetName}-33, .#{$offsetName}-34 {
-    margin-left: 33.33%;
+  .#{$offsetName}-33, .#{$offsetName}-34,
+  .md-css-only [#{$offsetName}="33"], .md-css-only [#{$offsetName}="34"]
+  {
+    margin-left: 34%;
   }
-  .#{$offsetName}-66, .#{$offsetName}-67 {
-    margin-left: 66.66%;
+  .#{$offsetName}-66, .#{$offsetName}-67,
+  .md-css-only [#{$offsetName}="66"], .md-css-only [#{$offsetName}="67"]
+  {
+    margin-left: 66%;
   }
 }
 
@@ -146,7 +174,7 @@
     $flexName: 'flex-#{$name}';
   }
 
-  .#{$flexName} {
+  .#{$flexName}, .md-css-only [#{$flexName}] {
     box-sizing: border-box;
     flex: 1;
   }
@@ -154,28 +182,42 @@
 
   // (0-20) * 5 = 0-100%
   @for $i from 0 through 20 {
-    .#{$flexName}-#{$i * 5} {
+    .#{$flexName}-#{$i * 5},
+    .md-css-only [#{$flexName}="#{$i * 5}"]
+    {
       flex: 0 0 #{$i * 5 + '%'};
     }
-    .layout-row > .#{$flexName}-#{$i * 5} {  }
-    .layout-column > .#{$flexName}-#{$i * 5} {  }
+    .layout-row > .#{$flexName}-#{$i * 5},
+    .md-css-only [layout="row"] > .md-css-only [#{$flexName}="#{$i * 5}"]
+    {
+      max-width: #{$i * 5 + '%'};
+    }
+
+    .layout-column > .#{$flexName}-#{$i * 5},
+    .md-css-only [layout="column"] > .md-css-only [#{$flexName}="#{$i * 5}"]
+    {
+      max-height: #{$i * 5 + '%'};
+    }
   }
 
-  .#{$flexName}-33, .#{$flexName}-34 {
-    flex: 0 0 34%;
+  .#{$flexName}-33, .#{$flexName}-34
+  {
+    flex: 0 0 33%;
   }
-  .#{$flexName}-66, .#{$flexName}-67 {
-    flex: 0 0 66%;
+
+  .#{$flexName}-66, .#{$flexName}-67
+  {
+    flex: 0 0 67%;
 
   }
 
-  .layout-row {
-    > .#{$flexName}-33, > .#{$flexName}-34 {  }
-    > .#{$flexName}-66, > .#{$flexName}-67 {  }
+  .layout-row, .md-css-only [layout="row"] {
+    > .#{$flexName}-33, > .#{$flexName}-34 { max-width: 33%; }
+    > .#{$flexName}-66, > .#{$flexName}-67 { max-width: 67%;  }
   }
-  .layout-column {
-    > .#{$flexName}-33, > .#{$flexName}-34 {  }
-    > .#{$flexName}-66, > .#{$flexName}-67 {  }
+  .layout-column, .md-css-only [layout="column"] {
+    > .#{$flexName}-33, > .#{$flexName}-34 { max-height: 33%;  }
+    > .#{$flexName}-66, > .#{$flexName}-67 { max-height: 33%; }
   }
 }
 
@@ -192,10 +234,15 @@
   }
 
   // Main Axis Center
-  .#{$name}-center, //stretch
+  .#{$name}-center,           //stretch
   .#{$name}-center-center,
   .#{$name}-center-start,
-  .#{$name}-center-end {
+  .#{$name}-center-end,
+  .md-css-only [#{$name}="center"],
+  .md-css-only [#{$name}="center center"],
+  .md-css-only [#{$name}="center start"],
+  .md-css-only [#{$name}="center end"]
+  {
     justify-content: center;
   }
 
@@ -203,7 +250,12 @@
   .#{$name}-end, //stretch
   .#{$name}-end-center,
   .#{$name}-end-start,
-  .#{$name}-end-end {
+  .#{$name}-end-end,
+  .md-css-only [#{$name}="end"], //stretch
+  .md-css-only [#{$name}="end center"],
+  .md-css-only [#{$name}="end start"],
+  .md-css-only [#{$name}="end end"]
+  {
     justify-content: flex-end;
   }
 
@@ -211,7 +263,12 @@
   .#{$name}-space-around, //stretch
   .#{$name}-space-around-center,
   .#{$name}-space-around-start,
-  .#{$name}-space-around-end {
+  .#{$name}-space-around-end,
+  .md-css-only [#{$name}="space-around"], //stretch
+  .md-css-only [#{$name}="space-around center"],
+  .md-css-only [#{$name}="space-around start"],
+  .md-css-only [#{$name}="space-around end"]
+  {
     justify-content: space-around;
   }
 
@@ -219,7 +276,12 @@
   .#{$name}-space-between, //stretch
   .#{$name}-space-between-center,
   .#{$name}-space-between-start,
-  .#{$name}-space-between-end {
+  .#{$name}-space-between-end,
+  .md-css-only [#{$name}="space-between"], //stretch
+  .md-css-only [#{$name}="space-between center"],
+  .md-css-only [#{$name}="space-between start"],
+  .md-css-only [#{$name}="space-between end"]
+  {
     justify-content: space-between;
   }
 
@@ -229,22 +291,34 @@
   // stretch is the default for align-items
   // ------------------------------
 
-  // Cross Axis Center
-  .#{$name}-center-center,
-  .#{$name}-start-center,
-  .#{$name}-end-center,
-  .#{$name}-space-between-center,
-  .#{$name}-space-around-center {
-    align-items: center;
-  }
-
   // Cross Axis Start
   .#{$name}-center-start,
   .#{$name}-start-start,
   .#{$name}-end-start,
   .#{$name}-space-between-start,
-  .#{$name}-space-around-start {
+  .#{$name}-space-around-start,
+  .md-css-only [#{$name}="center start"],
+  .md-css-only [#{$name}="start start"],
+  .md-css-only [#{$name}="end start"],
+  .md-css-only [#{$name}="space-between start"],
+  .md-css-only [#{$name}="space-around start"]
+  {
     align-items: flex-start;
+  }
+
+  // Cross Axis Center
+  .#{$name}-center-center,
+  .#{$name}-start-center,
+  .#{$name}-end-center,
+  .#{$name}-space-between-center,
+  .#{$name}-space-around-center,
+  .md-css-only [#{$name}="center center"],
+  .md-css-only [#{$name}="start center"],
+  .md-css-only [#{$name}="end center"],
+  .md-css-only [#{$name}="space-between center"],
+  .md-css-only [#{$name}="space-around center"]
+  {
+    align-items: center;
   }
 
   // Cross Axis End
@@ -252,7 +326,13 @@
   .#{$name}-start-end,
   .#{$name}-end-end,
   .#{$name}-space-between-end,
-  .#{$name}-space-around-end {
+  .#{$name}-space-around-end,
+  .md-css-only [#{$name}="center end"],
+  .md-css-only [#{$name}="start end"],
+  .md-css-only [#{$name}="end end"],
+  .md-css-only [#{$name}="space-between end"],
+  .md-css-only [#{$name}="space-around end"]
+  {
     align-items: flex-end;
   }
 
@@ -280,6 +360,12 @@
     }
   }
 
+  .md-css-only [hide-sm], .md-css-only [hide] {
+    &:not([show-sm]):not([show]) {
+      display: none;
+    }
+  }
+
   @include flex-order-for-name(sm);
   @include layout-align-for-name(sm);
   @include layout-for-name(sm);
@@ -298,12 +384,22 @@
 
 // MEDIUM SCREEN
 @media (min-width: $layout-breakpoint-sm) and (max-width: $layout-breakpoint-md - 1) {
-  .hide, .hide-gt-sm {
+  .hide, .hide-gt-sm, {
     &:not(.show-gt-sm):not(.show-md):not(.show) {
       display: none;
     }
   }
+
   .hide-md:not(.show-md):not(.show) {
+    display: none;
+  }
+
+  .md-css-only [hide], .md-css-only [hide-gt-sm] {
+    &:not([show-gt-sm]):not([show-md]):not([show]) {
+      display: none;
+    }
+  }
+  .md-css-only [hide-md]:not([show-md]):not([show]) {
     display: none;
   }
 
@@ -334,6 +430,15 @@
     display: none;
   }
 
+  .md-css-only [hide], .md-css-only [hide-gt-sm], .md-css-only [hide-gt-md] {
+    &:not([show-gt-sm]):not([show-gt-md]):not([show-lg]):not([show]) {
+      display: none;
+    }
+  }
+  .md-css-only [hide-lg]:not([show-lg]):not([show]) {
+    display: none;
+  }
+
   @include flex-order-for-name(lg);
   @include layout-align-for-name(lg);
   @include layout-for-name(lg);
@@ -345,6 +450,12 @@
 @media (min-width: $layout-breakpoint-lg) {
   .hide-gt-sm, .hide-gt-md, .hide-gt-lg, .hide {
     &:not(.show-gt-sm):not(.show-gt-md):not(.show-gt-lg):not(.show) {
+      display: none;
+    }
+  }
+
+  .md-css-only [hide-gt-sm], .md-css-only [hide-gt-md], .md-css-only [hide-gt-lg], .md-css-only [hide] {
+    &:not([show-gt-sm]):not([show-gt-md]):not([show-gt-lg]):not([show]) {
       display: none;
     }
   }

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -94,8 +94,9 @@
 
 .layout-fill, .md-css-only [layout-fill] {
   margin: 0;
-  min-height: 100%;
   width: 100%;
+  min-height: 100%;
+  height: 100%;
 }
 @-moz-document url-prefix() {
   .layout-fill, .md-css-only [layout-fill] {

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -111,16 +111,12 @@
   @if $suffix != null {
     $selector: 'flex-order-#{$suffix}';
   }
-  .md-css-only [#{$selector}="0"] { order: 0; }
-  .md-css-only [#{$selector}="1"] { order: 1; }
-  .md-css-only [#{$selector}="2"] { order: 2; }
-  .md-css-only [#{$selector}="3"] { order: 3; }
-  .md-css-only [#{$selector}="4"] { order: 4; }
-  .md-css-only [#{$selector}="5"] { order: 5; }
-  .md-css-only [#{$selector}="6"] { order: 6; }
-  .md-css-only [#{$selector}="7"] { order: 7; }
-  .md-css-only [#{$selector}="8"] { order: 8; }
-  .md-css-only [#{$selector}="9"] { order: 9; }
+
+  @for $i from -9 through 9 {
+    .#{$selector}-#{$i}, .md-css-only .#{$selector}-#{$i} {
+      order: #{$i};
+    }
+  }
 }
 
 @mixin layout-for-name($name) {

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -1,4 +1,10 @@
 // Responsive attributes
+//
+// References:
+// 1) https://scotch.io/tutorials/a-visual-guide-to-css3-flexbox-properties#flex
+// 2) https://css-tricks.com/almanac/properties/f/flex/
+// 3) https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
+//
 // ------------------------------
 
 // hide means hide everywhere
@@ -175,10 +181,28 @@
     box-sizing: border-box;
     flex: 1;
   }
+  
+  @if ( $name == 'flex' ) {
+    .flex, .md-css-only [flex=""],
+    .flex-initial, .md-css-only [flex="initial"] {
+      box-sizing: border-box;
+      flex: 0 1 auto;
+    }
 
 
-  // (0-20) * 5 = 0-100%
-  @for $i from 0 through 20 {
+    .flex-1, .md-css-only [flex="1"] {
+      box-sizing: border-box;
+      flex: 1 1 0%;
+    }
+  
+    .flex-auto, .md-css-only [flex="auto"] {
+      box-sizing: border-box;
+      flex: 1 1 auto;
+    }
+  }
+
+  // (1-20) * 5 = 0-100%
+  @for $i from 1 through 20 {
     .#{$flexName}-#{$i * 5},
     .md-css-only [#{$flexName}="#{$i * 5}"]
     {
@@ -200,11 +224,13 @@
   .#{$flexName}-33, .#{$flexName}-34
   {
     flex: 0 0 33%;
+    max-width: 33%;
   }
 
   .#{$flexName}-66, .#{$flexName}-67
   {
     flex: 0 0 67%;
+    max-width: 67%;
 
   }
 
@@ -214,7 +240,7 @@
   }
   .layout-column, .md-css-only [layout="column"] {
     > .#{$flexName}-33, > .#{$flexName}-34 { max-height: 33%;  }
-    > .#{$flexName}-66, > .#{$flexName}-67 { max-height: 33%; }
+    > .#{$flexName}-66, > .#{$flexName}-67 { max-height: 67%; }
   }
 }
 
@@ -316,6 +342,8 @@
   .md-css-only [#{$name}="space-around center"]
   {
     align-items: center;
+    max-width: 100%;
+
   }
 
   // Cross Axis End

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -1,6 +1,11 @@
 describe('layout directives', function() {
   beforeEach(module('material.core', 'material.core.layout'));
 
+  afterEach(inject(function($document, $$mdLayout) {
+    angular.element($document[0].body).removeClass('md-css-only');
+    $$mdLayout.disablePostLinks = undefined;
+  }));
+
   describe('expecting layout classes', function() {
 
     var suffixes = ['sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg'];
@@ -49,6 +54,13 @@ describe('layout directives', function() {
       it('should fail if the class ' + expectedClass + ' was not added for attribute ' + attribute, inject(function($compile, $rootScope) {
         var element = $compile('<div ' + attribute + '>Layout</div>')($rootScope.$new());
         expect(element.hasClass(expectedClass)).toBe(true);
+      }));
+
+      it('should not add the class ' + expectedClass + ' if the body class has "md-css-only" ' + attribute, inject(function($compile, $rootScope, $document) {
+        angular.element($document[0].body).addClass('md-css-only');
+
+        var element = $compile('<div ' + attribute + '>Layout</div>')($rootScope.$new());
+        expect(element.hasClass(expectedClass)).toBe(false);
       }));
     }
 

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -14,14 +14,11 @@ describe('layout directives', function() {
     var flexValues = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 33, 34, 66, 67];
     var offsetValues = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 33, 34, 66, 67];
     var alignmentValues = [
-      'center', 'center center', 'center start', 'center end',
-      'end', 'end-center', 'end start', 'end end',
-      'space-around', 'space-around center', 'space-around start', 'space-around end',
-      'space-between', 'space-between center', 'space-between start', 'space-between end',
-      'center center', 'start center', 'end center', 'space-between center', 'space-around center',
-      'center start', 'start start', 'end start', 'space-between start', 'space-around start',
-      'center end', 'start end', 'end end', 'space-between end', 'space-around end'
-    ];
+      "center", "center center", "center start", "center end",
+      "end", "end center", "end start", "end end",
+      "space-around", "space-around center", "space-around start", "space-around end",
+      "space-between", "space-between center", "space-between start", "space-between end",
+      "start center", "start start", "start end"];
     var mappings = [
       { attribute: 'flex',           suffixes: suffixes, values: flexValues, addDirectiveAsClass: true, testStandAlone: true},
       { attribute: 'flex-order',     suffixes: suffixes, values: flexOrderValues },

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -6,7 +6,7 @@ describe('layout directives', function() {
     $$mdLayout.disablePostLinks = undefined;
   }));
 
-  describe('expecting layout classes', function() {
+  describe('translated to layout classes', function() {
 
     var suffixes = ['sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg'];
     var directionValues = ['row', 'column'];
@@ -123,4 +123,32 @@ describe('layout directives', function() {
     }
   });
 
+  describe('layout attribute with dynamic values', function() {
+
+    it('should observe the attribute value and update the layout class(es)', inject(function($rootScope, $compile) {
+      var scope = $rootScope.$new();
+          scope.size = undefined;
+
+      var element = angular.element($compile('<div flex-gt-md="{{size}}"></div>')(scope));
+
+      expect(element.hasClass('flex-gt-md')).toBe(true);
+      expect(element.hasClass('flex-gt-md-size')).toBe(false);
+
+      scope.$apply(function() {
+        scope.size = 32;
+      });
+
+      expect(element.hasClass('flex-gt-md-32')).toBe(true);
+
+      scope.$apply(function() {
+        scope.size = "fishCheeks";
+      });
+
+      expect(element.hasClass('flex-gt-md-32')).toBe(false);
+      expect(element.hasClass('flex-gt-md-fishCheeks')).toBe(true);
+
+      expect(element.attr('flex-gt-md')).toBeFalsy();
+    }));
+
+  })
 });

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -10,7 +10,7 @@ describe('layout directives', function() {
 
     var suffixes = ['sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg'];
     var directionValues = ['row', 'column'];
-    var flexOrderValues = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    var flexOrderValues = [-9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     var flexValues = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 100, 33, 34, 66, 67];
     var offsetValues = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95, 33, 34, 66, 67];
     var alignmentValues = [

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -197,7 +197,7 @@ InkRippleCtrl.prototype.clearTimeout = function () {
 InkRippleCtrl.prototype.isRippleAllowed = function () {
   var element = this.$element[0];
   do {
-    if (element.tagName && element.tagName !== 'BODY') break;
+    if (!element.tagName || element.tagName === 'BODY') break;
     if (element && element.hasAttribute && element.hasAttribute('disabled')) return false;
   } while (element = element.parentNode);
   return true;

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -194,12 +194,21 @@ InkRippleCtrl.prototype.clearTimeout = function () {
   }
 };
 
+InkRippleCtrl.prototype.isRippleAllowed = function () {
+  var element = this.$element[0];
+  do {
+    if (element && element.hasAttribute && element.hasAttribute('disabled')) return false;
+  } while (element = element.parentNode);
+};
+
 /**
  * Creates a new ripple and adds it to the container.  Also tracks ripple in `this.ripples`.
  * @param left
  * @param top
  */
 InkRippleCtrl.prototype.createRipple = function (left, top) {
+  if (!this.isRippleAllowed()) return;
+
   var ctrl        = this;
   var ripple      = angular.element('<div class="md-ripple"></div>');
   var width       = this.$element.prop('clientWidth');

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -197,8 +197,10 @@ InkRippleCtrl.prototype.clearTimeout = function () {
 InkRippleCtrl.prototype.isRippleAllowed = function () {
   var element = this.$element[0];
   do {
+    if (element.tagName && element.tagName !== 'BODY') break;
     if (element && element.hasAttribute && element.hasAttribute('disabled')) return false;
   } while (element = element.parentNode);
+  return true;
 };
 
 /**

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -100,8 +100,8 @@ var LIGHT_DEFAULT_HUES = {
 var DARK_DEFAULT_HUES = {
   'background': {
     'default': '800',
-    'hue-1': '300',
-    'hue-2': '600',
+    'hue-1': '600',
+    'hue-2': '300',
     'hue-3': '900'
   }
 };

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -15,10 +15,12 @@
 }
 
 @mixin input-placeholder-color($color) {
-  &::-webkit-input-placeholder { color: $color; }
-  &::-moz-placeholder { color: $color; } /* Firefox 19+ */
-  &:-moz-placeholder { color: $color; } /* Firefox 18- */
-  &:-ms-input-placeholder { color: $color; }
+  &::-webkit-input-placeholder,
+    &::-moz-placeholder,
+    &:-moz-placeholder,
+    &:-ms-input-placeholder {
+      color: $color;
+    }
 }
 
 @mixin pie-clearfix {

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -39,25 +39,36 @@ $toast-margin: $baseline-grid * 1 !default;
 
 // Whiteframes
 
-$shadow-multiplier: 0.7;
-$shadow-key-umbra-opacity:      $shadow-multiplier * 0.2;
-$shadow-key-penumbra-opacity:   $shadow-multiplier * 0.14;
-$shadow-ambient-shadow-opacity: $shadow-multiplier * 0.12;
+$shadow-key-umbra-opacity:      0.2;
+$shadow-key-penumbra-opacity:   0.14;
+$shadow-ambient-shadow-opacity: 0.12;
 
 // NOTE(shyndman): gulp-sass seems to be failing if I split the shadow defs across
 //    multiple lines. Ugly. Sorry.
-$whiteframe-shadow-z1: 0px 3px 1px -2px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 2px 2px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 1px 5px 0px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
-$whiteframe-zindex-z1: 1 !default;
-$whiteframe-shadow-z2: 0 2px 4px -1px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0 4px 5px 0 rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0 1px 10px 0 rgba(0, 0, 0, $shadow-ambient-shadow-opacity);
-$whiteframe-zindex-z2: 2 !default;
-$whiteframe-shadow-z3: 0px 3px 5px -1px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 6px 10px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 1px 18px 0px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
-$whiteframe-zindex-z3: 3 !default;
-$whiteframe-shadow-z4: 0px 5px 5px -3px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 8px 10px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 3px 14px 2px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
-$whiteframe-zindex-z4: 4 !default;
-$whiteframe-shadow-z5: 0px 8px 10px -5px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 16px 24px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 6px 30px 5px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
-$whiteframe-zindex-z5: 5 !default;
-
-
+$whiteframe-shadow-1dp: 0px 1px 3px 0px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 1px 1px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 2px 1px -1px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-2dp: 0px 1px 5px 0px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 2px 2px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 3px 1px -2px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-3dp: 0px 1px 8px 0px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 3px 4px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 3px 3px -2px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-4dp: 0px 2px 4px -1px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 4px 5px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 1px 10px 0px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-5dp: 0px 3px 5px -1px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 5px 8px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 1px 14px 0px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-6dp: 0px 3px 5px -1px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 6px 10px 0px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 1px 18px 0px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-7dp: 0px 4px 5px -2px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 7px 10px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 2px 16px 1px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-8dp: 0px 5px 5px -3px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 8px 10px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 3px 14px 2px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-9dp: 0px 5px 6px -3px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 9px 12px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 3px 16px 2px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-10dp: 0px 6px 6px -3px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 10px 14px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 4px 18px 3px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-11dp: 0px 6px 7px -4px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 11px 15px 1px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 4px 20px 3px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-12dp: 0px 7px 8px -4px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 12px 17px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 5px 22px 4px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-13dp: 0px 7px 8px -4px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 13px 19px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 5px 24px 4px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-14dp: 0px 7px 9px -4px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 14px 21px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 5px 26px 4px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-15dp: 0px 8px 9px -5px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 15px 22px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 6px 28px 5px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-16dp: 0px 8px 10px -5px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 16px 24px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 6px 30px 5px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-17dp: 0px 8px 11px -5px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 17px 26px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 6px 32px 5px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-18dp: 0px 9px 11px -5px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 18px 28px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 7px 34px 6px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-19dp: 0px 9px 12px -6px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 19px 29px 2px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 7px 36px 6px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-20dp: 0px 10px 13px -6px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 20px 31px 3px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 8px 38px 7px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-21dp: 0px 10px 13px -6px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 21px 33px 3px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 8px 40px 7px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-22dp: 0px 10px 14px -6px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 22px 35px 3px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 8px 42px 7px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-23dp: 0px 11px 14px -7px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 23px 36px 3px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 9px 44px 8px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
+$whiteframe-shadow-24dp: 0px 11px 15px -7px rgba(0, 0, 0, $shadow-key-umbra-opacity), 0px 24px 38px 3px rgba(0, 0, 0, $shadow-key-penumbra-opacity), 0px 9px 46px 8px rgba(0, 0, 0, $shadow-ambient-shadow-opacity) !default;
 
 // Z-indexes
 //--------------------------------------------

--- a/src/core/util/animation/animate.spec.js
+++ b/src/core/util/animation/animate.spec.js
@@ -1,10 +1,10 @@
 describe('animate', function() {
   beforeEach(module('material.core'));
 
-  var $animate, $rootScope, $timeout, $$mdAnimate;
-  beforeEach( inject(function(_$animate_,_$rootScope_,_$timeout_, _$$mdAnimate_, $mdUtil) {
+  var $material, $rootScope, $timeout, $$mdAnimate;
+  beforeEach( inject(function(_$material_,_$rootScope_,_$timeout_, _$$mdAnimate_, $mdUtil) {
       $$mdAnimate = _$$mdAnimate_($mdUtil);
-      $animate = _$animate_;
+      $material = _$material_;
       $rootScope = _$rootScope_;
       $timeout = _$timeout_;
   }));
@@ -88,7 +88,6 @@ describe('animate', function() {
 
   function flush() {
     $rootScope.$digest();
-    $animate.triggerCallbacks();
-    $timeout.flush();
+    $material.flushOutstandingAnimations();
   }
 });

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -141,7 +141,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
             // If the expression evaluates to FALSE, then it is not focusable target
             var focusExpression = it[0].getAttribute(attribute);
-            var isFocusable = focusExpression ? (it.scope().$eval(focusExpression) !== false ) : true;
+            var isFocusable = !focusExpression || !$mdUtil.validateScope(it) ? true :
+                              (it.scope().$eval(focusExpression) !== false );
 
             if (isFocusable) elFound = it;
           });
@@ -402,6 +403,22 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      */
     nextUid: function() {
       return '' + nextUniqueId++;
+    },
+
+    /**
+     * By default AngularJS attaches information about binding and scopes to DOM nodes,
+     * and adds CSS classes to data-bound elements. But this information is NOT available
+     * when `$compileProvider.debugInfoEnabled(false);`
+     *
+     * @see https://docs.angularjs.org/guide/production
+     */
+    validateScope : function(element) {
+      var hasScope = element && angular.isDefined(element.scope());
+      if ( !hasScope ) {
+        $log.warn("element.scope() is not available when 'debug mode' == false. @see https://docs.angularjs.org/guide/production!");
+      }
+
+      return hasScope;
     },
 
     // Stop watchers and events from firing on a scope without destroying it,

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -492,7 +492,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     extractElementByName: function(element, nodeName, scanDeep, warnNotFound) {
       var found = scanTree(element);
       if (!found && !!warnNotFound) {
-        $log.warn( $mdUtil.supplant("Unable to find node '{0}' in element '{1}'.",[nodeName, element[0].outerHTM]) );
+        $log.warn( $mdUtil.supplant("Unable to find node '{0}' in element '{1}'.",[nodeName, element[0].outerHTML]) );
       }
 
       return angular.element(found || element);

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -1,5 +1,39 @@
 describe('util', function() {
 
+  describe('validateScope',function() {
+
+    it("should not find a valid scope when debug is disabled", function() {
+      module(function($compileProvider) {
+        $compileProvider.debugInfoEnabled(false);
+      });
+
+      inject(function($compile, $rootScope, $mdUtil) {
+        var widget = angular.element($compile('<div><button><img></button></div>')($rootScope));
+        var button = angular.element(widget.children()[0]);
+
+        $rootScope.$apply();
+        expect(button.scope()).toBe(undefined);
+        expect($mdUtil.validateScope(button)).toBe(false);
+
+      });
+    });
+
+    it("should find a valid scope when debug is enabled", function() {
+      module(function($compileProvider) {
+        $compileProvider.debugInfoEnabled(true);
+      });
+
+      inject(function($compile, $rootScope, $mdUtil) {
+        var widget = angular.element($compile('<div><button><img></button></div>')($rootScope));
+        var button = angular.element(widget.children()[0]);
+
+        $rootScope.$apply();
+        expect(button.scope()).toBeDefined();
+        expect($mdUtil.validateScope(button)).toBe(true);
+      });
+    });
+  });
+
   describe('with no overrides', function() {
     beforeEach(module('material.core'));
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -259,11 +259,8 @@ describe('util', function() {
      }));
 
     function flush(expectation) {
-
       $rootScope.$digest();
-      $animate.triggerCallbacks();
       $timeout.flush();
-
       expectation && expectation();
     }
   });
@@ -292,5 +289,4 @@ describe('util', function() {
       }));
     });
   });
-
 });

--- a/test/angular-material-mocks.js
+++ b/test/angular-material-mocks.js
@@ -33,6 +33,24 @@ angular.module('ngMaterial-mock', [
   ])
   .config(['$provide', function($provide) {
 
+    $provide.factory('$material', ['$animate', '$timeout', function($animate, $timeout) {
+      return {
+        flushOutstandingAnimations: function() {
+          // this code is placed in a try-catch statement
+          // since 1.3 and 1.4 handle their animations differently
+          // and there may be situations where follow-up animations
+          // are run in one version and not the other
+          try { $animate.flush(); } catch(e) {}
+        },
+        flushInterimElement: function() {
+          this.flushOutstandingAnimations();
+          $timeout.flush();
+          this.flushOutstandingAnimations();
+          $timeout.flush();
+        }
+      };
+    }]);
+
     /**
       * Angular Material dynamically generates Style tags
       * based on themes and palletes; for each ng-app.
@@ -69,8 +87,8 @@ angular.module('ngMaterial-mock', [
 
       var ngFlush = $delegate.flush;
       $delegate.flush = function() {
-          try      { ngFlush();  }
-          catch(e) { ;           }
+        try      { ngFlush();  }
+        catch(e) { ;           }
       };
 
       return $delegate;
@@ -92,7 +110,7 @@ angular.module('ngMaterial-mock', [
       return $delegate;
     });
 
-  }]);
+  }])
 
   /**
    * Stylesheet Mocks used by `animateCss.spec.js`


### PR DESCRIPTION
* allow flex-order to be negative
* add support to observe interpolated layout values.
*  restore max-width for layouts
  *  restore `layout > flex` specifiers of max-width or max-height.
  * publish `$$mdLayout` service to allow Attribute selectors to be removed when the translation inject to Class selector finishes.
*  add `md-css-only` feature , 
  *  support use of `<body class="md-css-only">`  to use Layout features **without** any JS requirements or `ngMaterial` module dependencies.
    *  May use standard Attribute selectors
    *  May use class selectors
    *  Disables Layout directive postlinks for optimization

According to CSS Flexible Box Layout Module Level 1 and CSS Values and Units Module Level 3, the order property can be negative, -9 to -1, as well as positive, 1 to 9, and zero.

Fixes #4482. Closes #4592.

> Thx @flowersinthesand for original PR
