### PR TITLE
fix(mdAutocomplete): Fix scope watch bug.

### DIFF
--- a/src/components/autocomplete/js/autocompleteParentScopeDirective.js
+++ b/src/components/autocomplete/js/autocompleteParentScopeDirective.js
@@ -10,7 +10,7 @@ function MdAutocompleteItemScopeDirective($compile, $mdUtil) {
   };
 
   function postLink(scope, element, attr) {
-    var ctrl     = scope.$mdAutocompleteCtrl;
+    var ctrl = scope.$mdAutocompleteCtrl;
     var newScope = ctrl.parent.$new();
     var itemName = ctrl.itemName;
 
@@ -32,10 +32,13 @@ function MdAutocompleteItemScopeDirective($compile, $mdUtil) {
      * @param variable
      * @param alias
      */
-    function watchVariable (variable, alias) {
-      $mdUtil.nextTick(function () {
-        newScope[alias] = scope[variable];
-        scope.$watch(variable, function (value) { newScope[alias] = value; });
+    function watchVariable(variable, alias) {
+      newScope[alias] = scope[variable];
+
+      scope.$watch(variable, function(value) {
+        $mdUtil.nextTick(function() {
+          newScope[alias] = value;
+        });
       });
     }
   }


### PR DESCRIPTION
Commit 8849213ce42fa98169b6fbbb0805feb95a6ba678 introduced a scope watching bug causing the autocomplete to no longer update it's list of items as you scrolled (since it re-uses DOM elements). Fix by swapping nextTick to be inside the watch statement.

Fixes #4713.