### PR TITLE
fix(tests): PhantomJS crashes at 1037 tests run due to memory leak.

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -63,9 +63,9 @@ module.exports = function(config) {
     // - Firefox
     // - Opera (has to be installed with `npm install karma-opera-launcher`)
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
-    // - PhantomJS
+    // - PhantomJS/PhantomJS2
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
-    browsers: ['Firefox', 'PhantomJS'],
+    browsers: ['Firefox', 'PhantomJS2'],
 
     // you can define custom flags
     customLaunchers: {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs2-launcher": "^0.3.2",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "lazypipe": "^0.2.2",


### PR DESCRIPTION
Use karma-phantomjs2-launcher in order to be able to run complete test suite in PhantomJS.