### PR TITLE
fix(tests): PhantomJS crashes at 1037 tests due to memory leak on Windows

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -41,8 +41,7 @@ module.exports = function(config) {
 
   var testSrc = process.env.KARMA_TEST_COMPRESSED ? COMPILED_SRC : UNCOMPILED_SRC;
 
-  config.set({
-
+  var configuration = {
     basePath: __dirname + '/..',
     frameworks: ['jasmine'],
     files: dependencies.concat(testSrc),
@@ -63,7 +62,7 @@ module.exports = function(config) {
     // - Firefox
     // - Opera (has to be installed with `npm install karma-opera-launcher`)
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
-    // - PhantomJS
+    // - PhantomJS/PhantomJS2
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
     browsers: ['Firefox', 'PhantomJS'],
 
@@ -94,6 +93,11 @@ module.exports = function(config) {
         ]
       }
     }
-  });
+  };
 
+  // Only use PhantomJS2 on Windows. The karma-phantomjs2-launcher does not have good Linux images for Travis CI yet.
+  if (process.platform === 'win32') {
+    configuration.browsers = ['Firefox', 'PhantomJS2'];
+  }
+  config.set(configuration);
 };

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-jasmine": "^0.2.2",
     "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs2-launcher": "^0.3.2",
     "karma-safari-launcher": "^0.1.1",
     "karma-sauce-launcher": "^0.2.10",
     "lazypipe": "^0.2.2",


### PR DESCRIPTION
Use karma-phantomjs2-launcher in order to run complete test suite in PhantomJS on Windows.
Don't use it for all platforms since we don't have good Linux binaries for PhantomJS2.
Linux binaries are needed for Travis CI.

Fixes #4734.