### PR TITLE
chore(npm): add standard package.json fields

### DIFF
--- a/gulp/tasks/server.js
+++ b/gulp/tasks/server.js
@@ -1,13 +1,20 @@
 var gulp = require('gulp');
 var webserver = require('gulp-webserver');
 var LR_PORT = require('../const').LR_PORT;
+var util = require('../util');
 
 exports.task = function() {
-  return gulp.src('.')
+    var openUrl = false;
+    if (typeof util.args.o === 'string' ||
+        typeof util.args.o === 'boolean') {
+        openUrl = util.args.o;
+    }
+    return gulp.src('.')
       .pipe(webserver({
-        host: '0.0.0.0',
-        livereload: true,
-        port: LR_PORT,
-        directoryListing: true
-      }));
+            host: '0.0.0.0',
+            livereload: true,
+            port: LR_PORT,
+            directoryListing: true,
+            open: openUrl
+        }));
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,13 @@
 {
   "name": "angular-material-source",
   "version": "0.11.0",
+  "description": "The Angular Material project is an implementation of Material Design in Angular.js. This project provides a set of reusable, well-tested, and accessible UI components based on the Material Design system. Similar to the Polymer project's Paper elements collection, Angular Material is supported internally at Google by the Angular.js, Material Design UX and other product teams.",
+  "keywords": "client-side, browser, material, material-design, design, angular, css, components, google",
+  "homepage": "https://material.angularjs.org",
+  "bugs": "https://github.com/angular/material/issues",
+  "license": "MIT",
   "repository": {
+    "type" : "git",
     "url": "git://github.com/angular/material.git"
   },
   "devDependencies": {
@@ -59,6 +65,7 @@
     "through2": "^0.6.3"
   },
   "scripts": {
+    "start": "gulp server -o http://localhost:8080/dist/docs/index.html",
     "prom": "git pull --rebase origin master",
     "current-branch": "git rev-parse --abbrev-ref HEAD",
     "merge-base": "git merge-base $(npm run -s current-branch) origin/master",


### PR DESCRIPTION
Fix license warnings from npm
Add a useful `npm start` script. It opens the docs in your default browser
Add other standard fields as detailed in https://docs.npmjs.com/files/package.json

Closes #3552.