### PR TITLE
check for undefined before trying to compute animation style values, …

### DIFF
--- a/src/core/util/animation/animateCss.js
+++ b/src/core/util/animation/animateCss.js
@@ -315,16 +315,18 @@ if (angular.version.minor >= 4) {
 
       function parseMaxTime(str) {
         var maxValue = 0;
-        var values = (str || "").split(/\s*,\s*/);
-        forEach(values, function(value) {
-          // it's always safe to consider only second values and omit `ms` values since
-          // getComputedStyle will always handle the conversion for us
-          if (value.charAt(value.length - 1) == 's') {
-            value = value.substring(0, value.length - 1);
-          }
-          value = parseFloat(value) || 0;
-          maxValue = maxValue ? Math.max(value, maxValue) : value;
-        });
+        if (str) {
+          var values = (str || "").split(/\s*,\s*/);
+          forEach(values, function(value) {
+            // it's always safe to consider only second values and omit `ms` values since
+            // getComputedStyle will always handle the conversion for us
+            if (value.charAt(value.length - 1) == 's') {
+              value = value.substring(0, value.length - 1);
+            }
+            value = parseFloat(value) || 0;
+            maxValue = maxValue ? Math.max(value, maxValue) : value;
+          });
+        }
         return maxValue;
       }
 


### PR DESCRIPTION
When checking animationDuration on computeTimings, the cs property was not there on Safari and Ubuntu Linux (Chrome). Checking for str first.
…Fixes #4752 