### PR TITLE
fix(mdTooltip): Tooltip inside subheader causes Firefox hang.

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -106,9 +106,12 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
      */
     function getParentWithPointerEvents () {
       var parent = element.parent();
-      while (parent && hasComputedStyleValue('pointer-events','none', parent[0])) {
+
+      // jqLite might return a non-null, but still empty, parent; so check for parent and length
+      while (parent && parent.length && hasComputedStyleValue('pointer-events','none', parent[0])) {
         parent = parent.parent();
       }
+
       return parent;
     }
 


### PR DESCRIPTION
When a `<md-tooltip>` was placed inside the `<md-subheader>`, an infinite loop was being hit (only in Firefox) which was causing the browser to hang.

The infinite loop was caused by the tooltip's `getParentWithPointerEvents()` method which travels up the
DOM looking for a parent who has pointer events. In Firefox, the `element.parent()` can apparently return an empty jqLite object that is not null, but whose length is 0. In this case, calling `parent.parent()` again will return the same object.

Add a check to the tooltip's loop to ensure that `parent.length` is never 0.

Fixes #4777.