### PR TITLE
(#4823) add topIndex attribute to virtualRepeatContainer

### DIFF
--- a/src/components/virtualRepeat/demoScrollTo/index.html
+++ b/src/components/virtualRepeat/demoScrollTo/index.html
@@ -1,0 +1,24 @@
+<div ng-controller="AppCtrl as ctrl">
+  <md-content layout="column" class="md-padding">
+    <p>
+      Use the <code>md-top-index</code> attribute to watch which item is at the top of the scroll
+      container, and also to jump to a specific item.
+    </p>
+
+    <div class="wrapper">
+      <md-input-container>
+        <md-select ng-model="ctrl.selectedYear" aria-label="Select a Year">
+          <md-option ng-value="$index" ng-repeat="year in ctrl.years">{{ year }}</md-option>
+        </md-select>
+      </md-input-container>
+
+      <md-virtual-repeat-container id="vertical-container" md-top-index="ctrl.topIndex">
+        <div md-virtual-repeat="item in ctrl.items"
+            class="repeated-item" ng-class="{header: item.header}" flex>
+          {{item.text}}
+        </div>
+      </md-virtual-repeat-container>
+    </div>
+
+  </md-content>
+</div>

--- a/src/components/virtualRepeat/demoScrollTo/script.js
+++ b/src/components/virtualRepeat/demoScrollTo/script.js
@@ -1,0 +1,35 @@
+(function () {
+  'use strict';
+
+    angular
+      .module('virtualRepeatScrollToDemo', ['ngMaterial'])
+      .controller('AppCtrl', function($scope) {
+        this.selectedYear = 0;
+        this.years = [];
+        this.items = [];
+        var currentYear = new Date().getFullYear();
+        var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
+          'July', 'August', 'September', 'October', 'November', 'December'];
+        // Build a list of months over 20 years
+        for (var y = currentYear; y >= (currentYear-20); y--) {
+          this.years.push(y);
+          this.items.push({year: y, text: y, header: true});
+          for (var m = 11; m >= 0; m--) {
+            this.items.push({year: y, month: m, text: monthNames[m]});
+          }
+        }
+        // Whenever a different year is selected, scroll to that year
+        $scope.$watch('ctrl.selectedYear', angular.bind(this, function(yearIndex) {
+          var scrollYear = Math.floor(this.topIndex / 13);
+          if(scrollYear !== yearIndex) {
+            this.topIndex = yearIndex * 13;
+          }
+        }));
+        // The selected year should follow the year that is at the top of the scroll container
+        $scope.$watch('ctrl.topIndex', angular.bind(this, function(topIndex) {
+          var scrollYear = Math.floor(topIndex / 13);
+          this.selectedYear = scrollYear;
+        }));
+      });
+
+})();

--- a/src/components/virtualRepeat/demoScrollTo/style.css
+++ b/src/components/virtualRepeat/demoScrollTo/style.css
@@ -1,0 +1,34 @@
+.wrapper {
+    width: 400px;
+}
+
+#vertical-container {
+  height: 292px;
+  width: 400px;
+}
+
+#vertical-container .repeated-item {
+  border-bottom: 1px solid #ddd;
+  box-sizing: border-box;
+  height: 40px;
+  padding-top: 10px;
+}
+
+#vertical-container .repeated-item.header {
+    background-color: #3F51B5;
+    color: white;
+    text-align: center;
+    font-weight: bold;
+}
+
+#vertical-container md-content {
+  margin: 16px;
+}
+
+md-virtual-repeat-container {
+  border: solid 1px grey;
+}
+
+.md-virtual-repeat-container .md-virtual-repeat-offsetter {
+  padding-left: 16px;
+}

--- a/src/components/virtualRepeat/demoScrollTo/style.css
+++ b/src/components/virtualRepeat/demoScrollTo/style.css
@@ -15,7 +15,7 @@
 }
 
 #vertical-container .repeated-item.header {
-    background-color: #3F51B5;
+    background-color: #106CC8;
     color: white;
     text-align: center;
     font-weight: bold;

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -102,19 +102,19 @@ function VirtualRepeatContainerController($$rAF, $parse, $scope, $element, $attr
   /** @type {number} Amount to offset the total scroll size by. */
   this.offsetSize = parseInt(this.$attrs.mdOffsetSize, 10) || 0;
 
-  if(this.$attrs.hasOwnProperty('mdTopIndex')) {
-    /** @type {function} An Angular expression that binds to topIndex on the scope */
+  if (this.$attrs.mdTopIndex) {
+    /** @type {function(angular.Scope): number} Binds to topIndex on Angular scope */
     this.bindTopIndex = $parse(this.$attrs.mdTopIndex);
     /** @type {number} The index of the item that is at the top of the scroll container */
     this.topIndex = this.bindTopIndex(this.$scope);
 
-    if(!angular.isDefined(this.topIndex)) {
+    if (!angular.isDefined(this.topIndex)) {
       this.topIndex = 0;
       this.bindTopIndex.assign(this.$scope, 0);
     }
 
     this.$scope.$watch(this.bindTopIndex, angular.bind(this, function(newIndex) {
-      if(newIndex !== this.topIndex) {
+      if (newIndex !== this.topIndex) {
         this.scrollToIndex(newIndex);
       }
     }));
@@ -313,9 +313,9 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
   this.offsetter.style.webkitTransform = transform;
   this.offsetter.style.transform = transform;
 
-  if(this.bindTopIndex) {
+  if (this.bindTopIndex) {
     var topIndex = Math.floor(offset / itemSize);
-    if(topIndex !== this.topIndex && topIndex < this.repeater.itemsLength) {
+    if (topIndex !== this.topIndex && topIndex < this.repeater.itemsLength) {
       this.topIndex = topIndex;
       this.bindTopIndex.assign(this.$scope, topIndex);
       if (!this.$scope.$root.$$phase) this.$scope.$digest();
@@ -602,7 +602,9 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
 
   if (this.isFirstRender) {
     this.isFirstRender = false;
-    var startIndex = this.$attrs.mdStartIndex ? this.$scope.$eval(this.$attrs.mdStartIndex) : this.container.topIndex;
+    var startIndex = this.$attrs.mdStartIndex ?
+      this.$scope.$eval(this.$attrs.mdStartIndex) :
+      this.container.topIndex;
     this.container.scrollToIndex(startIndex);
   }
 

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -23,11 +23,13 @@ angular.module('material.components.virtualRepeat', [
  * @usage
  * <hljs lang="html">
  *
- * <md-virtual-repeat-container>
+ * <md-virtual-repeat-container md-top-index="topIndex">
  *   <div md-virtual-repeat="i in items" md-item-size="20">Hello {{i}}!</div>
  * </md-virtual-repeat-container>
  * </hljs>
  *
+ * @param {number=} md-top-index Binds the index of the item that is at the top of the scroll
+ *     container to $scope. It can both read and set the scroll position.
  * @param {boolean=} md-orient-horizontal Whether the container should scroll horizontally
  *     (defaults to orientation and scrolling vertically).
  * @param {boolean=} md-auto-shrink When present, the container will shrink to fit
@@ -76,7 +78,7 @@ var MAX_ELEMENT_SIZE = 1533917;
 var NUM_EXTRA = 3;
 
 /** @ngInject */
-function VirtualRepeatContainerController($$rAF, $scope, $element, $attrs) {
+function VirtualRepeatContainerController($$rAF, $parse, $scope, $element, $attrs) {
   this.$scope = $scope;
   this.$element = $element;
   this.$attrs = $attrs;
@@ -100,6 +102,25 @@ function VirtualRepeatContainerController($$rAF, $scope, $element, $attrs) {
   /** @type {number} Amount to offset the total scroll size by. */
   this.offsetSize = parseInt(this.$attrs.mdOffsetSize, 10) || 0;
 
+  if(this.$attrs.hasOwnProperty('mdTopIndex')) {
+    /** @type {function} An Angular expression that binds to topIndex on the scope */
+    this.bindTopIndex = $parse(this.$attrs.mdTopIndex);
+    /** @type {number} The index of the item that is at the top of the scroll container */
+    this.topIndex = this.bindTopIndex(this.$scope);
+
+    if(!angular.isDefined(this.topIndex)) {
+      this.topIndex = 0;
+      this.bindTopIndex.assign(this.$scope, 0);
+    }
+
+    this.$scope.$watch(this.bindTopIndex, angular.bind(this, function(newIndex) {
+      if(newIndex !== this.topIndex) {
+        this.scrollToIndex(newIndex);
+      }
+    }));
+  } else {
+    this.topIndex = 0;
+  }
 
   this.scroller = $element[0].getElementsByClassName('md-virtual-repeat-scroller')[0];
   this.sizer = this.scroller.getElementsByClassName('md-virtual-repeat-sizer')[0];
@@ -258,6 +279,19 @@ VirtualRepeatContainerController.prototype.scrollTo = function(position) {
   this.handleScroll_();
 };
 
+/**
+ * Scrolls the item with the given index to the top of the scroll container.
+ * @param {number} index
+ */
+VirtualRepeatContainerController.prototype.scrollToIndex = function(index) {
+  var itemSize = this.repeater.getItemSize();
+  var itemsLength = this.repeater.itemsLength;
+  if(index > itemsLength) {
+    index = itemsLength - 1;
+  }
+  this.scrollTo(itemSize * index);
+};
+
 VirtualRepeatContainerController.prototype.resetScroll = function() {
   this.scrollTo(0);
 };
@@ -278,6 +312,15 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
   this.scrollOffset = offset;
   this.offsetter.style.webkitTransform = transform;
   this.offsetter.style.transform = transform;
+
+  if(this.bindTopIndex) {
+    var topIndex = Math.floor(offset / itemSize);
+    if(topIndex !== this.topIndex && topIndex < this.repeater.itemsLength) {
+      this.topIndex = topIndex;
+      this.bindTopIndex.assign(this.$scope, topIndex);
+      if (!this.$scope.$root.$$phase) this.$scope.$digest();
+    }
+  }
 
   this.repeater.containerUpdated();
 };
@@ -559,8 +602,8 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
 
   if (this.isFirstRender) {
     this.isFirstRender = false;
-    var startIndex = this.$attrs.mdStartIndex ? this.$scope.$eval(this.$attrs.mdStartIndex) : 0;
-    this.container.scrollTo(startIndex * this.itemSize);
+    var startIndex = this.$attrs.mdStartIndex ? this.$scope.$eval(this.$attrs.mdStartIndex) : this.container.topIndex;
+    this.container.scrollToIndex(startIndex);
   }
 
   // Detach and pool any blocks that are no longer in the viewport.

--- a/src/components/virtualRepeat/virtual-repeater.spec.js
+++ b/src/components/virtualRepeat/virtual-repeater.spec.js
@@ -408,6 +408,50 @@ describe('<md-virtual-repeat>', function() {
     expect(getRepeated().length).toBe(numItemRenderers);
   });
 
+  it('should update topIndex when scrolling', function() {
+    container.attr({'md-top-index': 'topIndex'});
+    scope.items = createItems(NUM_ITEMS);
+    createRepeater();
+
+    scope.$apply();
+    expect(scope.topIndex).toBe(0);
+
+    scroller[0].scrollTop = ITEM_SIZE * 50;
+    scroller.triggerHandler('scroll');
+    scope.$apply();
+    expect(scope.topIndex).toBe(50);
+
+    scroller[0].scrollTop = 25 * ITEM_SIZE;
+    scroller.triggerHandler('scroll');
+    scope.$apply();
+    expect(scope.topIndex).toBe(25);
+  });
+
+  it('should start at the given topIndex position', function() {
+    container.attr({'md-top-index': 'topIndex'});
+    repeater.removeAttr('md-start-index');
+    scope.topIndex = 10;
+    scope.items = createItems(200);
+    createRepeater();
+    scope.$apply();
+
+    expect(scroller[0].scrollTop).toBe(10 * ITEM_SIZE);
+  });
+
+  it('should scroll when topIndex is updated', function() {
+    container.attr({'md-top-index': 'topIndex'});
+    scope.items = createItems(200);
+    createRepeater();
+
+    scope.topIndex = 50;
+    scope.$apply();
+    expect(scroller[0].scrollTop).toBe(50 * ITEM_SIZE);
+
+    scope.topIndex = 25;
+    scope.$apply();
+    expect(scroller[0].scrollTop).toBe(25 * ITEM_SIZE);
+  });
+
   /**
    * Facade to access transform properly even when jQuery is used;
    * since jQuery's css function is obtaining the computed style (not wanted)


### PR DESCRIPTION
This PR adds an `md-top-index` attribute on the virtual repeat container. This allows the developer to watch which item is at the top of the scroll container, and also scroll to any item on demand.

Includes passing unit tests, documentation and working demo.

Live demo: http://codepen.io/colinskow/pen/jbVaRj