### PR TITLE
fix(dialog) use keydown instead of keyup

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -630,16 +630,16 @@ function MdDialogProvider($$interimElementProvider) {
           }
         };
 
-        // Add keyup listeners
-        element.on('keyup', keyHandlerFn);
-        target.on('keyup', keyHandlerFn);
+        // Add keydown listeners
+        element.on('keydown', keyHandlerFn);
+        target.on('keydown', keyHandlerFn);
         window.on('resize', onWindowResize);
 
         // Queue remove listeners function
         removeListeners.push(function() {
 
-          element.off('keyup', keyHandlerFn);
-          target.off('keyup', keyHandlerFn);
+          element.off('keydown', keyHandlerFn);
+          target.off('keydown', keyHandlerFn);
           window.off('resize', onWindowResize);
 
         });

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -346,7 +346,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       parent.triggerHandler({
-        type: 'keyup',
+        type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
       runAnimation();
@@ -405,7 +405,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       parent.triggerHandler({
-        type: 'keyup',
+        type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
       $timeout.flush();
@@ -501,7 +501,7 @@ describe('$mdDialog', function() {
       expect(parent.find('md-dialog').length).toBe(1);
 
       parent.triggerHandler({
-        type: 'keyup',
+        type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ESCAPE
       });
       $timeout.flush();
@@ -523,7 +523,7 @@ describe('$mdDialog', function() {
       runAnimation();
       expect(parent.find('md-dialog').length).toBe(1);
 
-      $rootElement.triggerHandler({type: 'keyup', keyCode: $mdConstant.KEY_CODE.ESCAPE});
+      $rootElement.triggerHandler({type: 'keydown', keyCode: $mdConstant.KEY_CODE.ESCAPE});
       runAnimation();
 
       expect(parent.find('md-dialog').length).toBe(1);


### PR DESCRIPTION
The rest of angular material watches for keydown events, not keyup. 

fixes #4041