### PR TITLE
fix(card): position md-card-footer at bottom of card

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -28,6 +28,7 @@ md-card {
     }
   }
   md-card-footer {
+    margin-top: auto;
     padding: $card-padding;
   }
 }


### PR DESCRIPTION
Old behavior did not cause the footer to stick to the bottom of the card
if the card had an assigned height taller than its content.

Fixes #3144