### PR TITLE
docs: fix demos GitCDN link to use proper URL for versioning

### DIFF
--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -19,7 +19,7 @@ function run {
   rm -rf code.material.angularjs.org/HEAD
 
   echo "-- Copying docs site to snapshot..."
-  sed -i "s,http://localhost:8080/angular-material,https://gitcdn.xyz/repo/angular/bower-material/v$VERSION/angular-material,g" dist/docs/docs.js
+  sed -i "s,http://localhost:8080/angular-material,https://cdn.gitcdn.xyz/cdn/angular/bower-material/v$VERSION/angular-material,g" dist/docs/docs.js
 
 
   cp -Rf dist/docs code.material.angularjs.org/HEAD


### PR DESCRIPTION
The GitCDN link used in the current demos points to a URL which is redirected to a new one. When this redirect occurs, the version info supplied in the URL is lost and the file always points to HEAD making it difficult to track down.

Fix snapshot script to use the new link which retains the version information.

_**NOTE:** I can't really test this without actually pushing a snapshot, but I copy/pasted the URL to make sure it worked._