### PR TITLE
feat(docs): use html5mode routing and simplify urls. Fixes #544

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -6,8 +6,12 @@ var DocsApp = angular.module('docsApp', [ 'angularytics', 'ngRoute', 'ngMessages
   'DEMOS',
   'PAGES',
   '$routeProvider',
+  '$locationProvider',
   '$mdThemingProvider',
-function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider) {
+function(SERVICES, COMPONENTS, DEMOS, PAGES,
+    $routeProvider, $locationProvider, $mdThemingProvider) {
+  $locationProvider.html5Mode(true);
+
   $routeProvider
     .when('/', {
       templateUrl: 'partials/home.tmpl.html'
@@ -18,37 +22,31 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
       }
     })
     .when('/layout/', {
-      redirectTo: function() {
-        return "/layout/container";
-      }
+      redirectTo:  '/layout/container'
     })
     .when('/demo/', {
-      redirectTo: function() {
-        return DEMOS[0].url;
-      }
+      redirectTo: DEMOS[0].url
     })
     .when('/api/', {
-      redirectTo: function() {
-        return COMPONENTS[0].docs[0].url;
-      }
+      redirectTo: COMPONENTS[0].docs[0].url
     })
     .when('/getting-started', {
       templateUrl: 'partials/getting-started.tmpl.html'
     });
   $mdThemingProvider.definePalette('docs-blue', $mdThemingProvider.extendPalette('blue', {
-      '50':   '#DCEFFF',
-      '100':  '#AAD1F9',
-      '200':  '#7BB8F5',
-      '300':  '#4C9EF1',
-      '400':  '#1C85ED',
-      '500':  '#106CC8',
-      '600':  '#0159A2',
-      '700':  '#025EE9',
-      '800':  '#014AB6',
-      '900':  '#013583',
-      'contrastDefaultColor': 'light',
-      'contrastDarkColors': '50 100 200 A100',
-      'contrastStrongLightColors': '300 400 A200 A400'
+    '50': '#DCEFFF',
+    '100': '#AAD1F9',
+    '200': '#7BB8F5',
+    '300': '#4C9EF1',
+    '400': '#1C85ED',
+    '500': '#106CC8',
+    '600': '#0159A2',
+    '700': '#025EE9',
+    '800': '#014AB6',
+    '900': '#013583',
+    'contrastDefaultColor': 'light',
+    'contrastDarkColors': '50 100 200 A100',
+    'contrastStrongLightColors': '300 400 A200 A400'
   }));
   $mdThemingProvider.definePalette('docs-red', $mdThemingProvider.extendPalette('red', {
     'A100': '#DE3641'
@@ -74,8 +72,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
 
   angular.forEach(COMPONENTS, function(component) {
     angular.forEach(component.docs, function(doc) {
-      doc.url = '/' + doc.url;
-      $routeProvider.when(doc.url, {
+      $routeProvider.when('/' + doc.url, {
         templateUrl: doc.outputPath,
         resolve: {
           component: function() { return component; },
@@ -87,11 +84,10 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
   });
 
   angular.forEach(SERVICES, function(service) {
-    service.url = '/' + service.url;
-    $routeProvider.when(service.url, {
+    $routeProvider.when('/' + service.url, {
       templateUrl: service.outputPath,
       resolve: {
-        component: function() { return undefined; },
+        component: angular.noop,
         doc: function() { return service; }
       },
       controller: 'ComponentDocCtrl'
@@ -100,13 +96,16 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
 
   angular.forEach(DEMOS, function(componentDemos) {
     var demoComponent;
-    angular.forEach(COMPONENTS, function(component) {
-      if (componentDemos.name === component.name) {
+
+    COMPONENTS.forEach(function(component) {
+      if (componentDemos.moduleName === component.name) {
         demoComponent = component;
+        component.demoUrl = componentDemos.url;
       }
     });
+
     demoComponent = demoComponent || angular.extend({}, componentDemos);
-    $routeProvider.when(componentDemos.url, {
+    $routeProvider.when('/' + componentDemos.url, {
       templateUrl: 'partials/demo.tmpl.html',
       controller: 'DemoCtrl',
       resolve: {
@@ -123,11 +122,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $routeProvider, $mdThemingProvider)
    AngularyticsProvider.setEventHandlers(['Console', 'GoogleUniversal']);
 }])
 
-.run([
-   'Angularytics',
-   '$rootScope',
-    '$timeout',
-function(Angularytics, $rootScope,$timeout) {
+.run(['Angularytics', function(Angularytics) {
   Angularytics.init();
 }])
 
@@ -291,7 +286,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
         var commonVersions = versionId === 'head' ? [] : [ head ];
         var knownVersions = getAllVersions();
         var listVersions = knownVersions.filter(removeCurrentVersion);
-        var currentVersion = getCurrentVersion();
+        var currentVersion = getCurrentVersion() || {name: 'local'};
         version.current = currentVersion;
         sections.unshift({
           name: 'Documentation Version',
@@ -311,17 +306,21 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
           }
         }
         function getAllVersions () {
-          return response.versions.map(function(version) {
-            var latest = response.latest === version;
-            return {
-              type: 'version',
-              url: '/' + version,
-              name: getVersionFullString({ id: version, latest: latest }),
-              id: version,
-              latest: latest,
-              github: 'tree/v' + version
-            };
-          });
+          if (response && response.versions && response.versions.length) {
+            return response.versions.map(function(version) {
+              var latest = response.latest === version;
+              return {
+                type: 'version',
+                url: '/' + version,
+                name: getVersionFullString({ id: version, latest: latest }),
+                id: version,
+                latest: latest,
+                github: 'tree/v' + version
+              };
+            });
+          }
+
+          return [];
         }
         function getVersionFullString (version) {
           return version.latest
@@ -367,11 +366,6 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
     }
   };
 
-  function sortByHumanName(a,b) {
-    return (a.humanName < b.humanName) ? -1 :
-      (a.humanName > b.humanName) ? 1 : 0;
-  }
-
   function onLocationChange() {
     var path = $location.path();
     var introLink = {
@@ -387,14 +381,14 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
     }
 
     var matchPage = function(section, page) {
-      if (path === page.url) {
+      if (path.indexOf(page.url) !== -1) {
         self.selectSection(section);
         self.selectPage(section, page);
       }
     };
 
     sections.forEach(function(section) {
-      if(section.children) {
+      if (section.children) {
         // matches nested section toggles, such as API or Customization
         section.children.forEach(function(childSection){
           if(childSection.pages){
@@ -404,7 +398,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
           }
         });
       }
-      else if(section.pages) {
+      else if (section.pages) {
         // matches top-level section toggles, such as Demos
         section.pages.forEach(function(page) {
           matchPage(section, page);
@@ -448,8 +442,6 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
     templateUrl: 'partials/menu-toggle.tmpl.html',
     link: function($scope, $element) {
       var controller = $element.parent().controller();
-      var $ul = $element.find('ul');
-      var originalHeight;
 
       $scope.isOpen = function() {
         return controller.isOpen($scope.section);
@@ -500,9 +492,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
   'menu',
   '$location',
   '$rootScope',
-  '$window',
-  '$log',
-function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu, $location, $rootScope, $window, $log) {
+function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu, $location, $rootScope) {
   var self = this;
 
   $scope.COMPONENTS = COMPONENTS;
@@ -525,8 +515,9 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
     enumerable: true,
     configurable: true
   });
-  $rootScope.redirectToUrl = function (url) {
-    $window.location.hash = url;
+
+  $rootScope.redirectToUrl = function(url) {
+    $location.path(url);
     $timeout(function () { $rootScope.relatedPage = null; }, 100);
   };
 
@@ -646,10 +637,7 @@ function($scope, $attrs, $location, $rootScope) {
   'doc',
   'component',
   '$rootScope',
-  '$templateCache',
-  '$http',
-  '$q',
-function($scope, doc, component, $rootScope, $templateCache, $http, $q) {
+function($scope, doc, component, $rootScope) {
   $rootScope.currentComponent = component;
   $rootScope.currentDoc = doc;
 }])
@@ -661,8 +649,7 @@ function($scope, doc, component, $rootScope, $templateCache, $http, $q) {
   'demos',
   '$http',
   '$templateCache',
-  '$q',
-function($rootScope, $scope, component, demos, $http, $templateCache, $q) {
+function($rootScope, $scope, component, demos, $http, $templateCache) {
   $rootScope.currentComponent = component;
   $rootScope.currentDoc = null;
 

--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -8,14 +8,14 @@
     </p>
     <ul class="buckets" layout layout-align="center center" layout-wrap>
       <li flex="25" flex-md="50" flex-sm="50" ng-repeat="(index, link) in [
-        { href: 'getting-started', icon: 'school', text: 'Getting Started' },
-        { href: 'demo', icon: 'play_circle_fill', text: 'Demos' },
-        { href: 'CSS/typography', icon: 'build', text: 'Customization' },
-        { href: 'api', icon: 'code', text: 'API Reference' }
+        { href: './getting-started', icon: 'school', text: 'Getting Started' },
+        { href: './demo', icon: 'play_circle_fill', text: 'Demos' },
+        { href: './CSS/typography', icon: 'build', text: 'Customization' },
+        { href: './api', icon: 'code', text: 'API Reference' }
       ]">
         <md-button
             class="md-primary md-raised"
-            ng-href="#/{{link.href}}"
+            ng-href="{{link.href}}"
             aria-label="{{link.text}}">
           <md-icon class="block" md-svg-src="img/icons/ic_{{link.icon}}_24px.svg"></md-icon>
           {{link.text}}

--- a/docs/app/partials/menu-link.tmpl.html
+++ b/docs/app/partials/menu-link.tmpl.html
@@ -1,6 +1,6 @@
 <md-button
     ng-class="{'active' : isSelected()}"
-    ng-href="{{(section.type === 'version' ? '' : '#') + section.url}}"
+    ng-href="{{section.url}}"
     ng-click="focusSection()">
   {{section | humanizeDoc}}
   <span class="md-visually-hidden"

--- a/docs/config/index.js
+++ b/docs/config/index.js
@@ -46,6 +46,7 @@ module.exports = new Package('angular-md', [
     getAliases: function(doc) { return [doc.id]; }
   });
 
+  // Build custom paths and outputPaths for "content" pages (theming and CSS).
   computePathsProcessor.pathTemplates.push({
     docTypes: ['content'],
     getPath: function(doc) {
@@ -60,6 +61,17 @@ module.exports = new Package('angular-md', [
         'partials',
         path.dirname(doc.fileInfo.relativePath),
         doc.fileInfo.baseName) + '.html';
+    }
+  });
+
+  // The default dgeni path for directives and services is something like
+  // "api/material.components.autocomplete/directive/mdAutocomplete".
+  // The module name is rather unnecessary, so we override with the shorter
+  // "api/directive/mdAutocomplete".
+  computePathsProcessor.pathTemplates.push({
+    docTypes: ['directive', 'service'],
+    getPath: function(doc) {
+      return path.join(doc.area, doc.docType, doc.name);
     }
   });
 })

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html ng-app="docsApp" ng-controller="DocsCtrl" lang="en" ng-strict-di>
 <head>
+<base href="/">
 <title ng-bind="'Angular Material - ' + menu.currentSection.name +
     (menu.currentSection === menu.currentPage ? '' : ' > ' + menu.currentPage.name)">
   Angular Material
@@ -18,7 +19,7 @@
               md-is-locked-open="$mdMedia('gt-sm')">
 
     <header class="nav-header">
-      <a ng-href="#/" class="docs-logo">
+      <a ng-href="/" class="docs-logo">
         <img src="img/icons/angular-logo.svg" alt="" />
         <h1 class="docs-logotype md-heading">Angular Material</h1>
       </a>
@@ -132,7 +133,7 @@
               class="md-icon-button"
               aria-label="View Demo"
               ng-class="{hide: !currentDoc || !currentDoc.hasDemo}"
-              ng-href="#/demo/{{currentComponent.name}}">
+              ng-href="{{currentComponent.demoUrl}}">
               <md-icon md-svg-src="img/icons/ic_play_circle_fill_24px.svg" style="fill:green"></md-icon>
               <md-tooltip>View Demo</md-tooltip>
             </md-button>

--- a/docs/gulpfile.js
+++ b/docs/gulpfile.js
@@ -36,11 +36,13 @@ gulp.task('demos', function() {
       var demoIndex = _(demos)
         .groupBy('moduleName')
         .map(function(moduleDemos, moduleName) {
+          var componentName = moduleName.split('.').pop();
           return {
-            name: moduleName,
-            label: utils.humanizeCamelCase(moduleName.split('.').pop()),
+            name: componentName,
+            moduleName: moduleName,
+            label: utils.humanizeCamelCase(componentName),
             demos: moduleDemos,
-            url: '/demo/' + moduleName
+            url: 'demo/' + componentName
           };
         })
         .value();

--- a/gulp/tasks/site.js
+++ b/gulp/tasks/site.js
@@ -5,6 +5,11 @@ exports.task = function () {
   connect.server({
     root: './dist/docs',
     livereload: true,
-    port: LR_PORT
+    port: LR_PORT,
+
+    // For any 404, respond with index.html. This enables html5Mode routing.
+    // In a production environment, this would be done with much more
+    // fine-grained URL rewriting rules.
+    fallback: './dist/docs/index.html'
   });
 };

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -20,6 +20,7 @@ function run {
 
   echo "-- Copying docs site to snapshot..."
   sed -i "s,http://localhost:8080/angular-material,https://cdn.gitcdn.xyz/cdn/angular/bower-material/v$VERSION/angular-material,g" dist/docs/docs.js
+  sed -i "s,base href=\",base href=\"/HEAD,g" dist/docs/index.html
 
 
   cp -Rf dist/docs code.material.angularjs.org/HEAD

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -63,7 +63,7 @@ angular
  *     the item if the search text is an exact match
  *
  * @usage
- * ###Basic Example
+ * ### Basic Example
  * <hljs lang="html">
  *   <md-autocomplete
  *       md-selected-item="selectedItem"
@@ -74,7 +74,7 @@ angular
  *   </md-autocomplete>
  * </hljs>
  *
- * ###Example with "not found" message
+ * ### Example with "not found" message
  * <hljs lang="html">
  * <md-autocomplete
  *     md-selected-item="selectedItem"

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -33,7 +33,7 @@ angular.module('material.components.card', [
  * fit within a single view on a platform, but it can temporarily expand as needed.
  *
  * @usage
- * ###Card with optional footer
+ * ### Card with optional footer
  * <hljs lang="html">
  * <md-card>
  *  <img src="card-image.png" class="md-card-image" alt="image caption">
@@ -47,7 +47,7 @@ angular.module('material.components.card', [
  * </md-card>
  * </hljs>
  *
- * ###Card with actions
+ * ### Card with actions
  * <hljs lang="html">
  * <md-card>
  *  <img src="card-image.png" class="md-card-image" alt="image caption">


### PR DESCRIPTION
DO NOT MERGE, REVIEW ONLY - I will merge this once we've confirmed the deployment will go smoothly.

@robertmesserle @ThomasBurleson @rschmukler for review

This change should capture everything needed to make the ng-material site better indexed by search engines. 

### Summary of changes
Changes to the docs app:
* Add a `<base>` element to the document head. This is required to enable Angular's html5 routing mode.
* Set html5 mode with `$locationProvider`
* Remove hard-coded `#` URLs
* Change all links to _relative_ URLs, while at the same time not changing what is passed to `$routeProvider`.
* Make `demo/` and `api/` URLs much shorter/cleaner by modifying dgeni configuration.

Changes to the release script and snapshot sync process:
* Add URL rewriting rules to `firebase.json` for our production site. These rules will rewrite things like `https://material.angularjs.org/HEAD/demo/autocomplete` to `https://material.angularjs.org/HEAD/index.html`
* Rewrite the base tag's `href` property to match the version (e.g., `/HEAD/`, `/latest/`, `/0.11.2/`, etc.)


### Impact
* Existing links to `/head/` (and `/latest/` after the next release) containing `#` paths will land users on the home page.
* URLs for existing versions will remain unchanged.