### PR TITLE
only in menubar should the element be preserved

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -97,7 +97,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout) {
       nestLevel: self.nestLevel,
       element: menuContainer,
       target: triggerElement,
-      preserveElement: self.isInMenuBar || self.nestedMenus.length > 0,
+      preserveElement: self.isInMenuBar,
       parent: self.isInMenuBar ? $element : 'body'
     });
   };


### PR DESCRIPTION
enables nested menues. example:
```html
<md-menu>
  <md-button ng-click="$mdOpenMenu($event)">Open menu</md-button>
  <md-menu-content>
    <md-menu-item>
      <md-menu>
        <md-button ng-click="$mdOpenMenu($event)">Submenu</md-button>
        <md-menu-content>
          <md-menu-item>Item 1</md-menu-item>
          <md-menu-item>item 2</md-menu-item>
        </md-menu-content>
      </md-menu>
    </md-menu-item>
  </md-menu-content>
</md-menu>
```