### PR TITLE
update(docs): significant improvements to the layout and flex docs

### DIFF
--- a/docs/app/css/layout-demo.css
+++ b/docs/app/css/layout-demo.css
@@ -2,41 +2,49 @@ demo-include {
   display: block;
 }
 
-.colorNested > div  {
+.colorNested .demo-content > div div  {
   padding: 8px;
   box-shadow: 0px 2px 5px 0 rgba(0,0,0,0.26);
   opacity: 0.9;
   color: white;
+  text-align: center;
 }
 
-.colorNested-noPad> div  {
+.colorNested-noPad .demo-content > div div  {
   box-shadow: 0px 2px 5px 0 rgba(0,0,0,0.26);
   opacity: 0.9;
   color: white;
+  text-align: center;
 }
 
-.colorNested > div:nth-child(1),
-.colorNested-noPad > div:nth-child(1)
- {
+.colorNested .demo-content > div div:nth-child(1),
+.colorNested-noPad .demo-content > div div:nth-child(1) {
   background-color: #009688;
 }
-.colorNested> div:nth-child(2),
-.colorNested-noPad> div:nth-child(2) {
+.colorNested .demo-content > div div:nth-child(2),
+.colorNested-noPad .demo-content > div div:nth-child(2) {
   background-color: #3949ab;
 }
-.colorNested> div:nth-child(3),
-.colorNested-noPad> div:nth-child(3) {
+.colorNested .demo-content > div div:nth-child(3),
+.colorNested-noPad .demo-content > div div:nth-child(3) {
   background-color: #9c27b0;
 }
-.colorNested > div:nth-child(4),
-.colorNested-noPad > div:nth-child(4) {
+.colorNested .demo-content > div div:nth-child(4),
+.colorNested-noPad .demo-content > div div:nth-child(4) {
   background-color: #8bc34a;
 }
-.colorNested  > div:nth-child(5),
-.colorNested-noPad  > div:nth-child(5)  {
+.colorNested .demo-content > div div:nth-child(5),
+.colorNested-noPad .demo-content > div div:nth-child(5)  {
   background-color: #deb867;
 }
-
+.colorNested .demo-content > div div:nth-child(6),
+.colorNested-noPad .demo-content > div div:nth-child(6) {
+  background-color: #FF5722;
+}
+.colorNested .demo-content > div div:nth-child(7),
+.colorNested-noPad .demo-content > div div:nth-child(7)  {
+  background-color: #03A9F4;
+}
 
 .layout-content md-divider {
   margin-top: 16px;

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -518,7 +518,13 @@ md-tabs.demo-source-tabs .active md-tab-label {
 .demo-content > div[layout-fill] {
   min-height: 448px;
 }
+.demo-content > div.layout-fill {
+  min-height: 448px;
+}
 .small-demo .demo-content > div[layout-fill] {
+  min-height: 224px;
+}
+.small-demo .demo-content > div.layout-fill {
   min-height: 224px;
 }
 .layout-content .small-demo .demo-content > div[layout],

--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -44,9 +44,10 @@
 
   <section class="layout-panel-parent">
     <div ng-panel="layoutDemo">
-      <docs-demo demo-title='layout="{{layoutDemo.direction}}" layout-align="{{layoutAlign()}}"' class="small-demo" interpolate-code="true">
+      <docs-demo demo-title='layout="{{layoutDemo.direction}}" layout-align="{{layoutAlign()}}"'
+                 class="small-demo colorNested" interpolate-code="true">
         <demo-file name="index.html">
-          <div layout="{{layoutDemo.direction}}" layout-align="{{layoutAlign()}}" class="colorNested">
+          <div layout="{{layoutDemo.direction}}" layout-align="{{layoutAlign()}}">
             <div>one</div>
             <div>two</div>
             <div>three</div>

--- a/docs/app/partials/layout-container.tmpl.html
+++ b/docs/app/partials/layout-container.tmpl.html
@@ -8,30 +8,48 @@
 
   <p>
     The layout system is based upon element attributes rather than CSS classes.
-    Attributes provide an easy way to set a value (eg <code>layout="row"</code>), and additionally
-    helps us separate concerns: attributes define layout, and classes define styling.
+    Attributes provide an easy way to set a value (eg. <code>layout="row"</code>) and
+    help us separate concerns: attributes define layout, and classes define styling.
+  </p>
+  <p>
+    <i>
+      Note: Due to performance problems related to attribute selectors in IE11, our attributes are converted
+      to class selectors at runtime. You should continue to use layout attribute selectors in your code.
+    </i>
   </p>
 
-  <br/>
   <h3>Layout Attribute</h3>
   <p>
     Use the <code>layout</code> attribute on an element to arrange its children
-    horizontally in a row (<code>layout="row"</code>), or vertically in
-    a column (<code>layout="column"</code>). 
+    horizontally in a row (<code>layout="row"</code>) or vertically in a column (<code>layout="column"</code>).
+    Row layout is the default if you specify the <code>layout</code> attribute without a value.
   </p>
 
-  <hljs lang="html">
-    <div layout="row" class="colorNested">
-      <div>I'm left.</div>
-      <div>I'm right.</div>
+  <table>
+    <tr>
+      <td>row</td>
+      <td>Items arranged horizontally. Max height is 100% and max width is the width of the items in the container.</td>
+    </tr>
+    <tr>
+      <td>column</td>
+      <td>Items arranged vertically. Max width is 100% and max height is the height of the items in the container.</td>
+    </tr>
+  </table>
+
+  <docs-demo demo-title="Layout Attribute" class="small-demo colorNested">
+    <demo-file name="index.html">
+    <div layout="row">
+      <div flex>First item in row</div>
+      <div flex>Second item in row</div>
     </div>
-    <div layout="column" class="colorNested">
-      <div>I'm above.</div>
-      <div>I'm below.</div>
+    <div layout="column">
+      <div flex>First item in column</div>
+      <div flex>Second item in column</div>
     </div>
-  </hljs>
+    </demo-file>
+  </docs-demo>
 
   <p>
-    See <a href="#/layout/options">Layout Options</a> for information on responsive layouts and other options.
+    See the <a href="#/layout/options">layout options page</a> for information on responsive layouts and other options.
   </p>
 </div>

--- a/docs/app/partials/layout-grid.tmpl.html
+++ b/docs/app/partials/layout-grid.tmpl.html
@@ -2,16 +2,16 @@
 
   <p>
     To customize the size and position of elements in a layout, use the
-    <code>flex</code>, <code>offset</code>, and <code>flex-order</code> attributes.
+    <code>flex</code>, <code>flex-order</code>, and <code>offset</code> attributes.
   </p>
 
-  <docs-demo demo-title="Flex Attribute" class="small-demo" >
+  <docs-demo demo-title="Flex Attribute" class="small-demo colorNested">
     <demo-file name="index.html">
-      <div layout="row" class="colorNested">
+      <div layout="row">
         <div flex>
           [flex]
         </div>
-        <div flex style="color:white">
+        <div flex>
           [flex]
         </div>
         <div flex hide-sm>
@@ -21,26 +21,32 @@
     </demo-file>
   </docs-demo>
   <p>
-    Add the <code>flex</code> attribute to a layout's child element, and it
-    will flex (stretch) to fill the available area.
+    Add the <code>flex</code> attribute to a layout's child element and the element will flex (grow or shrink) to fit
+    the area unused by other elements.
   </p>
 
-  <docs-demo demo-title="Flex Percent Values" class="small-demo">
+  <docs-demo demo-title="Flex Percent Values" class="small-demo colorNested-noPad">
     <demo-file name="index.html">
-      <div layout="row" layout-wrap class="colorNested">
-        <div flex="33">
-          [flex="34"]
+      <div layout="row" layout-wrap>
+        <div flex="30">
+          [flex="30"]
         </div>
-        <div flex="55" style="color:white">
-          [flex="55"]
+        <div flex="45">
+          [flex="45"]
+        </div>
+        <div flex="25">
+          [flex="25"]
+        </div>
+        <div flex="33">
+          [flex="33"]
+        </div>
+        <div flex="67">
+          [flex="67"]
+        </div>
+        <div flex="50">
+          [flex="50"]
         </div>
         <div flex>
-          [flex]
-        </div>
-        <div flex="66">
-          [flex="66"]
-        </div>
-        <div flex=>
           [flex]
         </div>
       </div>
@@ -51,27 +57,90 @@
     A layout child's <code>flex</code> attribute can be given an integer value from 0-100.
     The element will stretch to the percentage of available space matching the value.
     <br/><br/>
-    The <code>flex</code> attribute value is restricted to 33, 66, and multiples
-    of five.
+    The <code>flex</code> attribute value is restricted to 33, 67, and multiples of five.
     <br/>
-    For example: <code>flex="5", flex="20", flex="33", flex="50", flex="66", flex="75", ...</code>.
+    For example: <code>flex="0", flex="5", flex="20", flex="33", flex="50", flex="67", flex="75", ... flex="100"</code>.
   </p>
   <p>
-  See the <a href="#/layout/options">layout options page</a> for more information on responsive flex attributes.
+    See the <a href="#/layout/options">layout options page</a> for more information on responsive flex attributes like
+    <code>hide-sm</code> and <code>layout-wrap</code> used in the above examples.
   </p>
 
-  <docs-demo demo-title="Flex Order Attribute" class="small-demo">
+  <docs-demo demo-title="Other Flex Values" class="small-demo colorNested-noPad">
     <demo-file name="index.html">
-      <div layout="row" layout-margin class="colorNested">
-        <div flex flex-order="1" flex-order-gt-md="3" layout-padding>
-          <p show hide-gt-md>[flex-order="1"]</p>
+      <div layout="row" layout-wrap>
+        <div flex="0">
+          [flex="0"]
+        </div>
+        <div flex="none">
+          [flex="none"]
+        </div>
+        <div flex>
+          [flex]
+        </div>
+        <div flex="grow">
+          [flex="grow"]
+        </div>
+        <div flex="auto">
+          [flex="auto"]
+        </div>
+        <div flex="auto">
+          [flex="auto"]
+        </div>
+        <div flex="initial">
+          [flex="initial"]
+        </div>
+      </div>
+    </demo-file>
+  </docs-demo>
+
+  <p>
+    There are additional flex values provided by Angular Material to improve flexibility and to make the API
+    easier to understand.
+  </p>
+  <table>
+    <tr>
+      <td>flex="0"</td>
+      <td>Will not grow or shrink. Size of 0%. I.e. not visible, but still on the page.</td>
+    </tr>
+    <tr>
+      <td>flex="none"</td>
+      <td>Will not grow or shrink. Sized based on it's <code>width</code> and <code>height</code> values.</td>
+    </tr>
+    <tr>
+      <td>flex="initial"</td>
+      <td>Will shrink as needed. Starts with a size based on it's <code>width</code> and <code>height</code> values.</td>
+    </tr>
+    <tr>
+      <td>flex</td>
+      <td>Will grow and shrink as needed. Starts with a size of 0%.</td>
+    </tr>
+    <tr>
+      <td>flex="auto"</td>
+      <td>Will grow and shrink as needed. Starts with a size based on it's <code>width</code> and <code>height</code> values.</td>
+    </tr>
+    <tr>
+      <td>flex="grow"</td>
+      <td>Will grow and shrink as needed. Starts with a size of 100%.</td>
+    </tr>
+    <tr>
+      <td>flex="100"</td>
+      <td>Will not grow or shrink. Size of 100%.</td>
+    </tr>
+  </table>
+
+  <docs-demo demo-title="Flex Order Attribute" class="small-demo colorNested">
+    <demo-file name="index.html">
+      <div layout="row">
+        <div flex flex-order="1" flex-order-gt-md="3">
+          <p hide-gt-md>[flex-order="1"]</p>
           <p hide show-gt-md>[flex-order-gt-md="3"]</p>
         </div>
-        <div flex flex-order="2" layout-padding>
+        <div flex flex-order="2">
           <p>[flex-order="2"]</p>
         </div>
-        <div flex flex-order="3" flex-order-gt-md="1" layout-padding>
-          <p show hide-gt-md>[flex-order="3"]</p>
+        <div flex flex-order="3" flex-order-gt-md="1">
+          <p hide-gt-md>[flex-order="3"]</p>
           <p hide show-gt-md>[flex-order-gt-md="1"]</p>
         </div>
       </div>
@@ -111,14 +180,18 @@
       <td>Sets element order on devices greater than 1200px wide.</td>
     </tr>
   </table>
+  <p>
+    See the <a href="#/layout/options">layout options page</a> for more information on attributes like
+    <code>hide</code>, <code>hide-gt-md</code>, and <code>show-gt-md</code> used in the above examples.
+  </p>
 
-  <docs-demo demo-title="Flex Offset Attribute" class="small-demo">
+  <docs-demo demo-title="Flex Offset Attribute" class="small-demo colorNested">
     <demo-file name="index.html">
-      <div layout="row" class="colorNested">
+      <div layout="row">
         <div flex offset="33">
           [flex offset="33"]
         </div>
-        <div flex >
+        <div flex>
           [flex]
         </div>
       </div>

--- a/docs/app/partials/layout-options.tmpl.html
+++ b/docs/app/partials/layout-options.tmpl.html
@@ -1,8 +1,8 @@
 <div ng-controller="LayoutCtrl" class="layout-content layout-options" ng-cloak>
 
-  <docs-demo demo-title="Responsive Layout" class="small-demo">
+  <docs-demo demo-title="Responsive Layout" class="small-demo colorNested">
     <demo-file name="index.html">
-      <div layout="row" layout-sm="column" class="colorNested">
+      <div layout="row" layout-sm="column">
         <div flex>
           I'm above on mobile, and to the left on larger devices.
         </div>
@@ -14,10 +14,10 @@
   </docs-demo>
 
   <p>
-    See the <a href="#/layout/container">Layout Container</a> page for a basic explanation
+    See the <a href="#/layout/container">Container Elements</a> page for a basic explanation
     of layout attributes.
     <br/>
-    To make your layout change depending upon the device size, there are
+    To make your layout change depending upon the device screen size, there are
     other <code>layout</code> attributes available:
   </p>
 
@@ -55,11 +55,19 @@
 
   <br/>
 
-  <docs-demo demo-title="Layout Margin, Padding and Fill" class="small-demo">
+  <docs-demo demo-title="Layout Margin, Padding, and Fill" class="small-demo colorNested-noPad">
     <demo-file name="index.html">
-      <div layout="row" layout-margin layout-fill layout-padding class="colorNested">
-        <div flex>I'm on the left, and there's an empty area around me.</div>
-        <div flex>I'm on the right, and there's an empty area around me.</div>
+      <div layout="row" layout-margin>
+        <div flex>Parent layout and this element have margins.</div>
+      </div>
+      <div layout="row" layout-padding>
+        <div flex>Parent layout and this element have padding.</div>
+      </div>
+      <div layout="row" layout-fill style="min-height: 224px;">
+        <div flex>Parent layout is set to fill available space.</div>
+      </div>
+      <div layout="row" layout-padding layout-margin layout-fill style="min-height: 224px;">
+        <div flex>I am using all three at once.</div>
       </div>
     </demo-file>
   </docs-demo>
@@ -76,12 +84,15 @@
 
   <br/>
 
-  <docs-demo demo-title="Wrap" class="small-demo">
+  <docs-demo demo-title="Wrap" class="small-demo colorNested-noPad">
     <demo-file name="index.html">
-      <div layout="row" layout-wrap class="colorNested-noPad">
+      <div layout="row" layout-wrap>
         <div flex="33">[flex=33]</div>
         <div flex="67">[flex=67]</div>
         <div flex="67">[flex=67]</div>
+        <div flex="33">[flex=33]</div>
+        <div flex="33">[flex=33]</div>
+        <div flex="34">[flex=34]</div>
         <div flex="33">[flex=33]</div>
       </div>
     </demo-file>
@@ -95,13 +106,13 @@
 
   <br/>
 
-  <docs-demo demo-title="Responsive Flex & Offset Attributes" class="small-demo">
+  <docs-demo demo-title="Responsive Flex Attributes" class="small-demo colorNested-noPad">
     <demo-file name="index.html">
-      <div layout="row" class="colorNested">
-        <div flex="66" flex-sm="34">
+      <div layout="row">
+        <div flex="67" flex-sm="33">
           I flex to one-third of the space on mobile, and two-thirds on other devices.
         </div>
-        <div flex="34" flex-sm="66">
+        <div flex="33" flex-sm="67">
           I flex to two-thirds of the space on mobile, and one-third on other devices.
         </div>
       </div>
@@ -109,7 +120,7 @@
   </docs-demo>
 
   <p>
-    See the <a href="#/layout/grid">Layout Grid</a> page for a basic explanation
+    See the <a href="#/layout/grid">Grid System</a> page for a basic explanation
     of flex and offset attributes.
   </p>
 
@@ -146,15 +157,24 @@
 
   <br/>
 
-  <docs-demo demo-title="Hide and Show Attributes" class="small-demo">
+  <docs-demo demo-title="Hide and Show Attributes" class="small-demo colorNested">
     <demo-file name="index.html">
-      <div layout layout-align="center center" class="colorNested">
-        <md-subheader show hide-gt-sm>
-          I'm hidden on mobile and shown on larger devices.
-        </md-subheader>
-        <md-subheader show-sm hide>
-          I'm shown on mobile and hidden on larger devices.
-        </md-subheader>
+      <div layout="row">
+        <div hide show-gt-sm flex>
+          Hidden on small and shown on larger devices.
+        </div>
+        <div hide-gt-sm flex>
+          Shown on small and hidden on larger devices.
+        </div>
+        <div hide-gt-md flex>
+          Shown on small and medium size devices.
+        </div>
+        <div hide show-md flex>
+          Shown on medium size devices only.
+        </div>
+        <div hide show-gt-lg flex>
+          Shown on devices larger than 1200px wide only.
+        </div>
       </div>
     </demo-file>
   </docs-demo>


### PR DESCRIPTION
add new section on other flex values like grow, initial, auto, none
remove `colorNested` and `colorNested-noPad` from the example code while keeping the functionality
improve clarity and consistency of layout docs
add real examples for `layout-margin`, `layout-padding`, and `layout-fill`
improve hide and show examples and fix display issue on mobile caused by using `md-subheader`
improve `layout-wrap` examples to cover new flex percentages
remove redundant `style="color:white"` styles
fix hide/show implementation for flex order attribute examples
improve the container demo and make it consistent with the other layout/flex demos
add details about max-height and max-width settings on row and column layouts
add note about attribute vs class selectors and IE11 performance
add example of use of 33/34/33 flex sizes with `layout-wrap`