### PR TITLE
fix(mdDialog): fixed alert and confim `md-transition-in` class attachment

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -414,7 +414,7 @@ function MdDialogProvider($$interimElementProvider) {
   function advancedDialogOptions($mdDialog, $mdTheming) {
     return {
       template: [
-        '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" class="{{ dialog.css }}">',
+        '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
         ' <md-dialog-content role="document" tabIndex="-1">',
         '   <h2 class="md-title">{{ dialog.title }}</h2>',
         '   <div class="md-dialog-content-body" md-template="::dialog.mdContent"></div>',


### PR DESCRIPTION
Alert and confirm dialogs had in their template class attribute that was binded to `dialog.css`, in case the css property was undefined it caused the `md-transition-in` class to be applied but then deleted.

The solution was to change the usage to ng-class and let angular set the class.

fixes #4862