### PR TITLE
Allow FAB Speed Dial to work for both touch and mouse devices

### DIFF
--- a/docs/app/partials/layout-grid.tmpl.html
+++ b/docs/app/partials/layout-grid.tmpl.html
@@ -67,7 +67,7 @@
           <p show hide-gt-md>[flex-order="1"]</p>
           <p hide show-gt-md>[flex-order-gt-md="3"]</p>
         </div>
-        <div flex flex-order="2" layout-padding style="color:white">
+        <div flex flex-order="2" layout-padding>
           <p>[flex-order="2"]</p>
         </div>
         <div flex flex-order="3" flex-order-gt-md="1" layout-padding>
@@ -118,7 +118,7 @@
         <div flex offset="33">
           [flex offset="33"]
         </div>
-        <div flex style="color:white">
+        <div flex >
           [flex]
         </div>
       </div>

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -115,27 +115,27 @@
       events.push(latestEvent.type);
 
       // Handle desktop click
-      if (equalsEvents(['mousedown', 'mouseup'])) {
+      if (equalsEvents(['mousedown', 'focusin?', 'mouseup', 'click'])) {
         handleItemClick(latestEvent);
         resetEvents();
         return;
       }
 
-      // Handle mobile click/tap (and keyboard enter)
-      if (equalsEvents(['touchstart', 'touchend'])) {
+      // Handle mobile click/tap
+      if (equalsEvents(['touchstart', 'touchend', 'mousedown', 'focusin?', 'mouseup', 'click'])) {
         handleItemClick(latestEvent);
         resetEvents();
         return;
       }
 
-        // Handle mobile click/tap (and keyboard enter)
+      // Handle click/tap
       if (equalsEvents(['click'])) {
-          handleItemClick(latestEvent);
-          resetEvents();
-          return;
+         handleItemClick(latestEvent);
+         resetEvents();
+         return;
       }
 
-        // Handle tab keys (focusin)
+      // Handle tab keys (focusin)
       if (equalsEvents(['focusin'])) {
         vm.open();
         resetEvents();


### PR DESCRIPTION
FAB Speed Dial should work on touch devices (e.g. - iPad, Android), mouse, and devices that support both (e.g. - Windows 10 on Surface Pro).
