### PR TITLE
fix(mdTabs): Tab label width correction in mdDialog

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -486,7 +486,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function shouldPaginate () {
     if (ctrl.noPagination || !loaded) return false;
-    var canvasWidth = $element.prop('clientWidth');
+    var canvasWidth = Math.min($element.prop('clientWidth'), ctrl.maxTabWidth);
     angular.forEach(elements.dummies, function (tab) { canvasWidth -= tab.offsetWidth; });
     return canvasWidth < 0;
   }


### PR DESCRIPTION
The Tab label width is set correctly when used in a dialog.
Changed one line to a previous version (1 commit prior to 4a16038be56b285fdc2c7cbdfcd8853d65408b21)
That commit addressed issue #4743. This issue is not reproduced by reverting this line of code.

Addressing issues #4834 #4873 #4744