### PR TITLE
fix(mdMaxlengthDirective): Render character count after keyup

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -384,7 +384,7 @@ function mdMaxlengthDirective($animate) {
 
     ngModelCtrl.$formatters.push(renderCharCount);
     ngModelCtrl.$viewChangeListeners.push(renderCharCount);
-    element.on('input keydown', function() {
+    element.on('input keydown keyup', function() {
       renderCharCount(); //make sure it's called with no args
     });
 


### PR DESCRIPTION
Please see [this CodePen](http://codepen.io/Anaphase/pen/KdWPjy) for details.

---

If an input's model is changed as the result of a key press, the character count is not rendered properly if the modification occurs *after* the default key action.

For instance, consider a chat application where a form is submitted and reset when the user presses enter in a text input. The correct character count (0) will not be rendered after the input's model is reset in the form's `ng-submit` function since the `renderCharCount` method is called on `keydown`. The default action of the enter press (submitting the form) happens after `keydown` and before the `keyup` event. The CodePen link above demonstrates this bug.

Simply adding `keyup` to the list of events that trigger `renderCharCount` is enough to fix this problem. If there's a better way of updating the character count after the key's default action, please discuss here.