### PR TITLE
fix(gridList): Animation reflow fix.

### DIFF
--- a/src/components/gridList/grid-list.js
+++ b/src/components/gridList/grid-list.js
@@ -724,7 +724,7 @@ function GridTileDirective($mdMedia) {
     scope.$on('$destroy', function() {
       // Mark the tile as destroyed so it is no longer considered in layout,
       // even if the DOM element sticks around (like during a leave animation)
-      element.$$mdDestroyed = true;
+      element[0].$$mdDestroyed = true;
       unwatchAttrs();
       gridCtrl.invalidateLayout();
     });


### PR DESCRIPTION
Now correctly decorates the element with the destroyed flag.

Closes #1559. For real.