### PR TITLE
Upgrade build system to support Node 4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gulp-ng-html2js": "^0.1.8",
     "gulp-plumber": "^1.0.0",
     "gulp-rename": "^1.2.0",
-    "gulp-sass": "^1.3.3",
+    "gulp-sass": "^2.0.4",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.1",
     "gulp-webserver": "^0.9.1",

--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -290,7 +290,7 @@ exports.cssToNgConstant = function(ngModule, factoryName) {
   return through2.obj(function(file, enc, next) {
 
     var template = '(function(){ \nangular.module("%1").constant("%2", "%3"); \n})();\n\n';
-    var output = file.contents.toString().replace(/\n/g, '').replace(/\"/,'\\"');
+    var output = file.contents.toString().replace(/\n/g, '').replace(/\"/g,'\\"');
 
     var jsFile = new gutil.File({
       base: file.base,


### PR DESCRIPTION
The current build system uses a version of Node-Sass which does not work with recent versions of Node. However, the newest version of Node-Sass (3.3.3) writes quotes slightly different, which causes `cssToNgConstant` to fail. This is fixed by adding a global flag to the escape regex.

I am unable to build Angular Material on Node 4.x without this patch.