### PR TITLE
fix(toast.scss): Change height to defined for IE11

### DIFF
--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -18,7 +18,7 @@ md-toast {
   font-size: 14px;
   cursor: default;
 
-  height:auto;
+  height: 0px;
   max-height: 7*$toast-height;
   max-width: 100%;
 


### PR DESCRIPTION
Height updated to value below min-height. IE11 does not layout correctly
without. Tried 'inherit' but caniuse.com says not supported.

Fixes #4946