### PR TITLE
add the reload function inside the themingProvider

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -145,6 +145,7 @@ function ThemingProvider($mdColorPalette) {
     alwaysWatchTheme: function(alwaysWatch) {
       alwaysWatchTheme = alwaysWatch;
     },
+    reload: registerTheme,
     $get: ThemingService,
     _LIGHT_DEFAULT_HUES: LIGHT_DEFAULT_HUES,
     _DARK_DEFAULT_HUES: DARK_DEFAULT_HUES,


### PR DESCRIPTION
We were trying to register theme on the fly and the only way to do it is assign $mdThemingProvider as $provide.value('themeService', $mdThemingProvider) inside the angular config.

In this case the themeService will be accessible to angular controllers and we can registerTheme with $http resolve values.

To apply the theme we call themeService.reload($injector);