### PR TITLE
fix(chips): remove right padding on disabled chips

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -61,10 +61,6 @@ $contact-chip-name-width: rem(12) !default;
 
   &:not(.md-readonly) {
     cursor: text;
-
-    .md-chip {
-      padding-right: $chip-remove-padding-right;
-    }
   }
 
   .md-chip {
@@ -79,6 +75,10 @@ $contact-chip-name-width: rem(12) !default;
     box-sizing: border-box;
     max-width: 100%;
     position: relative;
+
+    &:not(.md-readonly) {
+      padding-right: $chip-remove-padding-right;
+    }
 
     .md-chip-content {
       display: block;


### PR DESCRIPTION
An existing style for preventing right padding on disabled chips uses the wrong selector.