### PR TITLE
fix(alert): restore scroll to proper place

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -234,6 +234,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           body.setAttribute('style', restoreBodyStyle);
           htmlNode.setAttribute('style', restoreHtmlStyle);
           body.scrollTop = scrollOffset;
+          $document[0].documentElement.scrollTop = scrollOffset;
         };
       }
 


### PR DESCRIPTION
It looks like `scrollTop` is not cross-browser consistent. See https://bugs.webkit.org/show_bug.cgi?id=106133 for more information.

Fix tested on Windows 7 IE10.