### PR TITLE
fix(mdCard): Content padding not showing in IE 10.

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -18,8 +18,10 @@ md-card {
   }
 
   md-card-content {
+    display: block;
     padding: $card-padding;
   }
+
   .md-actions {
     margin: 0;
 


### PR DESCRIPTION
In IE 10, the padding in the content area was not being properly applied because the `<md-card-content>` element had no display property set.

Fixes #2974.