### PR TITLE
docs: Add optional dependencies to getting started guide.

### DIFF
--- a/docs/app/partials/getting-started.tmpl.html
+++ b/docs/app/partials/getting-started.tmpl.html
@@ -18,6 +18,22 @@
       <li><a href="https://github.com/angular/material#cdn">Using a CDN</a> (example below)</li>
     </ul>
 
+    <h3>Include Optional Dependencies</h3>
+    <p>
+      Angular Material integrates with some additional libraries which you may optionally include:
+    </p>
+    <ul style="margin-bottom: 2em;">
+      <li>
+        <a href="https://docs.angularjs.org/api/ngMessages">ngMessages</a>
+        - Provides a consistent mechanism for displaying form errors and other messages.
+      </li>
+
+      <li>
+        <a href="https://docs.angularjs.org/api/ngRoute">ngRoute</a>
+        - Provides a clean routing system for your application.
+      </li>
+    </ul>
+
     <iframe height='272' scrolling='no' data-default-tab="html"
             src='//codepen.io/marcysutton/embed/OPbpKm?height=272&theme-id=11083'
             frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>


### PR DESCRIPTION
Many users have had some issues with getting things to work correctly because they did not realize that certain dependencies were optional and not automatically included.

Add a section to the getting started guide to let people know which dependencies these are.

Fixes #2820. References #4921.