### PR TITLE
fix(autocomplete): fixed integration with dialog

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -168,6 +168,43 @@ describe('<md-autocomplete>', function() {
 
       element.remove();
     }));
+
+    it('should not close list on ENTER key if nothing is selected', inject(function($timeout, $mdConstant, $material) {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+
+      $material.flushInterimElement();
+
+      // Update the scope
+      element.scope().searchText = 'fo';
+      waitForVirtualRepeat(element);
+
+      // Focus the input
+      ctrl.focus();
+      $timeout.flush();
+
+      expect(ctrl.hidden).toBe(false);
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+      $timeout.flush();
+
+      // Check expectations again
+      expect(ctrl.hidden).toBe(false);
+
+      element.remove();
+    }));
   });
 
   describe('basic functionality with template', function() {

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -389,10 +389,13 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         updateMessages();
         break;
       case $mdConstant.KEY_CODE.TAB:
-      case $mdConstant.KEY_CODE.ENTER:
         if (ctrl.hidden || ctrl.loading || ctrl.index < 0 || ctrl.matches.length < 1) return;
+        select(ctrl.index);
+        break;
+      case $mdConstant.KEY_CODE.ENTER:
         event.stopPropagation();
         event.preventDefault();
+        if (ctrl.hidden || ctrl.loading || ctrl.index < 0 || ctrl.matches.length < 1) return;
         select(ctrl.index);
         break;
       case $mdConstant.KEY_CODE.ESCAPE:


### PR DESCRIPTION
ENTER key on autocomplete with unselected list item didn't prevented the event to bubble up to the dialog which caused the dialog to be rejected.

Separated TAB and ENTER keys behavior to prevent event bubbling and ensuring that no matter what, TAB should always move to the next element.

closes #3979