### PR TITLE
fix(autocomplete): force $scope.searchText to string

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -678,7 +678,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * results first, then forwards the process to `fetchResults` if necessary.
    */
   function handleQuery () {
-    var searchText = $scope.searchText,
+    var searchText = $scope.searchText || '',
         term       = searchText.toLowerCase();
     //-- if results are cached, pull in cached results
     if (!$scope.noCache && cache[ term ]) {
@@ -697,7 +697,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * `md-select-on-match` flag.
    */
   function selectItemOnMatch () {
-    var searchText = $scope.searchText,
+    var searchText = $scope.searchText || '',
         matches    = ctrl.matches,
         item       = matches[ 0 ];
     if (matches.length === 1) getDisplayValue(item).then(function (displayValue) {


### PR DESCRIPTION
Discovered when I had an autocomplete that was hidden until a previous autocomplete had data.
Failing example: http://codepen.io/justmike/pen/wKrzdg

This only started happening when I upgraded from 0.11.1 to 0.11.4.