### PR TITLE
Correct md-tooltip positioning when scrolled

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -118,7 +118,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
      function getNearestContentElement () {
        var current = element.parent()[0];
        // Look for the nearest parent md-content, stopping at the rootElement.
-       while (current && current !== $rootElement[0] && current !== document.body) {
+       while (current && current !== $rootElement[0] && current !== document.body && current.nodeName !== 'MD-CONTENT') {
          current = current.parentNode;
        }
        return current;


### PR DESCRIPTION
There are several issues out there (e.g. #2406) that point to tooltip positioning when the page is scrolled and, on experiencing this issue myself, I found the comment in the getNearestContentElement that suggests that the enclosed loop is supposed to stop at md-content but does not. Adding that condition to the loop fixed the positioning issue for me.