### PR TITLE
Variables are not included in the standalone flexgrid

### DIFF
--- a/src/core/services/layout/standalone.scss
+++ b/src/core/services/layout/standalone.scss
@@ -15,6 +15,11 @@
 *
 */
 
+$layout-gutter-width: 1em;
+$layout-breakpoint-sm: 30em;
+$layout-breakpoint-md: 50em;
+$layout-breakpoint-lg: 80em;
+
 @-moz-document url-prefix() {
   [layout-fill] {
     margin: 0;


### PR DESCRIPTION
These Variables are missing:

```sass
$layout-gutter-width
$layout-breakpoint-sm
$layout-breakpoint-md
$layout-breakpoint-lg
```