### PR TITLE
Missing flex values for flex=33,34 and flex=66,67

### DIFF
--- a/src/core/services/layout/standalone.scss
+++ b/src/core/services/layout/standalone.scss
@@ -173,6 +173,14 @@
       max-height: #{$i * 5 + '%'};
     }
   }
+  
+  [#{$flexName}="33"], [#{$flexName}="34"] {
+    flex: 1 1 33%;
+  }
+
+  [#{$flexName}="66"], [#{$flexName}="67"] {
+    flex: 1 1 67%;
+  }
 
   [layout#{$name}="row"] {
     > [#{$flexName}="33"], > [#{$flexName}="34"]  {  max-width: 33%;  max-height: 100%; }


### PR DESCRIPTION
If using flex in responsive context (especially in the gt-xx media queries), flex 33,34,66 and 67 won't work in that way, that they grow to 33% (or 67%).
Instead they have the default flex behavior, which is: stuff everything into one line.

**See this example:**

Flexboxes should be 50% on md - breakpoint and 33% on gt-md breakpoint.

Existing Flexgrid makes it look like this:
http://plnkr.co/edit/2rOBRuNquiyAkkjKTqdH?p=preview

My addition makes them render correctly:
http://plnkr.co/edit/iGkIG6Wq8KadbjqdSEen?p=preview