### PR TITLE
feat(dialog): add before dialog close event

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -426,6 +426,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *   - `preserveScope` - `{boolean=}`: whether to preserve the scope when the element is removed. Default is false
  *   - `disableParentScroll` - `{boolean=}`: Whether to disable scrolling while the dialog is open.
  *     Default true.
+ *   - `beforeClose` - `{function=}`: A function that returns a promise. If the promise resolves, the dialog will close immediately.
  *   - `hasBackdrop` - `{boolean=}`: Whether there should be an opaque backdrop behind the dialog.
  *     Default true.
  *   - `clickOutsideToClose` - `{boolean=}`: Whether the user can click outside the dialog to
@@ -555,7 +556,7 @@ function MdDialogProvider($$interimElementProvider) {
   }
 
   /* @ngInject */
-  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $window, $rootElement, $log, $injector) {
+  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $window, $rootElement, $log, $injector, $q) {
     return {
       hasBackdrop: true,
       isolateScope: true,
@@ -774,8 +775,18 @@ function MdDialogProvider($$interimElementProvider) {
       var smartClose = function() {
         // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
         // cancel or fallback to hide.
-        var closeFn = ( options.$type == 'alert' ) ? $mdDialog.hide : $mdDialog.cancel;
-        $mdUtil.nextTick(closeFn, true);
+        var closeFn = (options.$type == 'alert') ? $mdDialog.hide : $mdDialog.cancel;
+        var beforeClosePromise = $q.resolve();
+
+        if (options.beforeClose) {
+          beforeClosePromise = $q.when(
+            options.beforeClose(options.scope, element, options)
+          );
+        }
+        
+        beforeClosePromise.then(function(){
+          $mdUtil.nextTick(closeFn, true);
+        })
       };
 
       if (options.escapeToClose) {

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -241,7 +241,6 @@ describe('$mdDialog', function() {
 
       expect(container.length).toBe(0);
     }));
-
   });
 
   describe('#confirm()', function() {
@@ -785,6 +784,116 @@ describe('$mdDialog', function() {
       }));
     });
 
+    describe('before close', function() {
+      it('should close the dialog when beforeClose promise is placed and resolved', inject(function ($mdDialog, $mdConstant, $q) {
+        var container, parent = angular.element('<div>');
+
+        var beforeFunction = jasmine.createSpy('beforeFunction').and.callFake(
+          function() {
+            var deferred = $q.defer();
+            deferred.resolve();
+            return deferred.promise;
+          }
+        );
+
+        $mdDialog.show(
+          $mdDialog.alert({
+            template:
+              '<md-dialog>' +
+              '  <md-dialog-content tabIndex="0">' +
+              '    <p>Kermit is my king</p>' +
+              '  </md-dialog-content>' +
+              '</md-dialog>',
+            parent: parent,
+            escapeToClose: true,
+            beforeClose: beforeFunction
+          })
+        );
+
+        runAnimation();
+        parent.triggerHandler({
+          type: 'keydown',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+        runAnimation();
+
+        container = angular.element(parent[0].querySelector('.md-dialog-container'));
+        expect(beforeFunction).toHaveBeenCalled();
+        expect(container.length).toBe(0);
+      }));
+
+      it('should not close the dialog when beforeClose promise is placed and rejected', inject(function ($mdDialog, $mdConstant, $q) {
+        var container, parent = angular.element('<div>');
+
+        var beforeFunction = jasmine.createSpy('beforeFunction').and.callFake(
+          function() {
+            var deferred = $q.defer();
+            deferred.reject();
+            return deferred.promise;
+          }
+        );
+
+        $mdDialog.show(
+          $mdDialog.alert({
+            template:
+              '<md-dialog>' +
+              '  <md-dialog-content tabIndex="0">' +
+              '    <p>Kermit is my king</p>' +
+              '  </md-dialog-content>' +
+              '</md-dialog>',
+            parent: parent,
+            escapeToClose: true,
+            beforeClose: beforeFunction
+          })
+        );
+
+        runAnimation();
+        parent.triggerHandler({
+          type: 'keydown',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+        runAnimation();
+
+        container = angular.element(parent[0].querySelector('.md-dialog-container'));
+        expect(beforeFunction).toHaveBeenCalled();
+        expect(container.length).toBe(1);
+      }));
+
+      it('should close the dialog when beforeClose is not a promise', inject(function ($mdDialog, $mdConstant, $q) {
+        var container, parent = angular.element('<div>');
+
+        var beforeFunction = jasmine.createSpy('beforeFunction').and.callFake(
+          function() {
+            return 6;
+          }
+        );
+
+        $mdDialog.show(
+          $mdDialog.alert({
+            template:
+              '<md-dialog>' +
+              '  <md-dialog-content tabIndex="0">' +
+              '    <p>Kermit is my king</p>' +
+              '  </md-dialog-content>' +
+              '</md-dialog>',
+            parent: parent,
+            escapeToClose: true,
+            beforeClose: beforeFunction
+          })
+        );
+
+        runAnimation();
+        parent.triggerHandler({
+          type: 'keydown',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+        runAnimation();
+
+        container = angular.element(parent[0].querySelector('.md-dialog-container'));
+        expect(beforeFunction).toHaveBeenCalled();
+        expect(container.length).toBe(0);
+      }));
+    });
 
     describe('when autoWrap parameter is false', function() {
 


### PR DESCRIPTION
Add before close event to dialog.
Great for confirmation of closing dialog (user accidentally closed dialog with changes).
beforeClonse function should return promise. when resolved, the dialog will close.