### PR TITLE
feat(core): add ngMaterial global with version info.

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -54,6 +54,7 @@ function buildJs () {
       .pipe(concat('angular-material.js'))
       .pipe(BUILD_MODE.transform())
       .pipe(insert.prepend(config.banner))
+      .pipe(insert.append('window.ngMaterial={version:{full: "' + VERSION +'"}}'))
       .pipe(gulp.dest(config.outputDir))
       .pipe(gulpif(!IS_DEV, uglify({ preserveComments: 'some' })))
       .pipe(rename({ extname: '.min.js' }))


### PR DESCRIPTION
@ThomasBurleson @robertmesserle I just added the `full` version for now since I don't think we need to bother independently listing `major`, `minor`, and `dot` at this point. And we don't have release code-names like angular does.

Adding this as part of the build process for now so that it gets the version directly from package.json.