### PR TITLE
fix(layout): Prevent class overriding when lastClass is null

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -322,7 +322,9 @@
     return function updateClassFn(newValue) {
       var value = validateAttributeValue(className, newValue || "");
       if ( angular.isDefined(value) ) {
-        element.removeClass(lastClass);
+        if (lastClass) { 
+          element.removeClass(lastClass);
+        }
         lastClass = !value ? className : className + "-" + value.replace(WHITESPACE, "-")
         element.addClass(lastClass);
       }


### PR DESCRIPTION
This fixes an annoying behavior of the layout attributes that is removing all the element's other classes when trying to convert layout attributes to classes.