### PR TITLE
cssToNgConstant should generate valid json literal using double quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "prompt-sync": "^1.0.0",
     "q": "^1.0.1",
     "stream-series": "^0.1.1",
-    "through2": "^0.6.3"
+    "through2": "^0.6.3",
+    "jsesc": "^0.5.0"
   },
   "scripts": {
     "watch": "gulp watch site --dev",
@@ -70,8 +71,5 @@
     "current-branch": "git rev-parse --abbrev-ref HEAD",
     "merge-base": "git merge-base $(npm run -s current-branch) origin/master",
     "squash": "git rebase -i $(npm run -s merge-base)"
-  },
-  "dependencies": {
-    "jsesc": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,5 +70,8 @@
     "current-branch": "git rev-parse --abbrev-ref HEAD",
     "merge-base": "git merge-base $(npm run -s current-branch) origin/master",
     "squash": "git rebase -i $(npm run -s merge-base)"
+  },
+  "dependencies": {
+    "jsesc": "^0.5.0"
   }
 }

--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -8,6 +8,7 @@ var fs = require('fs');
 
 var path = require('path');
 var findModule = require('../config/ngModuleData.js');
+var jsesc = require('jsesc');
 
 exports.humanizeCamelCase = function(str) {
   switch (str) {
@@ -290,7 +291,7 @@ exports.cssToNgConstant = function(ngModule, factoryName) {
   return through2.obj(function(file, enc, next) {
 
     var template = '(function(){ \nangular.module("%1").constant("%2", "%3"); \n})();\n\n';
-    var output = file.contents.toString().replace(/\n/g, '').replace(/\"/,'\\"');
+    var output = jsesc(file.contents.toString(), {'quotes': 'double'});
 
     var jsFile = new gutil.File({
       base: file.base,
@@ -301,6 +302,8 @@ exports.cssToNgConstant = function(ngModule, factoryName) {
           .replace('%3', output)
       )
     });
+	
+	fs.writeFile(path.join(process.cwd(), 'theme.js'), jsFile.contents, function(err){})
 
     this.push(jsFile);
     next();

--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -302,8 +302,6 @@ exports.cssToNgConstant = function(ngModule, factoryName) {
           .replace('%3', output)
       )
     });
-	
-	fs.writeFile(path.join(process.cwd(), 'theme.js'), jsFile.contents, function(err){})
 
     this.push(jsFile);
     next();


### PR DESCRIPTION
when I run 'gulp build-js', the gulp-uglify throws an error due to the fact that cssToNgConstant contains invalid string literal. 