### PR TITLE
fix(autocomplete): fixed autocomplete submit on enter

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -411,6 +411,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         select(ctrl.index);
         break;
       case $mdConstant.KEY_CODE.ENTER:
+        if (hasSelection()) return;
         event.stopPropagation();
         event.preventDefault();
         if (ctrl.hidden || ctrl.loading || ctrl.index < 0 || ctrl.matches.length < 1) return;


### PR DESCRIPTION
When enter key was pressed due to 1df38df the event stopped bubbling to the form submit.
Added selection check; if the autocomplete has selection it should bubble the event up.

fixes #5228