### PR TITLE
fix(dialog, menu, animate): added origin element fallback to bounds

### DIFF
--- a/src/core/util/animation/animate.js
+++ b/src/core/util/animation/animate.js
@@ -93,7 +93,7 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
       var zoomStyle = buildZoom({centerX: 0, centerY: 0, scaleX: 0.5, scaleY: 0.5});
 
       if (origin || bounds) {
-        var originBnds = origin ? self.clientRect(origin) : self.copyRect(bounds);
+        var originBnds = origin ? self.clientRect(origin) || self.copyRect(bounds) : self.copyRect(bounds);
         var dialogRect = self.copyRect(element[0].getBoundingClientRect());
         var dialogCenterPt = self.centerPointFor(dialogRect);
         var originCenterPt = self.centerPointFor(originBnds);


### PR DESCRIPTION
The dialog was opened from the menu item, when the dialog tries to close to the element that opened it, the element is long gone.

Added fallback of the origin clientRect to the Rect of the bounds.

fixes #5195