### PR TITLE
Fix position of toast element

### DIFF
--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -3,7 +3,7 @@
 
 md-toast {
   display: flex;
-  position:absolute;
+  position: fixed;
   z-index: $z-index-toast;
 
   box-sizing: border-box;


### PR DESCRIPTION
If page has too long  content — user can miss toast element. Just fixed it. :facepunch: 