### PR TITLE
add non-zero priority to mdButton

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -67,6 +67,7 @@ function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
     restrict: 'EA',
     replace: true,
     transclude: true,
+    priority: 100,
     template: getTemplate,
     link: postLink
   };


### PR DESCRIPTION
Since mdButton replaces the element it should have a non-zero priority so that other directives could be reliably linked after this element is replaced.

Specifically, this issue was encoutered when trying to add [ngclipboard](https://github.com/sachinchoolur/ngclipboard/blob/master/src/ngclipboard.js) directive.