### PR TITLE
docs: Fix incorrect Codepen GitCDN links.

### DIFF
--- a/release.js
+++ b/release.js
@@ -266,7 +266,7 @@
     exec([
            'rm -rf dist',
            'gulp docs',
-           'sed -i \'\' \'s,http:\\/\\/localhost:8080\\/angular-material,https:\\/\\/gitcdn.xyz/repo/angular/bower-material/v{{newVersion}}/angular-material,g\' dist/docs/docs.js',
+           'sed -i \'\' \'s,http:\\/\\/localhost:8080\\/angular-material,https:\\/\\/cdn.gitcdn.xyz/cdn/angular/bower-material/v{{newVersion}}/angular-material,g\' dist/docs/docs.js',
            'sed -i \'\' \'s,base\ href=\\",base\ href=\\"/{{newVersion}},g\' dist/docs/index.html'
          ]);
 


### PR DESCRIPTION
The release script still pointed to the old GitCDN links which
always redirect to the master branch instead of the version
specified.

Update release script to use proper links.

Fixes #5391.