### PR TITLE
perf(theming): add on-demand style generation.

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -2,7 +2,7 @@ angular.module('material.core.theming', ['material.core.theming.palette'])
   .directive('mdTheme', ThemingDirective)
   .directive('mdThemable', ThemableDirective)
   .provider('$mdTheming', ThemingProvider)
-  .run(generateThemes);
+  .run(generateAllThemes);
 
 /**
  * @ngdoc service
@@ -122,6 +122,9 @@ var VALID_HUE_VALUES = [
   '700', '800', '900', 'A100', 'A200', 'A400', 'A700'
 ];
 
+// Whether or not themes are to be generated on-demand (vs. eagerly).
+var generateOnDemand = false;
+
 function ThemingProvider($mdColorPalette) {
   PALETTES = { };
   THEMES = { };
@@ -145,6 +148,9 @@ function ThemingProvider($mdColorPalette) {
     },
     alwaysWatchTheme: function(alwaysWatch) {
       alwaysWatchTheme = alwaysWatch;
+    },
+    generateThemesOnDemand: function(onDemand) {
+      generateOnDemand = onDemand;
     },
     $get: ThemingService,
     _LIGHT_DEFAULT_HUES: LIGHT_DEFAULT_HUES,
@@ -349,6 +355,7 @@ function ThemingProvider($mdColorPalette) {
     applyTheme.THEMES = angular.extend({}, THEMES);
     applyTheme.defaultTheme = function() { return defaultTheme; };
     applyTheme.registered = registered;
+    applyTheme.generateTheme = generateTheme;
 
     return applyTheme;
 
@@ -450,10 +457,11 @@ function parseRules(theme, colorType, rules) {
   return generatedRules;
 }
 
-// Generate our themes at run time given the state of THEMES and PALETTES
-function generateThemes($injector) {
+var rulesByType = {};
 
-  var head = document.getElementsByTagName('head')[0];
+// Generate our themes at run time given the state of THEMES and PALETTES
+function generateAllThemes($injector) {
+  var head = document.head;
   var firstChild = head ? head.firstElementChild : null;
   var themeCss = $injector.has('$MD_THEME_CSS') ? $injector.get('$MD_THEME_CSS') : '';
 
@@ -467,7 +475,6 @@ function generateThemes($injector) {
   // components as templates
 
   // Break the CSS into individual rules
-  var rulesByType = {};
   var rules = themeCss
                   .split(/\}(?!(\}|'|"|;))/)
                   .filter(function(rule) { return rule && rule.length; })
@@ -503,32 +510,15 @@ function generateThemes($injector) {
     return rulesByType[DEFAULT_COLOR_TYPE] += rule;
   });
 
-    // For each theme, use the color palettes specified for
-    // `primary`, `warn` and `accent` to generate CSS rules.
+  // If themes are being generated on-demand, quit here. The user will later manually
+  // call generateTheme to do this on a theme-by-theme basis.
+  if (generateOnDemand) return;
 
-    angular.forEach(THEMES, function(theme) {
-      if ( !GENERATED[theme.name] ) {
-
-
-        THEME_COLOR_TYPES.forEach(function(colorType) {
-          var styleStrings = parseRules(theme, colorType, rulesByType[colorType]);
-          while (styleStrings.length) {
-            var style = document.createElement('style');
-                style.setAttribute('type', 'text/css');
-            style.appendChild(document.createTextNode(styleStrings.shift()));
-            head.insertBefore(style, firstChild);
-          }
-        });
-
-
-        if (theme.colors.primary.name == theme.colors.accent.name) {
-          console.warn("$mdThemingProvider: Using the same palette for primary and" +
-                       " accent. This violates the material design spec.");
-        }
-
-        GENERATED[theme.name] = true;
-      }
-    });
+  angular.forEach(THEMES, function(theme) {
+    if (!GENERATED[theme.name]) {
+      generateTheme(theme.name);
+    }
+  });
 
 
   // *************************
@@ -589,9 +579,40 @@ function generateThemes($injector) {
       }
     });
   }
+}
 
+function generateTheme(name) {
+  var theme = THEMES[name];
+  var head = document.head;
+  var firstChild = head ? head.firstElementChild : null;
+
+  if (!GENERATED[name]) {
+    // For each theme, use the color palettes specified for
+    // `primary`, `warn` and `accent` to generate CSS rules.
+    THEME_COLOR_TYPES.forEach(function(colorType) {
+      var styleStrings = parseRules(theme, colorType, rulesByType[colorType]);
+      while (styleStrings.length) {
+        var styleContent = styleStrings.shift();
+        if (styleContent) {
+          var style = document.createElement('style');
+          style.setAttribute('md-theme-style', '');
+          style.appendChild(document.createTextNode(styleContent));
+          head.insertBefore(style, firstChild);
+        }
+      }
+    });
+
+
+    if (theme.colors.primary.name == theme.colors.accent.name) {
+      console.warn('$mdThemingProvider: Using the same palette for primary and' +
+                   ' accent. This violates the material design spec.');
+    }
+
+    GENERATED[theme.name] = true;
+  }
 
 }
+
 
 function checkValidPalette(theme, colorType) {
   // If theme attempts to use a palette that doesnt exist, throw error

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -311,6 +311,64 @@ describe('$mdThemingProvider', function() {
 
 });
 
+describe('$mdThemeProvider with on-demand generation', function() {
+  var $mdTheming;
+
+  function getThemeStyleElements() {
+    return document.head.querySelectorAll('style[md-theme-style]');
+  }
+
+  function cleanThemeStyleElements() {
+    angular.forEach(getThemeStyleElements(), function(style) {
+      document.head.removeChild(style);
+    });
+  }
+
+  beforeEach(module('material.core', function($provide, $mdThemingProvider) {
+    // Theming requires that there is at least one element present in the document head.
+    cleanThemeStyleElements();
+
+    // Use a single simple style rule for which we can check presence / absense.
+    $provide.constant('$MD_THEME_CSS',
+        "sparkle.md-THEME_NAME-theme { color: '{{primary-color}}' }");
+
+    $mdThemingProvider.theme('sweden')
+        .primaryPalette('light-blue')
+        .accentPalette('yellow');
+
+    $mdThemingProvider.theme('belarus')
+        .primaryPalette('red')
+        .accentPalette('green');
+
+    $mdThemingProvider.generateThemesOnDemand(true);
+  }));
+
+  beforeEach(inject(function(_$mdTheming_) {
+    $mdTheming = _$mdTheming_;
+  }));
+
+  it('should not add any theme styles automatically', function() {
+    var styles = getThemeStyleElements();
+    expect(styles.length).toBe(0);
+  });
+
+  it('should add themes on-demand', function() {
+    $mdTheming.generateTheme('sweden');
+
+    var styles = getThemeStyleElements();
+    // One style tag for each default hue (default, hue-1, hue-2, hue-3).
+    expect(styles.length).toBe(4);
+    expect(document.head.innerHTML).toMatch(/md-sweden-theme/);
+    expect(document.head.innerHTML).not.toMatch(/md-belarus-theme/);
+
+    $mdTheming.generateTheme('belarus');
+    styles = getThemeStyleElements();
+    expect(styles.length).toBe(8);
+    expect(document.head.innerHTML).toMatch(/md-sweden-theme/);
+    expect(document.head.innerHTML).toMatch(/md-belarus-theme/);
+  });
+});
+
 describe('$mdTheming service', function() {
   var $mdThemingProvider;
   beforeEach(module('material.core', function(_$mdThemingProvider_) {


### PR DESCRIPTION
This change adds a new method to the `$mdTheming` service: `generateTheme(themeName)`. 

This is meant to super large apps that have such a large number of themes that the style generation is a substantial start-up cost. Being able to load themes on-demand as their needed should address this.

For now, I'm purposefully leaving this *out* of the documentation in order to get feedback from the people who are running into this issue in Google.

I tried to make my changes to theming as absolutely minimal as possible as to avoid causing any regressions. 

cc @rschmukler and @ThomasBurleson for review.
@ThomasBurleson don't merge this until I have a chance to run the change by a couple of people with the problem.