### PR TITLE
Reset selected chip

### DIFF
--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -52,7 +52,7 @@ function MdChip($mdTheming, $mdUtil) {
 
       if (ctrl) angular.element(element[0].querySelector('.md-chip-content'))
           .on('blur', function () {
-            ctrl.selectedChip = -1;
+            ctrl.resetSelectedChip();
           });
     };
   }


### PR DESCRIPTION
On chip blur event handler was doing the same thing as the method in the controller, so I thought it should call the method to avoid code duplication and possible errors in the future.