### PR TITLE
Update documentation for <md-list-item> and 'md-2/3-line' classes

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -53,6 +53,8 @@ function mdListDirective($mdTheming) {
  *
  * @description
  * The `<md-list-item>` directive is a container intended for row items in a `<md-list>` container.
+ * The `md-2-line` and `md-3-line` classes can be added to a `<md-list-item>` 
+ * to increase the height with 22px and 40px respectively.
  *
  * ## CSS
  * `.md-avatar` - class for image avatars


### PR DESCRIPTION
Update the doc for md-list-item to include a description of the classes `md-2-line` and `md-3-line`, which can be used to increase the height of list items.