### PR TITLE
fix(autocomplete): handle undefined searchText

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -582,6 +582,38 @@ describe('<md-autocomplete>', function() {
     }));
   });
 
+  describe('when required', function() {
+    it('properly handles md-min-length="0" and undefined searchText', function() {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              md-min-length="0" \
+              required\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+
+      var error;
+
+      try {
+        var element = compile(template, scope);
+
+        scope.searchText = undefined;
+        scope.$digest();
+      } catch (e) {
+        error = e;
+      }
+
+      expect(error).toBe(undefined);
+
+      element.remove();
+    });
+  });
+
   describe('md-highlight-text', function() {
     it('should update when content is modified', inject(function() {
       var template = '<div md-highlight-text="query">{{message}}</div>';

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -699,7 +699,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * results first, then forwards the process to `fetchResults` if necessary.
    */
   function handleQuery () {
-    var searchText = $scope.searchText,
+    var searchText = $scope.searchText || '',
         term       = searchText.toLowerCase();
     //-- if results are cached, pull in cached results
     if (!$scope.noCache && cache[ term ]) {


### PR DESCRIPTION
If the autocomplete's bound searchText was set to undefined, it would throw an error.

Fix by ensuring that the searchText will always be an empty string when performing the `handleQuery()` method.

Fixes #5162. Fixes #5393. References #5344.