### PR TITLE
fix(layout) remove attribute only if it exists

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -264,7 +264,7 @@
       updateFn(getNormalizedAttrValue(className, attrs, ""));
       scope.$on("$destroy", function() { unwatch() });
 
-      if (config.removeAttributes) element.removeAttr(className);
+      if (config.removeAttributes && element.attr(className)) element.removeAttr(className);
     }
   }
 


### PR DESCRIPTION
![captura de tela 2015-10-30 as 12 18 14](https://cloud.githubusercontent.com/assets/5341727/10847913/5fecb4d4-7f00-11e5-827c-571287b08d06.png)

Using the ng-messages-include causing error when you try to remove the element attribute.