### PR TITLE
Rename .md-actions to md-dialog-actions/md-card-actions

### DIFF
--- a/docs/app/partials/view-source.tmpl.html
+++ b/docs/app/partials/view-source.tmpl.html
@@ -17,9 +17,9 @@
     </div>
   </md-dialog-content>
 
-  <div class="md-actions" layout="horizontal">
+  <md-dialog-actions layout="horizontal">
     <md-button class="md-primary" ng-click="$hideDialog()">
       Done
     </md-button>
-  </div>
+  </md-dialog-actions>
 </md-dialog>

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -26,7 +26,7 @@ angular.module('material.components.card', [
  * container will wrap text content and provide padding. An `<md-card-footer>` element can be
  * optionally included to put content flush against the bottom edge of the card.
  *
- * Action buttons can be included in an element with the `.md-actions` class, also used in `md-dialog`.
+ * Action buttons can be included in an `<md-card-actions>` element, similar to `<md-dialog-actions>`.
  * You can then position buttons using layout attributes.
  *
  * Cards have constant width and variable heights; where the maximum height is limited to what can
@@ -55,10 +55,10 @@ angular.module('material.components.card', [
  *    <h2>Card headline</h2>
  *    <p>Card content</p>
  *  </md-card-content>
- *  <div class="md-actions" layout="row" layout-align="end center">
+ *  <md-card-actions layout="row" layout-align="end center">
  *    <md-button>Action 1</md-button>
  *    <md-button>Action 2</md-button>
- *  </div>
+ *  </md-card-actions>
  * </md-card>
  * </hljs>
  *

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -22,7 +22,7 @@ md-card {
     padding: $card-padding;
   }
 
-  .md-actions {
+  .md-actions, md-card-actions {
     margin: 0;
 
     .md-button {

--- a/src/components/card/demoBasicUsage/index.html
+++ b/src/components/card/demoBasicUsage/index.html
@@ -12,10 +12,10 @@
           two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
         </p>
       </md-card-content>
-      <div class="md-actions" layout="row" layout-align="end center">
+      <md-card-actions layout="row" layout-align="end center">
         <md-button>Action 1</md-button>
         <md-button>Action 2</md-button>
-      </div>
+      </md-card-actions>
     </md-card>
     <br/>
 

--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -1,43 +1,44 @@
 <md-dialog aria-label="Mango (Fruit)"  ng-cloak>
   <form>
-  <md-toolbar>
-    <div class="md-toolbar-tools">
-      <h2>Mango (Fruit)</h2>
-      <span flex></span>
-      <md-button class="md-icon-button" ng-click="cancel()">
-        <md-icon md-svg-src="img/icons/ic_close_24px.svg" aria-label="Close dialog"></md-icon>
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <h2>Mango (Fruit)</h2>
+        <span flex></span>
+        <md-button class="md-icon-button" ng-click="cancel()">
+          <md-icon md-svg-src="img/icons/ic_close_24px.svg" aria-label="Close dialog"></md-icon>
+        </md-button>
+      </div>
+    </md-toolbar>
+
+    <md-dialog-content style="max-width:800px;max-height:810px; ">
+      <div class="md-dialog-content">
+        <h2>Using .md-dialog-content class that sets the padding as the spec</h2>
+        <p>
+          The mango is a juicy stone fruit belonging to the genus Mangifera, consisting of numerous tropical fruiting trees, cultivated mostly for edible fruit. The majority of these species are found in nature as wild mangoes. They all belong to the flowering plant family Anacardiaceae. The mango is native to South and Southeast Asia, from where it has been distributed worldwide to become one of the most cultivated fruits in the tropics.
+        </p>
+
+        <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="img/mangues.jpg">
+
+        <p>
+          The highest concentration of Mangifera genus is in the western part of Malesia (Sumatra, Java and Borneo) and in Burma and India. While other Mangifera species (e.g. horse mango, M. foetida) are also grown on a more localized basis, Mangifera indica&mdash;the "common mango" or "Indian mango"&mdash;is the only mango tree commonly cultivated in many tropical and subtropical regions.
+        </p>
+        <p>
+          It originated in Indian subcontinent (present day India and Pakistan) and Burma. It is the national fruit of India, Pakistan, and the Philippines, and the national tree of Bangladesh. In several cultures, its fruit and leaves are ritually used as floral decorations at weddings, public celebrations, and religious ceremonies.
+        </p>
+      </div>
+    </md-dialog-content>
+
+    <md-dialog-actions layout="row">
+      <md-button href="http://en.wikipedia.org/wiki/Mango" target="_blank" md-autofocus>
+        More on Wikipedia
       </md-button>
-    </div>
-  </md-toolbar>
-  <md-dialog-content style="max-width:800px;max-height:810px; ">
-    <div class="md-dialog-content">
-      <h2>Using .md-dialog-content class that sets the padding as the spec</h2>
-      <p>
-        The mango is a juicy stone fruit belonging to the genus Mangifera, consisting of numerous tropical fruiting trees, cultivated mostly for edible fruit. The majority of these species are found in nature as wild mangoes. They all belong to the flowering plant family Anacardiaceae. The mango is native to South and Southeast Asia, from where it has been distributed worldwide to become one of the most cultivated fruits in the tropics.
-      </p>
-
-      <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="img/mangues.jpg">
-
-      <p>
-        The highest concentration of Mangifera genus is in the western part of Malesia (Sumatra, Java and Borneo) and in Burma and India. While other Mangifera species (e.g. horse mango, M. foetida) are also grown on a more localized basis, Mangifera indica&mdash;the "common mango" or "Indian mango"&mdash;is the only mango tree commonly cultivated in many tropical and subtropical regions.
-      </p>
-      <p>
-        It originated in Indian subcontinent (present day India and Pakistan) and Burma. It is the national fruit of India, Pakistan, and the Philippines, and the national tree of Bangladesh. In several cultures, its fruit and leaves are ritually used as floral decorations at weddings, public celebrations, and religious ceremonies.
-      </p>
-    </div>
-  </md-dialog-content>
-
-  <div class="md-actions" layout="row">
-    <md-button href="http://en.wikipedia.org/wiki/Mango" target="_blank" md-autofocus>
-      More on Wikipedia
-    </md-button>
-    <span flex></span>
-    <md-button ng-click="answer('not useful')" >
-     Not Useful
-    </md-button>
-    <md-button ng-click="answer('useful')" style="margin-right:20px;" >
-      Useful
-    </md-button>
-  </div>
+      <span flex></span>
+      <md-button ng-click="answer('not useful')">
+       Not Useful
+      </md-button>
+      <md-button ng-click="answer('useful')" style="margin-right:20px;">
+        Useful
+      </md-button>
+    </md-dialog-actions>
   </form>
 </md-dialog>

--- a/src/components/dialog/dialog-theme.scss
+++ b/src/components/dialog/dialog-theme.scss
@@ -4,7 +4,7 @@ md-dialog.md-THEME_NAME-theme {
   border-radius: $dialog-border-radius;
   background-color: '{{background-color}}';
 
-  &.md-content-overflow .md-actions {
+  &.md-content-overflow md-dialog-actions {
     border-top-color: '{{foreground-4}}';
   }
 }

--- a/src/components/dialog/dialog-theme.scss
+++ b/src/components/dialog/dialog-theme.scss
@@ -4,8 +4,10 @@ md-dialog.md-THEME_NAME-theme {
   border-radius: $dialog-border-radius;
   background-color: '{{background-color}}';
 
-  &.md-content-overflow md-dialog-actions {
-    border-top-color: '{{foreground-4}}';
+  &.md-content-overflow {
+    .md-actions, md-dialog-actions {
+      border-top-color: '{{foreground-4}}';
+    }
   }
 }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -459,7 +459,7 @@ function MdDialogProvider($$interimElementProvider) {
   }
 
   /* @ngInject */
-  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $rootElement, $log) {
+  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $window, $rootElement, $log) {
     return {
       hasBackdrop: true,
       isolateScope: true,
@@ -505,8 +505,20 @@ function MdDialogProvider($$interimElementProvider) {
         .then(function() {
           activateListeners(element, options);
           lockScreenReader(element, options);
+          warnDeprecatedActions();
           focusOnOpen();
         });
+
+      /**
+       * Check to see if they used the deprecated .md-actions class and log a warning
+       */
+      function warnDeprecatedActions() {
+        var badActions = element[0].querySelectorAll('.md-actions');
+
+        if (badActions.length > 0) {
+          $log.warn('Using a class of md-actions is deprected, please use <md-dialog-actions>.');
+        }
+      }
 
       /**
        * For alerts, focus on content... otherwise focus on
@@ -519,15 +531,15 @@ function MdDialogProvider($$interimElementProvider) {
         }
 
         /**
-         *  If no element with class dialog-close, try to find the last
-         *  button child in md-actions and assume it is a close button
+         * If no element with class dialog-close, try to find the last
+         * button child in md-actions and assume it is a close button.
          *
          * If we find no actions at all, log a warning to the console.
          */
         function findCloseButtonOrWarn() {
           var closeButton = element[0].querySelector('.dialog-close');
           if (!closeButton) {
-            var actionButtons = element[0].querySelectorAll('md-dialog-actions .md-button');
+            var actionButtons = element[0].querySelectorAll('.md-actions button, md-dialog-actions button');
             closeButton = actionButtons[actionButtons.length - 1];
             if (actionButtons.length === 0) {
               $log.warn('At least one action button is required for <md-dialog-actions>.');
@@ -849,7 +861,6 @@ function MdDialogProvider($$interimElementProvider) {
      * Ensure the dialog container fill-stretches to the viewport
      */
     function stretchDialogContainerToViewport(container, options) {
-
       var isFixed = $window.getComputedStyle($document[0].body).position == 'fixed';
       var backdrop = options.backdrop ? $window.getComputedStyle(options.backdrop[0]) : null;
       var height = backdrop ? Math.min($document[0].body.clientHeight, Math.ceil(Math.abs(parseInt(backdrop.height, 10)))) : 0;
@@ -866,7 +877,6 @@ function MdDialogProvider($$interimElementProvider) {
      *  Dialog open and pop-in animation
      */
     function dialogPopIn(container, options) {
-
       // Add the `md-dialog-container` to the DOM
       options.parent.append(container);
       stretchDialogContainerToViewport(container, options);

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -58,7 +58,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * - The dialog is always given an isolate scope.
  * - The dialog's template must have an outer `<md-dialog>` element.
  *   Inside, use an `<md-dialog-content>` element for the dialog's content, and use
- *   an element with class `md-actions` for the dialog's actions.
+ *   an `<md-dialog-actions>` element for the dialog's actions.
  * - Dialogs must cover the entire application to keep interactions inside of them.
  * Use the `parent` option to change where dialogs are appended.
  *
@@ -139,11 +139,11 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *            '      </md-item>'+
  *            '    </md-list>'+
  *            '  </md-dialog-content>' +
- *            '  <div class="md-actions">' +
+ *            '  <md-dialog-actions>' +
  *            '    <md-button ng-click="closeDialog()" class="md-primary">' +
  *            '      Close Dialog' +
  *            '    </md-button>' +
- *            '  </div>' +
+ *            '  </md-dialog-actions>' +
  *            '</md-dialog>',
  *          locals: {
  *            items: $scope.items
@@ -218,11 +218,11 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *
  *             '  <md-dialog-content>Hello {{ employee }}!</md-dialog-content>' +
  *
- *             '  <div class="md-actions">' +
+ *             '  <md-dialog-actions>' +
  *             '    <md-button ng-click="closeDialog()" class="md-primary">' +
  *             '      Close Greeting' +
  *             '    </md-button>' +
- *             '  </div>' +
+ *             '  </md-dialog-actions>' +
  *             '</md-dialog>',
  *           controller: 'GreetingController',
  *           onComplete: afterShowAnimation,
@@ -429,19 +429,19 @@ function MdDialogProvider($$interimElementProvider) {
     return {
       template: [
         '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
-        ' <md-dialog-content class="md-dialog-content" role="document" tabIndex="-1">',
-        '   <h2 class="md-title">{{ dialog.title }}</h2>',
-        '   <div class="md-dialog-content-body" md-template="::dialog.mdContent"></div>',
-        ' </md-dialog-content>',
-        ' <div class="md-actions">',
-        '   <md-button ng-if="dialog.$type == \'confirm\'"' +
-        '     ng-click="dialog.abort()" class="md-primary">',
-        '     {{ dialog.cancel }}',
-        '   </md-button>',
-        '   <md-button ng-click="dialog.hide()" class="md-primary" md-autofocus="dialog.$type!=\'confirm\'">',
-        '     {{ dialog.ok }}',
-        '   </md-button>',
-        ' </div>',
+        '  <md-dialog-content class="md-dialog-content" role="document" tabIndex="-1">',
+        '    <h2 class="md-title">{{ dialog.title }}</h2>',
+        '    <div class="md-dialog-content-body" md-template="::dialog.mdContent"></div>',
+        '  </md-dialog-content>',
+        '  <md-dialog-actions>',
+        '    <md-button ng-if="dialog.$type == \'confirm\'"' +
+        '               ng-click="dialog.abort()" class="md-primary">',
+        '      {{ dialog.cancel }}',
+        '    </md-button>',
+        '    <md-button ng-click="dialog.hide()" class="md-primary" md-autofocus="dialog.$type!=\'confirm\'">',
+        '      {{ dialog.ok }}',
+        '    </md-button>',
+        '  </md-dialog-actions>',
         '</md-dialog>'
       ].join('').replace(/\s\s+/g, ''),
       controller: function mdDialogCtrl() {
@@ -459,7 +459,7 @@ function MdDialogProvider($$interimElementProvider) {
   }
 
   /* @ngInject */
-  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $window, $rootElement) {
+  function dialogDefaultOptions($mdDialog, $mdAria, $mdUtil, $mdConstant, $animate, $document, $rootElement, $log) {
     return {
       hasBackdrop: true,
       isolateScope: true,
@@ -514,19 +514,24 @@ function MdDialogProvider($$interimElementProvider) {
        */
       function focusOnOpen() {
         if (options.focusOnOpen) {
-          var target = $mdUtil.findFocusTarget(element) || findCloseButton();
+          var target = $mdUtil.findFocusTarget(element) || findCloseButtonOrWarn();
           target.focus();
         }
 
         /**
          *  If no element with class dialog-close, try to find the last
          *  button child in md-actions and assume it is a close button
+         *
+         * If we find no actions at all, log a warning to the console.
          */
-        function findCloseButton() {
+        function findCloseButtonOrWarn() {
           var closeButton = element[0].querySelector('.dialog-close');
           if (!closeButton) {
-            var actionButtons = element[0].querySelectorAll('.md-actions button');
+            var actionButtons = element[0].querySelectorAll('md-dialog-actions .md-button');
             closeButton = actionButtons[actionButtons.length - 1];
+            if (actionButtons.length === 0) {
+              $log.warn('At least one action button is required for <md-dialog-actions>.');
+            }
           }
           return angular.element(closeButton);
         }
@@ -643,7 +648,6 @@ function MdDialogProvider($$interimElementProvider) {
             // If we have a reference to a raw dom element, always wrap it in jqLite
             return angular.element(element || defaultElement);
           }
-
 
         }
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -86,7 +86,7 @@ md-dialog {
     }
   }
 
-  .md-actions {
+  md-dialog-actions {
     display: flex;
     order: 2;
     box-sizing: border-box;
@@ -105,7 +105,7 @@ md-dialog {
       margin-top: $baseline-grid;
     }
   }
-  &.md-content-overflow .md-actions {
+  &.md-content-overflow md-dialog-actions {
     border-top-width: 1px;
     border-top-style: solid;
   }

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -86,7 +86,7 @@ md-dialog {
     }
   }
 
-  md-dialog-actions {
+  .md-actions, md-dialog-actions {
     display: flex;
     order: 2;
     box-sizing: border-box;
@@ -105,9 +105,11 @@ md-dialog {
       margin-top: $baseline-grid;
     }
   }
-  &.md-content-overflow md-dialog-actions {
-    border-top-width: 1px;
-    border-top-style: solid;
+  &.md-content-overflow {
+    .md-actions, md-dialog-actions {
+      border-top-width: 1px;
+      border-top-style: solid;
+    }
   }
 
 }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -282,11 +282,11 @@ describe('$mdDialog', function() {
       var parent = angular.element('<div>');
       $mdDialog.show({
         template: '' +
-        '<md-dialog>' +
-        '  <div class="md-actions">' +
-        '    <button class="dialog-close">Close</button>' +
-        '  </div>' +
-        '</md-dialog>',
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button class="dialog-close">Close</button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
         parent: parent
       });
       runAnimation();
@@ -756,12 +756,13 @@ describe('$mdDialog', function() {
       $mdDialog.show({
         focusOnOpen: true,
         parent: parent,
-        template: '<md-dialog>' +
-        '<div class="md-actions">' +
-        '<button id="a">A</md-button>' +
-        '<button id="focus-target">B</md-button>' +
-        '</div>' +
-        '</md-dialog>'
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button id="a">A</md-button>' +
+              '<button id="focus-target">B</md-button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>'
       });
 
       $rootScope.$apply();
@@ -777,12 +778,13 @@ describe('$mdDialog', function() {
       $mdDialog.show({
         focusOnOpen: false,
         parent: parent,
-        template: '<md-dialog>' +
-        '<div class="md-actions">' +
-        '<button id="a">A</md-button>' +
-        '<button id="focus-target">B</md-button>' +
-        '</div>' +
-        '</md-dialog>',
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button id="a">A</md-button>' +
+              '<button id="focus-target">B</md-button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
       });
 
       $rootScope.$apply();
@@ -930,23 +932,76 @@ describe('$mdDialog', function() {
         'translate3d(240px, 120px, 0px) scale(0.5, 0.5)');
     }));
 
-    it('should focus the last `md-button` in md-actions open if no `.dialog-close`', inject(function($mdDialog, $rootScope, $document, $timeout, $mdConstant) {
+    it('should focus the last `md-button` in md-dialog-actions open if no `.dialog-close`', inject(function($mdDialog, $rootScope, $document, $timeout, $mdConstant) {
       jasmine.mockElementFocus(this);
 
       var parent = angular.element('<div>');
       $mdDialog.show({
-        template: '<md-dialog>' +
-        '<div class="md-actions">' +
-        '<button id="a">A</md-button>' +
-        '<button id="focus-target">B</md-button>' +
-        '</div>' +
-        '</md-dialog>',
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button id="a">A</md-button>' +
+              '<button id="focus-target">B</md-button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
         parent: parent
       });
 
       runAnimation();
 
       expect($document.activeElement).toBe(parent[0].querySelector('#focus-target'));
+    }));
+
+    it('should warn if md-dialog-actions does not contain actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+      spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<p>Why is this here</p>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      $rootScope.$apply();
+      $timeout.flush();
+
+      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+
+      container.triggerHandler('transitionend');
+      $rootScope.$apply();
+      parent.find('md-dialog').triggerHandler('transitionend');
+      $rootScope.$apply();
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
+    it('should not warn if md-dialog-actions has actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+      spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<md-dialog-actions>' +
+              '<button class="md-button">Ok good</button>' +
+            '</md-dialog-actions>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      $rootScope.$apply();
+      $timeout.flush();
+      container.triggerHandler('transitionend');
+      $rootScope.$apply();
+      parent.find('md-dialog').triggerHandler('transitionend');
+      $rootScope.$apply();
+
+      expect($log.warn).not.toHaveBeenCalled();
     }));
 
     it('should only allow one open at a time', inject(function($mdDialog, $rootScope, $animate) {
@@ -1163,7 +1218,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
     var content = mdContent.find('p');
-    var mdActions = angular.element(mdDialog[0].querySelector('.md-actions'));
+    var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
     expect(mdDialog.attr('aria-label')).toBe('test alert');
@@ -1190,7 +1245,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
     var content = mdContent.find('p');
-    var mdActions = angular.element(mdDialog[0].querySelector('.md-actions'));
+    var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
     expect(mdDialog.attr('aria-label')).toBe('test alert');

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -283,9 +283,9 @@ describe('$mdDialog', function() {
       $mdDialog.show({
         template: '' +
           '<md-dialog>' +
-            '<md-dialog-actions>' +
-              '<button class="dialog-close">Close</button>' +
-            '</md-dialog-actions>' +
+          '  <md-dialog-actions>' +
+          '    <button class="dialog-close">Close</button>' +
+          '  </md-dialog-actions>' +
           '</md-dialog>',
         parent: parent
       });
@@ -758,10 +758,10 @@ describe('$mdDialog', function() {
         parent: parent,
         template:
           '<md-dialog>' +
-            '<md-dialog-actions>' +
-              '<button id="a">A</md-button>' +
-              '<button id="focus-target">B</md-button>' +
-            '</md-dialog-actions>' +
+          '  <md-dialog-actions>' +
+          '    <button id="a">A</md-button>' +
+          '    <button id="focus-target">B</md-button>' +
+          '  </md-dialog-actions>' +
           '</md-dialog>'
       });
 
@@ -939,10 +939,10 @@ describe('$mdDialog', function() {
       $mdDialog.show({
         template:
           '<md-dialog>' +
-            '<md-dialog-actions>' +
-              '<button id="a">A</md-button>' +
-              '<button id="focus-target">B</md-button>' +
-            '</md-dialog-actions>' +
+          '  <md-dialog-actions>' +
+          '    <button id="a">A</md-button>' +
+          '    <button id="focus-target">B</md-button>' +
+          '  </md-dialog-actions>' +
           '</md-dialog>',
         parent: parent
       });
@@ -952,11 +952,32 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('#focus-target'));
     }));
 
-    it('should warn if md-dialog-actions does not contain actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+    it('should warn if the deprecated .md-actions class is used', inject(function($mdDialog, $rootScope, $log, $timeout) {
+       spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<div class="md-actions">' +
+              '<button class="md-button">Ok good</button>' +
+            '</div>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      runAnimation();
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
+    it('should warn if focusOnOpen == true and md-dialog-actions does not contain actions',
+        inject(function($mdDialog, $rootScope, $log, $timeout) {
       spyOn($log, 'warn');
 
       var parent = angular.element('<div>');
       $mdDialog.show({
+        focusOnOpen: true,
         template:
           '<md-dialog>' +
             '<md-dialog-actions>' +
@@ -966,24 +987,21 @@ describe('$mdDialog', function() {
         parent: parent
       });
 
-      $rootScope.$apply();
-      $timeout.flush();
-
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-
-      container.triggerHandler('transitionend');
-      $rootScope.$apply();
-      parent.find('md-dialog').triggerHandler('transitionend');
-      $rootScope.$apply();
+      runAnimation();
 
       expect($log.warn).toHaveBeenCalled();
     }));
 
-    it('should not warn if md-dialog-actions has actions', inject(function($mdDialog, $rootScope, $log, $timeout) {
+    // This also covers the case of NOT warning when the deprecated .md-actions class is NOT used
+    it('should not warn if focusOnOpen == true and md-dialog-actions has actions',
+        inject(function($mdDialog, $rootScope, $log, $timeout) {
       spyOn($log, 'warn');
 
-      var parent = angular.element('<div>');
+      // Style the parent so <md-backdrop> doesn't fire a warning in Firefox
+      var parent = angular.element('<div style="position: absolute; left:0;right:0;top:0;bottom:0">');
+
       $mdDialog.show({
+        focusOnOpen: true,
         template:
           '<md-dialog>' +
             '<md-dialog-actions>' +
@@ -993,13 +1011,7 @@ describe('$mdDialog', function() {
         parent: parent
       });
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-      $rootScope.$apply();
-      $timeout.flush();
-      container.triggerHandler('transitionend');
-      $rootScope.$apply();
-      parent.find('md-dialog').triggerHandler('transitionend');
-      $rootScope.$apply();
+      runAnimation();
 
       expect($log.warn).not.toHaveBeenCalled();
     }));


### PR DESCRIPTION
Via @marcysutton 

To be more semantic, this PR includes a change from `<div class="md-actions">` in both cards and dialogs to `<md-card-actions>` and `<md-dialog-actions>`, respectively. Breaking changes noted in the commits.

Via @topherfangio

This adds on to PR #3112 by rebasing against master and deprecating the `.md-actions` class instead of removing it.