### PR TITLE
fix(datepicker): apply ngMessages errors when using text input. Fixes #5353

### DIFF
--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -349,15 +349,19 @@
    * Sets the custom ngModel.$error flags to be consumed by ngMessages. Flags are:
    *   - mindate: whether the selected date is before the minimum date.
    *   - maxdate: whether the selected flag is after the maximum date.
+   *
+   * @param {Date=} opt_date Date to check. If not given, defaults to the datepicker's model value.
    */
-  DatePickerCtrl.prototype.setErrorFlags = function() {
-    if (this.dateUtil.isValidDate(this.date)) {
+  DatePickerCtrl.prototype.setErrorFlags = function(opt_date) {
+    var date = opt_date || this.date;
+
+    if (this.dateUtil.isValidDate(date)) {
       if (this.dateUtil.isValidDate(this.minDate)) {
-        this.ngModelCtrl.$setValidity('mindate', this.date >= this.minDate);
+        this.ngModelCtrl.$setValidity('mindate', date >= this.minDate);
       }
 
       if (this.dateUtil.isValidDate(this.maxDate)) {
-        this.ngModelCtrl.$setValidity('maxdate', this.date <= this.maxDate);
+        this.ngModelCtrl.$setValidity('maxdate', date <= this.maxDate);
       }
       
       if (angular.isFunction(this.dateFilter)) {
@@ -388,9 +392,11 @@
         this.isDateEnabled(parsedDate)) {
       this.ngModelCtrl.$setViewValue(parsedDate);
       this.date = parsedDate;
+      this.setErrorFlags();
       this.inputContainer.classList.remove(INVALID_CLASS);
     } else {
       // If there's an input string, it's an invalid date.
+      this.setErrorFlags(parsedDate);
       this.inputContainer.classList.toggle(INVALID_CLASS, inputString);
     }
   };

--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -16,6 +16,7 @@ describe('md-date-picker', function() {
          'md-min-date="minDate" ' +
          'md-date-filter="dateFilter"' +
          'ng-model="myDate" ' +
+         'ng-change="dateChangedHandler()" ' +
          'ng-required="isRequired" ' +
          'ng-disabled="isDisabled">' +
     '</md-datepicker>';
@@ -40,6 +41,7 @@ describe('md-date-picker', function() {
     pageScope = $rootScope.$new();
     pageScope.myDate = initialDate;
     pageScope.isDisabled = false;
+    pageScope.dateChangedHandler = jasmine.createSpy('ng-change handler');
 
     createDatepickerInstance(DATEPICKER_TEMPLATE);
     controller.closeCalendarPane();
@@ -222,6 +224,21 @@ describe('md-date-picker', function() {
 
       populateInputElement('6/2/2014');
       expect(controller.ngModelCtrl.$modelValue).toEqual(new Date(2014, JUN, 2));
+    });
+
+    it('should apply ngMessages errors when the date changes from keyboard input', function() {
+      pageScope.minDate = new Date(2014, JUN, 1);
+      pageScope.$apply();
+
+      populateInputElement('5/30/2012');
+
+      expect(controller.ngModelCtrl.$error['mindate']).toBe(true);
+    });
+
+    it('should evaluate ngChange expression when date changes from keyboard input', function() {
+      populateInputElement('2/14/1976');
+
+      expect(pageScope.dateChangedHandler).toHaveBeenCalled();
     });
 
     it('should add and remove the invalid class', function() {


### PR DESCRIPTION
Problem was that error flags only got called on `$render`, which didn't occur because the ngModel isn't updated when the value is invalid.

@mhchen for review