### PR TITLE
features(select): Open around label

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -47,6 +47,7 @@ angular.module('material.components.select', [
  * explicit label is present.
  * @param {string=} md-container-class Class list to get applied to the `.md-select-menu-container`
  * element (for custom styling).
+ * @param {boolean=} md-open-around Whether the select menu should open under the label
  *
  * @usage
  * With a placeholder (label and aria-label are added dynamically)
@@ -1198,13 +1199,14 @@ function SelectProvider($$interimElementProvider) {
     function calculateMenuPositions(scope, element, opts) {
       var optionNodes,
         containerNode = element[0],
-        targetNode = opts.target[0].firstElementChild, // target the label
+        targetNode = opts.target[0],
+        labelNode = targetNode.firstElementChild,
         parentNode = opts.parent[0],
         selectNode = opts.selectEl[0],
         contentNode = opts.contentEl[0],
         parentRect = parentNode.getBoundingClientRect(),
-        targetRect = targetNode.getBoundingClientRect(),
-        shouldOpenAroundTarget = false,
+        targetRect = labelNode.getBoundingClientRect(),
+        shouldOpenAroundTarget = targetNode.hasAttribute('md-open-around'),
         bounds = {
           left: parentRect.left + SELECT_EDGE_MARGIN,
           top: SELECT_EDGE_MARGIN,


### PR DESCRIPTION
Add a parameter called 'md-open-around' to position the select menu under the label / select element.
I'll complete the docs if it's ok.

cf: https://github.com/angular/material/issues/4125
https://groups.google.com/forum/#!searchin/ngmaterial/md-select$20position/ngmaterial/0QWcy-nMdzs/wH1Ig5DIAZQJ