### PR TITLE
fix(all): fix issue with removeClass removing previous classes

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -167,7 +167,7 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
         if(ngModelCtrl.$viewValue) {
           element.addClass(CHECKED_CSS);
         } else {
-          element.removeClass(CHECKED_CSS);
+          if (CHECKED_CSS) element.removeClass(CHECKED_CSS);
         }
       }
     };

--- a/src/components/progressCircular/progress-circular.js
+++ b/src/components/progressCircular/progress-circular.js
@@ -118,11 +118,11 @@ function MdProgressCircularDirective($mdTheming, $mdUtil, $log) {
          case MODE_DETERMINATE:
          case MODE_INDETERMINATE:
            spinnerWrapper.removeClass('ng-hide');
-           spinnerWrapper.removeClass( lastMode );
+           if (lastMode) spinnerWrapper.removeClass(lastMode);
            spinnerWrapper.addClass( lastMode = "md-mode-" + mode );
            break;
          default:
-           spinnerWrapper.removeClass( lastMode );
+           if (lastMode) spinnerWrapper.removeClass( lastMode );
            spinnerWrapper.addClass('ng-hide');
            lastMode = undefined;
            break;

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -117,7 +117,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
             container.addClass( lastMode = "md-mode-" + mode );
             break;
           default:
-            container.removeClass( lastMode );
+            if (lastMode) container.removeClass( lastMode );
             container.addClass('ng-hide');
             lastMode = undefined;
             break;

--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -302,7 +302,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
 
       } else {
         markParentAsChecked(false);
-        element.removeClass(CHECKED_CSS);
+        if (CHECKED_CSS) element.removeClass(CHECKED_CSS);
       }
 
       /**
@@ -310,7 +310,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
        */
       function markParentAsChecked(addClass ) {
         if ( element.parent()[0].nodeName != "MD-RADIO-GROUP") {
-          element.parent()[ !!addClass ? 'addClass' : 'removeClass'](CHECKED_CSS);
+          if (CHECKED_CSS) element.parent()[ !!addClass ? 'addClass' : 'removeClass'](CHECKED_CSS);
         }
 
       }

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -260,7 +260,7 @@ function MdToastProvider($$interimElementProvider) {
 
     function onRemove(scope, element, options) {
       element.off(SWIPE_EVENTS, options.onSwipe);
-      options.parent.removeClass(options.openClass);
+      if (options.openClass) options.parent.removeClass(options.openClass);
 
       return (options.$destroy == true) ? element.remove() : $animate.leave(element);
     }

--- a/test/angular-material-spec.js
+++ b/test/angular-material-spec.js
@@ -64,7 +64,7 @@
 
           // Prepare auto-restore
           enableAnimations = function() {
-            body.removeClass(DISABLE_ANIMATIONS);
+            if (DISABLE_ANIMATIONS) body.removeClass(DISABLE_ANIMATIONS);
             styleSheet.remove();
           };
         };


### PR DESCRIPTION
In certain parts of the project, a "removeClass(className)" is used to remove the class from the element. While this works fine in latest versions of jQuery, in jQuery < 1.9 this results in the element classes being removed when className is undefined, thus breaking the whole layout.

Adding a null check for each of those statements to prevent this behavior.