### PR TITLE
fix(autocompleteController): fix ng-click on the mdNotFound not trigg…

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -359,8 +359,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Handles input blur event, determines if the dropdown should hide.
    */
   function blur () {
-    hasFocus = false;
     if (!noBlur) {
+      hasFocus = false;
       ctrl.hidden = shouldHide();
     }
   }


### PR DESCRIPTION
…ering

This fixes a bug introduced in the commit 309cef5d023913d2e67c7e88d9a52745f7c05825 that prevent triggering of ng-click on the md-no-tab element.