### PR TITLE
fix(toolbar button): Fix color of raised buttons.

### DIFF
--- a/src/components/toolbar/demoBasicUsage/index.html
+++ b/src/components/toolbar/demoBasicUsage/index.html
@@ -3,6 +3,8 @@
 
   <md-content>
 
+    <br>
+
     <md-toolbar>
       <div class="md-toolbar-tools">
         <md-button class="md-icon-button" aria-label="Settings">
@@ -17,6 +19,26 @@
         </md-button>
         <md-button class="md-icon-button" aria-label="More">
           <md-icon md-svg-icon="img/icons/more_vert.svg"></md-icon>
+        </md-button>
+      </div>
+    </md-toolbar>
+
+    <br>
+
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <md-button aria-label="Go Back">
+          Go Back
+        </md-button>
+        <h2>
+          <span>Toolbar with Standard Buttons</span>
+        </h2>
+        <span flex></span>
+        <md-button class="md-raised" aria-label="Learn More">
+          Learn More
+        </md-button>
+        <md-button class="md-fab md-mini" aria-label="Favorite">
+          <md-icon md-svg-icon="img/icons/favorite.svg"></md-icon>
         </md-button>
       </div>
     </md-toolbar>

--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -6,7 +6,7 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     color: '{{primary-contrast}}';
   }
 
-  .md-button {
+  .md-button:not(.md-raised) {
     color: '{{primary-contrast}}';
   }
 


### PR DESCRIPTION
Raised buttons inside of a toolbar had the incorrect text color applied.

Fix styles to not apply special toolbar styling to raised buttons and
add demo so we can see similar issues in the future.

Fixes #4845.