### PR TITLE
mdAutocomplete: Add attribute for always opening the dropdown on focus

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -498,7 +498,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    */
   function shouldHide () {
     if (ctrl.loading && !hasMatches()) return true; // Hide while loading initial matches
-    else if (hasSelection()) return true;           // Hide if there is already a selection
+    else if (hasSelection() && !$scope.openOnFocus) return true; // Hide if there is already a selection
     else if (!hasFocus) return true;                // Hide if the input does not have focus
     else return !shouldShow();                      // Defer to standard show logic
   }
@@ -508,6 +508,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * @returns {boolean}
    */
   function shouldShow() {
+    if(hasFocus && $scope.openOnFocus) return true; // If autocomplete has focus and is set to always show on focus
     return (isMinLengthMet() && hasMatches()) || notFoundVisible();
   }
 

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -50,6 +50,8 @@ angular
  * @param {number=} md-delay Specifies the amount of time (in milliseconds) to wait before looking
  *     for results
  * @param {boolean=} md-autofocus If true, will immediately focus the input element
+ * @param {boolean=} md-open-on-focus If true, the dropdown will always be shown when autocomplete
+ *     gets focus
  * @param {boolean=} md-autoselect If true, the first item will be selected by default
  * @param {string=} md-menu-class This will be applied to the dropdown menu for styling
  * @param {string=} md-floating-label This will add a floating label to autocomplete and wrap it in
@@ -139,6 +141,7 @@ function MdAutocomplete () {
       minLength:      '=?mdMinLength',
       delay:          '=?mdDelay',
       autofocus:      '=?mdAutofocus',
+      openOnFocus:    '=?mdOpenOnFocus',
       floatingLabel:  '@?mdFloatingLabel',
       autoselect:     '=?mdAutoselect',
       menuClass:      '@?mdMenuClass',


### PR DESCRIPTION
As the Material Design specifications doesn't really state the proper behaviour, and I've seen several use cases where it would make sense to have the dropdown open even if an item was already selected, I made this PoC implementation of a boolean attribute that will make the dropdown always open whenever the autocomplete gets focus.