### PR TITLE
fix(button): set color of disabled button to highest css priority.

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -141,7 +141,7 @@ a.md-button.md-THEME_NAME-theme,
   &.md-fab[disabled],
   &.md-accent[disabled],
   &.md-warn[disabled] {
-    color: '{{foreground-3}}';
+    color: '{{foreground-3}}' !important;
     cursor: not-allowed;
 
     md-icon {


### PR DESCRIPTION
Normally a disabled button in the toolbar won't get the disabled button style, because the theme style is injected after the default style

Fixes #5569