### PR TITLE
fix(sidenav): Only restore focus if user interaction was keyboard

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -277,7 +277,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
 
       // UNREGISTER INTERACTION EVENTS
       body.off('keydown', onInput);
-      body.off(_eventType, onInput);
+      body.off(_mouseEvent, onInput);
       body.off('mouseenter', onInput);
       if ('ontouchstart' in document.documentElement) body.off('touchstart', onBufferInput);
     });

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -245,9 +245,8 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
 
     $mdTheming.inherit(backdrop, element);
 
-    // KEY CHECK
     var body = angular.element(document.body);
-    var _mouseEvent = window.MSPointerEvent ? 'MSPointerEvent' : window.PointerEvent ? 'pointerdown' : 'mousedown';
+    var _mouseEvent = window.MSPointerEvent ? 'MSPointerDown' : window.PointerEvent ? 'pointerdown' : 'mousedown';
 
     body.on('keydown', onInput);
     body.on(_mouseEvent, onInput);
@@ -269,13 +268,11 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
         buffer = false;
       }, 1000);
     }
-    // END INTERACTION CHECK
 
     element.on('$destroy', function() {
       backdrop.remove();
       sidenavCtrl.destroy();
 
-      // UNREGISTER INTERACTION EVENTS
       body.off('keydown', onInput);
       body.off(_mouseEvent, onInput);
       body.off('mouseenter', onInput);


### PR DESCRIPTION
Normally the Sidenav restores every time the last active element, so the focus won't disappear from the triggered button after closing the sidenav

Fixes #5563