### PR TITLE
style(disabled components): changed cursor to default when disabled

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -42,7 +42,7 @@ md-autocomplete {
   min-width: 190px;
   &[disabled] {
     input {
-      cursor: not-allowed;
+      cursor: default;
     }
   }
   &[md-floating-label] {

--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -142,7 +142,7 @@ a.md-button.md-THEME_NAME-theme,
   &.md-accent[disabled],
   &.md-warn[disabled] {
     color: '{{foreground-3}}' !important;
-    cursor: not-allowed;
+    cursor: default;
 
     md-icon {
       color: '{{foreground-3}}';

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -121,7 +121,7 @@ md-checkbox {
 
   // disabled
   &[disabled] {
-    cursor: no-drop;
+    cursor: default;
   }
 
 

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -12,6 +12,15 @@ md-radio-button {
   cursor: pointer;
   position: relative;
 
+  // disabled
+  &[disabled] {
+    cursor: default;
+
+    .md-container {
+      cursor: default;
+    }
+  }
+
   .md-container {
     position: absolute;
     top: 50%;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -179,6 +179,10 @@ md-option {
   align-items: center;
   width: auto;
 
+  &[disabled] {
+    cursor: default;
+  }
+
   &:focus {
     outline: none;
   }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -29,6 +29,14 @@ md-switch {
     @include rtl(margin-left, inherit, 0);
     @include rtl(margin-right, 0, inherit);
   }
+  
+  &[disabled] {
+    cursor: default;
+
+    .md-container {
+      cursor: default;
+    }
+  }
 
   .md-container {
     cursor: grab;


### PR DESCRIPTION
Replaced all `no-drop` and `not-allowed` cursors to `default`

fixes #4831 