### PR TITLE
style(list): overridden button and ripple default radius

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -60,6 +60,11 @@ md-list-item {
       white-space: normal;
       flex-direction: inherit;
       align-items: inherit;
+      border-radius: 0;
+
+      & > .md-ripple-container {
+        border-radius: 0;
+      }
     }
     &:focus {
       outline: none


### PR DESCRIPTION
Removed button border radius when was placed instead of the list item

fixes #5177