### PR TITLE
fix(textarea): text area auto grow fix

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -322,7 +322,9 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
             node.style.minHeight = null;
           }
 
-          var rows = Math.max(min_rows, Math.round(node.scrollHeight / lineHeight));
+          var rows = Math.min(min_rows, Math.round(node.scrollHeight / lineHeight));
+          node.style.height = lineHeight * rows + "px";
+
           node.setAttribute("rows", rows);
         }
 


### PR DESCRIPTION
Textarea should grow automatically if no `rows` attribute is specified.
Textarea should stay fixed with given `rows` attribute (no growing or shrinking).

If there are other thinks of the textarea, not wished as I fixed it, please tell me.
I'm always up for improving my PR through suggestions or wishes.

Fixes #5627 