### PR TITLE
fix(progressCircular): Fix progress circular height/width used with md-…

### DIFF
--- a/src/components/progressCircular/progress-circular.js
+++ b/src/components/progressCircular/progress-circular.js
@@ -135,8 +135,10 @@ function MdProgressCircularDirective($mdTheming, $mdUtil, $log) {
      * Watch the "value" and "md-mode" attributes
      */
     function updateScale() {
+      var diameterRatio = getDiameterRatio();
       circle.css(toVendorCSS({
-        transform : $mdUtil.supplant('scale( {0} )',[getDiameterRatio()])
+        transform : $mdUtil.supplant('scale( {0} )',[diameterRatio]),
+        height: DEFAULT_PROGRESS_SIZE * diameterRatio
       }));
     }
 

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -80,6 +80,7 @@ describe('mdProgressCircular', function() {
     var value = Math.round( (37 / DEFAULT_SIZE) * 100 )/100;
 
     expect( getScale(progress) ).toBe(value);
+    expect( getHeight(progress )).toBe('37px');
   });
 
   /**
@@ -103,4 +104,10 @@ describe('mdProgressCircular', function() {
 
     return Math.round(scale * 100)/100;
   }
+
+  function getHeight(element) {
+    var el = angular.element(element)[0];
+    return el.style['height'];
+  }
+
 });


### PR DESCRIPTION
…diameter

Resizes the md-progress-circular width and height when used in conjunction with md-diameter. This also explains why the demo is broken.
This fixes #5594 (https://github.com/angular/material/issues/5594).