### PR TITLE
fix(list): apply md-no-style to `a` tags

### DIFF
--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -15,6 +15,7 @@ body {
   padding: 10px;
 }
 
+a._md-no-style,
 button._md-no-style {
   font-weight: normal;
   background-color: inherit;


### PR DESCRIPTION
Earlier it was only applied to `button` tags, making list items
converted to buttons behave different from list items converted to
links in some cases.