### PR TITLE
fix(tooltip): set initial position of tooltip

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -175,8 +175,9 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     }
 
     function showTooltip() {
-      // Insert the element before positioning it, so we can get the position
+      // Insert the element and position at top left, so we can get the position
       // and check if we should display it
+      element.css({top: 0, left: 0});
       tooltipParent.append(element);
 
       // Check if we should display it or not.


### PR DESCRIPTION
Set initial position of the tooltip so that its inclusion at the bottom
of the page does not cause the scroll bar to appear and offset the
calculation of the tooltip's final position.

Fixes #4345