### PR TITLE
fix(menu): use light menu item texts in a dark theme

### DIFF
--- a/src/components/menu/menu-theme.scss
+++ b/src/components/menu/menu-theme.scss
@@ -1,4 +1,5 @@
 md-menu-content.md-THEME_NAME-theme {
+  color: '{{foreground-1}}';
   background-color: '{{background-color}}';
 
   md-menu-divider {


### PR DESCRIPTION
The menu item texts were badly readable, because they were black on a
dark background.