### PR TITLE
pref(list): prevented unnecessary ripple container on list with ng-click

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -230,7 +230,9 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           if (proxies.length || hasClick) {
             $element.addClass('md-clickable');
 
-            ctrl.attachRipple($scope, angular.element($element[0].querySelector('.md-no-style')));
+            if (!hasClick) {
+              ctrl.attachRipple($scope, angular.element($element[0].querySelector('.md-no-style')));
+            }
           }
         }
 


### PR DESCRIPTION
By checking if the element hasClick we preventing unnecessary ripple-container to be attached to the already attached element.

fixes #5295