### PR TITLE
fix(toast): added position relative to toast parent

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -265,6 +265,12 @@ function MdToastProvider($$interimElementProvider) {
 
       // 'top left' -> 'md-top md-left'
       options.parent.addClass(options.openClass);
+
+      // static is the default position
+      if ($mdUtil.hasComputedStyle(options.parent, 'position', 'static')) {
+        options.parent.css('position', 'relative');
+      }
+
       element.on(SWIPE_EVENTS, options.onSwipe);
       element.addClass(options.position.split(' ').map(function(pos) {
         return 'md-' + pos;
@@ -277,7 +283,12 @@ function MdToastProvider($$interimElementProvider) {
       element.off(SWIPE_EVENTS, options.onSwipe);
       if (options.openClass) options.parent.removeClass(options.openClass);
 
-      return (options.$destroy == true) ? element.remove() : $animate.leave(element);
+      return ((options.$destroy == true) ? element.remove() : $animate.leave(element))
+        .then(function () {
+          if ($mdUtil.hasComputedStyle(options.parent, 'position', 'static')) {
+            options.parent.css('position', '');
+          }
+        });
     }
 
     function toastOpenClass(position) {


### PR DESCRIPTION
Toast is aligned by `position: absolute` therefore its parent must have `position: relative` to enable the toast align properly,

Added `position: relative` to the parent only if there's no computed style for position (checking for `static` because this is the default computed position)

fixes #4542