### PR TITLE
fix(mdUtil): disableBodyScroll no longer scrolls page to top in IE

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -252,6 +252,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           body.setAttribute('style', restoreBodyStyle);
           htmlNode.setAttribute('style', restoreHtmlStyle);
           body.scrollTop = scrollOffset;
+          htmlNode.scrollTop = scrollOffset;
         };
       }
 


### PR DESCRIPTION
IE needs to set scrollTop on html element in order to not scroll the page to the top

Fixes #4640
Fixes #5334
Fixes #3627