### PR TITLE
fix(mdUtil): fix IE rendering bug when body scroll is disabled

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -238,6 +238,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           applyStyles(body, {
             position: 'fixed',
             width: '100%',
+            height: 'auto',
             top: -scrollOffset + 'px'
           });
 


### PR DESCRIPTION
Applying auto height to the body when disabling the scrollbar fixes rendering issue in IE.

Fixes #5650 