### PR TITLE
Wip/tool tip positioning

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -243,6 +243,8 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       }
 
       function getPosition (dir) {
+        // recalc position every time, as parent and tooltipParent can change
+        parentRect = $mdUtil.offsetRect(parent, tooltipParent);
         return dir === 'left'
           ? { left: parentRect.left - tipRect.width - TOOLTIP_WINDOW_EDGE_SPACE,
               top: parentRect.top + parentRect.height / 2 - tipRect.height / 2 }

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -117,6 +117,12 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       element.attr('role', 'tooltip');
     }
 
+    function windowScrollHandler (e) {
+      // in case of scroll, remove the fixed positioned tooltip.
+      setVisible(false)
+    };
+
+
     function bindEvents () {
       var mouseActive = false;
 
@@ -127,10 +133,14 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         elementFocusedOnWindowBlur = document.activeElement === parent[0];
       };
       var elementFocusedOnWindowBlur = false;
+
       ngWindow.on('blur', windowBlurHandler);
+      ngWindow.on('scroll', windowScrollHandler)
       scope.$on('$destroy', function() {
         ngWindow.off('blur', windowBlurHandler);
+        ngWindow.off('scroll', windowScrollHandler)
       });
+
 
       var enterHandler = function(e) {
         // Prevent the tooltip from showing when the window is receiving focus.
@@ -155,7 +165,10 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       parent.on('mousedown', function() { mouseActive = true; });
       parent.on('focus mouseenter touchstart', enterHandler );
 
-
+      // SanderElias: I noted this line, it is leaking bindings,
+      // and possible memory. Easy fix: move it to above with the
+      //  rest of the ngWindow bindings, and remove it on $destroy
+      //  like the rest of the event listeners
       angular.element($window).on('resize', debouncedOnResize);
     }
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -217,14 +217,13 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
 
     function positionTooltip() {
       var tipRect = $mdUtil.offsetRect(element, tooltipParent);
-      var parentRect = $mdUtil.offsetRect(parent, tooltipParent);
       var newPosition = getPosition(scope.direction);
 
       // If the user provided a direction, just nudge the tooltip onto the screen
       // Otherwise, recalculate based on 'top' since default is 'bottom'
       if (scope.direction) {
         newPosition = fitInParent(newPosition);
-      } else if (newPosition.top > element.prop('offsetParent').scrollHeight - tipRect.height - TOOLTIP_WINDOW_EDGE_SPACE) {
+      } else if (newPosition.top > tooltipParent.prop('offsetParent').scrollHeight - tipRect.height - TOOLTIP_WINDOW_EDGE_SPACE) {
         newPosition = fitInParent(getPosition('top'));
       }
 
@@ -242,9 +241,16 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         return newPosition;
       }
 
+      function getbrc(el) {
+        // small helper function to
+        // convert getBoundingClientRect to a normal object
+        var brc = el.getBoundingClientRect();
+        return {left: brc.left, top: brc.top, width: brc.width, height: brc.height};
+      }
+
       function getPosition (dir) {
-        // recalc position every time, as parent and tooltipParent can change
-        parentRect = $mdUtil.offsetRect(parent, tooltipParent);
+        var parentRect = getbrc(parent[0]);
+
         return dir === 'left'
           ? { left: parentRect.left - tipRect.width - TOOLTIP_WINDOW_EDGE_SPACE,
               top: parentRect.top + parentRect.height / 2 - tipRect.height / 2 }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -9,7 +9,7 @@ $tooltip-lr-padding-sm: rem(1.6);
 $tooltip-max-width: rem(3.20);
 
 md-tooltip {
-  position: absolute;
+  position: fixed;
   z-index: $z-index-tooltip;
   overflow: hidden;
   pointer-events: none;


### PR DESCRIPTION
fix(tooltip): a number of positional issues

The tootltip is changed from absolute to fixed positioning. This is done to support the different available layout modes. Also the tooltip will get removed on scroll events to prevent wrong offsets

fixes: #5430  #4954 #2844 #2791 and #2037 