### PR TITLE
fix(tabs): rename `disabled` to the right `ng-disabled`

### DIFF
--- a/src/components/tabs/js/tabDirective.js
+++ b/src/components/tabs/js/tabDirective.js
@@ -20,7 +20,7 @@
  * be initiated via data binding changes, programmatic invocation, or user gestures.
  *
  * @param {string=} label Optional attribute to specify a simple string as the tab label
- * @param {boolean=} disabled If present, disabled tab selection.
+ * @param {boolean=} ng-disabled If present, disabled tab selection.
  * @param {expression=} md-on-deselect Expression to be evaluated after the tab has been de-selected.
  * @param {expression=} md-on-select Expression to be evaluated after the tab has been selected.
  * @param {boolean=} md-active When true, sets the active tab.  Note: There can only be one active tab at a time.


### PR DESCRIPTION
In the documentation the wrong attribute ```disabled``` is present, it should be ```ng-disabled```

Fixes #5691