### PR TITLE
docs(datepicker): fix typo in dateLocaleProvider

### DIFF
--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -10,7 +10,7 @@
    * The `$mdDateLocaleProvider` is the provider that creates the `$mdDateLocale` service.
    * This provider that allows the user to specify messages, formatters, and parsers for date
    * internationalization. The `$mdDateLocale` service itself is consumed by Angular Material
-   * components that that deal with dates.
+   * components that deal with dates.
    *
    * @property {(Array<string>)=} months Array of month names (in order).
    * @property {(Array<string>)=} shortMonths Array of abbreviated month names.


### PR DESCRIPTION
Duplicate `that` is present

Fixes #4739 

@ThomasBurleson @EladBezalel 