### PR TITLE
fix(tooltip): change default delay from zero to 300 as referenced in …

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -35,7 +35,7 @@ angular
 function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdTheming, $rootElement,
                             $animate, $q) {
 
-  var TOOLTIP_SHOW_DELAY = 0;
+  var TOOLTIP_SHOW_DELAY = 300;
   var TOOLTIP_WINDOW_EDGE_SPACE = 8;
 
   return {


### PR DESCRIPTION
…the docs

https://material.angularjs.org/latest/api/directive/mdTooltip says: defaults to 300ms
![](https://i.gyazo.com/595ca9d7665d4ee5b7ce4cacb248df74.png)


Fixes #1847