### PR TITLE
fix(input): calculate icon vertical offset

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -19,6 +19,8 @@ $error-padding-top: ($input-error-height - $input-error-line-height) / 2;
 
 $icon-offset: 36px !default;
 
+$icon-top-offset: ($icon-offset - $input-padding-top - $input-border-width-focused) / 4;
+
 $icon-float-focused-top: -8px !default;
 
 md-input-container {
@@ -45,7 +47,7 @@ md-input-container {
 
   > md-icon {
     position: absolute;
-    top: 5px;
+    top: $icon-top-offset;
     @include rtl(left, 2px, auto);
     @include rtl(right, auto, 2px);
   }
@@ -308,7 +310,7 @@ md-input-container {
     }
 
     > md-icon {
-      top: 2px;
+      top: $icon-top-offset;
       @include rtl(left, 2px, auto);
       @include rtl(right, auto, 2px);
     }


### PR DESCRIPTION
This centers the icon in the middle as required.

Fixes #5731