### PR TITLE
style(list): enable avatar to be contained in other elements

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -109,7 +109,7 @@ md-list-item, md-list-item .md-list-item-inner {
   }
   & > div.md-primary > md-checkbox,
   & > div.md-secondary > md-checkbox,
-  & > md-checkbox:first-child,
+  & > md-checkbox,
   md-checkbox.md-secondary {
     align-self: center;
     .md-label { display: none; }
@@ -118,23 +118,23 @@ md-list-item, md-list-item .md-list-item-inner {
   & > md-icon:first-child:not(.md-avatar-icon) {
     margin-right: $list-item-primary-width - $list-item-primary-icon-width;
   }
-  & > md-checkbox:first-child {
+  & > md-checkbox {
     width: 3 * $baseline-grid;
     margin-left: 3px;
     margin-right: 29px;
   }
-  & > .md-avatar, .md-avatar-icon {
+  & .md-avatar, .md-avatar-icon {
     margin-top: $baseline-grid;
     margin-bottom: $baseline-grid;
     margin-right: $list-item-primary-width - $list-item-primary-avatar-width;
     border-radius: 50%;
     box-sizing: content-box;
   }
-  & > .md-avatar {
+  & .md-avatar {
     width: $list-item-primary-avatar-width;
     height: $list-item-primary-avatar-width;
   }
-  & > .md-avatar-icon {
+  & .md-avatar-icon {
     padding: 8px;
   }
 


### PR DESCRIPTION
`.md-avatar` was requested to be used inside `<a>` element

fixes #5749