### PR TITLE
fix(util): added toUpperCase to nodeName

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -671,7 +671,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     getNearestContentElement: function (element) {
       var current = element.parent()[0];
       // Look for the nearest parent md-content, stopping at the rootElement.
-      while (current && current !== $rootElement[0] && current !== document.body && current.nodeName !== 'MD-CONTENT') {
+      while (current && current !== $rootElement[0] && current !== document.body && current.nodeName.toUpperCase() !== 'MD-CONTENT') {
         current = current.parentNode;
       }
       return current;


### PR DESCRIPTION
[Custom elements do not always follow the upper case rules](http://ejohn.org/blog/nodename-case-sensitivity/)

fixes #5609