### PR TITLE
fix(dialog): removed no dialog actions warning

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -554,7 +554,7 @@ function MdDialogProvider($$interimElementProvider) {
        */
       function focusOnOpen() {
         if (options.focusOnOpen) {
-          var target = $mdUtil.findFocusTarget(element) || findCloseButtonOrWarn();
+          var target = $mdUtil.findFocusTarget(element) || findCloseButton();
           target.focus();
         }
 
@@ -564,14 +564,11 @@ function MdDialogProvider($$interimElementProvider) {
          *
          * If we find no actions at all, log a warning to the console.
          */
-        function findCloseButtonOrWarn() {
+        function findCloseButton() {
           var closeButton = element[0].querySelector('.dialog-close');
           if (!closeButton) {
             var actionButtons = element[0].querySelectorAll('.md-actions button, md-dialog-actions button');
             closeButton = actionButtons[actionButtons.length - 1];
-            if (actionButtons.length === 0) {
-              $log.warn('At least one action button is required for <md-dialog-actions>.');
-            }
           }
           return angular.element(closeButton);
         }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -991,51 +991,6 @@ describe('$mdDialog', function() {
       expect($log.warn).toHaveBeenCalled();
     }));
 
-    it('should warn if focusOnOpen == true and md-dialog-actions does not contain actions',
-        inject(function($mdDialog, $rootScope, $log, $timeout) {
-      spyOn($log, 'warn');
-
-      var parent = angular.element('<div>');
-      $mdDialog.show({
-        focusOnOpen: true,
-        template:
-          '<md-dialog>' +
-            '<md-dialog-actions>' +
-              '<p>Why is this here</p>' +
-            '</md-dialog-actions>' +
-          '</md-dialog>',
-        parent: parent
-      });
-
-      runAnimation();
-
-      expect($log.warn).toHaveBeenCalled();
-    }));
-
-    // This also covers the case of NOT warning when the deprecated .md-actions class is NOT used
-    it('should not warn if focusOnOpen == true and md-dialog-actions has actions',
-        inject(function($mdDialog, $rootScope, $log, $timeout) {
-      spyOn($log, 'warn');
-
-      // Style the parent so <md-backdrop> doesn't fire a warning in Firefox
-      var parent = angular.element('<div style="position: absolute; left:0;right:0;top:0;bottom:0">');
-
-      $mdDialog.show({
-        focusOnOpen: true,
-        template:
-          '<md-dialog>' +
-            '<md-dialog-actions>' +
-              '<button class="md-button">Ok good</button>' +
-            '</md-dialog-actions>' +
-          '</md-dialog>',
-        parent: parent
-      });
-
-      runAnimation();
-
-      expect($log.warn).not.toHaveBeenCalled();
-    }));
-
     it('should only allow one open at a time', inject(function($mdDialog, $rootScope, $animate) {
       var parent = angular.element('<div>');
       $mdDialog.show({


### PR DESCRIPTION
It is a valid use-case to have a dialog that you only close programmatically based on some user action. As such, there shouldn't be a warning when there are no md-dialog-actions present.

fixes #5767