### PR TITLE
fix(interimElement): added isRemoved indication to support remove before compile finish

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -404,7 +404,7 @@ function InterimElementProvider() {
        * Used internally to manage the DOM element and related data
        */
       function InterimElement(options) {
-        var self, element, showAction = $q.when(true);
+        var self, element, isRemoved, showAction = $q.when(true);
 
         options = configureScopeAndTransitions(options);
 
@@ -421,9 +421,12 @@ function InterimElementProvider() {
          */
         function createAndTransitionIn() {
           return $q(function(resolve, reject){
-
             compileElement(options)
               .then(function( compiledData ) {
+                if (isRemoved) {
+                  return resolve();
+                }
+
                 element = linkElement( compiledData, options );
 
                 showAction = showElement(element, options, compiledData.controller)
@@ -448,6 +451,7 @@ function InterimElementProvider() {
          * - perform optional clean up scope.
          */
         function transitionOutAndRemove(response, isCancelled, opts) {
+          isRemoved = true;
 
           // abort if the show() and compile failed
           if ( !element ) return $q.when(false);


### PR DESCRIPTION
Sometimes `compileElement` didn't finished before `close` has been called so the element was `transitionIn` but never out cause technically it was removed.

Now when remove is call we turn on the `isRemoved` flag and when `compileElement` will finish it won't show the element.

fixes #5635