### PR TITLE
fix(chips): remove style of chip if it blurs.

### DIFF
--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -52,7 +52,8 @@ function MdChip($mdTheming, $mdUtil) {
 
       if (ctrl) angular.element(element[0].querySelector('.md-chip-content'))
           .on('blur', function () {
-            ctrl.selectedChip = -1;
+            ctrl.resetSelectedChip();
+            ctrl.$scope.$apply();
           });
     };
   }


### PR DESCRIPTION
After the user clicks everywhere else to deselect the chip, the selected chip variable will change in the controller but this needs to be applied to the scope

Fixes #5662