### PR TITLE
fix(tabs): labels with fraction CSS width disabling pagination

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -541,7 +541,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
 
   function updatePagingWidth() {
     var width = 1;
-    angular.forEach(getElements().dummies, function (element) { width += element.offsetWidth; });
+    angular.forEach(getElements().dummies, function (element) { width += element.offsetWidth + 1; });
     angular.element(elements.paging).css('width', width + 'px');
   }
 


### PR DESCRIPTION
When the md-tab-label CSS width is calculated to a fraction numbem, its value and element.offsetWidth don't match. When the paging container's width is calculated, depending on how the offsetWidth of each label is truncated/rounded, the resulting width is smaller then the actual sum of
all labels. The smaller width causes a line break and forces the last label to go to next line with its offsetLeft to be zero, and that results in the next page button to be disabled. The new width calculation adds 1px to the offsetWidth to account for rounding/truncating errors, resulting in a slightly bigger paging container.

Fixes angular/material#5794, Fixes angular/material#5770, Fixes angular/material#5692.