### PR TITLE
style(layout): fix typo in warnAttrNotSupported

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -353,7 +353,7 @@
   function warnAttrNotSupported(className) {
     var parts = className.split("-");
     return ["$log", function($log) {
-      $log.warn(className + "has been deprecated. Please use a `" + parts[0] + "-gt-<xxx>` variant.");
+      $log.warn(className + " has been deprecated. Please use a `" + parts[0] + "-gt-<xxx>` variant.");
       return angular.noop;
     }];
   }


### PR DESCRIPTION
change from "layout-lt-mdhas been deprecated. Please use a `layout-gt-<xxx>` variant."
to "layout-lt-md has been deprecated. Please use a `layout-gt-<xxx>` variant."