### PR TITLE
fix(md-tabs): doesn't scroll when width of tab wider than width of md-tabs-canvas tag

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -313,7 +313,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         i, tab;
     for (i = 0; i < elements.tabs.length; i++) {
       tab = elements.tabs[ i ];
-      if (tab.offsetLeft + tab.offsetWidth > totalWidth) break;
+      if (tab.offsetLeft > ctrl.offsetLeft && tab.offsetLeft + tab.offsetWidth > totalWidth) break;
     }
     ctrl.offsetLeft = fixOffset(tab.offsetLeft);
   }
@@ -322,12 +322,20 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * Slides the tabs over approximately one page backward.
    */
   function previousPage () {
-    var i, tab;
+    var i, tab, newOffset;
     for (i = 0; i < elements.tabs.length; i++) {
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth >= ctrl.offsetLeft) break;
     }
-    ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
+
+    // if the first tab to show is bigger than the client width, move viewport canvas to the start of the tab
+    if(tab.offsetWidth > elements.canvas.clientWidth) {
+      newOffset = tab.offsetLeft;
+    } else {
+      newOffset = tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth;
+    }
+
+    ctrl.offsetLeft = fixOffset(newOffset);
   }
 
   /**


### PR DESCRIPTION
The pagination tries to move the viewport to the start of the tab when going forward, and to its end when going backwards. This strategy won't work when the tab width is bigger than that of the canvas, because it'll get stuck in the same tab. Behaviour changed to:
- when paging forward, search for next tab after current offset, so it discards the current showing tab when it's bigger than the viewport;
- when paging backwards, if the tab is bigger than the current viewport, move the canvas to the start of the tab. Otherwise, keep sliding the canvas to its end (current behaviour/RC4).

Fixes angular/material#5697.