### PR TITLE
fix(slider): allow tabindex overwrite

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -74,10 +74,8 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
   // **********************************************************
 
   function compile (tElement, tAttrs) {
-    tElement.attr({
-      tabIndex: 0,
-      role: 'slider'
-    });
+    if (!tAttrs.tabindex) tElement.attr('tabindex', 0);
+    tElement.attr('role', 'slider');
 
     $mdAria.expect(tElement, 'aria-label');
 

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -274,4 +274,14 @@ describe('md-slider', function() {
 
   });
 
+  it('should set a default tabindex', function() {
+    var slider = setup();
+    expect(slider.attr('tabindex')).toBe('0');
+  });
+
+  it('should not overwrite tabindex attribute', function() {
+    var slider = setup('tabindex="2"');
+    expect(slider.attr('tabindex')).toBe('2');
+  });
+
 });


### PR DESCRIPTION
This commit allows the user to specify the ```tabindex``` of the slider element.

If there are anymore suggestions or other wishes, please tell me :+1: 

Fixes #5829