### PR TITLE
fix(autocomplete): announce item change only when a new item is selected

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -492,7 +492,7 @@ describe('<md-autocomplete>', function() {
               md-selected-item="selectedItem"\
               md-search-text="searchText"\
               md-items="item in match(searchText)"\
-              md-selected-item-change="itemChanged(selectedItem)"\
+              md-selected-item-change="itemChanged(item)"\
               md-item-text="item.display"\
               placeholder="placeholder">\
             <span md-highlight-text="searchText">{{item.display}}</span>\
@@ -520,11 +520,12 @@ describe('<md-autocomplete>', function() {
       ctrl.unregisterSelectedItemWatcher(registeredWatcher);
 
       ctrl.clear();
+      $timeout.flush();
       element.scope().$apply();
 
       expect(registeredWatcher.calls.count()).toBe(1);
       expect(scope.itemChanged.calls.count()).toBe(2);
-      expect(scope.itemChanged.calls.mostRecent().args[0]).toBeNull();
+      expect(scope.itemChanged.calls.mostRecent().args[0]).toBeUndefined();
       expect(scope.selectedItem).toBeNull();
 
       element.remove();

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -274,9 +274,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         $scope.searchText = val;
         handleSelectedItemChange(selectedItem, previousSelectedItem);
       });
+    } else {
+      if (!hasFocus) {
+        $scope.searchText = '';
+      }
     }
-
-    if (selectedItem !== previousSelectedItem) announceItemChange();
   }
 
   /**
@@ -337,7 +339,10 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     getDisplayValue($scope.selectedItem).then(function (val) {
       // clear selected item if search text no longer matches it
       if (searchText !== val) {
-        $scope.selectedItem = null;
+        if ($scope.selectedItem) {
+          $scope.selectedItem = null;
+          $mdUtil.nextTick(announceItemChange, false, $scope);
+        }
 
         // trigger change event if available
         if (searchText !== previousSearchText) announceTextChange();
@@ -582,6 +587,10 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * @param index
    */
   function select (index) {
+    var selectedItem = (typeof ctrl.matches[ index ] !== 'undefined') ? ctrl.matches[ index ] : null;
+    var hasChanged = selectedItem !== $scope.selectedItem;
+    $scope.selectedItem = selectedItem;
+
     //-- force form to update state for validation
     $mdUtil.nextTick(function () {
       getDisplayValue(ctrl.matches[ index ]).then(function (val) {
@@ -589,7 +598,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         ngModel.$setViewValue(val);
         ngModel.$render();
       }).finally(function () {
-        $scope.selectedItem = ctrl.matches[ index ];
+        if (hasChanged) {
+          announceItemChange();
+        }
         setLoading(false);
       });
     }, false);


### PR DESCRIPTION
Right now, md-selected-item-change fires when there is an update to the underlying model. The specs states that it should only fire when a new item is selected. The current behavior makes it very hard to differentiate a user initiated change from an underlying model change.

Fixes #5276
Fixes #3003