### PR TITLE
perf(tabs): add md-dynamic-height-animation attribute & css optimisation

### DIFF
--- a/src/components/tabs/demoDynamicHeight/index.html
+++ b/src/components/tabs/demoDynamicHeight/index.html
@@ -1,6 +1,6 @@
-<div ng-cloak>
-  <md-content>
-    <md-tabs md-dynamic-height md-border-bottom>
+<div ng-controller="AppCtrl" ng-cloak>
+  <md-content class="md-padding">
+    <md-tabs md-dynamic-height md-dynamic-height-animation="{{animate}}" md-border-bottom>
       <md-tab label="one">
         <md-content class="md-padding">
           <h1 class="md-display-2">Tab One</h1>
@@ -22,5 +22,9 @@
         </md-content>
       </md-tab>
     </md-tabs>
+  </md-content>
+
+  <md-content class="md-padding">
+    <md-checkbox ng-model="animate" aria-label="Animate height">Animate height</md-checkbox>
   </md-content>
 </div>

--- a/src/components/tabs/demoDynamicHeight/script.js
+++ b/src/components/tabs/demoDynamicHeight/script.js
@@ -1,0 +1,11 @@
+(function () {
+  'use strict';
+
+  angular
+      .module('tabsDemoDynamicHeightTabs', ['ngMaterial'] )
+      .controller('AppCtrl', AppCtrl);
+
+  function AppCtrl ( $scope ) {
+    $scope.animate = false;
+  }
+})();

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -28,6 +28,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   // define boolean attributes
   defineBooleanAttribute('noInkBar', handleInkBar);
   defineBooleanAttribute('dynamicHeight', handleDynamicHeight);
+  defineBooleanAttribute('dynamicHeightAnimation', handleDynamicHeightAnimation);
   defineBooleanAttribute('noPagination');
   defineBooleanAttribute('swipeContent');
   defineBooleanAttribute('noDisconnect');
@@ -355,6 +356,14 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   /**
+   * Toggle dynamic height animation class when value changes
+   * @param value
+   */
+  function handleDynamicHeightAnimation (value) {
+    $element.toggleClass('md-dynamic-height-animation', value);
+  }
+
+  /**
    * Remove a tab from the data and select the nearest valid tab.
    * @param tabData
    */
@@ -634,7 +643,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @returns {*}
    */
   function updateHeightFromContent () {
-    if (!ctrl.dynamicHeight) return $element.css('height', '');
+    if (!ctrl.dynamicHeight || !ctrl.dynamicHeightAnimation) return $element.css('height', '');
     if (!ctrl.tabs.length) return queue.push(updateHeightFromContent);
 
     var tabContent    = elements.contents[ ctrl.selectedIndex ],
@@ -653,10 +662,10 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     }
 
     // Lock during animation so the user can't change tabs
-    locked = true;
-
     var fromHeight = { height: currentHeight + 'px' },
         toHeight = { height: newHeight + 'px' };
+
+    locked = true;
 
     // Set the height to the current, specific pixel height to fix a bug on iOS where the height
     // first animates to 0, then back to the proper height causing a visual glitch
@@ -686,6 +695,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       // And unlock so tab changes can occur
       locked = false;
     });
+
   }
 
   /**

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -44,6 +44,8 @@ md-tabs {
     }
   }
   &.md-dynamic-height {
+    will-change: height;
+
     md-tabs-content-wrapper {
       min-height: 0;
       position: relative;
@@ -186,7 +188,11 @@ md-tab-content {
   right: 0;
   bottom: 0;
   transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
+  will-change: transform;
   overflow: auto;
+  & > * {
+    will-change: visibility;
+  }
   &.md-no-scroll {
     bottom: auto;
     overflow: hidden;
@@ -194,11 +200,14 @@ md-tab-content {
   &.ng-leave, &.md-no-transition {
     transition: none;
   }
+  &.md-left, &.md-right {
+    will-change: opacity;
+  }
   &.md-left {
     transform: translateX(-100%);
     animation: 2 * $swift-ease-in-out-duration md-tab-content-hide;
     opacity: 0;
-    * {
+    & > * {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;
       visibility: hidden;
@@ -208,7 +217,7 @@ md-tab-content {
     transform: translateX(100%);
     animation: 2 * $swift-ease-in-out-duration md-tab-content-hide;
     opacity: 0;
-    * {
+    & > * {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;
       visibility: hidden;


### PR DESCRIPTION
Animating height has a huge performance impact, this make it optional

BREAKING CHANGE: height animation is not default anymore

change your code from:

```html
<md-tabs md-dynamic-height>
```

to:

```html
<md-tabs md-dynamic-height md-dynamic-height-animation>
```