### PR TITLE
fix(slider): use validators too if its numeric string

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -277,6 +277,8 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     function minMaxValidator(value) {
       if (angular.isNumber(value)) {
         return Math.max(min, Math.min(max, value));
+      } else if (angular.isString(value) && !isNaN(value)) {
+        return minMaxValidator(parseInt(value));
       }
     }
     function stepValidator(value) {
@@ -284,6 +286,8 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
         var formattedValue = (Math.round((value - min) / step) * step + min);
         // Format to 3 digits after the decimal point - fixes #2015.
         return (Math.round(formattedValue * 1000) / 1000);
+      } else if (angular.isString(value) && !isNaN(value)) {
+        return stepValidator(parseInt(value));
       }
     }
 


### PR DESCRIPTION
Normally the numeric string will be applied to the model and the slider won't check for min and max.
This checks the strings too and validates for min and max

Before: http://codepen.io/anon/pen/vNMvNZ
After: http://codepen.io/DevVersion/pen/yYrGVW

Fixes #5872