### PR TITLE
fix(list): add `target` to copied attributes for `md-list-item` buttons

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -137,7 +137,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         } else {
           container = angular.element('<md-button class="md-no-style"><div class="md-list-item-inner"></div></md-button>');
           var copiedAttrs = ['ng-click', 'aria-label', 'ng-disabled', 
-            'ui-sref', 'href', 'ng-href', 'ng-attr-ui-sref'];
+            'ui-sref', 'href', 'ng-href', 'target', 'ng-attr-ui-sref'];
           angular.forEach(copiedAttrs, function(attr) {
             if (tEl[0].hasAttribute(attr)) {
               container[0].setAttribute(attr, tEl[0].getAttribute(attr));


### PR DESCRIPTION
This is to complement the previous fix in issue #481 that added support for `target` on `md-button`, however, that support was not carried over to an `md-button` auto-created in an `md-list-item`.