### PR TITLE
feat(slider): add ability to disable ticks when in discrete mode

### DIFF
--- a/src/components/slider/demoBasicUsage/index.html
+++ b/src/components/slider/demoBasicUsage/index.html
@@ -62,6 +62,22 @@
       </md-slider>
     </div>
 
+    <h3>Ticks</h3>
+    <div layout>
+      <div flex="10" layout layout-align="center center">
+        <span class="md-body-1">visible</span>
+      </div>
+      <md-slider flex md-discrete ng-model="tick1" step="1" min="0" max="100" aria-label="ticks enabled">
+      </md-slider>
+    </div>
+    <div layout>
+      <div flex="10" layout layout-align="center center">
+        <span class="md-body-1">hidden</span>
+      </div>
+      <md-slider flex md-discrete ng-model="tick2" step="1" min="0" max="100" aria-label="ticks disabled" md-disable-ticks>
+      </md-slider>
+    </div>
+
     <h3>Disabled</h3>
     <md-slider ng-model="disabled1" ng-disabled="true" aria-label="Disabled 1"></md-slider>
     <md-slider ng-model="disabled2" ng-disabled="true" aria-label="Disabled 2"></md-slider>

--- a/src/components/slider/demoBasicUsage/index.html
+++ b/src/components/slider/demoBasicUsage/index.html
@@ -65,14 +65,14 @@
     <h3>Ticks</h3>
     <div layout>
       <div flex="10" layout layout-align="center center">
-        <span class="md-body-1">visible</span>
+        <span class="md-body-1">enabled</span>
       </div>
       <md-slider flex md-discrete ng-model="tick1" step="1" min="0" max="100" aria-label="ticks enabled">
       </md-slider>
     </div>
     <div layout>
       <div flex="10" layout layout-align="center center">
-        <span class="md-body-1">hidden</span>
+        <span class="md-body-1">disabled</span>
       </div>
       <md-slider flex md-discrete ng-model="tick2" step="1" min="0" max="100" aria-label="ticks disabled" md-disable-ticks>
       </md-slider>

--- a/src/components/slider/demoBasicUsage/script.js
+++ b/src/components/slider/demoBasicUsage/script.js
@@ -16,4 +16,7 @@ angular.module('sliderDemo1', ['ngMaterial'])
   $scope.disabled1 = 0;
   $scope.disabled2 = 70;
 
+  $scope.tick1 = 25;
+  $scope.tick2 = 75;
+
 });

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -44,6 +44,7 @@
  * @param {number=} step The distance between values the user is allowed to pick. Default 1.
  * @param {number=} min The minimum value the user is allowed to pick. Default 0.
  * @param {number=} max The maximum value the user is allowed to pick. Default 100.
+ * @param {boolean=} md-disable-ticks Whether to enable ticks (only used in discrete mode).
  */
 function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture, $parse, $log) {
   return {
@@ -186,8 +187,9 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     // which could quickly become a performance bottleneck.
     var tickCanvas, tickCtx;
     function redrawTicks() {
-      if (!angular.isDefined(attr.mdDiscrete)) return;
-      if ( angular.isUndefined(step) )         return;
+      if (!angular.isDefined(attr.mdDiscrete))      return;
+      if ( angular.isUndefined(step) )              return;
+      if ( angular.isDefined(attr.mdDisableTicks) ) return;
 
       if ( step <= 0 ) {
         var msg = 'Slider step value must be greater than zero when in discrete mode';

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -44,7 +44,7 @@
  * @param {number=} step The distance between values the user is allowed to pick. Default 1.
  * @param {number=} min The minimum value the user is allowed to pick. Default 0.
  * @param {number=} max The maximum value the user is allowed to pick. Default 100.
- * @param {boolean=} md-disable-ticks Whether to enable ticks (only used in discrete mode).
+ * @param {boolean=} md-disable-ticks Whether to disable ticks (only used in discrete mode).
  */
 function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture, $parse, $log) {
   return {


### PR DESCRIPTION
Summed up really well in #3512. 

Essentially don't generate the ticks canvas if it is not required, which is better than just putting `display:none` (which is the current method).