### PR TITLE
Allow focus on contentEditable fields

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -108,8 +108,8 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
 
           return (element.getAttribute('tabindex') != '-1') &&
               !element.hasAttribute('DISABLED') &&
-              (element.hasAttribute('tabindex') || element.hasAttribute('href') ||
-              (focusableElements.indexOf(element.nodeName) != -1|| element.isContentEditable));
+              (element.hasAttribute('tabindex') || element.hasAttribute('href') || element.isContentEditable ||
+              (focusableElements.indexOf(element.nodeName) != -1));
         }
       }
     });

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -109,7 +109,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
           return (element.getAttribute('tabindex') != '-1') &&
               !element.hasAttribute('DISABLED') &&
               (element.hasAttribute('tabindex') || element.hasAttribute('href') ||
-              (focusableElements.indexOf(element.nodeName) != -1));
+              (focusableElements.indexOf(element.nodeName) != -1|| element.isContentEditable));
         }
       }
     });


### PR DESCRIPTION
Fixes #5937

Not sure if this is cross-browser, tested etc, but does seem to fix the issue for Android/iOS