### PR TITLE
fix(dialog, autocomplete): only autofocus instant if not in dialog + trigger focus events of dialog show

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -669,4 +669,48 @@ describe('<md-autocomplete>', function() {
     }));
   });
 
+  describe('$mdDialog compatibility', function() {
+
+    beforeEach(module('material.components.dialog', 'material.components.autocomplete'));
+
+    it('should only focus the autocomplete after opening the dialog', inject(function($rootScope, $timeout, $material, $mdDialog) {
+      var parent = angular.element('<div>');
+
+      $mdDialog.show({
+        template: '<md-autocomplete\
+            md-floating-label="Some Label"\
+            md-selected-item="selectedItem"\
+            md-search-text="searchText"\
+            md-items="item in match(searchText)"\
+            md-item-text="item.display"\
+            md-autofocus="true"\
+            placeholder="placeholder">\
+              <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>',
+        parent: parent
+      });
+      document.body.appendChild(parent[0]);
+
+      $rootScope.$apply();
+
+      var autocomplete = parent.find('md-autocomplete');
+      var focusSpy = jasmine.createSpy('focus');
+      autocomplete.on('focus', focusSpy);
+
+      $timeout.flush();
+
+      expect(focusSpy).not.toHaveBeenCalled();
+
+      $material.flushInterimElement();
+
+      autocomplete.focus();
+
+      expect(focusSpy).toHaveBeenCalled();
+
+      $mdDialog.hide();
+      document.body.removeChild(parent[0]);
+    }));
+
+  });
+
 });

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -66,7 +66,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     $mdUtil.nextTick(function () {
       gatherElements();
       moveDropdown();
-      focusElement();
+
+      // Only auto focus if not compiling in dialog
+      var parentDialogs = $mdUtil.getClosest($element, "md-dialog");
+      if (parentDialogs == null) focusElement();
+
       $element.on('focus', focusElement);
     });
   }

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -156,9 +156,7 @@ function MdAutocomplete () {
       // Set our variable for the link function above which runs later
       hasNotFoundTemplate = noItemsTemplate ? true : false;
 
-      if (attr.hasOwnProperty('tabindex')) {
-        element.attr('tabindex', '-1');
-      }
+      if (!attr.hasOwnProperty('tabindex')) element.attr('tabindex', '-1');
 
       return '\
         <md-autocomplete-wrap\


### PR DESCRIPTION
Normally if we put a Autocomplete in a dialog and we specify the autofocus attribute. Then the autocomplete will open the list at beginning of the fade in, but it should only open if the dialog is finished with fade in effect.

Fixes #5776