### PR TITLE
style(button): changed raised color to background-900 and not background-contrast

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -70,7 +70,7 @@ a.md-button.md-THEME_NAME-theme,
   }
 
   &.md-raised {
-    color: '{{background-contrast}}';
+    color: '{{background-900}}';
     background-color: '{{background-50}}';
     &:not([disabled]) {
       .md-icon {


### PR DESCRIPTION
Contrast made the raised button text color on dark theme to be white, as the button color,
Changing that to background-900 made it almost black no-matter the background color.

<b>NOTICE:</b> Merge this if the UX team agreed that button should always be white themed

fixes #5670