### PR TITLE
feat(calendar) month selector for calendar clarity

### DIFF
--- a/src/components/datepicker/calendar-theme.scss
+++ b/src/components/datepicker/calendar-theme.scss
@@ -9,6 +9,11 @@
 }
 .md-THEME_NAME-theme {
 
+  .md-calendar-month-selector {
+    background: '{{primary-500}}'; // blue-500
+    color: '{{primary-500-contrast}}'; // white
+  }
+
   .md-calendar-day-header {
     background: '{{background-hue-1}}';
     color: '{{foreground-1}}';

--- a/src/components/datepicker/calendar.js
+++ b/src/components/datepicker/calendar.js
@@ -43,6 +43,11 @@
   function calendarDirective() {
     return {
       template:
+          '<div class="md-calendar-month-selector">' +
+            '<md-button class="md-icon-button" ng-click="ctrl.decreaseMonth()">&#60;</md-button>' +
+            '<span>{{ ctrl.getFormatedScrollMonth() }}</span>' +
+            '<md-button class="md-icon-button" ng-click="ctrl.increaseMonth()">&#62;</md-button>' +
+          '</div>' +
           '<table aria-hidden="true" class="md-calendar-day-header"><thead></thead></table>' +
           '<div class="md-calendar-scroll-mask">' +
           '<md-virtual-repeat-container class="md-calendar-scroll-container" ' +
@@ -216,6 +221,13 @@
         });
       }
     };
+
+    /**
+     * Fire watchers of scope on scrolling to refresh the current month label
+     */
+    this.calendarScroller.addEventListener('scroll', function() {
+      $scope.$digest();
+    });
 
     this.attachCalendarEventListeners();
   }
@@ -514,6 +526,45 @@
     }
 
     this.$element.find('thead').append(row);
+  };
+
+  /**
+   * Get the current visible month distance of the view
+   * @returns {number}
+   */
+  CalendarCtrl.prototype.getScrollDistanceMonth = function() {
+    var monthDistance = this.calendarScroller.scrollTop / TBODY_HEIGHT;
+    return Math.round(monthDistance);
+  };
+
+  /**
+   * Get the current visible month of the view
+   * @returns {Date}
+   */
+  CalendarCtrl.prototype.getScrollMonth = function() {
+    return this.dateUtil.incrementMonths(this.firstRenderableDate, this.getScrollDistanceMonth());
+  };
+
+  /**
+   * Gets the formated month, which is visible on the scroller
+   * @returns {string}
+   */
+  CalendarCtrl.prototype.getFormatedScrollMonth = function() {
+    return this.dateLocale.months[this.getScrollMonth().getMonth()] + " " + this.getScrollMonth().getFullYear();
+  };
+
+  /**
+   * Increases and scrolls the current visible Month
+   */
+  CalendarCtrl.prototype.increaseMonth = function() {
+    this.calendarScroller.scrollTop = (this.getScrollDistanceMonth() + 1) * TBODY_HEIGHT;
+  };
+
+  /**
+   * Decreases and scrolls the current visible Month
+   */
+  CalendarCtrl.prototype.decreaseMonth = function() {
+    this.calendarScroller.scrollTop = (this.getScrollDistanceMonth() - 1) * TBODY_HEIGHT;
   };
 
     /**

--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -52,6 +52,24 @@ md-calendar {
   user-select: none;
 }
 
+// Allow the User to scroll to a specific month
+.md-calendar-month-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .md-button {
+    font-weight: bold;
+  }
+
+  span {
+    flex-grow: 2;
+
+    text-align: center;
+    font-size: 15px;
+  }
+}
+
 // Wrap the scroll with overflow: hidden in order to hide the scrollbar.
 // The inner .md-calendar-scroll-container will using a padding-right to push the
 // scrollbar into the hidden area (done with javascript).

--- a/src/components/datepicker/calendar.spec.js
+++ b/src/components/datepicker/calendar.spec.js
@@ -517,4 +517,42 @@ describe('md-calendar', function() {
       }
     }
   });
+
+  describe('month-selector functions', function() {
+
+    it('should increase the current month scroll distance', function() {
+      var lastScrollDistance = controller.getScrollDistanceMonth();
+
+      // One Month Row is 265 Pixels height, so we should scroll more than the half of that (265 / 2 = 132.5)
+      // Because we round the scrollTop, so we should add one half pixel
+      controller.calendarScroller.scrollTop += 133;
+
+      expect(controller.getScrollDistanceMonth()).toBeGreaterThan(lastScrollDistance);
+    });
+
+    it('should increase the scroll month on executing increaseMonth', function() {
+      var lastScrollMonth = controller.getScrollMonth().getMonth();
+
+      controller.increaseMonth();
+
+      expect(controller.getScrollMonth().getMonth()).toBeGreaterThan(lastScrollMonth);
+    });
+
+    it('should decrease the scroll month on executing decreaseMonth', function() {
+      var lastScrollMonth = controller.getScrollMonth().getMonth();
+
+      controller.decreaseMonth();
+
+      expect(controller.getScrollMonth().getMonth()).toBeLessThan(lastScrollMonth);
+    });
+
+    it('should change the month selector label on scrolling', function() {
+      var lastLabel = controller.getFormatedScrollMonth();
+
+      controller.calendarScroller.scrollTop += 133;
+      angular.element(controller.calendarScroller).triggerHandler('scroll');
+
+      expect(lastLabel).not.toBe(controller.getFormatedScrollMonth());
+    });
+  });
 });


### PR DESCRIPTION
## Summary 
Month Selector containing:
- Forward Month
- Backward Month
- Current Visible Month and Year (calculation)
- Calendar Tests for the new features

## Questions and Examples
**How is it looking?**
- ![](https://i.gyazo.com/b5103099b8e2aedc724988608a5ce543.png)

**What happens when I scroll?**
- ![](https://i.gyazo.com/54916175c3264e797c04f299ffb59664.gif)

**What happens when I click on the arrows?**
![](https://i.gyazo.com/4803e962d93367bf8b14861586b797da.gif)

Fixes #5779 Fixes #4251