### PR TITLE
feat(datepicker): reworked datepicker and calendar design to match the material specs

### DIFF
--- a/src/components/datepicker/calendar-theme.scss
+++ b/src/components/datepicker/calendar-theme.scss
@@ -10,8 +10,7 @@
 .md-THEME_NAME-theme {
 
   .md-calendar-day-header {
-    background: '{{background-hue-1}}';
-    color: '{{foreground-1}}';
+    color: '{{foreground-2}}';
   }
 
   .md-calendar-date.md-calendar-date-today {

--- a/src/components/datepicker/calendar.js
+++ b/src/components/datepicker/calendar.js
@@ -40,9 +40,26 @@
    */
   var TBODY_SINGLE_ROW_HEIGHT = 45;
 
+  var CHEVRON_RIGHT =
+    '<svg fill="#757575" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">\
+      <path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/>\
+      <path d="M0 0h24v24H0z" fill="none"/>\
+    </svg>';
+
+  var CHEVRON_LEFT =
+    '<svg fill="#757575" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">\
+      <path d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"/>\
+      <path d="M0 0h24v24H0z" fill="none"/>\
+    </svg>';
+
   function calendarDirective() {
     return {
       template:
+          '<div class="md-calendar-month-selector">' +
+            '<md-button class="md-icon-button" ng-click="ctrl.decreaseMonth()"><md-icon>' + CHEVRON_LEFT + '</md-icon></md-button>' +
+            '<span>{{ ctrl.getFormatedScrollMonth() }}</span>' +
+            '<md-button class="md-icon-button" ng-click="ctrl.increaseMonth()"><md-icon>' + CHEVRON_RIGHT +'</md-icon></md-button>' +
+          '</div>' +
           '<table aria-hidden="true" class="md-calendar-day-header"><thead></thead></table>' +
           '<div class="md-calendar-scroll-mask">' +
           '<md-virtual-repeat-container class="md-calendar-scroll-container" ' +
@@ -216,6 +233,13 @@
         });
       }
     };
+
+    /**
+     * Fire watchers of scope on scrolling to refresh the current month label
+     */
+    this.calendarScroller.addEventListener('scroll', function() {
+      $scope.$digest();
+    });
 
     this.attachCalendarEventListeners();
   }
@@ -514,6 +538,45 @@
     }
 
     this.$element.find('thead').append(row);
+  };
+
+  /**
+   * Get the current visible month distance of the view
+   * @returns {number}
+   */
+  CalendarCtrl.prototype.getScrollDistanceMonth = function() {
+    var monthDistance = this.calendarScroller.scrollTop / TBODY_HEIGHT;
+    return Math.round(monthDistance);
+  };
+
+  /**
+   * Get the current visible month of the view
+   * @returns {Date}
+   */
+  CalendarCtrl.prototype.getScrollMonth = function() {
+    return this.dateUtil.incrementMonths(this.firstRenderableDate, this.getScrollDistanceMonth());
+  };
+
+  /**
+   * Gets the formated month, which is visible on the scroller
+   * @returns {string}
+   */
+  CalendarCtrl.prototype.getFormatedScrollMonth = function() {
+    return this.dateLocale.months[this.getScrollMonth().getMonth()] + " " + this.getScrollMonth().getFullYear();
+  };
+
+  /**
+   * Increases and scrolls the current visible Month
+   */
+  CalendarCtrl.prototype.increaseMonth = function() {
+    this.calendarScroller.scrollTop = (this.getScrollDistanceMonth() + 1) * TBODY_HEIGHT;
+  };
+
+  /**
+   * Decreases and scrolls the current visible Month
+   */
+  CalendarCtrl.prototype.decreaseMonth = function() {
+    this.calendarScroller.scrollTop = (this.getScrollDistanceMonth() - 1) * TBODY_HEIGHT;
   };
 
     /**

--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -3,7 +3,7 @@ $md-calendar-cell-size: 44px !default;
 $md-calendar-header-height: 40px;
 $md-calendar-cell-emphasis-size: 40px !default;
 $md-calendar-side-padding: 16px !default;
-$md-calendar-weeks-to-show: 7 !default;
+$md-calendar-weeks-to-show: 6 !default;
 
 $md-calendar-month-label-padding: 8px !default;
 $md-calendar-month-label-font-size: 14px !default;
@@ -52,6 +52,21 @@ md-calendar {
   user-select: none;
 }
 
+// Allow the User to scroll to a specific month
+.md-calendar-month-selector {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  & > span {
+    flex-grow: 2;
+
+    text-align: center;
+    font-size: 14.5px;
+    font-weight: bold;
+  }
+}
+
 // Wrap the scroll with overflow: hidden in order to hide the scrollbar.
 // The inner .md-calendar-scroll-container will using a padding-right to push the
 // scrollbar into the hidden area (done with javascript).
@@ -81,11 +96,6 @@ md-calendar {
 
 // Contains the scrolling element (this is the md-virtual-repeat-container).
 .md-calendar-scroll-container {
-  // Add an inset shadow to help cue users that the calendar is scrollable. Use a negative x
-  // offset to push the vertical edge shadow off to the right so that it's cut off by the edge
-  // of the calendar container.
-  box-shadow: inset -3px 3px $md-calendar-scroll-cue-shadow-radius rgba(black, 0.2);
-
   display: inline-block;
   height: $md-calendar-weeks-to-show * $md-calendar-cell-size;
 
@@ -118,21 +128,13 @@ md-calendar {
   }
 }
 
-// The label above each month (containing the month name and the year, e.g. "Jun 2014").
-.md-calendar-month-label {
-  height: $md-calendar-cell-size;
-  font-size: $md-calendar-month-label-font-size;
-  font-weight: 500; // Roboto Medium
-  padding: 0 0 0 $md-calendar-side-padding + $md-calendar-month-label-padding;
-}
-
 // Table containing the day-of-the-week header.
 .md-calendar-day-header {
   @include md-calendar-table();
 
   th {
     @include md-calendar-cell();
-    font-weight: normal;
+    font-weight: bold;
     height: $md-calendar-header-height;
   }
 }

--- a/src/components/datepicker/calendar.spec.js
+++ b/src/components/datepicker/calendar.spec.js
@@ -59,22 +59,12 @@ describe('md-calendar', function() {
 
     for (var i = 0; i < months.length; i++) {
       month = months[i];
-      if (month.querySelector('tr:first-child td:first-child').textContent === monthHeader) {
+      if (month.querySelector('tr:first-child').getAttribute('data-month') === monthHeader) {
         return month;
       }
     }
     return null;
   }
-
-  /**
-   * Gets the month label for a given date cell.
-   * @param {HTMLElement|DocumentView} cell
-   * @returns {string}
-   */
-  function getMonthLabelForDateCell(cell) {
-    return $mdUtil.getClosest(cell, 'tbody').querySelector('.md-calendar-month-label').textContent;
-  }
-
 
   /** Creates and compiles an md-calendar element. */
   function createElement(parentScope) {
@@ -170,7 +160,6 @@ describe('md-calendar', function() {
 
       var selectedDate = element.querySelector('.md-calendar-selected-date');
 
-      expect(getMonthLabelForDateCell(selectedDate)).toBe('May 2014');
       expect(selectedDate.textContent).toBe('30');
     });
   });
@@ -228,12 +217,12 @@ describe('md-calendar', function() {
         });
 
         var expectedDates = [
-          ['May 2014', '', '', '1', '2', '3'],
+          ['', '', '', '', '1', '2', '3'],
           ['4', '5', '6', '7', '8', '9', '10'],
           ['11', '12', '13', '14', '15', '16', '17'],
           ['18', '19', '20', '21', '22', '23', '24'],
           ['25', '26', '27', '28', '29', '30', '31'],
-          ['', '', '', '', '', '', ''],
+          ['', '', '', '', '', '', '']
         ];
         expect(calendarDates).toEqual(expectedDates);
       });
@@ -251,35 +240,15 @@ describe('md-calendar', function() {
         });
 
         var expectedDates = [
-          ['May 2014', '', '1', '2', '3', '4'],
+          ['', '', '', '1', '2', '3', '4'],
           ['5', '6', '7', '8', '9', '10', '11'],
           ['12', '13', '14', '15', '16', '17', '18'],
           ['19', '20', '21', '22', '23', '24', '25'],
           ['26', '27', '28', '29', '30', '31', ''],
-          ['', '', '', '', '', '', ''],
+          ['', '', '', '', '', '', '']
         ];
         expect(calendarDates).toEqual(expectedDates);
         dateLocale.firstDayOfWeek = 0;
-      });
-
-      it('should show the month on its own row if the first day is before Tuesday', function() {
-        var date = new Date(2014, JUN, 30); // 1st on Sunday
-        var monthElement = monthCtrl.buildCalendarForMonth(date);
-
-        var firstRow = monthElement.querySelector('tr');
-        expect(extractRowText(firstRow)).toEqual(['Jun 2014']);
-      });
-
-      it('should apply the locale-specific month header formatter', function() {
-        var date = new Date(2014, JUN, 30);
-        spyOn(dateLocale, 'monthHeaderFormatter').and.callFake(function(expectedDateArg) {
-          expect(expectedDateArg).toBeSameDayAs(date);
-          return 'Junz 2014';
-        });
-        var monthElement = monthCtrl.buildCalendarForMonth(date);
-
-        var monthHeader = monthElement.querySelector('tr');
-        expect(monthHeader.textContent).toEqual('Junz 2014');
       });
 
       it('should update the model on cell click', function() {
@@ -366,47 +335,36 @@ describe('md-calendar', function() {
 
       dispatchKeyEvent(keyCodes.LEFT_ARROW);
       expect(getFocusedDateElement().textContent).toBe('10');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.UP_ARROW);
       expect(getFocusedDateElement().textContent).toBe('3');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.RIGHT_ARROW);
       expect(getFocusedDateElement().textContent).toBe('4');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.DOWN_ARROW);
       expect(getFocusedDateElement().textContent).toBe('11');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.HOME);
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.END);
       expect(getFocusedDateElement().textContent).toBe('28');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.RIGHT_ARROW);
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Mar 2014');
 
       dispatchKeyEvent(keyCodes.PAGE_UP);
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.PAGE_DOWN);
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Mar 2014');
 
       dispatchKeyEvent(keyCodes.UP_ARROW, {meta: true});
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.DOWN_ARROW, {meta: true});
       expect(getFocusedDateElement().textContent).toBe('1');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Mar 2014');
 
       dispatchKeyEvent(keyCodes.ENTER);
       applyDateChange();
@@ -424,27 +382,21 @@ describe('md-calendar', function() {
 
       dispatchKeyEvent(keyCodes.UP_ARROW);
       expect(getFocusedDateElement().textContent).toBe('5');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.LEFT_ARROW);
       expect(getFocusedDateElement().textContent).toBe('5');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.DOWN_ARROW);
       expect(getFocusedDateElement().textContent).toBe('10');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.RIGHT_ARROW);
       expect(getFocusedDateElement().textContent).toBe('10');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.UP_ARROW, {meta: true});
       expect(getFocusedDateElement().textContent).toBe('5');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
       dispatchKeyEvent(keyCodes.DOWN_ARROW, {meta: true});
       expect(getFocusedDateElement().textContent).toBe('10');
-      expect(getMonthLabelForDateCell(getFocusedDateElement())).toBe('Feb 2014');
 
     });
 
@@ -505,8 +457,6 @@ describe('md-calendar', function() {
     // First date of May 2014 on Thursday (i.e. has 3 dates on the first row).
     var nextMonth = findMonthElement(new Date(2014, MAY, 1));
     expect(nextMonth).not.toBeNull();
-    expect(nextMonth.querySelector('.md-calendar-month-label')).toHaveClass(
-        'md-calendar-month-label-disabled');
     expect(nextMonth.querySelectorAll('tr').length).toBe(1);
 
     var dates = nextMonth.querySelectorAll('.md-calendar-date');
@@ -516,5 +466,43 @@ describe('md-calendar', function() {
         expect(date).toHaveClass('md-calendar-date-disabled');
       }
     }
+  });
+
+  describe('month-selector functions', function() {
+
+    it('should increase the current month scroll distance', function() {
+      var lastScrollDistance = controller.getScrollDistanceMonth();
+
+      // One Month Row is 265 Pixels height, so we should scroll more than the half of that (265 / 2 = 132.5)
+      // Because we round the scrollTop, so we should add one half pixel
+      controller.calendarScroller.scrollTop += 133;
+
+      expect(controller.getScrollDistanceMonth()).toBeGreaterThan(lastScrollDistance);
+    });
+
+    it('should increase the scroll month on executing increaseMonth', function() {
+      var lastScrollMonth = controller.getScrollMonth().getMonth();
+
+      controller.increaseMonth();
+
+      expect(controller.getScrollMonth().getMonth()).toBeGreaterThan(lastScrollMonth);
+    });
+
+    it('should decrease the scroll month on executing decreaseMonth', function() {
+      var lastScrollMonth = controller.getScrollMonth().getMonth();
+
+      controller.decreaseMonth();
+
+      expect(controller.getScrollMonth().getMonth()).toBeLessThan(lastScrollMonth);
+    });
+
+    it('should change the month selector label on scrolling', function() {
+      var lastLabel = controller.getFormatedScrollMonth();
+
+      controller.calendarScroller.scrollTop += 133;
+      angular.element(controller.calendarScroller).triggerHandler('scroll');
+
+      expect(lastLabel).not.toBe(controller.getFormatedScrollMonth());
+    });
   });
 });

--- a/src/components/datepicker/calendarMonth.js
+++ b/src/components/datepicker/calendarMonth.js
@@ -193,42 +193,18 @@
     var row = this.buildDateRow(rowNumber);
     monthBody.appendChild(row);
 
+    // Store the month string in the row
+    row.setAttribute("data-month", this.dateLocale.monthHeaderFormatter(date));
+
     // If this is the final month in the list of items, only the first week should render,
     // so we should return immediately after the first row is complete and has been
     // attached to the body.
     var isFinalMonth = this.offset === this.calendarCtrl.items.length - 1;
 
-    // Add a label for the month. If the month starts on a Sun/Mon/Tues, the month label
-    // goes on a row above the first of the month. Otherwise, the month label takes up the first
-    // two cells of the first row.
-    var blankCellOffset = 0;
-    var monthLabelCell = document.createElement('td');
-    monthLabelCell.classList.add('md-calendar-month-label');
-    // If the entire month is after the max date, render the label as a disabled state.
-    if (this.calendarCtrl.maxDate && firstDayOfMonth > this.calendarCtrl.maxDate) {
-      monthLabelCell.classList.add('md-calendar-month-label-disabled');
-    }
-    monthLabelCell.textContent = this.dateLocale.monthHeaderFormatter(date);
-    if (firstDayOfTheWeek <= 2) {
-      monthLabelCell.setAttribute('colspan', '7');
-
-      var monthLabelRow = this.buildDateRow();
-      monthLabelRow.appendChild(monthLabelCell);
-      monthBody.insertBefore(monthLabelRow, row);
-
-      if (isFinalMonth) {
-        return monthBody;
-      }
-    } else {
-      blankCellOffset = 2;
-      monthLabelCell.setAttribute('colspan', '2');
-      row.appendChild(monthLabelCell);
-    }
-
     // Add a blank cell for each day of the week that occurs before the first of the month.
     // For example, if the first day of the month is a Tuesday, add blank cells for Sun and Mon.
     // The blankCellOffset is needed in cases where the first N cells are used by the month label.
-    for (var i = blankCellOffset; i < firstDayOfTheWeek; i++) {
+    for (var i = 0; i < firstDayOfTheWeek; i++) {
       row.appendChild(this.buildDateCell());
     }
 

--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -6,6 +6,11 @@ md-datepicker.md-THEME_NAME-theme {
 
 .md-THEME_NAME-theme {
 
+  .md-datepicker-header {
+    background: '{{primary-500}}';
+    color: '{{primary-500-contrast}}';
+  }
+
   .md-datepicker-input {
     @include input-placeholder-color('{{foreground-3}}');
     color: '{{background-contrast}}';
@@ -22,10 +27,6 @@ md-datepicker.md-THEME_NAME-theme {
     &.md-datepicker-invalid {
       border-bottom-color: '{{warn-500}}';
     }
-  }
-
-  .md-datepicker-calendar-pane {
-    border-color: '{{background-300}}';
   }
 
   .md-datepicker-triangle-button {

--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -70,9 +70,10 @@
           '</div>' +
 
           // This pane will be detached from here and re-attached to the document body.
-          '<div class="md-datepicker-calendar-pane md-whiteframe-z1">' +
-            '<div class="md-datepicker-input-mask">' +
-              '<div class="md-datepicker-input-mask-opaque"></div>' +
+          '<md-datepicker-pane class="md-datepicker-calendar-pane md-whiteframe-z1">' +
+            '<div class="md-datepicker-header">' +
+              '<span>{{ ctrl.getCalendarCtrl().selectedDate | date: \'yyyy\' }}</span>' +
+              '<span>{{ getFormatedHeaderDate() }} </span>' +
             '</div>' +
             '<div class="md-datepicker-calendar">' +
               '<md-calendar role="dialog" aria-label="{{::ctrl.dateLocale.msgCalendar}}" ' +
@@ -81,7 +82,7 @@
                   'ng-model="ctrl.date" ng-if="ctrl.isCalendarOpen">' +
               '</md-calendar>' +
             '</div>' +
-          '</div>',
+          '</md-datepicker-pane>',
       require: ['ngModel', 'mdDatepicker', '?^mdInputContainer'],
       scope: {
         minDate: '=mdMinDate',
@@ -184,12 +185,6 @@
     /** @type {HTMLElement} Calendar icon button. */
     this.calendarButton = $element[0].querySelector('.md-datepicker-button');
 
-    /**
-     * Element covering everything but the input in the top of the floating calendar pane.
-     * @type {HTMLElement}
-     */
-    this.inputMask = $element[0].querySelector('.md-datepicker-input-mask-opaque');
-
     /** @final {!angular.JQLite} */
     this.$element = $element;
 
@@ -244,6 +239,13 @@
     $scope.$on('$destroy', function() {
       self.detachCalendarPane();
     });
+
+    $scope.getFormatedHeaderDate = function() {
+      if (self.getCalendarCtrl()) {
+        var selectedDate = self.getCalendarCtrl().selectedDate;
+        return $mdDateLocale.days[selectedDate.getDay()].substring(0, 3) + ", " + $mdDateLocale.shortMonths[selectedDate.getMonth()] + " " + selectedDate.getDate();
+      }
+    };
   }
 
   /**
@@ -469,12 +471,6 @@
     calendarPane.style.top = paneTop + 'px';
     document.body.appendChild(calendarPane);
 
-    // The top of the calendar pane is a transparent box that shows the text input underneath.
-    // Since the pane is floating, though, the page underneath the pane *adjacent* to the input is
-    // also shown unless we cover it up. The inputMask does this by filling up the remaining space
-    // based on the width of the input.
-    this.inputMask.style.left = elementRect.width + 'px';
-
     // Add CSS class after one frame to trigger open animation.
     this.$$rAF(function() {
       calendarPane.classList.add('md-pane-open');
@@ -567,9 +563,8 @@
    */
   DatePickerCtrl.prototype.handleBodyClick = function(event) {
     if (this.isCalendarOpen) {
-      // TODO(jelbourn): way want to also include the md-datepicker itself in this check.
-      var isInCalendar = this.$mdUtil.getClosest(event.target, 'md-calendar');
-      if (!isInCalendar) {
+      var isInPane = this.$mdUtil.getClosest(event.target, 'md-datepicker-pane');
+      if (!isInPane) {
         this.closeCalendarPane();
       }
 

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -54,34 +54,44 @@ md-datepicker {
 
 
 // Floating pane that contains the calendar at the bottom of the input.
-.md-datepicker-calendar-pane {
+md-datepicker-pane {
   position: absolute;
   top: 0;
   left: 0;
   z-index: $z-index-menu;
 
-  border-width: 1px;
-  border-style: solid;
   background: transparent;
+
+  overflow: hidden;
 
   transform: scale(0);
   transform-origin: 0 0;
   transition: transform $md-datepicker-open-animation-duration $swift-ease-out-timing-function;
+
+  border-radius: 3px;
 
   &.md-pane-open {
     transform: scale(1);
   }
 }
 
-// Portion of the floating panel that sits, invisibly, on top of the input.
-.md-datepicker-input-mask {
-  height: 40px;
-  width: $md-calendar-width;
-  position: relative;
+.md-datepicker-header {
+  box-sizing: border-box;
+  height: 90px;
 
-  background: transparent;
+  padding: 12px 18px;
+
   pointer-events: none;
   cursor: text;
+
+  span:first-child {
+    font-size: 15px;
+  }
+
+  span:last-child {
+    font-size: 32px;
+    display: block;
+  }
 }
 
 .md-datepicker-input-mask-opaque {
@@ -183,7 +193,7 @@ md-datepicker[disabled] {
 
 // Animate the calendar inside of the floating calendar pane such that it appears to "scroll" into
 // view while the pane is opening. This is done as a cue to users that the calendar is scrollable.
-.md-datepicker-calendar-pane {
+md-datepicker-pane {
   .md-calendar {
     transform: translateY(-85px);
     transition: transform 0.65s $swift-ease-out-timing-function;

--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -269,7 +269,6 @@ describe('md-date-picker', function() {
       $timeout.flush();
 
       expect(controller.calendarPane.offsetHeight).toBeGreaterThan(0);
-      expect(controller.inputMask.style.left).toBe(controller.inputContainer.clientWidth + 'px');
 
       // Click off of the calendar.
       document.body.click();


### PR DESCRIPTION
## General
This is a second PR from me, which redesigns completely the datepicker.
The other PR only adds the Month Selector (so this PR contains this PR too).
I made this, so you only need to decide which PR you take.

**Expected Result by Google Material Specs**
![](https://i.gyazo.com/6485685471aeadac33e6bd6a2347e698.png)

## Showcase
**Default View**
![](https://i.gyazo.com/f9268df21201a2f711a6e30013f87b11.png)

**Use the Chevrons**
![](https://i.gyazo.com/1a98e4101a9f2009eada0f481e0d1ffb.gif)

**Scrolling is updating the Month Selector**
![](https://i.gyazo.com/65476bded97bbcfc12a8b709b6e065dc.gif)

## Important Information
PR Depends on #5967

## At last
If there are any suggestions or wishes, I'm always up for that :smile: 

 Closes #5967 Fixes #5779 Fixes #4251
