### PR TITLE
feat(sidenav): observe component id change

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -404,6 +404,11 @@ function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
   self.close  = function() { return self.$toggleOpen( false ); };
   self.toggle = function() { return self.$toggleOpen( !$scope.isOpen );  };
   self.$toggleOpen = function(value) { return $q.when($scope.isOpen = value); };
+  self.destroy = angular.noop;
 
-  self.destroy = $mdComponentRegistry.register(self, $attrs.mdComponentId);
+  $attrs.$observe('mdComponentId', function(id){
+    self.destroy();
+
+    self.destroy = $mdComponentRegistry.register(self, id);
+  });
 }

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -1,14 +1,14 @@
 describe('mdSidenav', function() {
   beforeEach(module('material.components.sidenav'));
 
-  function setup(attrs) {
+  function setup(attrs, scope) {
     var el;
     inject(function($compile, $rootScope) {
       var parent = angular.element('<div>');
       el = angular.element('<md-sidenav ' + (attrs||'') + '>');
       parent.append(el);
-      $compile(parent)($rootScope);
-      $rootScope.$apply();
+      $compile(parent)(scope || $rootScope);
+      scope ? scope.$apply() :$rootScope.$apply();
     });
     return el;
   }
@@ -290,6 +290,57 @@ describe('mdSidenav', function() {
       expect(el.hasClass('md-closed')).toBe(false);
 
       instance.toggle();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(true);
+    }));
+
+    it('should grab interpolated instance', inject(function($mdSidenav, $rootScope) {
+      var scope = $rootScope.$new();
+
+      scope.id = 'left';
+      scope.$apply();
+
+      var el = setup('md-component-id="{{id}}"', scope);
+
+      var instance = $mdSidenav(scope.id);
+      expect(instance).toBeTruthy();
+
+      instance.open();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(false);
+
+      instance.close();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(true);
+
+      scope.id = 'right';
+      scope.$apply();
+
+      instance = $mdSidenav(scope.id);
+      expect(instance).toBeTruthy();
+
+      instance.open();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(false);
+
+      instance.close();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(true);
+
+      instance = $mdSidenav('left');
+      expect(instance).toBeTruthy();
+
+      instance.open();
+      scope.$apply();
+
+      expect(el.hasClass('md-closed')).toBe(true);
+
+      instance.close();
       scope.$apply();
 
       expect(el.hasClass('md-closed')).toBe(true);


### PR DESCRIPTION
Sidenav was registering the first interpolated component id.
Now observing the component id attribute changes, removing the old registration and registering with the new interpolated value.

fixes #4987 and #3171