### PR TITLE
fix(datepicker): remove calendar pane after close transition is done

### DIFF
--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -487,11 +487,19 @@
     this.calendarPane.classList.remove('md-pane-open');
     this.calendarPane.classList.remove('md-datepicker-pos-adjusted');
 
-    if (this.calendarPane.parentNode) {
+    if (!this.calendarPane.parentNode) return;
+
+    // Remove the Calendar Pane after the close transition is done
+    var calendarPane = angular.element(this.calendarPane);
+    var transitionEvents = 'transitionend webkitTransitionEnd oTransitionEnd MSTransitionEnd';
+    calendarPane.on(transitionEvents, function() {
+
       // Use native DOM removal because we do not want any of the angular state of this element
       // to be disposed.
-      this.calendarPane.parentNode.removeChild(this.calendarPane);
-    }
+      calendarPane[0].parentNode.removeChild(calendarPane[0]);
+
+      calendarPane.off(transitionEvents);
+    });
   };
 
   /**

--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -273,6 +273,10 @@ describe('md-date-picker', function() {
 
       // Click off of the calendar.
       document.body.click();
+
+      // Skip the close transition delay
+      angular.element(controller.calendarPane).triggerHandler('transitionend');
+
       expect(controller.calendarPane.offsetHeight).toBe(0);
     });
 


### PR DESCRIPTION
Currently the close transition will be ignored because we directly remove the pane from the DOM