### PR TITLE
fix(list): copy data prefixed attributes too

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -210,7 +210,10 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         var copiedAttrs = ['ng-if', 'ng-click', 'aria-label', 'ng-disabled',
           'ui-sref', 'href', 'ng-href', 'ng-attr-ui-sref'];
         angular.forEach(copiedAttrs, function(attr) {
-          if (item.hasAttribute(attr)) {
+          if (item.hasAttribute(attr) || item.hasAttribute('data-' + attr) || item.hasAttribute('x-' + attr)) {
+            if (!item.hasAttribute(attr)) {
+              attr = item.hasAttribute('data-' + attr) ? 'data-' + attr : 'x-' + attr;
+            }
             wrapper.setAttribute(attr, item.getAttribute(attr));
             item.removeAttribute(attr);
           }


### PR DESCRIPTION
At the moment the attributes prefixed with `data-` will be ignored, so for example the `data-ng-click` won't be applied to the wrapped button.

Fixes #4392