### PR TITLE
style(core): change warn color from red to deep-orange as spec

### DIFF
--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -20,7 +20,7 @@ md-datepicker.md-THEME_NAME-theme {
     }
 
     &.md-datepicker-invalid {
-      border-bottom-color: '{{warn-500}}';
+      border-bottom-color: '{{warn-A700}}';
     }
   }
 

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -21,7 +21,7 @@ md-input-container.md-THEME_NAME-theme {
   [ng-message], [data-ng-message], [x-ng-message],
   [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
     :not(.md-char-counter) {
-      color: '{{warn-500}}';
+      color: '{{warn-A700}}';
     }
   }
 
@@ -51,26 +51,26 @@ md-input-container.md-THEME_NAME-theme {
       }
       &.md-warn {
         .md-input {
-          border-color: '{{warn-500}}';
+          border-color: '{{warn-A700}}';
         }
         label {
-          color: '{{warn-500}}';
+          color: '{{warn-A700}}';
         }
       }
     }
   }
   &.md-input-invalid {
     .md-input {
-      border-color: '{{warn-500}}';
+      border-color: '{{warn-A700}}';
     }
     &.md-input-focused label {
-      color: '{{warn-500}}';
+      color: '{{warn-A700}}';
     }
     ng-message, data-ng-message, x-ng-message,
     [ng-message], [data-ng-message], [x-ng-message],
     [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
     .md-char-counter {
-      color: '{{warn-500}}';
+      color: '{{warn-A700}}';
     }
   }
   .md-input {

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -12,8 +12,8 @@ md-select.md-THEME_NAME-theme {
   }
   &.ng-invalid.ng-dirty {
     .md-select-value {
-      color: '{{warn-500}}' !important;
-      border-bottom-color: '{{warn-500}}' !important;
+      color: '{{warn-A700}}' !important;
+      border-bottom-color: '{{warn-A700}}' !important;
     }
   }
   &:not([disabled]):focus {

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -19,7 +19,7 @@ function MdCoreConfigure($provide, $mdThemingProvider) {
   $mdThemingProvider.theme('default')
     .primaryPalette('indigo')
     .accentPalette('pink')
-    .warnPalette('red')
+    .warnPalette('deep-orange')
     .backgroundPalette('grey');
 }
 


### PR DESCRIPTION
In #3973 OP addressed us that the color of the input error should be `#DD2C00` which is `A700` from the deep-orange palette so i changed all `warn-500` (the old value from the red palette) to `warn-A700` and change the default warn palette to deep-orange.

fixes #3973