### PR TITLE
feat(select): support for value change through key up and key down

### DIFF
--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -781,19 +781,35 @@ describe('<md-select>', function() {
         expectSelectOpen(el);
       });
 
-      it('can be opened with an enter key', function() {
+      it('can be opened with a space key using allow-keyboard-change', inject(function($document) {
+        var el = setupSelect('ng-model="someModel" allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 32);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
+
+      it('can be opened with an enter key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 13);
         waitForSelectOpen();
         expectSelectOpen(el);
-      });
+      }));
 
-      it('can be opened with the up key', function() {
+      it('can be opened with an enter key using allow-keyboard-change', inject(function($document) {
+        var el = setupSelect('ng-model="someModel" allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 13);
+        waitForSelectOpen();
+        var selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
+
+      it('can be opened with the up key', inject(function($document) {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 38);
         waitForSelectOpen();
         expectSelectOpen(el);
-      });
+      }));
 
       it('can be opened with the down key', function() {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
@@ -806,6 +822,46 @@ describe('<md-select>', function() {
         var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
         pressKey(el, 50);
         expect($rootScope.someModel).toBe(2);
+      }));
+
+      it('can have value changed with the up key', inject(function($document, $rootScope) {
+        var el, selectMenu;
+
+        $rootScope.someModel = 2;
+        el = setupSelect('ng-model="someModel" allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 38);
+        selectMenu = angular.element($document.find('md-select-menu'));
+        expect($rootScope.someModel).toBe(1);
+      }));
+
+      it('can have value changed with the down key', inject(function($document, $rootScope) {
+        var el, selectMenu;
+
+        $rootScope.someModel = 1;
+        el = setupSelect('ng-model="someModel" allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 40);
+        selectMenu = angular.element($document.find('md-select-menu'));
+        expect($rootScope.someModel).toBe(2);
+      }));
+
+      it('cannot have value changed with the up key when type is multiple', inject(function($document, $rootScope) {
+        var el, selectMenu;
+
+        el = setupSelect('ng-model="someModel" multiple allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 38);
+        waitForSelectOpen();
+        selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
+      }));
+
+      it('cannot have value changed with the down key when type is multiple', inject(function($document, $rootScope) {
+        var el, selectMenu;
+
+        el = setupSelect('ng-model="someModel" multiple allow-keyboard-change', [1, 2, 3]).find('md-select');
+        pressKey(el, 40);
+        waitForSelectOpen();
+        selectMenu = angular.element($document.find('md-select-menu'));
+        expect(selectMenu.length).toBe(1);
       }));
     });
 


### PR DESCRIPTION
This pull request adds support for a new attribute: `allow-keyboard-change`

When this attribute is set, key up and key down will change the selected value.

User's of data-entry applications are accustomed to key up and key down being used to change a value in a drop down field. The default behavior of `md-select` strays away from this behavior and the user is required to make a few extra clicks or use the mouse. This update aims to make `md-select` behave in a more familiar fashion.

Notes:
 - Defaults to false.
 - Ignored if `multiple` is set.

Also, I'm not exactly happy with the name of the attribute. If anyone has any ideas for a better name please let me know.