### PR TITLE
Incomplete installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,3 +160,9 @@ pull directly from the distribution GitHub
   </body>
 ```
 
+Once you have all the necessary assets installed, add `ngMaterial` as a dependency for your app:
+
+```javascript
+angular.module('myApp', ['ngMaterial']);
+```
+


### PR DESCRIPTION
I was a bit annoyed I had to hunt this down. I honestly was under the impression that adding the CSS file would be enough to get started just like many other UI frameworks. I was wrong; though not mentioning the module to add in the instructions those give that same impression.