### PR TITLE
feat(core): added the initial benchpress structure

### DIFF
--- a/benchmarks/BENCHMARKS.MD
+++ b/benchmarks/BENCHMARKS.MD
@@ -1,0 +1,18 @@
+## Benchpress Benchmarks
+
+This document contains all necessary instructions for creating and adding new benchmarks for tunning the performance of
+Angular Material Design.
+
+### Before running the benchmarks
+Make sure you're running node version >= 4.2.2!
+
+```
+$ npm install .
+$ ./node_modules/.bin/webdriver-manager update #Installs chromedriver and selenium standalone
+$ ./node_modules/.bin/protractor config/protractor.conf.js #runs benchmark spec and logs output
+```
+
+## See The Code
+ * Benchmark code: [test-500-angular-buttons.html](test-500-angular-buttons.html), [app.js](app.js)
+ * Benchmark spec: [initial-benchmark-spec.js](../test/initial-benchmark-spec.js)
+ * Protractor config: [protractor.conf.js](../config/protractor.conf.js)

--- a/benchmarks/app.js
+++ b/benchmarks/app.js
@@ -1,0 +1,16 @@
+var materialBenchmarks = angular.module('materialBenchmarks', ['ngMaterial']);
+
+materialBenchmarks.controller('AppCtrl', function($scope, $compile) {
+  $scope.testName = 'Test 500 material design buttons';
+  $scope.domAction = function(actionName) {
+    if (actionName === 'create') {
+      for (i = 0; i <= 500; i++) {
+        var html = '<md-button class="md-raised">BTN</md-button>';
+        var compiledDirective = $compile(html)($scope);
+        $('#benckmarkInsertZone').append(compiledDirective[0]);
+      }
+    } else {
+      $('#benckmarkInsertZone').empty();
+    }
+  };
+});

--- a/benchmarks/test-500-angular-buttons.html
+++ b/benchmarks/test-500-angular-buttons.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" ng-app="materialBenchmarks">
+<head>
+  <meta charset="UTF-8">
+  <title>Test 500 Angular Material Buttons</title>
+  <!-- Angular Material Latest build from running `gulp build` -->
+  <link rel="stylesheet" href="../dist/angular-material.min.css">
+</head>
+<body ng-controller="AppCtrl">
+
+  <div layout="column" layout-margin>
+    <div flex>
+      <h1>{{::testName}}</h1>
+    </div>
+    <div flex>
+      <md-button class="md-raised md-warn" id="destroyDom" ng-click="domAction('destroy')">destroy Dom</md-button>
+      <md-button class="md-raised md-primary" id="createDom" ng-click="domAction('create')">create Dom</md-button>
+    </div>
+  </div>
+
+  <div layout="row" layout-wrap layout-margin layout-align="center start" id='benckmarkInsertZone'></div>
+
+  <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+  <!-- Angular Material Dependencies -->
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-animate.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-aria.min.js"></script>
+
+  <!-- Angular Material Latest build from running `gulp build` -->
+  <script src="../dist/angular-material.min.js"></script>
+  <script src="app.js"></script>
+
+</body>
+</html>

--- a/config/protractor.conf.js
+++ b/config/protractor.conf.js
@@ -1,0 +1,49 @@
+var httpServer = require('http-server');
+
+exports.config = {
+  directConnect: true,
+
+  capabilities: {
+    browserName: 'chrome',
+    chromeOptions: {
+      //Important for benchpress to get timeline data from the browser
+      'args': ['--js-flags=--expose-gc'],
+      'perfLoggingPrefs': {
+        'traceCategories': 'v8,blink.console,devtools.timeline'
+      }
+    },
+    loggingPrefs: {
+      performance: 'ALL'
+    }
+  },
+
+  specs: ['../test/initial-benchmark-spec.js'],
+  framework: 'jasmine2',
+
+  beforeLaunch: function () {
+    httpServer.createServer({
+      showDir: false
+    }).listen('8080', 'localhost');
+  },
+
+  onPrepare: function() {
+    // open a new browser for every benchmark
+    var originalBrowser = browser;
+    var _tmpBrowser;
+    beforeEach(function() {
+      global.browser = originalBrowser.forkNewDriverInstance();
+      global.element = global.browser.element;
+      global.$ = global.browser.$;
+      global.$$ = global.browser.$$;
+    });
+    afterEach(function() {
+      global.browser.quit();
+      global.browser = originalBrowser;
+    });
+  },
+
+  jasmineNodeOpts: {
+    showColors: true,
+    defaultTimeoutInterval: 30000
+  },
+};

--- a/package.json
+++ b/package.json
@@ -64,7 +64,11 @@
     "prompt-sync": "^1.0.0",
     "q": "^1.0.1",
     "stream-series": "^0.1.1",
-    "through2": "^0.6.3"
+    "through2": "^0.6.3",
+    "benchpress": "^2.0.0-alpha.25",
+    "http-server": "^0.7.5",
+    "protractor": "^3.0.0",
+    "reflect-metadata": "^0.1.0"
   },
   "scripts": {
     "watch": "gulp watch site --dev",

--- a/test/initial-benchmark-spec.js
+++ b/test/initial-benchmark-spec.js
@@ -1,0 +1,44 @@
+require('reflect-metadata');
+var benchpress = require('benchpress');
+var runner = new benchpress.Runner([
+  //use protractor as Webdriver client
+  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
+  //use RegressionSlopeValidator to validate samples
+  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
+  //use 10 samples to calculate slope regression
+  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
+  //use the script metric to calculate slope regression
+  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
+  benchpress.bind(benchpress.Options.FORCE_GC).toValue(true)
+]);
+
+describe('deep tree baseline', function() {
+  it('should be fast!', function(done) {
+    var depth = 11;
+    //Tells protractor this isn't an Angular 1 application
+    browser.ignoreSynchronization = true;
+    //Load the benchmark, with a tree depth of 9
+    browser.get('http://localhost:8080/benchmarks/test-500-angular-buttons.html');
+    /*
+     * Tell benchpress to click the buttons to destroy and re-create the tree for each sample.
+     * Benchpress will log the collected metrics after each sample is collected, and will stop
+     * sampling as soon as the calculated regression slope for last 20 samples is stable.
+     */
+    runner.sample({
+      id: 'deep-tree',
+      execute: function() {
+        /*
+         * Will call querySelector in the browser, but benchpress is smart enough to ignore injected
+         * script.
+         */
+        $('#destroyDom').click();
+        $('#createDom').click();
+      },
+      bindings: [
+        benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
+          depth: depth
+        })
+      ]
+    }).then(done, done.fail);
+  });
+});


### PR DESCRIPTION
Just the starting structure for testing the entire framework as proposed (in #5358) and discussed in the design doc with @jelbourn & @ThomasBurleson.

It's a WIP and I would like to push more changes to it (include it in the travis build plan, define a proper benchmark folder structure for every component, define and implement a full test plan for angular material design) after the initial review.