### PR TITLE
update(layout): add corrections and warnings for IE-related issues

### DIFF
--- a/src/components/checkbox/demoSyncing/index.html
+++ b/src/components/checkbox/demoSyncing/index.html
@@ -2,31 +2,39 @@
   <div layout="row" layout-wrap>
 
     <div flex="100" flex-gt-sm="50" layout="column">
-      <fieldset class="standard" flex>
-        <legend>Using <code>md-checkbox</code> with <code>ng-checked</code></legend>
-        <div layout="row" layout-wrap flex>
-          <div flex="50" ng-repeat="item in items">
-            <md-checkbox ng-checked="exists(item, selected)" ng-click="toggle(item, selected)">
-              {{ item }} <span ng-if="exists(item, selected)">selected</span>
-            </md-checkbox>
+      <div flex>
+        <!--
+          In IE, we cannot apply flex directly to <fieldset>
+          @see https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers
+        -->
+        <fieldset class="standard" >
+          <legend>Using <code>md-checkbox</code> with <code>ng-checked</code></legend>
+          <div layout="row" layout-wrap flex>
+            <div flex="50" ng-repeat="item in items">
+              <md-checkbox ng-checked="exists(item, selected)" ng-click="toggle(item, selected)">
+                {{ item }} <span ng-if="exists(item, selected)">selected</span>
+              </md-checkbox>
+            </div>
           </div>
-        </div>
-      </fieldset>
+        </fieldset>
+      </div>
     </div>
 
     <div flex="100" flex-gt-sm="50" layout="column">
-      <fieldset class="standard" flex>
-        <legend>Using <code>&lt;input type="checkbox"&gt;</code></legend>
-        <div layout="row" layout-wrap flex>
-          <div ng-repeat="item in items" class="standard" flex="50">
-            <label>
-              <input type="checkbox" ng-checked="exists(item, selected)"
-                     ng-click="toggle(item, selected)"/>
-              {{ item }}
-            </label>
+      <div flex>
+        <fieldset class="standard">
+          <legend>Using <code>&lt;input type="checkbox"&gt;</code></legend>
+          <div layout="row" layout-wrap flex>
+            <div ng-repeat="item in items" class="standard" flex="50">
+              <label>
+                <input type="checkbox" ng-checked="exists(item, selected)"
+                       ng-click="toggle(item, selected)"/>
+                {{ item }}
+              </label>
+            </div>
           </div>
-        </div>
-      </fieldset>
+        </fieldset>
+      </div>
     </div>
 
   </div>

--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -229,7 +229,9 @@
           element.addClass(className);
 
           return function( scope, element ) {
-            // Wait while layout injectors configure, then uncload
+            // Wait while layout injectors configure, then uncloak
+            // NOTE: $rAF does not delay enough... and this is a 1x-only event,
+            //       $timeout is acceptable.
             $timeout( function(){
               element.removeClass(className);
             }, 10, false);


### PR DESCRIPTION
* Some HTML elements can't be flex containers: read https://github.com/philipwalton/flexbugs#9-some-html-elements-cant-be-flex-containers for details.
* Add warnings (with url) for above issue.
* update checkbox demo with workaround.

Fixes #5084.