### PR TITLE
fix(cards): applying zero margin only on first and last p elements

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -117,7 +117,13 @@ md-card {
     padding: $card-padding;
 
     & > p {
-      margin: 0;
+      &:first-child {
+        margin-top: 0;
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     .md-media-xl {

--- a/src/components/card/demoCardActionButtons/index.html
+++ b/src/components/card/demoCardActionButtons/index.html
@@ -13,6 +13,14 @@
             The titles of Washed Out's breakthrough song and the first single from Paracosm share the
             two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
           </p>
+          <p>
+            The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+            two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+          </p>
+          <p>
+            The titles of Washed Out's breakthrough song and the first single from Paracosm share the
+            two most important words in Ernest Greene's musical language: feel it. It's a simple request, as well...
+          </p>
         </md-card-content>
         <md-card-actions layout="row" layout-align="end center">
           <md-button>Action 1</md-button>

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -487,7 +487,7 @@ describe('<md-select>', function() {
       }));
 
 
-      iit('removing a valid value from the model deselects its option', inject(function($rootScope) {
+      it('removing a valid value from the model deselects its option', inject(function($rootScope) {
         $rootScope.model = [2,3];
         var el = setupMultiple('ng-model="$root.model"', [1,2,3,4]);
 


### PR DESCRIPTION
Accidentally applied zero margin to every `p` in the card, which caused multiple `p` elements to stick together.
This fix is only applies zero margin to the first and last element