### PR TITLE
fix(docs): update getting started CodePen to be usable again

### DIFF
--- a/docs/app/partials/getting-started.tmpl.html
+++ b/docs/app/partials/getting-started.tmpl.html
@@ -19,7 +19,7 @@
     </ul>
 
     <iframe height='412' scrolling='no'
-            src='//codepen.io/team/AngularMaterial/embed/JYvaxJ/?height=412&theme-id=20485&default-tab=result'
+            src='//codepen.io/team/AngularMaterial/embed/JYvaxJ/?height=412&default-tab=result'
             frameborder='no' allowtransparency='true' allowfullscreen='true' style='width: 100%;'>
       See the Pen <a href='http://codepen.io/team/AngularMaterial/pen/JYvaxJ/'>Angular Material Basic App</a>
       by Angular Material (<a href='http://codepen.io/AngularMaterial'>@AngularMaterial</a>) on


### PR DESCRIPTION
Re-enable the JS, HTML, CSS tabs as well as the 'Edit this on CodePen' link

Before:
![screen shot 2015-12-03 at 10 03 35 pm](https://cloud.githubusercontent.com/assets/3506071/11580994/3e127bf2-9a0b-11e5-897c-dade1b17024b.png)

After:
![screen shot 2015-12-03 at 10 03 45 pm](https://cloud.githubusercontent.com/assets/3506071/11580997/430dda52-9a0b-11e5-981e-da6cbcca04b0.png)
