### PR TITLE
fix(input): input error messages visible on form submit

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -212,8 +212,9 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-        return ngModelCtrl.$invalid && ngModelCtrl.$touched;
-      };
+      return ngModelCtrl.$invalid && (ngModelCtrl.$touched || ngModelCtrl.$$parentForm.$submitted);
+    };
+
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -50,6 +50,22 @@ describe('md-input-container directive', function() {
     expect(el).not.toHaveClass('md-input-invalid');
   });
 
+  it('should show error on $submitted and $invalid', function() {
+    var el = setup('ng-model="foo"', true);
+
+    expect(el.find('md-input-container')).not.toHaveClass('md-input-invalid');
+
+    var model = el.find('input').controller('ngModel');
+    model.$invalid = true;
+
+    var form = el.controller('form');
+    console.log(form);
+    form.$submitted = true;
+    pageScope.$apply();
+
+    expect(el.find('md-input-container')).toHaveClass('md-input-invalid');
+  });
+
   it('should show error with given md-is-error expression', function() {
     var el = $compile(
         '<md-input-container md-is-error="isError">' +


### PR DESCRIPTION
Added check for parent form `$submitted` attribute.

Notice that `novalidate` attribute should be applied on parent form in order to make it work (Browser preventing submit when not specified)

fixes #5752