### PR TITLE
fix(autocomplete): allow clicking on not-found template.

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -477,6 +477,75 @@ describe('<md-autocomplete>', function() {
       expect(ctrl2.hasNotFound).toBe(false);
     }));
 
+    it('should even show the md-not-found template if we have lost focus', inject(function($timeout) {
+      var scope = createScope();
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <md-item-template>{{item.display}}</md-item-template>' +
+        '  <md-not-found>Sorry, not found...</md-not-found>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+      var controller = element.controller('mdAutocomplete');
+
+      controller.focus();
+
+      scope.searchText = 'somethingthatdoesnotexist';
+
+      $timeout.flush();
+
+      controller.listEnter();
+      expect(controller.notFoundVisible()).toBe(true);
+
+      controller.blur();
+      expect(controller.notFoundVisible()).toBe(true);
+
+      controller.listLeave();
+      expect(controller.notFoundVisible()).toBe(false);
+
+      $timeout.flush();
+      element.remove();
+
+    }));
+
+    it('should not show the md-not-found template if we lost focus and left the list', inject(function($timeout) {
+      var scope = createScope();
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <md-item-template>{{item.display}}</md-item-template>' +
+        '  <md-not-found>Sorry, not found...</md-not-found>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+      var controller = element.controller('mdAutocomplete');
+
+      controller.focus();
+
+      scope.searchText = 'somethingthatdoesnotexist';
+
+      $timeout.flush();
+
+      controller.listEnter();
+      expect(controller.notFoundVisible()).toBe(true);
+
+      controller.listLeave();
+      controller.blur();
+      expect(controller.notFoundVisible()).toBe(false);
+
+      $timeout.flush();
+      element.remove();
+    }));
+
   });
 
   describe('xss prevention', function() {

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -18,7 +18,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       noBlur               = false,
       selectedItemWatchers = [],
       hasFocus             = false,
-      lastCount            = 0;
+      lastCount            = 0,
+      promiseFetch         = false;
 
   //-- public variables with handlers
   defineProperty('hidden', handleHiddenChange, true);
@@ -638,11 +639,13 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       handleResults(items);
     } else if (items) {
       setLoading(true);
+      promiseFetch = true;
       $mdUtil.nextTick(function () {
         if (items.success) items.success(handleResults);
         if (items.then)    items.then(handleResults);
         if (items.finally) items.finally(function () {
           setLoading(false);
+          promiseFetch = false;
         });
       },true, $scope);
     }
@@ -707,7 +710,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function notFoundVisible () {
     var textLength = (ctrl.scope.searchText || '').length;
 
-    return ctrl.hasNotFound && !hasMatches() && !ctrl.loading && textLength >= getMinLength() && hasFocus && !hasSelection();
+    return ctrl.hasNotFound && !hasMatches() && (!ctrl.loading || promiseFetch) && textLength >= getMinLength() && (hasFocus || noBlur) && !hasSelection();
   }
 
   /**


### PR DESCRIPTION
Currently the Not Found Template will be removed for a few seconds from the DOM, that's why clicks not getting registered.
This can be fixed by checking for the mouse position. 

If we loose focus, but we are still on the list, then we should ignore the focus (because it will be refocused after a few milliseconds). That's why the not-found template blinks for a few milliseconds

References #5308 Fixes #6191 Fixes #5526