### PR TITLE
feat(contactChips): add basic support for md-separator-keys

### DIFF
--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -8,6 +8,7 @@
         md-contact-image="image"
         md-contact-email="email"
         md-require-match="true"
+        md-separator-keys="ctrl.keys"
         md-highlight-flags="i"
         filter-selected="ctrl.filterSelected"
         placeholder="To">

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -4,13 +4,14 @@
       .module('contactChipsDemo', ['ngMaterial'])
       .controller('ContactChipDemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($timeout, $q) {
+  function DemoCtrl ($timeout, $q, $mdConstant) {
     var self = this;
 
     self.querySearch = querySearch;
     self.allContacts = loadContacts();
     self.contacts = [self.allContacts[0]];
     self.filterSelected = true;
+    self.keys = [$mdConstant.KEY_CODE.COMMA];
 
     /**
      * Search for contacts.

--- a/src/components/chips/js/contactChipsController.js
+++ b/src/components/chips/js/contactChipsController.js
@@ -24,6 +24,19 @@ MdContactChipsCtrl.prototype.queryContact = function(searchText) {
 };
 
 
+MdContactChipsCtrl.prototype.inputKeydown = function(event) {
+  if (!this.separatorKeys || this.separatorKeys.indexOf(event.keyCode) < 0) {
+    return;
+  }
+
+  event.stopPropagation();
+  event.preventDefault();
+
+  var autocompleteCtrl = angular.element(event.target).controller('mdAutocomplete');
+  autocompleteCtrl.select(autocompleteCtrl.index);
+};
+
+
 MdContactChipsCtrl.prototype.itemName = function(item) {
   return item[this.contactName];
 };

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -55,6 +55,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
       <md-chips class="md-contact-chips"\
           ng-model="$mdContactChipsCtrl.contacts"\
           md-require-match="$mdContactChipsCtrl.requireMatch"\
+          md-separator-keys="$mdContactChipsCtrl.separatorKeys"\
           md-autocomplete-snap>\
           <md-autocomplete\
               md-menu-class="md-contact-chips-suggestions"\
@@ -64,6 +65,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-item-text="$mdContactChipsCtrl.itemName(item)"\
               md-no-cache="true"\
               md-autoselect\
+              ng-keydown="$mdContactChipsCtrl.inputKeydown($event)"\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\
             <div class="md-contact-suggestion">\
@@ -118,6 +120,7 @@ function MdContactChips($mdTheming, $mdUtil) {
       contactEmail: '@mdContactEmail',
       contacts: '=ngModel',
       requireMatch: '=?mdRequireMatch',
+      separatorKeys: '=?mdSeparatorKeys',
       highlightFlags: '@?mdHighlightFlags'
     }
   };


### PR DESCRIPTION
Add basic support for md-separator-keys. The ENTER and TAB keys trigger
separation by default through md-autocomplete regardless of what
additional key codes are user defined.

Implements #6097 