### PR TITLE
fix(autocomplete): always set tabindex to allow receiving focus.

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -98,6 +98,29 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should allow receiving focus on the autocomplete', function() {
+      var scope = createScope(null, {inputId: 'custom-input-id'});
+      var template = '<md-autocomplete ' +
+            'md-input-id="{{inputId}}" ' +
+            'md-selected-item="selectedItem" ' +
+            'md-search-text="searchText" ' +
+            'md-items="item in match(searchText)" ' +
+            'md-item-text="item.display" ' +
+            'placeholder="placeholder">' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var element = compile(template, scope);
+      var focusSpy = jasmine.createSpy('focus');
+
+      document.body.appendChild(element[0]);
+
+      element.on('focus', focusSpy);
+
+      element.focus();
+
+      expect(focusSpy).toHaveBeenCalled();
+    });
+
     it('should allow you to set an input id without floating label', inject(function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template = '\

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -156,9 +156,7 @@ function MdAutocomplete () {
       // Set our variable for the link function above which runs later
       hasNotFoundTemplate = noItemsTemplate ? true : false;
 
-      if (attr.hasOwnProperty('tabindex')) {
-        element.attr('tabindex', '-1');
-      }
+      if (!attr.hasOwnProperty('tabindex')) element.attr('tabindex', '-1');
 
       return '\
         <md-autocomplete-wrap\


### PR DESCRIPTION
At the moment we only set the `tabindex` if we specify a `tabindex` attribute.

That's why the autocomplete won't receive focus on `sidenav` autofocus.

Closes #6101 Fixes #5665

Please review @jelbourn 