### PR TITLE
fix(input): ngMessages jump with ngShow, ngIf, etc

### DIFF
--- a/src/components/input/demoErrors/index.html
+++ b/src/components/input/demoErrors/index.html
@@ -2,6 +2,7 @@
 
   <md-content layout-padding>
     <form name="projectForm">
+
       <md-input-container class="md-block">
         <label>Description</label>
         <input md-maxlength="30" required name="description" ng-model="project.description">
@@ -36,7 +37,7 @@
         <input required type="number" step="any" name="rate" ng-model="project.rate" min="800"
                max="4999" ng-pattern="/^1234$/" md-maxlength="20" />
 
-        <div ng-messages="projectForm.rate.$error" multiple>
+        <div ng-messages="projectForm.rate.$error" multiple md-auto-hide="false">
           <div ng-message="required">
             You've got to charge something! You can't just <b>give away</b> a Missile Defense
             System.

--- a/src/components/input/demoErrorsAdvanced/index.html
+++ b/src/components/input/demoErrorsAdvanced/index.html
@@ -1,0 +1,106 @@
+<div ng-controller="AppCtrl" layout="column" ng-cloak>
+
+  <md-content layout-padding>
+    <form name="userForm">
+      <div layout="row" layout-xs="column" layout-sm="column" layout-align="space-between center">
+        <div flex-gt-sm="80">
+          <p>
+            The <code>md-input-container</code> gives you the flexibility to display your messages
+            using many standard angular directives.
+          </p>
+
+          <p>
+            For instance, toggle the switch
+
+            <span hide-xs hide-sm>to the right</span>
+            <span hide-gt-sm>below</span>
+
+            to see the messages switch between some custom hints, and the actual error messages.
+            Note that some of the <code>ng-messages</code> containers use <code>ngIf</code> while
+            others use <code>ng-show</code> or <code>ng-hide</code>.
+          </p>
+        </div>
+
+        <md-input-container>
+          <md-switch ng-model="showHints">Showing {{showHints ? "Hints" : "Errors"}}</md-switch>
+        </md-input-container>
+      </div>
+
+      <div layout-gt-sm="row">
+
+        <md-input-container class="md-block" flex-gt-sm>
+          <label>Name</label>
+          <input md-maxlength="30" required name="name" ng-model="user.name" />
+
+          <div class="hint" ng-if="showHints">Tell us what we should call you!</div>
+
+          <div ng-messages="userForm.name.$error" ng-if="!showHints">
+            <div ng-message="required">Name is required.</div>
+            <div ng-message="md-maxlength">The name has to be less than 30 characters long.</div>
+          </div>
+        </md-input-container>
+
+        <div flex="5" hide-xs hide-sm>
+          <!-- Spacer //-->
+        </div>
+
+        <md-input-container class="md-block" flex-gt-sm>
+          <label>Social Security Number</label>
+          <input name="social" ng-model="user.social" ng-pattern="/^[0-9]{3}-[0-9]{2}-[0-9]{4}$/" />
+
+          <div class="hint" ng-if="showHints">###-##-####</div>
+
+          <div ng-messages="userForm.social.$error" ng-if="!showHints">
+            <div ng-message="pattern">###-##-#### - Please enter a valid SSN.</div>
+          </div>
+        </md-input-container>
+
+      </div>
+
+      <div layout-gt-sm="row">
+
+        <md-input-container class="md-block" flex-gt-sm>
+          <label>Email</label>
+          <input name="email" ng-model="user.email"
+                 required minlength="10" maxlength="100" ng-pattern="/^.+@.+\..+$/" />
+
+          <div class="hint" ng-show="showHints">How can we reach you?</div>
+
+          <div ng-messages="userForm.email.$error" ng-hide="showHints">
+            <div ng-message-exp="['required', 'minlength', 'maxlength', 'pattern']">
+              Your email must be between 10 and 100 characters long and look like an e-mail address.
+            </div>
+          </div>
+        </md-input-container>
+
+        <div flex="5" hide-xs hide-sm>
+          <!-- Spacer //-->
+        </div>
+
+        <md-input-container class="md-block" flex-gt-sm>
+          <label>Phone Number</label>
+          <input name="phone" ng-model="user.phone" ng-pattern="/^([0-9]{3}) [0-9]{3}-[0-9]{4}$/" />
+
+          <div class="hint" ng-show="showHints">(###) ###-####</div>
+
+          <div ng-messages="userForm.phone.$error" ng-hide="showHints">
+            <div ng-message="pattern">(###) ###-#### - Please enter a valid phone number.</div>
+          </div>
+        </md-input-container>
+
+        <style>
+          /*
+           * The Material demos system does not currently allow targeting the body element, so this
+           * must go here in the HTML.
+           */
+          body[dir=rtl] .hint {
+            right: 2px;
+            left: auto;
+          }
+        </style>
+      </div>
+
+    </form>
+  </md-content>
+
+</div>

--- a/src/components/input/demoErrorsAdvanced/script.js
+++ b/src/components/input/demoErrorsAdvanced/script.js
@@ -1,0 +1,12 @@
+angular.module('inputErrorsAdvancedApp', ['ngMaterial', 'ngMessages'])
+
+  .controller('AppCtrl', function($scope) {
+    $scope.showHints = true;
+
+    $scope.user = {
+      name: "",
+      email: "",
+      social: "123456789",
+      phone: "N/A"
+    };
+  });

--- a/src/components/input/demoErrorsAdvanced/style.css
+++ b/src/components/input/demoErrorsAdvanced/style.css
@@ -1,0 +1,31 @@
+.hint {
+    /* Position the hint */
+    position: absolute;
+    left: 2px;
+    right: auto;
+    bottom: 7px;
+
+    /* Copy styles from ng-messages */
+    font-size: 12px;
+    line-height: 14px;
+    transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
+
+    /* Set our own color */
+    color: grey;
+}
+
+/* NOTE: Check the demo's HTML to see some additional RTL support CSS */
+
+/* Setup animations similar to the ng-messages */
+.hint.ng-hide,
+.hint.ng-enter,
+.hint.ng-leave.ng-leave-active {
+    bottom: 26px;
+    opacity: 0;
+}
+
+.hint.ng-leave,
+.hint.ng-enter.ng-enter-active {
+    bottom: 7px;
+    opacity: 1;
+}

--- a/src/components/input/demoIcons/index.html
+++ b/src/components/input/demoIcons/index.html
@@ -28,10 +28,8 @@
     <md-input-container class="md-icon-float md-icon-right md-block">
       <label>Donation Amount</label>
       <md-icon md-svg-src="img/icons/ic_card_giftcard_24px.svg"></md-icon>
-      <div layout="row">
-        <input ng-model="user.donation" type="number" step="0.01" flex>
-        <md-icon md-svg-src="img/icons/ic_euro_24px.svg" style="position: absolute; top: 4px;"></md-icon>
-      </div>
+      <input ng-model="user.donation" type="number" step="0.01">
+      <md-icon md-svg-src="img/icons/ic_euro_24px.svg"></md-icon>
     </md-input-container>
 
   </md-content>

--- a/src/components/input/demoIcons/style.scss
+++ b/src/components/input/demoIcons/style.scss
@@ -3,3 +3,12 @@ md-input-container:not(.md-input-invalid) > md-icon.email { color: green; }
 md-input-container:not(.md-input-invalid) > md-icon.name { color: dodgerblue; }
 md-input-container.md-input-invalid > md-icon.email,
 md-input-container.md-input-invalid > md-icon.name { color: red; }
+/*
+.right-icon {
+  position: absolute;
+  top: 4px;
+  right: 2px;
+  left: auto;
+  margin-top: 0;
+}
+*/

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -14,8 +14,10 @@ $input-padding-top: 2px !default;
 
 $input-error-font-size: 12px !default;
 $input-error-height: 24px !default;
+$input-error-line-height: $input-error-font-size + 2px;
+$error-padding-top: ($input-error-height - $input-error-line-height) / 2;
 
-$icon-offset : 36px !default;
+$icon-offset: 36px !default;
 
 $icon-float-focused-top: -8px !default;
 
@@ -31,10 +33,19 @@ md-input-container {
     display: block;
   }
 
-  // When we have ng-messages, remove the input error height from our bottom padding, since the
-  // ng-messages wrapper has a min-height of 1 error (so we don't adjust height as often; see below)
-  &.md-input-has-messages {
-    padding-bottom: $input-container-padding;
+  // Setup a spacer that is always there as a placeholder for any messages so we don't change
+  // height with only 1 message
+  .md-errors-spacer {
+    @include rtl(float, right, left);
+    min-height: $input-error-height;
+
+    // Ensure the element always takes up space, even if empty
+    min-width: 1px;
+  }
+
+  // Move the element after the spacer (likely an ng-messages container), on top of the spacer
+  .md-errors-spacer + * {
+    margin-top: -$input-error-height;
   }
 
   > md-icon {
@@ -138,7 +149,7 @@ md-input-container {
   &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-week-field,
   &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-year-field,
   &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-text {
-      color: transparent;
+    color: transparent;
   }
 
   /*
@@ -184,36 +195,30 @@ md-input-container {
   }
 
   .md-char-counter {
-    position: absolute;
-    @include rtl(right, $input-container-padding, auto);
-    @include rtl(left, auto, $input-container-padding);
-    bottom: 7px;
+    @include rtl(text-align, right, left);
+    @include rtl(padding-right, $input-container-padding, 0);
+    @include rtl(padding-left, 0, $input-container-padding);
   }
 
-  &.md-input-invalid {
-    ng-messages, data-ng-messages, x-ng-messages,
-    [ng-messages], [data-ng-messages], [x-ng-messages] {
-      opacity: 1;
-    }
-  }
-
+  //
+  // ngMessage base styles - animations moved to input.js
+  //
   ng-messages, data-ng-messages, x-ng-messages,
   [ng-messages], [data-ng-messages], [x-ng-messages] {
     position: relative;
     order: 4;
-    min-height: $input-error-height;
     overflow: hidden;
-    transition: $swift-ease-out;
-    transition-duration: $swift-ease-out-duration / 1.5;
-    opacity: 0;
+    min-height: $input-error-height;
     @include rtl(clear, left, right);
 
-    .md-char-counter {
-      position: absolute;
-      top: 0;
-      @include rtl(right, 0, auto);
-      @include rtl(left, auto, 0);
-      bottom: auto;
+    &.ng-enter {
+      // Upon entering the DOM, messages should be hidden
+      ng-message, data-ng-message, x-ng-message,
+      [ng-message], [data-ng-message], [x-ng-message],
+      [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
+        opacity: 0;
+        margin-top: -100px;
+      }
     }
   }
 
@@ -221,44 +226,40 @@ md-input-container {
   [ng-message], [data-ng-message], [x-ng-message],
   [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
   .md-char-counter {
-    $input-error-line-height: $input-error-font-size + 2px;
-    //-webkit-font-smoothing: antialiased;
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
     overflow: hidden;
 
+    transition: $swift-ease-in;
+
+    // Default state for messages is to be visible
+    opacity: 1;
+    margin-top: 0;
+
     // Add some top padding which is equal to half the difference between the expected height
     // and the actual height
-    $error-padding-top: ($input-error-height - $input-error-line-height) / 2;
     padding-top: $error-padding-top;
 
     &:not(.md-char-counter) {
-      @include rtl(padding-right, rem(5), 0);
-      @include rtl(padding-left, 0, rem(5));
+      // Add some padding so that the messages don't touch the character counter
+      @include rtl(padding-right, rem(0.5), 0);
+      @include rtl(padding-left, 0, rem(0.5));
     }
+  }
 
-    &.ng-enter {
-      transition: $swift-ease-in;
-
-      // Delay the enter transition so it happens after the leave
-      transition-delay: $swift-ease-in-duration / 1.5;
-
-      // Since we're delaying the transition, we speed up the duration a little bit to compensate
-      transition-duration: $swift-ease-in-duration / 1.5;
-      opacity: 0;
-      margin-top: -$input-error-line-height - $error-padding-top;
-      &.ng-enter-active {
-        opacity: 1;
-        margin-top: 0;
-      }
-    }
-    &.ng-leave {
-      transition: $swift-ease-out;
-      transition-duration: $swift-ease-out-duration / 1.5;
-      &.ng-leave-active {
-        margin-top: -$input-error-line-height - $error-padding-top;
+  &:not(.md-input-invalid) {
+    .md-auto-hide {
+      .md-input-message-animation {
         opacity: 0;
+        margin-top: -100px;
       }
+    }
+  }
+
+  .md-input-message-animation {
+    &.ng-enter, &:not(.ng-animate) {
+      opacity: 0;
+      margin-top: -100px;
     }
   }
 
@@ -266,7 +267,7 @@ md-input-container {
   &.md-input-has-placeholder,
   &.md-input-has-value {
     label:not(.md-no-float) {
-      transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
+      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
     }
   }
 
@@ -300,12 +301,11 @@ md-input-container {
 
 md-input-container.md-icon-float {
 
-  transition : margin-top 0.5s $swift-ease-out-timing-function ;
+  transition: margin-top 0.5s $swift-ease-out-timing-function;
 
-
-  > label  {
-      pointer-events:none;
-      position:absolute;
+  > label {
+    pointer-events: none;
+    position: absolute;
   }
 
   > md-icon {
@@ -318,21 +318,20 @@ md-input-container.md-icon-float {
   &.md-input-has-value {
 
     label {
-        transform: translate3d(0,$input-label-float-offset,0) scale($input-label-float-scale);
-        transition: transform $swift-ease-out-timing-function 0.5s;
-      }
+      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
+      transition: transform $swift-ease-out-timing-function 0.5s;
+    }
   }
 
 }
 
 md-input-container.md-icon-right {
-  input {
-    @include rtl(margin-right, $icon-offset, 0);
-    @include rtl(margin-left, 0, $icon-offset);
+  @include rtl(padding-right, $icon-offset, $icon-offset);
+  @include rtl(padding-left, $icon-offset, $icon-offset);
+
+  .md-errors-spacer {
     + md-icon {
-      top: 26px;
-      margin-right: 0;
-      margin-left: 0;
+      margin: 0;
 
       @include rtl(right, 2px, auto);
       @include rtl(left, auto, 2px);

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -34,6 +34,15 @@ describe('md-input-container directive', function() {
     return container;
   }
 
+  function compile(template) {
+    var container;
+
+    container = $compile(template)(pageScope);
+
+    pageScope.$apply();
+    return container;
+  }
+
   it('should by default show error on $touched and $invalid', function() {
     var el = setup('ng-model="foo"');
 
@@ -152,6 +161,10 @@ describe('md-input-container directive', function() {
           '</form>')(pageScope);
 
       pageScope.$apply();
+
+      // Flush any pending $mdUtil.nextTick calls
+      $timeout.flush();
+
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
       expect(getCharCounter(el).text()).toBe('0/5');
 
@@ -178,6 +191,10 @@ describe('md-input-container directive', function() {
       var element = $compile(template)(pageScope);
       pageScope.$apply();
 
+
+      // Flush any pending $mdUtil.nextTick calls
+      $timeout.flush();
+
       pageScope.item = {numberValue: 456};
       pageScope.$apply();
 
@@ -192,6 +209,10 @@ describe('md-input-container directive', function() {
         '</form>')(pageScope);
 
       pageScope.$apply();
+
+      // Flush any pending $mdUtil.nextTick calls
+      $timeout.flush();
+
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
       expect(getCharCounter(el).length).toBe(0);
 
@@ -279,6 +300,54 @@ describe('md-input-container directive', function() {
 
     expect(element.hasClass('md-input-has-value')).toBe(true);
   });
+
+  it('adds the md-auto-hide class to messages without a visiblity directive', inject(function() {
+    var el = compile(
+      '<md-input-container><input ng-model="foo">' +
+      '  <div ng-messages></div>' +
+      '</md-input-container>'
+    );
+
+    expect(el[0].querySelector("[ng-messages]").classList.contains('md-auto-hide')).toBe(true);
+  }));
+
+  it('does not add the md-auto-hide class with md-auto-hide="false" on the messages', inject(function() {
+    var el = compile(
+      '<md-input-container><input ng-model="foo">' +
+      '  <div ng-messages md-auto-hide="false">Test Message</div>' +
+      '</md-input-container>'
+    );
+
+    expect(el[0].querySelector("[ng-messages]").classList.contains('md-auto-hide')).toBe(false);
+  }));
+
+  var visibilityDirectives = ['ng-if', 'ng-show', 'ng-hide'];
+  visibilityDirectives.forEach(function(vdir) {
+    it('does not add the md-auto-hide class with ' + vdir + ' on the messages', inject(function() {
+      var el = compile(
+        '<md-input-container><input ng-model="foo">' +
+        '  <div ng-messages ' + vdir + '="true">Test Message</div>' +
+        '</md-input-container>'
+      );
+
+      expect(el[0].querySelector("[ng-messages]").classList.contains('md-auto-hide')).toBe(false);
+    }));
+  });
+
+  it('does not add the md-auto-hide class with ngSwitch on the messages', inject(function() {
+    pageScope.switchVal = 1;
+
+    var el = compile(
+      '<md-input-container ng-switch="switchVal">' +
+      '  <input ng-model="foo">' +
+      '  <div ng-messages ng-switch-when="1">1</div>' +
+      '  <div ng-messages ng-switch-when="2">2</div>' +
+      '  <div ng-messages ng-switch-default>Other</div>' +
+      '</md-input-container>'
+    );
+
+    expect(el[0].querySelector("[ng-messages]").classList.contains('md-auto-hide')).toBe(false);
+  }));
 
   describe('Textarea auto-sizing', function() {
     var ngElement, element, ngTextarea, textarea, scope, parentElement;

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -542,6 +542,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      *
      * @param el Element to start walking the DOM from
      * @param tagName Tag name to find closest to el, such as 'form'
+     * @param onlyParent Only start checking from the parent element, not `el`.
      */
     getClosest: function getClosest(el, tagName, onlyParent) {
       if (el instanceof angular.element) el = el[0];


### PR DESCRIPTION
When the ngMessages directive was used with the ngShow,
ngIf and other directives inside of an md-input-container,
the messages would flicker and jump rather than properly
animating.

Additionally, if the messages spanned multiple lines,
the animations were incorrect due to hard-coded values.

Fix many styles and move animations into JS so we can
properly calculate message heights.

Also, add more flexibility with the `md-auto-hide` CSS
class and associated attribute and update docs/demo
accordingly.

BREAKING CHANGE

By default, the `<md-input-container>` now automatically
hides any error messages until the component is in an
error state (determined by `md-is-error`). If you wish
to achieve the original behavior where messages are
always visible, add the `md-auto-hide="false"` attribute
to your `ng-messages` or use one of the following
visibility directives:

 - `ng-if`
 - `ng-show`/`ng-hide`
 - `ng-switch-when`/`ng-switch-default`

Fixes #5298. References #5837.