### PR TITLE
fix(chips): safety check before getting length

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -181,7 +181,7 @@ MdChipsCtrl.prototype.chipKeydown = function (event) {
  */
 MdChipsCtrl.prototype.getPlaceholder = function() {
   // Allow `secondary-placeholder` to be blank.
-  var useSecondary = (this.items.length &&
+  var useSecondary = (this.items && this.items.length &&
       (this.secondaryPlaceholder == '' || this.secondaryPlaceholder));
   return useSecondary ? this.placeholder : this.secondaryPlaceholder;
 };


### PR DESCRIPTION
If the model is not yet filled (ajax?) this functions fails with:
TypeError: Cannot read property 'length' of undefined

If we check the availability of "this.items" before accessing it we bypass this problem. 