### PR TITLE
fix(select): don't wrap multiple choices in new lines

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -104,6 +104,10 @@ md-select {
   min-height: 26px;
   flex-grow: 1;
 
+  .md-text {
+    display: inline;
+  }
+
   *:first-child {
     flex: 1 0 auto;
     text-overflow: ellipsis;


### PR DESCRIPTION
**Before the fix**

![](https://i.gyazo.com/20d001aa1455c3675800089a6f008e25.png)

**After that fix**

![](https://i.gyazo.com/11bc4bcd983cea6e4ff1f4485b6336ae.png)


Fixes #6176