### PR TITLE
fix(tooltip): Firefox scroll event was triggered cause the usage of translate3d

### DIFF
--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -67,6 +67,6 @@ md-tooltip {
   &.md-show {
     transition: $swift-ease-out;
     pointer-events: auto;
-    transform: translate3d(0,0,0);
+    will-change: opacity, height, width;
   }
 }


### PR DESCRIPTION
Switched `translate3d(0, 0, 0)` with `will-change: opacity, height, width` in order to fix Firefox behavior and preserve performance