### PR TITLE
fix(input): Spacing/padding issues.

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -8,7 +8,9 @@ $checkbox-top: 12px !default;
 
 .md-inline-form {
   md-checkbox {
-    margin: 19px 0 18px;
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 4px;
   }
 }
 

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -4,7 +4,16 @@ $md-datepicker-border-bottom-gap: 5px;  // Space between input and the grey unde
 $md-datepicker-open-animation-duration: 0.2s;
 $md-datepicker-triangle-button-width: 36px;
 
+.md-inline-form {
+  md-datepicker {
+    margin-top: 16px;
+  }
+}
+
 md-datepicker {
+  display: inline-block;
+  margin-top: 12px;
+
   // Don't let linebreaks happen between the open icon-button and the input.
   white-space: nowrap;
   overflow: hidden;
@@ -14,12 +23,6 @@ md-datepicker {
   margin-right: -$md-datepicker-triangle-button-width / 2;
 
   vertical-align: middle;
-}
-
-.md-inline-form {
-  md-datepicker {
-    margin-top: 12px;
-  }
 }
 
 // The calendar icon button used to open the calendar pane.

--- a/src/components/input/demoBasicUsage/index.html
+++ b/src/components/input/demoBasicUsage/index.html
@@ -1,57 +1,63 @@
-<div ng-controller="DemoCtrl" layout="column" ng-cloak class="md-inline-form">
+<div ng-controller="DemoCtrl" layout="column" ng-cloak>
 
-  <md-content md-theme="docs-dark" layout-padding layout-gt-sm="row">
-    <md-input-container>
-      <label>Title</label>
-      <input ng-model="user.title">
-    </md-input-container>
+  <md-content md-theme="docs-dark" layout-padding>
+    <form name="darkForm" class="md-inline-form">
+      <md-input-container style="width: 250px;" class="md-error-spacing">
+        <label>Title</label>
+        <input required name="title" ng-model="user.title">
 
-    <md-input-container>
-      <label>Email</label>
-      <input ng-model="user.email" type="email">
-    </md-input-container>
+        <div ng-messages="darkForm.title.$error">
+          <div ng-message="required">Title is required.</div>
+        </div>
+      </md-input-container>
+
+      <md-input-container class="md-error-spacing">
+        <label>Email</label>
+        <input ng-model="user.email" type="email">
+      </md-input-container>
+    </form>
   </md-content>
 
   <md-content layout-padding>
-    <form name="userForm">
+    <form name="userForm" class="md-block-form">
 
-      <div layout-gt-sm="row">
-        <md-input-container class="md-block" flex-gt-sm>
+      <div layout-gt-xs="row">
+        <md-input-container flex-gt-xs>
           <label>Company (Disabled)</label>
           <input ng-model="user.company" disabled>
         </md-input-container>
 
-        <md-datepicker ng-model="user.submissionDate" md-placeholder="Enter date"></md-datepicker>
+        <md-datepicker ng-model="user.submissionDate" md-placeholder="Enter date" flex-xs></md-datepicker>
       </div>
 
       <div layout-gt-sm="row">
-        <md-input-container class="md-block" flex-gt-sm>
+        <md-input-container flex-gt-sm>
           <label>First name</label>
           <input ng-model="user.firstName">
         </md-input-container>
 
-        <md-input-container class="md-block" flex-gt-sm>
+        <md-input-container flex-gt-sm>
           <label>Last Name</label>
           <input ng-model="theMax">
         </md-input-container>
       </div>
 
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>Address</label>
         <input ng-model="user.address">
       </md-input-container>
 
-      <md-input-container md-no-float class="md-block">
+      <md-input-container md-no-float>
         <input ng-model="user.address2" placeholder="Address 2">
       </md-input-container>
 
       <div layout-gt-sm="row">
-        <md-input-container class="md-block" flex-gt-sm>
+        <md-input-container flex-gt-sm>
           <label>City</label>
           <input ng-model="user.city">
         </md-input-container>
 
-        <md-input-container class="md-block" flex-gt-sm>
+        <md-input-container flex-gt-sm>
           <label>State</label>
           <md-select ng-model="user.state">
             <md-option ng-repeat="state in states" value="{{state.abbrev}}">
@@ -60,7 +66,7 @@
           </md-select>
         </md-input-container>
 
-        <md-input-container class="md-block" flex-gt-sm>
+        <md-input-container flex-gt-sm>
           <label>Postal Code</label>
           <input name="postalCode" ng-model="user.postalCode" placeholder="12345"
                  required ng-pattern="/^[0-9]{5}$/" md-maxlength="5">
@@ -77,11 +83,10 @@
         </md-input-container>
       </div>
 
-      <md-input-container class="md-block">
+      <md-input-container>
         <label>Biography</label>
         <textarea ng-model="user.biography" columns="1" md-maxlength="150" rows="5"></textarea>
       </md-input-container>
-
 
     </form>
   </md-content>

--- a/src/components/input/demoIcons/index.html
+++ b/src/components/input/demoIcons/index.html
@@ -2,35 +2,36 @@
 
   <br/>
   <md-content layout-padding class="autoScroll">
-    <md-input-container class="md-icon-float md-block">
-      <!-- Use floating label instead of placeholder -->
-      <label>Name</label>
-      <md-icon md-svg-src="img/icons/ic_person_24px.svg" class="name"></md-icon>
-      <input ng-model="user.name" type="text">
-    </md-input-container>
+    <div>
+      <md-input-container class="md-icon-float md-block">
+        <!-- Use floating label instead of placeholder -->
+        <label>Name</label>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg" class="name"></md-icon>
+        <input ng-model="user.name" type="text">
+      </md-input-container>
 
-    <md-input-container md-no-float class="md-block">
-      <md-icon md-svg-src="img/icons/ic_phone_24px.svg"></md-icon>
-      <input ng-model="user.phone" type="text" placeholder="Phone Number">
-    </md-input-container>
+      <md-input-container md-no-float class="md-block">
+        <md-icon md-svg-src="img/icons/ic_phone_24px.svg"></md-icon>
+        <input ng-model="user.phone" type="text" placeholder="Phone Number">
+      </md-input-container>
 
-    <md-input-container class="md-block">
-      <!-- Use floating placeholder instead of label -->
-      <md-icon md-svg-src="img/icons/ic_email_24px.svg" class="email"></md-icon>
-      <input ng-model="user.email" type="email" placeholder="Email (required)" ng-required="true">
-    </md-input-container>
+      <md-input-container md-no-float class="md-block">
+        <md-icon md-svg-src="img/icons/ic_email_24px.svg" class="email"></md-icon>
+        <input ng-model="user.email" type="email" placeholder="Email (required)" ng-required="true">
+      </md-input-container>
 
-    <md-input-container md-no-float class="md-block">
-      <md-icon md-svg-src="img/icons/ic_place_24px.svg" style="display:inline-block;"></md-icon>
-      <input ng-model="user.address" type="text" placeholder="Address" >
-    </md-input-container>
+      <md-input-container md-no-float class="md-block">
+        <md-icon md-svg-src="img/icons/ic_place_24px.svg" style="display:inline-block;"></md-icon>
+        <input ng-model="user.address" type="text" placeholder="Address">
+      </md-input-container>
 
-    <md-input-container class="md-icon-float md-icon-right md-block">
-      <label>Donation Amount</label>
-      <md-icon md-svg-src="img/icons/ic_card_giftcard_24px.svg"></md-icon>
-      <input ng-model="user.donation" type="number" step="0.01">
-      <md-icon md-svg-src="img/icons/ic_euro_24px.svg"></md-icon>
-    </md-input-container>
+      <md-input-container class="md-icon-float md-icon-right md-block">
+        <!-- Use floating placeholder instead of label -->
+        <md-icon md-svg-src="img/icons/ic_card_giftcard_24px.svg"></md-icon>
+        <input placeholder="Donation Amount" ng-model="user.donation" type="number" step="0.01">
+        <md-icon md-svg-src="img/icons/ic_euro_24px.svg"></md-icon>
+      </md-input-container>
+    </div>
 
   </md-content>
 

--- a/src/components/input/demoInline/index.html
+++ b/src/components/input/demoInline/index.html
@@ -1,0 +1,44 @@
+<div ng-controller="DemoCtrl" layout-padding="" ng-cloak="">
+  <md-content class="md-inline-form">
+
+    <md-datepicker ng-model="user.birthday" md-placeholder="Birthday"></md-datepicker>
+
+    <md-input-container>
+      <label>Favorite Food</label>
+      <md-select ng-model="user.food">
+        <md-option ng-repeat="food in user.foods" value="{{food}}">
+          {{food}}
+        </md-option>
+      </md-select>
+    </md-input-container>
+
+    <md-input-container>
+      <label>Name jane</label>
+      <input ng-model="user.name" type="text">
+    </md-input-container>
+
+    <md-input-container>
+      <md-radio-group ng-model="user.color">
+        <md-radio-button value="Red">Red</md-radio-button>
+        <md-radio-button value="Blue">Blue</md-radio-button>
+      </md-radio-group>
+    </md-input-container>
+
+    <md-input-container>
+      <md-button class="md-raised">View License Terms</md-button>
+    </md-input-container>
+
+    <md-input-container>
+      <md-checkbox ng-model="user.accept">Accept</md-checkbox>
+    </md-input-container>
+
+    <md-input-container>
+      <md-switch ng-model="user.theme">Use theme</md-switch>
+    </md-input-container>
+
+    <md-input-container>
+      <label>Description</label>
+      <textarea ng-model="user.description"></textarea>
+    </md-input-container>
+  </md-content>
+</div>

--- a/src/components/input/demoInline/script.js
+++ b/src/components/input/demoInline/script.js
@@ -1,0 +1,13 @@
+angular
+  .module('inputInlineDemo', ['ngMaterial', 'ngMessages'])
+  .controller('DemoCtrl', function($scope, $timeout) {
+    $scope.user = {
+      name: 'John Doe',
+      foods: ['Cookies', 'Cake', 'Ice Cream']
+    };
+
+    // TODO - Remove before live code; just scrolls my demo into position
+    $timeout(function() {
+      document.body.querySelector('md-content[md-scroll-y]').scrollTop = 10000;
+    }, 1000);
+  });

--- a/src/components/input/demoInline/style.scss
+++ b/src/components/input/demoInline/style.scss
@@ -1,0 +1,6 @@
+.inputInlineDemo {
+  md-content {
+    white-space: nowrap;
+    overflow-x: scroll;
+  }
+}

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -140,34 +140,99 @@ function labelDirective() {
  *   guarantees a reflow every digest cycle.
  *
  * @usage
+ *
+ * The `<md-input-container>` component provides many different usage scenarios as outlined below.
+ *
+ * <h3>Inline Forms</h3>
+ *
  * <hljs lang="html">
  * <md-input-container>
  *   <label>Color</label>
- *   <input type="text" ng-model="color" required md-maxlength="10">
+ *   <input type="text" ng-model="color">
  * </md-input-container>
  * </hljs>
  *
- * <h3>With Errors</h3>
+ * By default, input containers like the one above are considered inline form elements to be used
+ * side-by-side on the screen and they provide no additional spacing/margins for error messages or
+ * the like.
  *
- * `md-input-container` also supports errors using the standard `ng-messages` directives and
- * animates the messages when they become visible using from the `ngEnter`/`ngLeave` events or
- * the `ngShow`/`ngHide` events.
+ * This is perfect if you have a very minimal and compact form.
  *
- * By default, the messages will be hidden until the input is in an error state. This is based off
- * of the `md-is-error` expression of the `md-input-container`. This gives the user a chance to
- * fill out the form before the errors become visible.
+ * _<b>Note:</b> If your inline inputs have errors, you can add the `md-error-spacing` class to the
+ * `<md-input-container>` or the parent `<form>` element, which provide enough space for a 1 line
+ * error message. This space is automatically provided for `class="md-block"` containers as outlined
+ * below._
+ *
+ * <h3>Block Forms</h3>
+ *
+ * If you need your input to be treated more like a block element that takes up the full width of
+ * it's container, you may apply the `md-block` class to your input container. This will set the
+ * `display: block;` CSS property as well as provide some space below the input for any error
+ * messages or the `md-char-counter` provided by the `md-maxlength` directive.
  *
  * <hljs lang="html">
- * <form name="colorForm">
- *   <md-input-container>
+ * <md-input-container class="md-block">
+ *   <label>Username</label>
+ *   <input type="text" ng-model="username" required md-maxlength="10">
+ * </md-input-container>
+ *
+ * <md-input-container class="md-block">
+ *   <label>Password</label>
+ *   <input type="password" ng-model="password" required md-maxlength="10">
+ * </md-input-container>
+ * </hljs>
+ *
+ * If you have a large form with many inputs, you can also apply the `md-block` class directly to
+ * the form element and these styles will be applied to all `<md-input-container>` elements within
+ * the form.
+ *
+ * <hljs lang="html">
+ * <form class="md-block">
+ *   <md-input-container>...</md-input-container>
+ *   <md-input-container>...</md-input-container>
+ *   <md-input-container>...</md-input-container>
+ * </form>
+ * </hljs>
+ *
+ * _<b>Note:</b> This also works with the `ngForm` directive as well as standard `<form>` elements._
+ *
+ * <h3>With Errors</h3>
+ *
+ * `md-input-container` supports errors using the standard `ng-messages` directives and animates the
+ * messages when they become visible using the `ngEnter`/`ngLeave` events or the `ngShow`/`ngHide`
+ * events.
+ *
+ * <hljs lang="html">
+ * <form name="questForm">
+ *   <md-input-container class="md-error-spacing">
+ *     <label>Quest</label>
+ *     <input type="text" name="quest" ng-model="quest" required md-maxlength="10">
+ *     <div ng-messages="questForm.quest.$error">
+ *       <div ng-message="required">You must be on a quest!</div>
+ *       <div ng-message="md-maxlength">That quest is too long!</div>
+ *     </div>
+ *   </md-input-container>
+ *
+ *   <md-input-container class="md-error-spacing">
  *     <label>Favorite Color</label>
- *     <input name="favoriteColor" ng-model="favoriteColor" required>
- *     <div ng-messages="userForm.lastName.$error">
- *       <div ng-message="required">This is required!</div>
+ *     <input type="text" name="favoriteColor" ng-model="favoriteColor" required md-maxlength="10">
+ *     <div ng-messages="questForm.favoriteColor.$error">
+ *       <div ng-message="required">You have to have a favorite color!</div>
+ *       <div ng-message="md-maxlength">Can you give me the color's hex value?</div>
  *     </div>
  *   </md-input-container>
  * </form>
  * </hljs>
+ *
+ * _<b>Note:</b> If you plan to use two inline elements side-by-side, you should ensure that they
+ * either both have the `md-error-spacing` class, or that neither of them do. We do not currently
+ * support mixed styles._
+ *
+ * <h3>Messages Hiding and Animations</h3>
+ *
+ * By default, the messages will be hidden until the input is in an error state. This is based off
+ * of the `md-is-error` expression of the `md-input-container`. This gives the user a chance to
+ * fill out the form before the errors become visible.
  *
  * We automatically disable this auto-hiding functionality if you provide any of the following
  * visibility directives on the `ng-messages` container:
@@ -185,7 +250,7 @@ function labelDirective() {
  *
  * <hljs lang="html">
  * <form name="userForm">
- *   <md-input-container>
+ *   <md-input-container class="md-block">
  *     <label>Last Name</label>
  *     <input name="lastName" ng-model="lastName" required md-maxlength="10" minlength="4">
  *     <div ng-messages="userForm.lastName.$error" ng-show="userForm.lastName.$dirty">
@@ -194,7 +259,8 @@ function labelDirective() {
  *       <div ng-message="minlength">That's too short!</div>
  *     </div>
  *   </md-input-container>
- *   <md-input-container>
+ *
+ *   <md-input-container class="md-block">
  *     <label>Biography</label>
  *     <textarea name="bio" ng-model="biography" required md-maxlength="150"></textarea>
  *     <div ng-messages="userForm.bio.$error" ng-show="userForm.bio.$dirty">
@@ -202,9 +268,7 @@ function labelDirective() {
  *       <div ng-message="md-maxlength">That's too long!</div>
  *     </div>
  *   </md-input-container>
- *   <md-input-container>
- *     <input aria-label='title' ng-model='title'>
- *   </md-input-container>
+ *
  *   <md-input-container>
  *     <input placeholder='title' ng-model='title'>
  *   </md-input-container>

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -21,31 +21,51 @@ $icon-offset: 36px !default;
 
 $icon-float-focused-top: -8px !default;
 
+// For md-block and md-error-spacing classes, setup a spacer that is always visible as
+// placeholder for any messages so we don't change height with only 1 message
+@mixin errors-spacing() {
+  .md-errors-spacer {
+    // Ensure the element always takes up space, even if empty
+    min-height: $input-error-height;
+    min-width: 1px;
+  }
+}
+
+.md-error-spacing {
+  md-input-container {
+    @include errors-spacing();
+  }
+}
+
+.md-block-form {
+  md-input-container {
+    display: block;
+
+    @include errors-spacing();
+  }
+}
+
 md-input-container {
   @include pie-clearfix();
   display: inline-block;
   position: relative;
   padding: $input-container-padding;
-  margin: 18px 0;
   vertical-align: middle;
+
+  &:not([md-no-float]) {
+    margin-top: 18px;
+  }
 
   &.md-block {
     display: block;
   }
 
-  // Setup a spacer that is always there as a placeholder for any messages so we don't change
-  // height with only 1 message
   .md-errors-spacer {
     @include rtl(float, right, left);
-    min-height: $input-error-height;
-
-    // Ensure the element always takes up space, even if empty
-    min-width: 1px;
   }
 
-  // Move the element after the spacer (likely an ng-messages container), on top of the spacer
-  .md-errors-spacer + * {
-    margin-top: -$input-error-height;
+  &.md-block, &.md-error-spacing {
+    @include errors-spacing();
   }
 
   > md-icon {
@@ -93,7 +113,7 @@ md-input-container {
 
   label:not(.md-container-ignore) {
     position: absolute;
-    bottom: 100%;
+    bottom: calc(100% + 2px);
     @include rtl(left, 0, auto);
     @include rtl(right, auto, 0);
   }
@@ -113,8 +133,8 @@ md-input-container {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
-    @include rtl(padding-left, $input-container-padding, 0);
-    @include rtl(padding-right, 0, $input-container-padding);
+    @include rtl(padding-left, $input-container-padding + 1px, 0);
+    @include rtl(padding-right, 0, $input-container-padding + 1px);
     z-index: 1;
     transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
     transition: transform $swift-ease-out-timing-function 0.25s;
@@ -163,8 +183,6 @@ md-input-container {
     background: none;
     padding-top: $input-padding-top;
     padding-bottom: $input-border-width-focused - $input-border-width-default;
-    padding-left: 2px;
-    padding-right: 2px;
     border-width: 0 0 $input-border-width-default 0;
     line-height: $input-line-height;
     height: $input-line-height + ($input-padding-top * 2);
@@ -208,7 +226,6 @@ md-input-container {
     position: relative;
     order: 4;
     overflow: hidden;
-    min-height: $input-error-height;
     @include rtl(clear, left, right);
 
     &.ng-enter {

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -4,6 +4,25 @@ $radio-text-margin: 10px !default;
 $radio-top-left: 12px !default;
 $radio-margin: 16px;
 
+.md-inline-form {
+  md-radio-group {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+
+    md-radio-button {
+      display: inline-block;
+      margin-top: 0;
+      margin-bottom: 2px;
+
+      &:not(:first-child) {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+    }
+  }
+}
+
 md-radio-button {
   box-sizing: border-box;
   display: block;
@@ -143,20 +162,6 @@ md-radio-group {
       top: -8px;
       right: -8px;
       bottom: -8px;
-    }
-  }
-}
-
-.md-inline-form {
-  md-radio-group {
-    margin: 18px 0 19px;
-    md-radio-button {
-      display: inline-block;
-      height: 30px;
-      padding: 2px;
-      box-sizing: border-box;
-      margin-top: 0;
-      margin-bottom: 0;
     }
   }
 }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -6,8 +6,13 @@ $switch-margin: 16px !default;
 
 .md-inline-form {
   md-switch {
-    margin-top: 18px;
-    margin-bottom: 19px;
+    display: inline-block;
+    margin-top: 4px;
+    margin-bottom: 0;
+
+    .md-container {
+      margin-top: 1px;
+    }
   }
 }
 


### PR DESCRIPTION
The spacing and padding of inputs was incorrect due to recent changes.

**Fixes**

 - Alter margins and padding

 - Automatically apply the error spacing only to block-level inupts

 - Add a new `md-error-spacing` class for inline inputs

**Other Additions**

 - Update all components with custom CSS for `md-inline-form` class

 - Allow usage of `md-error-spacing` at the form level to quickly
   apply the spacing to all `<md-input-container>`s

 - Add new `md-block-form` class for quickly applying the `md-block`
   formatting to all nested `<md-input-container>`s

Update docs/demos accordingly and add new inline demo.

BREAKING CHANGE

We no longer automatically add bottom spacing to all instance of the
`<md-input-container>`. It is now applied only if you use the `md-block`
or `md-error-spacing` classes to allow for more compact form inputs.