### PR TITLE
fix(layouts): disable breaks associated with xs and xl

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -77,7 +77,7 @@
     var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
 
     // NOTE: these are also defined in constants::MEDIA_PRIORITY and constants::MEDIA
-    var BREAKPOINTS     = [ "", "xs", "gt-xs", "sm", "gt-sm", "md", "gt-md", "lg", "gt-lg", "xl" ];
+    var BREAKPOINTS     = [ "", "sm", "gt-sm", "md", "gt-md", "lg" ];
     var API_WITH_VALUES = [ "layout", "flex", "flex-order", "flex-offset", "layout-align" ];
     var API_NO_VALUES   = [ "show", "hide", "layout-padding", "layout-margin" ];
 

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -442,23 +442,23 @@
  */
 
 
-@media (max-width: $layout-breakpoint-xs - 1) {
-  // Xtra-SMALL  SCREEN
-  .hide-xs, .hide {
-    &:not(.show-xs):not(.show) {
-      display: none;
-    }
-  }
-  @include layouts_for_breakpoint(xs);
-}
+//@media (max-width: $layout-breakpoint-xs - 1) {
+//  // Xtra-SMALL  SCREEN
+//  .hide-xs, .hide {
+//    &:not(.show-xs):not(.show) {
+//      display: none;
+//    }
+//  }
+//  @include layouts_for_breakpoint(xs);
+//}
+//
+//@media (min-width: $layout-breakpoint-xs) {
+//  // BIGGER THAN Xtra-SMALL SCREEN
+//  @include layouts_for_breakpoint(gt-xs);
+//
+//}
 
-@media (min-width: $layout-breakpoint-xs) {
-  // BIGGER THAN Xtra-SMALL SCREEN
-  @include layouts_for_breakpoint(gt-xs);
-
-}
-
-@media (min-width: $layout-breakpoint-xs) and (max-width: $layout-breakpoint-sm - 1) {
+@media (max-width: $layout-breakpoint-sm - 1) {
   .hide, .hide-gt-xs {
     &:not(.show-gt-xs):not(.show-sm):not(.show) {
       display: none;
@@ -509,19 +509,19 @@
   @include layouts_for_breakpoint(lg);
 }
 
-@media (min-width: $layout-breakpoint-lg) {
-  @include layouts_for_breakpoint(gt-lg);
-  @include layouts_for_breakpoint(xl);
-
-  // BIGGER THAN LARGE SCREEN
-  .hide, .hide-gt-xs, .hide-gt-sm, .hide-gt-md, .hide-gt-lg {
-    &:not(.show-gt-xs):not(.show-gt-sm):not(.show-gt-md):not(.show-gt-lg):not(.show-xl):not(.show) {
-      display: none;
-    }
-  }
-  .hide-xl:not(.show-xl):not(.show-gt-lg):not(.show-gt-md):not(.show-gt-sm):not(.show-gt-xs):not(.show) {
-    display: none;
-  }
-
-}
+//@media (min-width: $layout-breakpoint-lg) {
+//  @include layouts_for_breakpoint(gt-lg);
+//  @include layouts_for_breakpoint(xl);
+//
+//  // BIGGER THAN LARGE SCREEN
+//  .hide, .hide-gt-xs, .hide-gt-sm, .hide-gt-md, .hide-gt-lg {
+//    &:not(.show-gt-xs):not(.show-gt-sm):not(.show-gt-md):not(.show-gt-lg):not(.show-xl):not(.show) {
+//      display: none;
+//    }
+//  }
+//  .hide-xl:not(.show-xl):not(.show-gt-lg):not(.show-gt-md):not(.show-gt-sm):not(.show-gt-xs):not(.show) {
+//    display: none;
+//  }
+//
+//}
 

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -1,6 +1,7 @@
 describe('layout directives', function() {
-  var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl'],
-    $mdUtil, $compile, pageScope;
+  //var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl'];
+  var suffixes = [ 'sm', 'gt-sm', 'md', 'gt-md', 'lg' ];
+  var  $mdUtil, $compile, pageScope;
 
   beforeEach(module('material.core', 'material.core.layout'));
 


### PR DESCRIPTION
To reduce CSS file size for some deployments, create branch that has disabled the Layout breakpoints and generated mediaQuery CSS for the *-xs, -gt-xs, -gt-lg, -xl*​ breakpoints.