### PR TITLE
feat(chips): Support input tag inside md-chip-template by fixing focusing issue

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -66,6 +66,20 @@ describe('<md-chips>', function() {
         expect(chip[0].querySelector('div.mychiptemplate')).not.toBeNull();
       });
 
+      it('should focus the main input when a user-provided chip template has an input', function() {
+        var template =
+          '<md-chips ng-model="items">' +
+          '  <md-chip-template><input type="text" /></md-chip-template>' +
+          '  <input type="text" id="mainInput" />' +
+          '</md-chips>';
+        var element = buildChips(template);
+        var input = element[0].querySelector('input#mainInput');
+        spyOn(input,'focus');
+        element.triggerHandler('focus');
+        $timeout.flush();
+        expect(input.focus).toHaveBeenCalled();
+      });
+
       it('should add a chip', function() {
         var element = buildChips(BASIC_CHIP_TEMPLATE);
         var ctrl = element.controller('mdChips');

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -436,7 +436,10 @@ MdChipsCtrl.prototype.configureNgModel = function(ngModelCtrl) {
 MdChipsCtrl.prototype.onFocus = function () {
   // Focus last input
   var inputs = this.$element[0].querySelectorAll('input');
-  inputs.length > 0 && inputs[inputs.length - 1].focus();
+  if(inputs.length > 0){
+    var lastInput = inputs[inputs.length - 1];
+    lastInput.focus();
+  }
   this.resetSelectedChip();
 };
 

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -434,8 +434,9 @@ MdChipsCtrl.prototype.configureNgModel = function(ngModelCtrl) {
 };
 
 MdChipsCtrl.prototype.onFocus = function () {
-  var input = this.$element[0].querySelector('input');
-  input && input.focus();
+  // Focus last input
+  var inputs = this.$element[0].querySelectorAll('input');
+  inputs.length > 0 && inputs[inputs.length - 1].focus();
   this.resetSelectedChip();
 };
 


### PR DESCRIPTION
When using `<md-autocomplete>` and chips together, change onFocus to select the last `<input>` (the autocomplete input) instead of the first input which would be an input inside a `<md-chip-template>` tag.

Currently if you click anything other than exactly where the autocomplete input it, it selects whatever the first input is.

Example:
```
<md-chips ng-model="myChips" md-autocomplete-snap ng-init="myChips = []">
  <md-autocomplete
    md-items="item in ['item1', 'item2']"
    md-min-length="0">
    <md-item-template>
      <span >{{item}}</span>
    </md-item-template>
  </md-autocomplete>
  <md-chip-template>
      <div md-autocomplete-snap>
        {{$chip}}:
        <input ng-model="something">
    </div>
  </md-chip-template>
</md-chips>
```

In reality I'm putting another autocomplete inside the `<md-chip-template>` for filtering but was trying to make the example cleaner by just using an `<input>`.