### PR TITLE
fix(select): removes usage of `element.scope()`

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -417,7 +417,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         selectContainer = angular.element(
           element[0].querySelector('.md-select-menu-container')
         );
-        selectScope = selectContainer.scope();
+        selectScope = scope;
         if (element.attr('md-container-class')) {
           var value = selectContainer[0].getAttribute('class') + ' ' + element.attr('md-container-class');
           selectContainer[0].setAttribute('class', value);


### PR DESCRIPTION
closes #6033