### PR TITLE
docs: Fix gulp task causing duplicate demo files.

### DIFF
--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -63,7 +63,7 @@ exports.readModuleDemos = function(moduleName, fileTasks) {
         css:[], html:[], js:[]
       };
 
-      gulp.src(demoFolder.path + '**/*', { base: path.dirname(demoFolder.path) })
+      gulp.src(demoFolder.path + '/**/*', { base: path.dirname(demoFolder.path) })
         .pipe(fileTasks(demoId))
         .pipe(through2.obj(function(file, enc, cb) {
           if (/index.html$/.test(file.path)) {


### PR DESCRIPTION
If two demo directories began with the same name (like demoErrors and demoErrorsAdvanced), the gulp task would miscalculate the number and type of files causing duplicate files to appear in the source view and Codepen examples.

Fix by ensuring we only match the proper directory.