### PR TITLE
fix(autocomplete): fix progressbar and messages alignment and bottom padding

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,6 +1,4 @@
 $autocomplete-option-height: 48px;
-$input-container-padding: 2px !default;
-$input-error-height: 24px !default;
 
 @keyframes md-autocomplete-list-out {
   0% {
@@ -51,14 +49,7 @@ md-autocomplete {
     height: auto;
 
     md-input-container {
-      padding-bottom: $input-container-padding + $input-error-height;
-
-      // When we have ng-messages, remove the input error height from our bottom padding, since the
-      // ng-messages wrapper has a min-height of 1 error (so we don't adjust height as often; see
-      // input.scss file)
-      &.md-input-has-messages {
-        padding-bottom: $input-container-padding;
-      }
+      padding-bottom: 0px;
     }
     md-autocomplete-wrap {
       height: auto;

--- a/src/components/autocomplete/demoFloatingLabel/script.js
+++ b/src/components/autocomplete/demoFloatingLabel/script.js
@@ -22,8 +22,10 @@
      * remote dataservice call.
      */
     function querySearch (query) {
-      var results = query ? self.states.filter( createFilterFor(query) ) : [];
-      return results;
+      var results = query ? self.states.filter( createFilterFor(query) ) : self.states;
+      var deferred = $q.defer();
+      $timeout(function () { deferred.resolve( results ); }, Math.random() * 1000, false);
+      return deferred.promise;
     }
 
     /**


### PR DESCRIPTION
- There was too much padding at the bottom (padding already done by the input container)
- Progressbar was wrong aligned due wrong bottom padding (as above said)

Fixes #6218 Closes #6231 Fixes #6255