### PR TITLE
fix(select): fix blur event not triggering, focus styles in containers

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -275,15 +275,17 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       };
 
       if (!isReadonly) {
-        element
-          .on('focus', function(ev) {
+        element[0]
+          .addEventListener('focus', function() {
             // only set focus on if we don't currently have a selected value. This avoids the "bounce"
             // on the label transition because the focus will immediately switch to the open menu.
             if (containerCtrl && containerCtrl.element.hasClass('md-input-has-value')) {
               containerCtrl.setFocused(true);
             }
-          })
-          .on('blur', function(ev) {
+          });
+
+        element[0]
+          .addEventListener('blur', function() {
             containerCtrl && containerCtrl.setFocused(false);
             inputCheckValue();
           });


### PR DESCRIPTION
### DO NOT MERGE ME YET

This issue was the culprit for the select double label when invalid error that was discussed by @jelbourn and @topherfangio in slack.

I have *no* idea why this fix works. Specifically, `focus` fires but `blur` does not with the jqlite `on` methods. I'd love to hear from anyone who has ideas on why this might be (ping @jelbourn, @ThomasBurleson, @robertmesserle)

I changed the focus listener for consistency, but this feels weird and I'd much rather get to the bottom of the issue than this quick-fix.