### PR TITLE
selectedIndex for radio-group starts at 1, not 0

### DIFF
--- a/src/components/radioButton/demoMultiColumn/script.js
+++ b/src/components/radioButton/demoMultiColumn/script.js
@@ -26,6 +26,6 @@ angular
     }];
     self.selectedIndex = 2;
     self.selectedUser = function() {
-      return self.contacts[self.selectedIndex].lastName;
+      return self.contacts[self.selectedIndex - 1].lastName;
     }
   });


### PR DESCRIPTION
The object at `self.contacts[self.selectedIndex]` references the next element after the one actually selected, showing the wrong last name for "Selected User:".

Moreover, when selecting the last user (Castel) the browser throws a `TypeError: Cannot read property 'lastName' of undefined`.