### PR TITLE
fix(input): Fix input errors CSS to properly display.

### DIFF
--- a/src/components/input/demoErrors/index.html
+++ b/src/components/input/demoErrors/index.html
@@ -35,7 +35,7 @@
       <md-input-container class="md-block">
         <label>Hourly Rate (USD)</label>
         <input required type="number" step="any" name="rate" ng-model="project.rate" min="800"
-               max="4999" ng-pattern="/^1234$/" md-maxlength="20" />
+               max="4999" ng-pattern="/^1234$/" />
 
         <div ng-messages="projectForm.rate.$error" multiple md-auto-hide="false">
           <div ng-message="required">

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -250,8 +250,18 @@ md-input-container {
     }
   }
 
+  // Note: This is a workaround to fix an ng-enter flicker bug
+  .md-auto-hide {
+    .md-input-message-animation {
+      &:not(.ng-animate) {
+        opacity: 0;
+        margin-top: -100px;
+      }
+    }
+  }
+
   .md-input-message-animation {
-    &.ng-enter, &:not(.ng-animate) {
+    &.ng-enter {
       opacity: 0;
       margin-top: -100px;
     }


### PR DESCRIPTION
Due to a CSS property that was not restrictive enough, standard error messages were hidden by default.

Restrict CSS to components with the `md-auto-hide` class. Note that this unfortunately re-introduces the message flicker bug for messages which do not use the `md-auto-hide`. This should be fixed when https://github.com/angular/angular.js/issues/12969 is merged and available.

Also, remove the `md-maxlength` requirement from the errors Hourly Rate demo to reduce confusion.

Fixes #5837. References #5321.