### PR TITLE
fix(dependencies): allow for wider Angular range in peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,15 @@
     "stream-series": "^0.1.1",
     "through2": "^0.6.3"
   },
+  "peerDependencies": {
+    "angular": ">=1.3 <1.6",
+    "angular-animate": ">=1.3 <1.6",
+    "angular-aria": ">=1.3 <1.6",
+    "angular-messages": ">=1.3 <1.6",
+    "angular-mocks": ">=1.3 <1.6",
+    "angular-route": ">=1.3 <1.6",
+    "angular-sanitize": ">=1.3 <1.6"
+  },
   "scripts": {
     "watch": "gulp watch site --dev",
     "prom": "git pull --rebase origin master",


### PR DESCRIPTION
1.0.0 has locked the Angular dependencies in at 1.4.7, which means that installation via `npm` can be blocked if a peer uses a lesser version. Tests pass on all minors of 1.3, 1.4 and 1.5, and therefore they should be added as allowed peerDependencies.

This would resolve #6305.