### PR TITLE
docs(layout): fix closing bold tag and change wrong hide attribute to show

### DIFF
--- a/docs/app/partials/layout-options.tmpl.html
+++ b/docs/app/partials/layout-options.tmpl.html
@@ -190,7 +190,7 @@
     </tr>
     <tr>
       <td>hide-gt-sm</td>
-      <td>hide-gt-sm</td>
+      <td>show-gt-sm</td>
       <td>width &gt;= <b>960</b>px</td>
     </tr>
     <tr>
@@ -211,7 +211,7 @@
     <tr>
       <td>hide-gt-lg</td>
       <td>show-gt-lg</td>
-      <td>width &gt;= <b>1920/b>px</td>
+      <td>width &gt;= <b>1920</b>px</td>
     </tr>
     <tr>
       <td>hide-xl</td>


### PR DESCRIPTION
- Fixes the wrong `hide-gt-sm` row
- +Fixes a missing closing tag for the `Bold` tag

Error with Bold Tag

![](https://i.gyazo.com/7500ec086ac2aaae81b639ab3b819ee7.png)


Fixes #6345