### PR TITLE
docs: Fix docs.css localhost href.

### DIFF
--- a/release.js
+++ b/release.js
@@ -267,6 +267,7 @@
            'rm -rf dist',
            'gulp docs',
            'sed -i \'\' \'s,http:\\/\\/localhost:8080\\/angular-material,https:\\/\\/cdn.gitcdn.xyz/cdn/angular/bower-material/v{{newVersion}}/angular-material,g\' dist/docs/docs.js',
+           'sed -i \'\' \'s,http:\\/\\/localhost:8080/docs.css,https:\\/\\/material.angularjs.org/{{newVersion}}/docs.css,g\' dist/docs/docs.js',
            'sed -i \'\' \'s,base\ href=\\",base\ href=\\"/{{newVersion}},g\' dist/docs/index.html'
          ]);
 

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -20,6 +20,7 @@ function run {
 
   echo "-- Copying docs site to snapshot..."
   sed -i "s,http://localhost:8080/angular-material,https://cdn.gitcdn.xyz/cdn/angular/bower-material/v$VERSION/angular-material,g" dist/docs/docs.js
+  sed -i "s,http://localhost:8080/docs.css,https://material.angularjs.org/$VERSION/docs.css,g" dist/docs/docs.js
   sed -i "s,base href=\",base href=\"/HEAD,g" dist/docs/index.html
 
 


### PR DESCRIPTION
The live docs currently point the `docs.css` file to localhost:8080.

Update scripts to replace this appropriately.

Fixes #6363.