### PR TITLE
Fix(tabs): IE is not processing the inline style for max-width

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -134,7 +134,7 @@ function MdTabs () {
               '<md-tab-item ' +
                   'tabindex="-1" ' +
                   'class="md-tab" ' +
-                  'style="max-width: {{ $mdTabsCtrl.maxTabWidth + \'px\' }}" ' +
+                  'ng-style="{\'max-width\': $mdTabsCtrl.maxTabWidth + \'px\'}"' + 
                   'ng-repeat="tab in $mdTabsCtrl.tabs" ' +
                   'role="tab" ' +
                   'aria-controls="tab-content-{{::tab.id}}" ' +


### PR DESCRIPTION
This issue was only found on IE:

![max-width-before](https://cloud.githubusercontent.com/assets/2235324/11880184/e47d3b80-a4c4-11e5-8e8e-3684bfa34b0b.png)

IE will not evaluate this correctly. Switching to ng-style alleviates the issue:

![max-width-after](https://cloud.githubusercontent.com/assets/2235324/11880183/e479bd3e-a4c4-11e5-9472-789cd3930ba1.png)
