### PR TITLE
fix(input): match up all label transitions

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -112,7 +112,7 @@ md-input-container {
     @include rtl(padding-right, 0, $input-container-padding + 1px);
     z-index: 1;
     transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
-    transition: transform $swift-ease-out-timing-function 0.25s;
+    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 
     @include rtl(transform-origin, left top, right top);
   }
@@ -305,7 +305,7 @@ md-input-container {
 
 md-input-container.md-icon-float {
 
-  transition: margin-top 0.25s $swift-ease-out-timing-function;
+  transition: margin-top $swift-ease-out-duration $swift-ease-out-timing-function;
 
   > label {
     pointer-events: none;
@@ -323,7 +323,7 @@ md-input-container.md-icon-float {
 
     label {
       transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
-      transition: transform $swift-ease-out-timing-function 0.25s;
+      transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
     }
   }
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -305,7 +305,7 @@ md-input-container {
 
 md-input-container.md-icon-float {
 
-  transition: margin-top 0.5s $swift-ease-out-timing-function;
+  transition: margin-top 0.25s $swift-ease-out-timing-function;
 
   > label {
     pointer-events: none;
@@ -323,7 +323,7 @@ md-input-container.md-icon-float {
 
     label {
       transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
-      transition: transform $swift-ease-out-timing-function 0.5s;
+      transition: transform $swift-ease-out-timing-function 0.25s;
     }
   }
 


### PR DESCRIPTION
Change all label `transitions` to be `0.25s` long, as the default is.

Fixes #6328