### PR TITLE
chore(build, demo): fix lodash template compilation.

### DIFF
--- a/gulp/tasks/build-module-demo.js
+++ b/gulp/tasks/build-module-demo.js
@@ -33,7 +33,7 @@ exports.task = function() {
       .pipe(through2.obj(function(demo, enc, next) {
         fs.writeFileSync(
             path.resolve(BUILD_MODE.outputDir, name, demo.name, 'index.html'),
-            _.template(demoIndexTemplate, demo)
+            _.template(demoIndexTemplate)(demo)
         );
         next();
       }));


### PR DESCRIPTION
The current usage of the lodash template compilation was wrong.

Fixes #6396