### PR TITLE
docs(virtualRepeat): fix padding on vertical demos

### DIFF
--- a/src/components/virtualRepeat/demoDeferredLoading/style.css
+++ b/src/components/virtualRepeat/demoDeferredLoading/style.css
@@ -18,6 +18,6 @@ md-virtual-repeat-container {
   border: solid 1px grey;
 }
 
-.md-virtual-repeat-container .md-virtual-repeat-offsetter {
+.md-virtual-repeat-container .md-virtual-repeat-offsetter div {
   padding-left: 16px;
 }

--- a/src/components/virtualRepeat/demoInfiniteScroll/style.css
+++ b/src/components/virtualRepeat/demoInfiniteScroll/style.css
@@ -18,6 +18,6 @@ md-virtual-repeat-container {
   border: solid 1px grey;
 }
 
-.md-virtual-repeat-container .md-virtual-repeat-offsetter {
+.md-virtual-repeat-container .md-virtual-repeat-offsetter div {
   padding-left: 16px;
 }

--- a/src/components/virtualRepeat/demoScrollTo/style.css
+++ b/src/components/virtualRepeat/demoScrollTo/style.css
@@ -29,6 +29,6 @@ md-virtual-repeat-container {
   border: solid 1px grey;
 }
 
-.md-virtual-repeat-container .md-virtual-repeat-offsetter {
+.md-virtual-repeat-container .md-virtual-repeat-offsetter div:not(.header) {
   padding-left: 16px;
 }

--- a/src/components/virtualRepeat/demoVerticalUsage/style.css
+++ b/src/components/virtualRepeat/demoVerticalUsage/style.css
@@ -18,6 +18,6 @@ md-virtual-repeat-container {
   border: solid 1px grey;
 }
 
-.md-virtual-repeat-container .md-virtual-repeat-offsetter {
+.md-virtual-repeat-container .md-virtual-repeat-offsetter div {
   padding-left: 16px;
 }


### PR DESCRIPTION
Apply padding to the container children that are not headers

Fixes #6421