### PR TITLE
feat(input): allow skip hidden inputs

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -33,6 +33,11 @@ angular.module('material.components.input', [
  * Input and textarea elements will not behave properly unless the md-input-container
  * parent is provided.
  *
+ * A single `<md-input-container>` should contain only one `<input>` element, otherwise it will throw an error.
+ *
+ * <b>Exception:</b> Hidden inputs (`<input type="hidden" />`) are ignored and will not throw an error, so
+ * you may combine these with other inputs.
+ *
  * @param md-is-error {expression=} When the given expression evaluates to true, the input container
  *   will go into error state. Defaults to erroring if the input has been touched and is invalid.
  * @param md-no-float {boolean=} When present, `placeholder` attributes on the input will not be converted to floating
@@ -265,7 +270,10 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 
 
     if (!containerCtrl) return;
-    if (containerCtrl.input) {
+    if (attr.type === 'hidden') {
+      element.attr('aria-hidden', 'true');
+      return;
+    } else if (containerCtrl.input) {
       throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
     }
     containerCtrl.input = element;

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -151,6 +151,20 @@ describe('md-input-container directive', function() {
     expect(el).not.toHaveClass('md-input-focused');
   });
 
+  it('should skip a hidden input', function() {
+    var container = setup('type="hidden"');
+    var controller = container.controller('mdInputContainer');
+    var textInput = angular.element('<input type="text">');
+
+    expect(controller.input).toBeUndefined();
+
+    container.append(textInput);
+    $compile(textInput)(pageScope);
+
+    expect(controller.input[0]).toBe(textInput[0]);
+  });
+
+
   it('should set has-value class on container for non-ng-model input', function() {
     var el = setup();
     expect(el).not.toHaveClass('md-input-has-value');


### PR DESCRIPTION
inputs with type `hidden` will be skipped by the `input-container`

#breaking

fixes #2153