### PR TITLE
chore: Add utility to take PhantomJS screenshots.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 /.idea/
 .nvmrc
 tmp/
+screenshots/

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -67,13 +67,22 @@ module.exports = function(config) {
     // - Safari (only Mac; has to be installed with `npm install karma-safari-launcher`)
     // - PhantomJS
     // - IE (only Windows; has to be installed with `npm install karma-ie-launcher`)
-    browsers: ['Firefox', 'PhantomJS'],
+    browsers: ['Firefox', 'PhantomJS_sized'],
 
     // you can define custom flags
     customLaunchers: {
       Chrome_without_security: {
         base: 'Chrome',
         flags: ['--disable-web-security']
+      },
+      PhantomJS_sized: {
+        base: 'PhantomJS',
+        options: {
+          viewportSize: {
+            width: 1400,
+            height: 900
+          }
+        }
       },
       PhantomJS_without_security: {
         base: 'PhantomJS',

--- a/phantom-screenshot.js
+++ b/phantom-screenshot.js
@@ -1,0 +1,41 @@
+/*
+ * Provides a test utility for taking screenshots of PhantomJS. Add the function below to your
+ * `*.spec.js` file and call `screenshot('my-screenshot')` from within the test. Make sure to call
+ * `screenshot('my-last-screenshot', true)` to kill this script, or you can manually kill it with
+ * Ctrl+C in the terminal.
+ *
+ * Once the below code has been added, and you have started Karma (the server must be running),
+ * launch this script by running `phantomjs phantom-screenshot.js` and it will connect to the
+ * running Karma instance, take the requested screenshots, and die.
+ *
+ * All screenshots are stored in the `screenshots` directory.
+ *
+ *     function screenshot(filename, done) {
+ *       // Attempt to take a screenshot, but fail silently if we can't
+ *       if (typeof window.callPhantom != 'undefined') {
+ *         window.callPhantom({ filename: filename + '.png', done: done });
+ *       }
+ *     }
+ *
+ */
+var page = require("webpage").create();
+
+page.onCallback = function(userData) {
+  var data = userData || {};
+  var options = {
+    filename: data.filename || 'phantom-screenshot.png',
+    done: data.done || false
+  };
+
+  if (options.filename) {
+    console.log('PSS - Rendering screenshot: screenshots/', options.filename);
+    page.render('screenshots/' + options.filename);
+  }
+
+  if (options.done) {
+    console.log ('PSS - Done! Exiting screenshot system.');
+    phantom.exit();
+  }
+};
+
+page.open("http://localhost:9876/debug.html");


### PR DESCRIPTION
Oftentimes, a PhantomJS test will fail while it passes on other browsers like Chrome or Firefox. This can be difficult to track down if it is related to layout/positioning as you cannot see what the browser looks like.

Add a new utility to capture a screenshot during your spec so that you can more easily debug the problem.