### PR TITLE
fix(toolbar): apply the warn color, accent color

### DIFF
--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -6,10 +6,6 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     color: '{{primary-contrast}}';
   }
 
-  .md-button:not(.md-raised) {
-    color: '{{primary-contrast}}';
-  }
-
   &.md-accent {
     background-color: '{{accent-color}}';
     color: '{{accent-contrast}}';


### PR DESCRIPTION
This PR to clean this issue #6422 in order to apply the warn and accent theme on the toolbar.