### PR TITLE
feat(checkbox): validate numeric booleans too

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -127,6 +127,11 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
 
       ngModelCtrl.$render = render;
 
+      ngModelCtrl.$formatters.push(function(modelValue) {
+        if (modelValue == '1' || modelValue == '0') return !!modelValue;
+        return modelValue;
+      });
+
       function $$watchExpr(expr, htmlAttr, valueOpts) {
         if (attr[expr]) {
           scope.$watch(attr[expr], function(val) {

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -64,6 +64,20 @@ describe('mdCheckbox', function() {
     expect(blueCheckbox.attr('role')).toEqual('checkbox');
   });
 
+  it('should format numeric boolean to booleans', function() {
+    var element = compileAndLink('<md-checkbox ng-model="blue"></md-checkbox>');
+
+    pageScope.blue = 0;
+    pageScope.$apply();
+
+    expect(element.hasClass(CHECKED_CSS)).toEqual(false);
+
+    pageScope.blue = 1;
+    pageScope.$apply();
+
+    expect(element.hasClass(CHECKED_CSS)).toEqual(true);
+  });
+
   it('should be disabled with ngDisabled attr', function() {
     var element = compileAndLink(
         '<div>' +


### PR DESCRIPTION
We should format numeric booleans `0` or `1` to real booleans.

Fixes #2796