### PR TITLE
test(util): add needed test for `disableScrollAround`

### DIFF
--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -243,6 +243,23 @@ describe('util', function() {
       });
     });
 
+    describe('disableScrollAround', function() {
+      it('should prevent scrolling of the passed element', inject(function($mdUtil) {
+        var element = angular.element('<div style="height: 2000px">');
+        document.body.appendChild(element[0]);
+
+        $mdUtil.disableScrollAround(element);
+
+        window.scrollTo(0, 1000);
+
+        expect(window.pageYOffset).toBe(0);
+
+        // Revert scroll
+        window.scrollTo(0, 0);
+        document.body.removeChild(element[0]);
+      }));
+    });
+
     describe('nextTick', function() {
       it('should combine multiple calls into a single digest', inject(function($mdUtil, $rootScope, $timeout) {
         var digestWatchFn = jasmine.createSpy('watchFn');


### PR DESCRIPTION
- We can append an element to the body which is higher than the actual window, so there should be space to scroll.
- So we disable scrolling with our specified method `disableScrollAround`.
- Then we try to scroll down to `y=1000px`
- So if `disableScrollAround` works, the `pageYOffset` will be zero.

Fixes #2305