### PR TITLE
Fixing a typo in the documentation.

### DIFF
--- a/docs/app/partials/layout-alignment.tmpl.html
+++ b/docs/app/partials/layout-alignment.tmpl.html
@@ -2,7 +2,7 @@
 
   <p>
     The <code>layout-align</code> directive takes two words.
-    The first word says how the children will be aligned in the lay3ut's direction, and the second word says how the children will be aligned perpendicular to the layout's direction.</p>
+    The first word says how the children will be aligned in the layout's direction, and the second word says how the children will be aligned perpendicular to the layout's direction.</p>
 
     <p>Only one value is required for this directive.
     For example, <code>layout="row" layout-align="center"</code> would make the elements


### PR DESCRIPTION
`lay3ut's` should be `layout's`