### PR TITLE
fix(bottomsheet): fix open animation for bottomsheet.

### DIFF
--- a/src/components/bottomSheet/bottom-sheet.scss
+++ b/src/components/bottomSheet/bottom-sheet.scss
@@ -17,17 +17,22 @@ md-bottom-sheet {
   border-top-width: 1px;
   border-top-style: solid;
 
-  transform: translate3d(0, $bottom-sheet-hidden-bottom-padding, 0);
-  transition: $swift-ease-out;
-  transition-property: transform;
+  transform: translate3d(0, 100%, 0);
+
+  &:not(.md-prepare-enter) {
+    transform: translate3d(0, $bottom-sheet-hidden-bottom-padding, 0);
+    transition: $swift-ease-out;
+    transition-property: transform;
+  }
 
   &.md-has-header {
     padding-top: 0;
   }
 
   &.ng-enter {
+    transition: $swift-ease-out;
+    transition-property: transform;
     opacity: 0;
-    transform: translate3d(0, 100%, 0);
   }
 
   &.ng-enter-active {
@@ -36,10 +41,13 @@ md-bottom-sheet {
     transform: translate3d(0, $bottom-sheet-hidden-bottom-padding, 0) !important;
   }
 
+  &.ng-leave {
+    transition: $swift-ease-in;
+    transition-property: transform;
+  }
 
   &.ng-leave-active {
     transform: translate3d(0, 100%, 0) !important;
-    transition: $swift-ease-in;
   }
 
   .md-subheader {

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -10,8 +10,8 @@ describe('$mdBottomSheet service', function () {
           parent: parent,
           clickOutsideToClose: true
         });
-
-        $material.flushOutstandingAnimations();
+        
+        $material.flushInterimElement();
 
         expect(parent.find('md-bottom-sheet').length).toBe(1);
 
@@ -35,7 +35,7 @@ describe('$mdBottomSheet service', function () {
           clickOutsideToClose: false
         });
 
-        $material.flushOutstandingAnimations();
+        $material.flushInterimElement();
 
         expect(parent.find('md-bottom-sheet').length).toBe(1);
 
@@ -59,7 +59,7 @@ describe('$mdBottomSheet service', function () {
           escapeToClose: true
         });
 
-        $material.flushOutstandingAnimations();
+        $material.flushInterimElement();
 
         expect(parent.find('md-bottom-sheet').length).toBe(1);
 
@@ -99,7 +99,7 @@ describe('$mdBottomSheet service', function () {
         });
 
         $rootScope.$apply();
-        $material.flushOutstandingAnimations();
+        $material.flushInterimElement();
 
         expect(parent.find('md-bottom-sheet').length).toBe(1);
 


### PR DESCRIPTION
This is fixing all the issues with close and open animation.
It work's perfectly, I already took a look at the Timings in the Chrome Dev Tools (Render Rate etc.)

But to be honest (in code) I'm not satisfied with using `$timeout`. But that's the only possibility because we inserting the element into the `DOM` at `80px` and then we wan't instant run the animation from `-100%`. But that's not possible. So we need to remove the transition and transform the bottomsheet at insertion down to `-100%`, and then after it got rendered down, we can fire the animation to `80px`. 

That's the only possibility to get run with $animate (entering / leaving). 

Fixes #6468