### PR TITLE
docs(layout/options): fix trivial copy paste error

### DIFF
--- a/docs/app/partials/layout-options.tmpl.html
+++ b/docs/app/partials/layout-options.tmpl.html
@@ -190,7 +190,7 @@
     </tr>
     <tr>
       <td>hide-gt-sm</td>
-      <td>hide-gt-sm</td>
+      <td>show-gt-sm</td>
       <td>width &gt;= <b>960</b>px</td>
     </tr>
     <tr>


### PR DESCRIPTION
The second column gives examples of `show`, but the second column of this line was a `hide`.