### PR TITLE
fix(list): fix list margin if anchor is present.

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -61,6 +61,7 @@ md-list-item {
       flex-direction: inherit;
       align-items: inherit;
       border-radius: 0;
+      margin: 0;
 
       & > .md-ripple-container {
         border-radius: 0;


### PR DESCRIPTION
If there is currently a `md-button` anchor, we should remove the margin to order the items as the other items.

Fixes #5608 Fixes #6317