### PR TITLE
fix(autocomplete): improve promise logic

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -641,9 +641,15 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       $mdUtil.nextTick(function () {
         if (items.success) items.success(handleResults);
         if (items.then)    items.then(handleResults);
-        if (items.finally) items.finally(function () {
-          setLoading(false);
-        });
+        if (items.finally) {
+          items.finally(function () {
+            setLoading(false);
+          });
+        } else if (items.then) {
+          items.then(function () {
+            setLoading(false);
+          });
+        }
       },true, $scope);
     }
     function handleResults (matches) {


### PR DESCRIPTION
The `finally`-function supported by [q] is not part of the [A+ spec]. Therefore, other promise implementations do not have it (e.g. the [promise polyfill] in [babel]). To ensure that `md-autocomplete` resets its loading state properly, I used `then` if `finally` is not available.

This pull request was joined with #6860.

[A+ spec]: https://promisesaplus.com/
[babel]: https://github.com/babel/babel/
[promise polyfill]: https://github.com/zloirock/core-js/blob/master/modules/es6.promise.js
[q]: https://github.com/kriskowal/q/