### PR TITLE
fix(md-chips placeholder): correct placeholder/secondary logic

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -362,6 +362,48 @@ describe('<md-chips>', function() {
         expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(false);
       }));
 
+      describe('placeholder', function() {
+
+        it('should put placeholder text in the input element when chips exist but there is no secondary-placeholder text', inject(function() {
+          var template =
+            '<md-chips ng-model="items" placeholder="placeholder text"></md-chips>';
+          var element = buildChips(template);
+          var ctrl = element.controller('mdChips');
+          var input = element.find('input')[0];
+
+          expect(scope.items.length).toBeGreaterThan(0);
+          expect(input.placeholder).toBe('placeholder text');
+        }));
+
+        it('should put placeholder text in the input element when there are no chips', inject(function() {
+          var ctrl, element, input, template;
+
+          scope.items = [];
+          template =
+            '<md-chips ng-model="items" placeholder="placeholder text" ' +
+            'secondary-placeholder="secondary-placeholder text"></md-chips>';
+          element = buildChips(template);
+          ctrl = element.controller('mdChips');
+          input = element.find('input')[0];
+
+          expect(scope.items.length).toBe(0);
+          expect(input.placeholder).toBe('placeholder text');
+        }));
+
+        it('should put secondary-placeholder text in the input element when there is at least one chip', inject(function() {
+          var template =
+            '<md-chips ng-model="items" placeholder="placeholder text" ' +
+            'secondary-placeholder="secondary-placeholder text"></md-chips>';
+          var element = buildChips(template);
+          var ctrl = element.controller('mdChips');
+          var input = element.find('input')[0];
+
+          expect(scope.items.length).toBeGreaterThan(0);
+          expect(input.placeholder).toBe('secondary-placeholder text');
+        }));
+
+      });
+
     });
 
     describe('custom inputs', function() {

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -183,7 +183,7 @@ MdChipsCtrl.prototype.getPlaceholder = function() {
   // Allow `secondary-placeholder` to be blank.
   var useSecondary = (this.items.length &&
       (this.secondaryPlaceholder == '' || this.secondaryPlaceholder));
-  return useSecondary ? this.placeholder : this.secondaryPlaceholder;
+  return useSecondary ? this.secondaryPlaceholder : this.placeholder;
 };
 
 /**


### PR DESCRIPTION
Test and then fix the md-chips placeholder logic so that the secondary placeholder text appears only when it is documented to appear. Addresses issues #2770 and #4476.

The first commit provides test code to demonstrate the failure. The second commit changes the implementation code to pass the tests.
