### PR TITLE
fix(docs): menu toggle is not open on the current page

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -473,8 +473,9 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
           },
           function (open) {
             var $ul = $element.find('ul');
-            var targetHeight = open ? getTargetHeight() : 0;
+
             $timeout(function () {
+              var targetHeight = open ? getTargetHeight() : 0;
               $ul.css({ height: targetHeight + 'px' });
             }, 0, false);
 

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -475,9 +475,14 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
             var $ul = $element.find('ul');
 
             $timeout(function () {
-              var targetHeight = open ? getTargetHeight() : 0;
-              $ul.css({ height: targetHeight + 'px' });
+              updateHeight(open ? getTargetHeight() : 0);
             }, 0, false);
+
+            function updateHeight(targetHeight) {
+              $timeout(function () {
+                $ul.css({ height: targetHeight + 'px' });
+              }, 0, false);
+            }
 
             function getTargetHeight () {
               var targetHeight;


### PR DESCRIPTION
Fix docs nav toggle to open the current page when refreshing the page or navigating directly to a section.