### PR TITLE
perf(md-tooltip): do not run tooltip toggle logic if tooltip is already in that state

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -187,6 +187,9 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     }
 
     function setVisible (value) {
+      // break if passed value is already in queue or there is no queue and passed value is current in the scope
+      if (setVisible.queued && setVisible.visible === !!value || scope.visible === !!value) return;
+      
       setVisible.value = !!value;
       if (!setVisible.queued) {
         if (value) {


### PR DESCRIPTION
Do not run tooltip toggle logic if tooltip is already in that state.

ps. is there any reason why onscroll event is not throttled like the resize event?
```
ngWindow.on('resize', debouncedOnResize);
document.addEventListener('scroll', windowScrollHandler, true);
```

closes #6557 