### PR TITLE
fix(ripple): remove translate from ripple animation

### DIFF
--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -365,8 +365,8 @@ InkRippleCtrl.prototype.createRipple = function (left, top) {
   var color       = this.calculateColor();
 
   ripple.css({
-    left:            left + 'px',
-    top:             top + 'px',
+    left:            (left - size / 2) + 'px',
+    top:             (top - size / 2) + 'px',
     background:      'black',
     width:           size + 'px',
     height:          size + 'px',

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -114,8 +114,7 @@ input {
 
 .md-ripple {
   position: absolute;
-  transform: translate(-50%, -50%) scale(0);
-  transform-origin: 50% 50%;
+  transform: scale(0);
   opacity: 0;
   border-radius: 50%;
   &.md-ripple-placed {
@@ -128,7 +127,7 @@ input {
                 transform $sizeDuration $swift-ease-out-timing-function;
   }
   &.md-ripple-scaled {
-    transform: translate(-50%, -50%) scale(1);
+    transform: scale(1);
   }
   &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
     opacity: 0.20;


### PR DESCRIPTION
`translate` transformation causes the ripple animation transition to be blocked by js code.
Set the ripple position in js and remove translate from css to prevent animation lag.

You can see the example of animation lag in anglar-material docs: https://material.angularjs.org/latest/demo/chips
When you select another page in the left sidenav menu, you can see, how the ripple of menu item lags when new page inits.

After removing `transform: translate(-50%, -50%)` from ripple classes, js code doesn't block the transition any more.