### PR TITLE
fix(datepicker): fix max date validation. Fixes #6622

### DIFF
--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -378,9 +378,10 @@
       }
 
       if (this.dateUtil.isValidDate(this.maxDate)) {
-        this.ngModelCtrl.$setValidity('maxdate', date <= this.maxDate);
+        var isBeforeMaxDate = date < this.dateUtil.incrementDays(this.maxDate, 1);
+        this.ngModelCtrl.$setValidity('maxdate', isBeforeMaxDate);
       }
-      
+
       if (angular.isFunction(this.dateFilter)) {
         this.ngModelCtrl.$setValidity('filtered', this.dateFilter(date));
       }


### PR DESCRIPTION
Allow date before max date (inclusive) not depending on time of date.
Fixes https://github.com/angular/material/issues/6622