### PR TITLE
docs: Fix MIT License link in footer.

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -159,7 +159,7 @@
       <div layout="row" flex="noshrink">
         <div id="license-footer">
           Powered by Google &copy;2014&#8211;{{thisYear}}.
-          Code licensed under the <a href="/license">MIT License</a>.
+          Code licensed under the <a href="./license">MIT License</a>.
           Documentation licensed under
           <a href="http://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>.
         </div>


### PR DESCRIPTION
The footer link incorrectly points to `/license` instead of `./license`
which causes it to not take the currently selected version into account.