### PR TITLE
fix(select): restrict setting untouched

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -285,7 +285,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           element.on('blur', function() {
             if (untouched) {
               untouched = false;
-              ngModelCtrl.$setUntouched();
+              if (selectScope.isOpen) {
+                ngModelCtrl.$setUntouched();
+              }
             }
 
             if (selectScope.isOpen) return;


### PR DESCRIPTION
Don't set untouched while using tab navigation, allows any error messages to show after tabbing out. Fixes #6506