### PR TITLE
Refactor private CSS classes.

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -193,7 +193,7 @@ function MdAutocomplete () {
           </md-virtual-repeat-container>\
         </md-autocomplete-wrap>\
         <aria-status\
-            class="md-visually-hidden"\
+            class="_md-visually-hidden"\
             role="status"\
             aria-live="assertive">\
           <p ng-repeat="message in $mdAutocompleteCtrl.messages track by $index" ng-if="message">{{message}}</p>\
@@ -269,7 +269,7 @@ function MdAutocomplete () {
                 ng-if="$mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled"\
                 ng-click="$mdAutocompleteCtrl.clear()">\
               <md-icon md-svg-icon="md-close"></md-icon>\
-              <span class="md-visually-hidden">Clear</span>\
+              <span class="_md-visually-hidden">Clear</span>\
             </button>\
                 ';
         }

--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -12,26 +12,26 @@ md-backdrop {
 
   z-index: $z-index-backdrop;
 
-  &.md-menu-backdrop {
+  &._md-menu-backdrop {
     position: fixed !important;
     z-index: $z-index-menu - 1;
   }
-  &.md-select-backdrop {
+  &._md-select-backdrop {
     z-index: $z-index-dialog + 1;
     transition-duration: 0;
   }
-  &.md-dialog-backdrop {
+  &._md-dialog-backdrop {
     z-index: $z-index-dialog - 1;
   }
-  &.md-bottom-sheet-backdrop {
+  &._md-bottom-sheet-backdrop {
     z-index: $z-index-bottom-sheet - 1;
   }
-  &.md-sidenav-backdrop {
+  &._md-sidenav-backdrop {
     z-index: $z-index-sidenav - 1;
   }
 
 
-  &.md-click-catcher {
+  &._md-click-catcher {
     position: absolute;
   }
 

--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -154,7 +154,7 @@ function MdBottomSheetProvider($$interimElementProvider) {
       element = $mdUtil.extractElementByName(element, 'md-bottom-sheet');
 
       // Add a backdrop that will close on click
-      backdrop = $mdUtil.createBackdrop(scope, "md-bottom-sheet-backdrop md-opaque");
+      backdrop = $mdUtil.createBackdrop(scope, "_md-bottom-sheet-backdrop md-opaque");
 
       if (options.clickOutsideToClose) {
         backdrop.on('click', function() {

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -66,7 +66,7 @@ $contact-chip-name-width: rem(12) !default;
     .md-chip:not(.md-readonly) {
       padding-right: $chip-remove-padding-right;
 
-      .md-chip-content {
+      ._md-chip-content {
         padding-right:rem(0.4);
       }
     }
@@ -85,7 +85,7 @@ $contact-chip-name-width: rem(12) !default;
     max-width: 100%;
     position: relative;
 
-    .md-chip-content {
+    ._md-chip-content {
       display: block;
       float: left;
       white-space: nowrap;
@@ -96,12 +96,12 @@ $contact-chip-name-width: rem(12) !default;
         outline: none;
       }
     }
-    .md-chip-remove-container {
+    ._md-chip-remove-container {
       position: absolute;
       right: 0;
       line-height: $chip-remove-line-height;
     }
-    .md-chip-remove {
+    ._md-chip-remove {
       text-align: center;
       width: $chip-height;
       height: $chip-height;
@@ -122,7 +122,7 @@ $contact-chip-name-width: rem(12) !default;
       }
     }
   }
-  .md-chip-input-container {
+  ._md-chip-input-container {
     display: block;
     line-height: $chip-height;
     margin: $chip-margin;
@@ -185,11 +185,11 @@ $contact-chip-name-width: rem(12) !default;
 }
 // IE only
 @media screen and (-ms-high-contrast: active) {
-  .md-chip-input-container,
+  ._md-chip-input-container,
   md-chip {
     border: 1px solid #fff;
   }
-  .md-chip-input-container md-autocomplete {
+  ._md-chip-input-container md-autocomplete {
     border: none;
   }
 }

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -65,7 +65,7 @@ describe('<md-contact-chips>', function() {
 
         var element = buildChips(CONTACT_CHIPS_TEMPLATE);
         var ctrl = element.controller('mdContactChips');
-        var chip = angular.element(element[0].querySelector('.md-chip-content'));
+        var chip = angular.element(element[0].querySelector('._md-chip-content'));
 
         expect(chip.find('img').length).toBe(1);
     });
@@ -77,7 +77,7 @@ describe('<md-contact-chips>', function() {
 
         var element = buildChips(CONTACT_CHIPS_TEMPLATE);
         var ctrl = element.controller('mdContactChips');
-        var chip = angular.element(element[0].querySelector('.md-chip-content'));
+        var chip = angular.element(element[0].querySelector('._md-chip-content'));
 
         expect(chip.find('img').length).toBe(0);
     });

--- a/src/components/chips/demoBasicUsage/style.scss
+++ b/src/components/chips/demoBasicUsage/style.scss
@@ -7,7 +7,7 @@
 .custom-chips {
   .md-chip {
     position: relative;
-    .md-chip-remove-container {
+    ._md-chip-remove-container {
       position: absolute;
       right: 4px;
       top: 4px;

--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -22,7 +22,7 @@ angular
 // This hint text is hidden within a chip but used by screen readers to
 // inform the user how they can interact with a chip.
 var DELETE_HINT_TEMPLATE = '\
-    <span ng-if="!$mdChipsCtrl.readonly" class="md-visually-hidden">\
+    <span ng-if="!$mdChipsCtrl.readonly" class="_md-visually-hidden">\
       {{$mdChipsCtrl.deleteHint}}\
     </span>';
 
@@ -50,7 +50,7 @@ function MdChip($mdTheming, $mdUtil) {
       element.addClass('md-chip');
       $mdTheming(element);
 
-      if (ctrl) angular.element(element[0].querySelector('.md-chip-content'))
+      if (ctrl) angular.element(element[0].querySelector('._md-chip-content'))
           .on('blur', function () {
             ctrl.selectedChip = -1;
           });

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -440,7 +440,7 @@ MdChipsCtrl.prototype.selectAndFocusChip = function(index) {
  * Call `focus()` on the chip at `index`
  */
 MdChipsCtrl.prototype.focusChip = function(index) {
-  this.$element[0].querySelector('md-chip[index="' + index + '"] .md-chip-content').focus();
+  this.$element[0].querySelector('md-chip[index="' + index + '"] ._md-chip-content').focus();
 };
 
 /**

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -126,17 +126,17 @@
         <md-chip ng-repeat="$chip in $mdChipsCtrl.items"\
             index="{{$index}}"\
             ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': $mdChipsCtrl.readonly}">\
-          <div class="md-chip-content"\
+          <div class="_md-chip-content"\
               tabindex="-1"\
               aria-hidden="true"\
               ng-focus="!$mdChipsCtrl.readonly && $mdChipsCtrl.selectChip($index)"\
               md-chip-transclude="$mdChipsCtrl.chipContentsTemplate"></div>\
           <div ng-if="!$mdChipsCtrl.readonly"\
-               class="md-chip-remove-container"\
+               class="_md-chip-remove-container"\
                md-chip-transclude="$mdChipsCtrl.chipRemoveTemplate"></div>\
         </md-chip>\
         <div ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl"\
-            class="md-chip-input-container"\
+            class="_md-chip-input-container"\
             md-chip-transclude="$mdChipsCtrl.chipInputTemplate"></div>\
         </div>\
       </md-chips-wrap>';
@@ -157,14 +157,14 @@
 
   var CHIP_REMOVE_TEMPLATE = '\
       <button\
-          class="md-chip-remove"\
+          class="_md-chip-remove"\
           ng-if="!$mdChipsCtrl.readonly"\
           ng-click="$mdChipsCtrl.removeChipAndFocusInput($$replacedScope.$index)"\
           type="button"\
           aria-hidden="true"\
           tabindex="-1">\
         <md-icon md-svg-icon="md-close"></md-icon>\
-        <span class="md-visually-hidden">\
+        <span class="_md-visually-hidden">\
           {{$mdChipsCtrl.deleteButtonLabel}}\
         </span>\
       </button>';

--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -18,11 +18,23 @@ angular.module('material.components.content', [
  * @restrict E
  *
  * @description
- * The `<md-content>` directive is a container element useful for scrollable content
+ *
+ * The `<md-content>` directive is a container element useful for scrollable content. It achieves
+ * this by setting the CSS `overflow` property to `auto` so that content can properly scroll.
+ *
+ * In general, `<md-content>` components are not designed to be nested inside one another. If
+ * possible, it is better to make them siblings. This often results in a better user experience as
+ * having nested scrollbars may confuse the user.
+ *
+ * ## Troubleshooting
+ *
+ * In some cases, you may wish to apply the `md-no-momentum` class to ensure that Safari's
+ * momentum scrolling is disabled. Momentum scrolling can cause flickering issues while scrolling
+ * SVG icons and some other components.
  *
  * @usage
  *
- * - Add the `[layout-padding]` attribute to make the content padded.
+ * Add the `[layout-padding]` attribute to make the content padded.
  *
  * <hljs lang="html">
  *  <md-content layout-padding>

--- a/src/components/content/content.scss
+++ b/src/components/content/content.scss
@@ -19,7 +19,7 @@ md-content {
   // For iOS allow disabling of momentum scrolling
   // @see issue #2640.
 
-  &.autoScroll {
+  &.md-no-momentum {
     -webkit-overflow-scrolling: auto;
   }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -862,7 +862,7 @@ function MdDialogProvider($$interimElementProvider) {
       }
 
       if (options.hasBackdrop) {
-        options.backdrop = $mdUtil.createBackdrop(scope, "md-dialog-backdrop md-opaque");
+        options.backdrop = $mdUtil.createBackdrop(scope, "_md-dialog-backdrop md-opaque");
         $animate.enter(options.backdrop, options.parent);
       }
 

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -44,7 +44,7 @@
       resetActionIndex();
 
       // Add an animations waiting class so we know not to run
-      $element.addClass('md-animations-waiting');
+      $element.addClass('_md-animations-waiting');
     }
 
     function setupListeners() {
@@ -142,9 +142,9 @@
       // If the element is actually visible on the screen
       if ($element[0].scrollHeight > 0) {
         // Fire our animation
-        $animate.addClass($element, 'md-animations-ready').then(function() {
+        $animate.addClass($element, '_md-animations-ready').then(function() {
           // Remove the waiting class
-          $element.removeClass('md-animations-waiting');
+          $element.removeClass('_md-animations-waiting');
         });
       }
 

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -114,7 +114,7 @@
 
     function FabSpeedDialLink(scope, element) {
       // Prepend an element to hold our CSS variables so we can use them in the animations below
-      element.prepend('<div class="md-css-variables"></div>');
+      element.prepend('<div class="_md-css-variables"></div>');
     }
   }
 
@@ -123,7 +123,7 @@
 
     function runAnimation(element) {
       // Don't run if we are still waiting and we are not ready
-      if (element.hasClass('md-animations-waiting') && !element.hasClass('md-animations-ready')) {
+      if (element.hasClass('_md-animations-waiting') && !element.hasClass('_md-animations-ready')) {
         return;
       }
 
@@ -135,7 +135,7 @@
       var triggerElement = el.querySelector('md-fab-trigger');
 
       // Grab our element which stores CSS variables
-      var variablesElement = el.querySelector('.md-css-variables');
+      var variablesElement = el.querySelector('._md-css-variables');
 
       // Setup JS variables based on our CSS variables
       var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);
@@ -220,7 +220,7 @@
       var items = el.querySelectorAll('.md-fab-action-item');
 
       // Grab our element which stores CSS variables
-      var variablesElement = el.querySelector('.md-css-variables');
+      var variablesElement = el.querySelector('._md-css-variables');
 
       // Setup JS variables based on our CSS variables
       var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -25,7 +25,7 @@ md-fab-speed-dial {
     }
   }
 
-  .md-css-variables {
+  ._md-css-variables {
     z-index: $z-index-fab;
   }
 
@@ -125,7 +125,7 @@ md-fab-speed-dial {
   }
 
   // For the initial animation, set the duration to be instant
-  &.md-fling.md-animations-waiting {
+  &.md-fling._md-animations-waiting {
     .md-fab-action-item {
       opacity: 0;
       transition-duration: 0s;

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -74,8 +74,8 @@
     return {
       restrict: 'E',
       transclude: true,
-      template: '<div class="md-fab-toolbar-wrapper">' +
-      '  <div class="md-fab-toolbar-content" ng-transclude></div>' +
+      template: '<div class="_md-fab-toolbar-wrapper">' +
+      '  <div class="_md-fab-toolbar-content" ng-transclude></div>' +
       '</div>',
 
       scope: {
@@ -96,7 +96,7 @@
 
       // Prepend the background element to the trigger's button
       element.find('md-fab-trigger').find('button')
-        .prepend('<div class="md-fab-toolbar-background"></div>');
+        .prepend('<div class="_md-fab-toolbar-background"></div>');
     }
   }
 
@@ -112,7 +112,7 @@
       var ctrl = element.controller('mdFabToolbar');
 
       // Grab the relevant child elements
-      var backgroundElement = el.querySelector('.md-fab-toolbar-background');
+      var backgroundElement = el.querySelector('._md-fab-toolbar-background');
       var triggerElement = el.querySelector('md-fab-trigger button');
       var toolbarElement = el.querySelector('md-toolbar');
       var iconElement = el.querySelector('md-fab-trigger button md-icon');

--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -12,7 +12,7 @@ md-fab-toolbar {
   /*
    * Closed styling
    */
-  .md-fab-toolbar-wrapper {
+  ._md-fab-toolbar-wrapper {
     display: block;
     position: relative;
     overflow: hidden;
@@ -29,7 +29,7 @@ md-fab-toolbar {
       overflow: visible !important;
     }
 
-    .md-fab-toolbar-background {
+    ._md-fab-toolbar-background {
       display: block;
       position: absolute;
       z-index: $z-index-fab + 1;

--- a/src/components/icon/js/iconDirective.js
+++ b/src/components/icon/js/iconDirective.js
@@ -44,13 +44,17 @@ angular
  *
  * <ol>
  * <li>Load the font library. e.g.<br/>
- *    &lt;link href="https://fonts.googleapis.com/icon?family=Material+Icons"
- *    rel="stylesheet"&gt;
+ *    `<link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+ *    rel="stylesheet">`
  * </li>
- * <li> Use either (a) font-icon class names or (b) font ligatures to render the font glyph by using its textual name</li>
- * <li> Use &lt;md-icon md-font-icon="classname" /&gt; or <br/>
- *     use &lt;md-icon md-font-set="font library classname or alias"&gt; textual_name &lt;/md-icon&gt; or <br/>
- *     use &lt;md-icon md-font-set="font library classname or alias"&gt; numerical_character_reference &lt;/md-icon&gt;
+ * <li>
+ *   Use either (a) font-icon class names or (b) font ligatures to render the font glyph by using
+ *   its textual name
+ * </li>
+ * <li>
+ *   Use `<md-icon md-font-icon="classname" />` or <br/>
+ *   use `<md-icon md-font-set="font library classname or alias"> textual_name </md-icon>` or <br/>
+ *   use `<md-icon md-font-set="font library classname or alias"> numerical_character_reference </md-icon>`
  * </li>
  * </ol>
  *

--- a/src/components/input/demoIcons/index.html
+++ b/src/components/input/demoIcons/index.html
@@ -1,7 +1,7 @@
 <div ng-controller="DemoCtrl" layout="column" layout-padding ng-cloak>
 
   <br/>
-  <md-content class="autoScroll">
+  <md-content class="md-no-momentum">
     <md-input-container class="md-icon-float md-block">
       <!-- Use floating label instead of placeholder -->
       <label>Name</label>

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -54,7 +54,7 @@ function MenuProvider($$interimElementProvider) {
       }
 
       if (options.hasBackdrop) {
-        options.backdrop = $mdUtil.createBackdrop(scope, "md-menu-backdrop md-click-catcher");
+        options.backdrop = $mdUtil.createBackdrop(scope, "_md-menu-backdrop _md-click-catcher");
 
         $animate.enter(options.backdrop, $document[0].body);
       }

--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -26,7 +26,7 @@ md-menu-bar {
     height: 5 * $baseline-grid;
   }
 
-  md-backdrop.md-menu-backdrop {
+  md-backdrop._md-menu-backdrop {
     z-index: -2;
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -155,7 +155,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     }
 
     if (attr.name) {
-      var autofillClone = angular.element('<select class="md-visually-hidden">');
+      var autofillClone = angular.element('<select class="_md-visually-hidden">');
       autofillClone.attr({
         'name': '.' + attr.name,
         'ng-model': attr.ngModel,
@@ -1030,7 +1030,7 @@ function SelectProvider($$interimElementProvider) {
 
         if (options.hasBackdrop) {
           // Override duration to immediately show invisible backdrop
-          options.backdrop = $mdUtil.createBackdrop(scope, "md-select-backdrop md-click-catcher");
+          options.backdrop = $mdUtil.createBackdrop(scope, "_md-select-backdrop _md-click-catcher");
           $animate.enter(options.backdrop, $document[0].body, null, {duration: 0});
         }
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -221,7 +221,7 @@ md-optgroup {
 }
 
 @media screen and (-ms-high-contrast: active) {
-  .md-select-backdrop {
+  ._md-select-backdrop {
     background-color: transparent;
   }
   md-select-menu {

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -240,7 +240,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
         $mdMedia: $mdMedia
       });
     };
-    var backdrop = $mdUtil.createBackdrop(scope, "md-sidenav-backdrop md-opaque ng-enter");
+    var backdrop = $mdUtil.createBackdrop(scope, "_md-sidenav-backdrop md-opaque ng-enter");
 
     $mdTheming.inherit(backdrop, element);
 

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -70,7 +70,7 @@ md-sidenav {
 
   @extend .md-sidenav-left;
 }
-.md-sidenav-backdrop.md-locked-open {
+._md-sidenav-backdrop.md-locked-open {
   display: none;
 }
 

--- a/src/components/sticky/sticky.scss
+++ b/src/components/sticky/sticky.scss
@@ -9,7 +9,7 @@
 
   &[sticky-state="active"] {
     transform: translate3d(0, 0, 0);
-    &:not(.md-sticky-no-effect) .md-subheader-inner {
+    &:not(.md-sticky-no-effect) ._md-subheader-inner {
       animation: subheaderStickyHoverIn 0.3s ease-out both;
     }
   }

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -48,8 +48,8 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     transclude: true,
     template: (
     '<div class="md-subheader">' +
-    '  <div class="md-subheader-inner">' +
-    '    <span class="md-subheader-content"></span>' +
+    '  <div class="_md-subheader-inner">' +
+    '    <span class="_md-subheader-content"></span>' +
     '  </div>' +
     '</div>'
     ),
@@ -58,7 +58,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
       var outerHTML = element[0].outerHTML;
 
       function getContent(el) {
-        return angular.element(el[0].querySelector('.md-subheader-content'));
+        return angular.element(el[0].querySelector('._md-subheader-content'));
       }
 
       // Transclude the user-given contents of the subheader
@@ -75,7 +75,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
           // compiled clone below will only be a comment tag (since they replace their elements with
           // a comment) which cannot be properly passed to the $mdSticky; so we wrap it in our own
           // DIV to ensure we have something $mdSticky can use
-          var wrapperHtml = '<div class="md-subheader-wrapper">' + outerHTML + '</div>';
+          var wrapperHtml = '<div class="_md-subheader-wrapper">' + outerHTML + '</div>';
           var stickyClone = $compile(wrapperHtml)(scope);
 
           // Append the sticky

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -22,7 +22,7 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   }
 }
 
-.md-subheader-wrapper {
+._md-subheader-wrapper {
 
   &:not(.md-sticky-no-effect) {
     .md-subheader {
@@ -39,7 +39,7 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
       margin-top: -2px;
     }
 
-    &:not(.md-sticky-clone)[sticky-prev-state="active"] .md-subheader-inner:after {
+    &:not(.md-sticky-clone)[sticky-prev-state="active"] ._md-subheader-inner:after {
       animation: subheaderStickyHoverOut 0.3s ease-out both;
     }
   }
@@ -54,12 +54,12 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   margin: $subheader-margin;
   position: relative;
 
-  .md-subheader-inner {
+  ._md-subheader-inner {
     display: block;
     padding: $subheader-padding;
   }
 
-  .md-subheader-content {
+  ._md-subheader-content {
     display: block;
     z-index: 1;
     position: relative;

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -153,7 +153,7 @@ function MdTabs () {
                   'md-scope="::tab.parent"></md-tab-item> ' +
               '<md-ink-bar></md-ink-bar> ' +
             '</md-pagination-wrapper> ' +
-            '<div class="md-visually-hidden md-dummy-wrapper"> ' +
+            '<div class="_md-visually-hidden md-dummy-wrapper"> ' +
               '<md-dummy-tab ' +
                   'class="md-tab" ' +
                   'tabindex="-1" ' +

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -64,7 +64,7 @@ input {
   }
 }
 
-.md-visually-hidden {
+._md-visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;


### PR DESCRIPTION
Many components use classes that should be noted as private/internal classes. Update components accordingly by prefixing classes with `_md-`.

Refactor the following components:

 * FAB SpeedDial/Toolbar
 * Backdrop
 * Subheader
 * Chips
 * Content

Refactor the `md-visually-hidden` class to `_md-visually-hidden` across multiple components.

Also make a slight change to icon docs for better readability.

Refactor `<md-content>`'s `autoScroll` class to `md-no-momentum` for better clarity and to define it as a public API class and add appropriate docs.

BREAKING CHANGE

The `autoScroll` class of the `<md-content>` directive has been renamed to `md-no-momentum` to increase clarity and mark it as an API-level class.

If you use the `autoScroll` class in your code, please update it to the new name `md-no-momentum`.

References #6653.