### PR TITLE
fix(autocomplete) improved ESCAPE key interaction

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -434,13 +434,13 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         select(ctrl.index);
         break;
       case $mdConstant.KEY_CODE.ESCAPE:
+        if (ctrl.hidden && !ctrl.loading) //fixes escape event not being sent up
+            return;
         event.stopPropagation();
         event.preventDefault();
-        clearValue();
-
-        // Force the component to blur if they hit escape
-        doBlur(true);
-
+        ctrl.matches = [];
+        ctrl.hidden  = true;
+        ctrl.index   = getDefaultIndex();
         break;
       default:
     }


### PR DESCRIPTION
If you press ESCAPE inside an autocomplete control, the input will always be captured, always clear the selection, and always blur.

The first change

        if (ctrl.hidden && !ctrl.loading) //fixes escape event not being sent up
            return;

 only responds when the autocomplete dropdown is hidden and not loading, which means the key event is sent upwards. This allows you to close dialogs when focused on an autocomplete control.

The removal of

        clearValue();

        // Force the component to blur if they hit escape
        doBlur(true);

and replaced with 

        ctrl.matches = [];
        ctrl.hidden  = true;
        ctrl.index   = getDefaultIndex();

is the EXACT same Google Chrome Autocomplete interaction. Escape will close the dropdown while the dropdown stays in focus. ESCAPE never clears the value of the window in Google Chrome. If the user wants to go one step further to provide this interaction (clear and blur focus), this is actually now supported because the ESCAPE key event is passed up.

This would keep user input consistent with the commonly used browser (Google Chrome). I'm not sure how Safari, Firefox, Edge, etc work, but I would assume they work the same.