### PR TITLE
fix(select): fix boolean validation multiple attribute

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -171,14 +171,16 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       element.parent().append(autofillClone);
     }
 
+    var isMultiple = angular.isDefined(attr.multiple) && attr.multiple !== 'false';
+
     // Use everything that's left inside element.contents() as the contents of the menu
-    var multiple = angular.isDefined(attr.multiple) ? 'multiple' : '';
+    var multipleContent = isMultiple ? 'multiple' : '';
     var selectTemplate = '' +
       '<div class="md-select-menu-container" aria-hidden="true">' +
       '<md-select-menu {0}>{1}</md-select-menu>' +
       '</div>';
 
-    selectTemplate = $mdUtil.supplant(selectTemplate, [multiple, element.html()]);
+    selectTemplate = $mdUtil.supplant(selectTemplate, [multipleContent, element.html()]);
     element.empty().append(valueEl);
     element.append(selectTemplate);
 
@@ -387,7 +389,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       var ariaAttrs = {
         role: 'listbox',
         'aria-expanded': 'false',
-        'aria-multiselectable': attr.multiple !== undefined && !attr.ngMultiple ? 'true' : 'false'
+        'aria-multiselectable': isMultiple && !attr.ngMultiple ? 'true' : 'false'
       };
 
       if (!element[0].hasAttribute('id')) {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -708,6 +708,16 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([1,3]);
       }));
 
+      it('should not be multiple if attr.multiple == `false`', inject(function($document) {
+        var el = setupSelect('multiple="false" ng-model="$root.model"').find('md-select');
+        openSelect(el);
+        expectSelectOpen(el);
+
+        var selectMenu = $document.find('md-select-menu')[0];
+
+        expect(selectMenu.hasAttribute('multiple')).toBe(false);
+      }));
+
     });
   });
 


### PR DESCRIPTION
Currently we just ignore the `false` <boolean> string.
That's why we should check for a `false` attribute string.
A truthy check won't work here.

Fixes  #6698