### PR TITLE
perf(icon): avoid multiple renders on frequent changes

### DIFF
--- a/src/components/icon/js/iconDirective.js
+++ b/src/components/icon/js/iconDirective.js
@@ -212,9 +212,11 @@ function mdIconDirective($mdIcon, $mdTheming, $mdAria ) {
 
         element.empty();
         if (attrVal) {
-          $mdIcon(attrVal).then(function(svg) {
-            element.append(svg);
-          });
+          $mdIcon(attrVal)
+            .then(function(svg) {
+              element.empty();
+              element.append(svg);
+            });
         }
 
       });


### PR DESCRIPTION
When the source value quickly changes it causing multiple icons rendering,
The `attr.$observe` callback gets executed twice, attempting to clear the container element, before the $mdIcon service's promise gets resolved.
This results in 2 SVGs getting appended to the element, without it being cleared.

Calling empty when the promise is resolved.

KUDOS to @voithos

fixes #5598