### PR TITLE
refactor(bottomSheet,dialog,list,select,input,menu,menuBar): denote private classes with _md prfix

### DIFF
--- a/docs/app/partials/menu-link.tmpl.html
+++ b/docs/app/partials/menu-link.tmpl.html
@@ -3,7 +3,7 @@
     ng-href="{{section.url}}"
     ng-click="focusSection()">
   {{section | humanizeDoc}}
-  <span class="md-visually-hidden"
+  <span class="_md-visually-hidden"
     ng-if="isSelected()">
     current page
   </span>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -65,7 +65,7 @@
             <span ng-if="menu.currentPage.name !== menu.currentSection.name">
               <span hide-sm hide-md>{{menu.currentSection.name}}</span>
               <span class="docs-menu-separator-icon" hide-sm hide-md style="transform: translate3d(0, 1px, 0)">
-                <span class="md-visually-hidden">-</span>
+                <span class="_md-visually-hidden">-</span>
                 <md-icon
                     aria-hidden="true"
                     md-svg-src="img/icons/ic_chevron_right_24px.svg"

--- a/src/components/bottomSheet/bottom-sheet.scss
+++ b/src/components/bottomSheet/bottom-sheet.scss
@@ -72,11 +72,6 @@ md-bottom-sheet {
       align-items: center;
       height: $bottom-sheet-list-item-height;
 
-      div.md-icon-container {
-        display: inline-block;
-        height: 3 * $baseline-grid;
-        margin-right: $bottom-sheet-icon-after-margin;
-      }
     }
   }
 
@@ -153,14 +148,6 @@ md-bottom-sheet {
         flex-direction: column;
         align-items: center;
         width: 10 * $baseline-grid;
-      }
-
-      .md-icon-container {
-        display: inline-block;
-        box-sizing: border-box;
-        height: 6 * $baseline-grid;
-        width: 6 * $baseline-grid;
-        margin: 0 0;
       }
 
       .md-grid-text {

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -481,9 +481,9 @@ function MdDialogProvider($$interimElementProvider) {
         '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
         '  <md-dialog-content class="md-dialog-content" role="document" tabIndex="-1">',
         '    <h2 class="md-title">{{ dialog.title }}</h2>',
-        '    <div ng-if="::dialog.mdHtmlContent" class="md-dialog-content-body" ',
+        '    <div ng-if="::dialog.mdHtmlContent" class="_md-dialog-content-body" ',
         '        ng-bind-html="::dialog.mdHtmlContent"></div>',
-        '    <div ng-if="::!dialog.mdHtmlContent" class="md-dialog-content-body">',
+        '    <div ng-if="::!dialog.mdHtmlContent" class="_md-dialog-content-body">',
         '      <p>{{::dialog.mdTextContent}}</p>',
         '    </div>',
         '  </md-dialog-content>',
@@ -530,7 +530,7 @@ function MdDialogProvider($$interimElementProvider) {
       autoWrap: true,
       fullscreen: false,
       transformTemplate: function(template, options) {
-        return '<div class="md-dialog-container">' + validatedTemplate(template) + '</div>';
+        return '<div class="_md-dialog-container">' + validatedTemplate(template) + '</div>';
 
         /**
          * The specified template should contain a <md-dialog> wrapper element....
@@ -870,7 +870,7 @@ function MdDialogProvider($$interimElementProvider) {
       // Set up elements before and after the dialog content to capture focus and
       // redirect back into the dialog.
       topFocusTrap = document.createElement('div');
-      topFocusTrap.classList.add('md-dialog-focus-trap');
+      topFocusTrap.classList.add('_md-dialog-focus-trap');
       topFocusTrap.tabIndex = 0;
 
       bottomFocusTrap = topFocusTrap.cloneNode(false);
@@ -957,7 +957,7 @@ function MdDialogProvider($$interimElementProvider) {
       var dialogEl = container.find('md-dialog');
       var animator = $mdUtil.dom.animator;
       var buildTranslateToOrigin = animator.calculateZoomToOrigin;
-      var translateOptions = {transitionInClass: 'md-transition-in', transitionOutClass: 'md-transition-out'};
+      var translateOptions = {transitionInClass: '_md-transition-in', transitionOutClass: '_md-transition-out'};
       var from = animator.toTransformCss(buildTranslateToOrigin(dialogEl, options.openFrom || options.origin));
       var to = animator.toTransformCss("");  // defaults to center display (or parent or $rootElement)
 
@@ -974,7 +974,7 @@ function MdDialogProvider($$interimElementProvider) {
 
             if (options.closeTo) {
               // Using the opposite classes to create a close animation to the closeTo element
-              translateOptions = {transitionInClass: 'md-transition-out', transitionOutClass: 'md-transition-in'};
+              translateOptions = {transitionInClass: '_md-transition-out', transitionOutClass: '_md-transition-in'};
               from = to;
               to = animator.toTransformCss(buildTranslateToOrigin(dialogEl, options.closeTo));
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -3,7 +3,7 @@ $dialog-padding: $baseline-grid * 3;
 .md-dialog-is-showing {
   max-height: 100%;
 }
-.md-dialog-container {
+._md-dialog-container {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -18,12 +18,12 @@ $dialog-padding: $baseline-grid * 3;
 
 md-dialog {
 
-  &.md-transition-in {
+  &._md-transition-in {
     opacity: 1;
     transition: $swift-ease-out;
     transform: translate3d(0,0,0) scale(1.0);
   }
-  &.md-transition-out {
+  &._md-transition-out {
     opacity: 0;
     transition: $swift-ease-out;
     transform: translate3d(0,100%,0) scale(0.2);
@@ -67,21 +67,9 @@ md-dialog {
 
     .md-subheader {
       margin: 0;
-
-      &.sticky-clone {
-        box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.16);
-      }
-    }
-    &.sticky-container {
-      padding: 0;
-
-      &> div {
-        padding: $dialog-padding;
-        padding-top: 0;
-      }
     }
 
-    .md-dialog-content-body {
+    ._md-dialog-content-body {
       width:100%;
     }
   }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -49,11 +49,11 @@ describe('$mdDialog', function() {
           $rootScope.$apply();
           runAnimation();
 
-          var mdContainer = angular.element(parent[0].querySelector('.md-dialog-container'));
+          var mdContainer = angular.element(parent[0].querySelector('._md-dialog-container'));
           var mdDialog = mdContainer.find('md-dialog');
           var mdContent = mdDialog.find('md-dialog-content');
           var title = mdContent.find('h2');
-          var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
+          var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
           var buttons = parent.find('md-button');
           var css = mdDialog.attr('class').split(' ');
 
@@ -90,11 +90,11 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
       runAnimation();
 
-      var mdContainer = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var mdContainer = angular.element(parent[0].querySelector('._md-dialog-container'));
       var mdDialog = mdContainer.find('md-dialog');
       var mdContent = mdDialog.find('md-dialog-content');
       var title = mdContent.find('h2');
-      var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
+      var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
       var buttons = parent.find('md-button');
       var theme = mdDialog.attr('md-theme');
       var css = mdDialog.attr('class').split(' ');
@@ -137,7 +137,7 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('md-dialog-content'));
     }));
 
-    it('should remove `md-dialog-container` on mousedown mouseup and remove', inject(function($mdDialog, $rootScope, $timeout) {
+    it('should remove `_md-dialog-container` on mousedown mouseup and remove', inject(function($mdDialog, $rootScope, $timeout) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
 
@@ -155,7 +155,7 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       container.triggerHandler({
         type: 'mousedown',
         target: container[0]
@@ -168,11 +168,11 @@ describe('$mdDialog', function() {
       $timeout.flush();
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(0);
     }));
 
-    it('should remove `md-dialog-container` on scope.$destroy()', inject(function($mdDialog, $rootScope, $timeout) {
+    it('should remove `_md-dialog-container` on scope.$destroy()', inject(function($mdDialog, $rootScope, $timeout) {
       var container, parent = angular.element('<div>');
 
       $mdDialog.show(
@@ -189,7 +189,7 @@ describe('$mdDialog', function() {
 
       runAnimation(parent.find('md-dialog'));
         $rootScope.$destroy();
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
 
       expect(container.length).toBe(0);
     }));
@@ -219,10 +219,10 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var dialog = parent.find('md-dialog');
       var title = parent.find('h2');
-      var contentBody = parent[0].querySelector('.md-dialog-content-body');
+      var contentBody = parent[0].querySelector('._md-dialog-content-body');
       var buttons = parent.find('md-button');
 
       expect(dialog.attr('role')).toBe('dialog');
@@ -254,7 +254,7 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var content = angular.element(container[0].querySelector('.mine'));
 
       expect(content.text()).toBe('Choose');
@@ -275,7 +275,7 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var contentBody = parent[0].querySelector('.md-dialog-content-body');
+      var contentBody = parent[0].querySelector('._md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('<div class="mine">Choose</div>');
     }));
@@ -295,8 +295,8 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-      var contentBody = container[0].querySelector('.md-dialog-content-body');
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
+      var contentBody = container[0].querySelector('._md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('Choose breakfast');
     }));
@@ -316,8 +316,8 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-      var contentBody = container[0].querySelector('.md-dialog-content-body');
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
+      var contentBody = container[0].querySelector('._md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('{{1 + 1}}');
     }));
@@ -340,7 +340,7 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('.dialog-close'));
     }));
 
-    it('should remove `md-dialog-container` after mousedown mouseup outside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
+    it('should remove `_md-dialog-container` after mousedown mouseup outside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
 
@@ -359,7 +359,7 @@ describe('$mdDialog', function() {
       );
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       container.triggerHandler({
         type: 'mousedown',
         target: container[0]
@@ -372,11 +372,11 @@ describe('$mdDialog', function() {
       runAnimation();
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(0);
     }));
 
-    it('should not remove `md-dialog-container` after mousedown outside mouseup inside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
+    it('should not remove `_md-dialog-container` after mousedown outside mouseup inside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
 
@@ -395,7 +395,7 @@ describe('$mdDialog', function() {
       );
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var content = angular.element(parent[0].querySelector('md-dialog-content'));
       container.triggerHandler({
         type: 'mousedown',
@@ -409,11 +409,11 @@ describe('$mdDialog', function() {
       runAnimation();
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(1);
     }));
 
-    it('should not remove `md-dialog-container` after mousedown inside mouseup outside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
+    it('should not remove `_md-dialog-container` after mousedown inside mouseup outside', inject(function($mdDialog, $rootScope, $timeout, $animate) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
 
@@ -432,7 +432,7 @@ describe('$mdDialog', function() {
       );
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var content = angular.element(parent[0].querySelector('md-dialog-content'));
       content.triggerHandler({
         type: 'mousedown',
@@ -446,11 +446,11 @@ describe('$mdDialog', function() {
       runAnimation();
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(1);
     }));
 
-    it('should remove `md-dialog-container` after ESCAPE key', inject(function($mdDialog, $rootScope, $timeout, $mdConstant) {
+    it('should remove `_md-dialog-container` after ESCAPE key', inject(function($mdDialog, $rootScope, $timeout, $mdConstant) {
       jasmine.mockElementFocus(this);
       var container, parent = angular.element('<div>');
       var response;
@@ -480,7 +480,7 @@ describe('$mdDialog', function() {
       runAnimation();
       runAnimation();
 
-      container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(0);
       expect(response).toBe(undefined);
     }));
@@ -504,7 +504,7 @@ describe('$mdDialog', function() {
 
       function onShowing(scope, element, options) {
         showing = true;
-        container = angular.element(parent[0].querySelector('.md-dialog-container'));
+        container = angular.element(parent[0].querySelector('._md-dialog-container'));
         expect(container.length).toBe(0);
       }
 
@@ -529,7 +529,7 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       expect(container.length).toBe(1);
       expect(ready).toBe(true);
     }));
@@ -552,7 +552,7 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
       expect(closing).toBe(false);
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       runAnimation();
 
       parent.triggerHandler({
@@ -583,7 +583,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       var owner = angular.element(body[0].querySelector('#owner'));
-      var container = angular.element(body[0].querySelector('.md-dialog-container'));
+      var container = angular.element(body[0].querySelector('._md-dialog-container'));
 
       expect(container[0].parentNode === owner[0]).toBe(true);
       nodes.remove();
@@ -645,7 +645,7 @@ describe('$mdDialog', function() {
       }));
     });
 
-    it('should append dialog within a md-dialog-container', inject(function($mdDialog, $rootScope) {
+    it('should append dialog within a _md-dialog-container', inject(function($mdDialog, $rootScope) {
 
       var template = '<md-dialog>Hello</md-dialog>';
       var parent = angular.element('<div>');
@@ -657,7 +657,7 @@ describe('$mdDialog', function() {
 
       $rootScope.$apply();
 
-      var container = parent[0].querySelectorAll('.md-dialog-container');
+      var container = parent[0].querySelectorAll('._md-dialog-container');
       expect(container.length).toBe(1);
     }));
 
@@ -670,7 +670,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       runAnimation();
 
       expect(parent.find('md-dialog').length).toBe(1);
@@ -694,7 +694,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       runAnimation();
       expect(parent.find('md-dialog').length).toBe(1);
 
@@ -714,7 +714,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       runAnimation();
       expect(parent.find('md-dialog').length).toBe(1);
 
@@ -744,7 +744,7 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
       expect(parent.find('md-dialog').length).toBe(1);
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
 
       container.triggerHandler({
         type: 'click',
@@ -834,7 +834,7 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
       runAnimation();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       runAnimation();
 
       expect($document.activeElement).toBe(undefined);
@@ -859,7 +859,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var dialog = parent.find('md-dialog');
 
       $$rAF.flush();
@@ -905,7 +905,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var dialog = parent.find('md-dialog');
 
       triggerTransitionEnd(dialog, false);
@@ -948,7 +948,7 @@ describe('$mdDialog', function() {
       });
       $rootScope.$apply();
 
-      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      var container = angular.element(parent[0].querySelector('._md-dialog-container'));
       var dialog = parent.find('md-dialog');
 
       verifyTransformCss(dialog, $mdConstant.CSS.TRANSFORM,
@@ -1188,7 +1188,7 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
 
       // It should add two focus traps to the document around the dialog content.
-      var focusTraps = parent.querySelectorAll('.md-dialog-focus-trap');
+      var focusTraps = parent.querySelectorAll('._md-dialog-focus-trap');
       expect(focusTraps.length).toBe(2);
 
       var topTrap = focusTraps[0];
@@ -1213,7 +1213,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       // All of the focus traps should be removed when the dialog is closed.
-      focusTraps = document.querySelectorAll('.md-dialog-focus-trap');
+      focusTraps = document.querySelectorAll('._md-dialog-focus-trap');
       expect(focusTraps.length).toBe(0);
 
       // Clean up our modifications to the DOM.
@@ -1267,11 +1267,11 @@ describe('$mdDialog with custom interpolation symbols', function() {
     $mdDialog.show(dialog);
     $rootScope.$digest();
 
-    var mdContainer = angular.element(parent[0].querySelector('.md-dialog-container'));
+    var mdContainer = angular.element(parent[0].querySelector('._md-dialog-container'));
     var mdDialog = mdContainer.find('md-dialog');
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
-    var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
+    var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
     var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
@@ -1294,11 +1294,11 @@ describe('$mdDialog with custom interpolation symbols', function() {
     $mdDialog.show(dialog);
     $rootScope.$digest();
 
-    var mdContainer = angular.element(parent[0].querySelector('.md-dialog-container'));
+    var mdContainer = angular.element(parent[0].querySelector('._md-dialog-container'));
     var mdDialog = mdContainer.find('md-dialog');
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
-    var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
+    var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
     var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -11,7 +11,7 @@ md-input-container.md-THEME_NAME-theme {
   }
 
   label,
-  .md-placeholder {
+  ._md-placeholder {
     text-shadow: '{{foreground-shadow}}';
     color: '{{foreground-3}}';
   }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -75,13 +75,13 @@ function mdInputContainerDirective($mdTheming, $parse) {
     };
     self.element = $element;
     self.setFocused = function(isFocused) {
-      $element.toggleClass('md-input-focused', !!isFocused);
+      $element.toggleClass('_md-input-focused', !!isFocused);
     };
     self.setHasValue = function(hasValue) {
-      $element.toggleClass('md-input-has-value', !!hasValue);
+      $element.toggleClass('_md-input-has-value', !!hasValue);
     };
     self.setHasPlaceholder = function(hasPlaceholder) {
-      $element.toggleClass('md-input-has-placeholder', !!hasPlaceholder);
+      $element.toggleClass('_md-input-has-placeholder', !!hasPlaceholder);
     };
     self.setInvalid = function(isInvalid) {
       if (isInvalid) {
@@ -105,7 +105,7 @@ function labelDirective() {
     restrict: 'E',
     require: '^?mdInputContainer',
     link: function(scope, element, attr, containerCtrl) {
-      if (!containerCtrl || attr.mdNoFloat || element.hasClass('md-container-ignore')) return;
+      if (!containerCtrl || attr.mdNoFloat || element.hasClass('_md-container-ignore')) return;
 
       containerCtrl.label = element;
       scope.$on('$destroy', function() {

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -86,7 +86,7 @@ md-input-container {
     -ms-flex-preferred-size: auto; //IE fix
   }
 
-  label:not(.md-container-ignore) {
+  label:not(._md-container-ignore) {
     position: absolute;
     bottom: 100%;
     @include rtl(left, 0, auto);
@@ -103,8 +103,8 @@ md-input-container {
     }
   }
 
-  label:not(.md-no-float):not(.md-container-ignore),
-  .md-placeholder {
+  label:not(.md-no-float):not(._md-container-ignore),
+  ._md-placeholder {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
@@ -116,19 +116,19 @@ md-input-container {
 
     @include rtl(transform-origin, left top, right top);
   }
-  .md-placeholder {
+  ._md-placeholder {
     position: absolute;
     top: 0;
     opacity: 0;
     transition-property: opacity, transform;
     transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
   }
-  &.md-input-focused .md-placeholder {
+  &.md-input-focused ._md-placeholder {
     opacity: 1;
     transform: translate3d(0, $input-placeholder-offset, 0);
   }
   // Placeholder should immediately disappear when the user starts typing
-  &.md-input-has-value .md-placeholder {
+  &.md-input-has-value ._md-placeholder {
     transition: none;
     opacity: 0;
   }

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -92,13 +92,13 @@ describe('md-input-container directive', function() {
 
   it('should set focus class on container', function() {
     var el = setup();
-    expect(el).not.toHaveClass('md-input-focused');
+    expect(el).not.toHaveClass('_md-input-focused');
 
     el.find('input').triggerHandler('focus');
-    expect(el).toHaveClass('md-input-focused');
+    expect(el).toHaveClass('_md-input-focused');
 
     el.find('input').triggerHandler('blur');
-    expect(el).not.toHaveClass('md-input-focused');
+    expect(el).not.toHaveClass('_md-input-focused');
   });
 
   it('not should set focus class on container if readonly', function() {
@@ -114,25 +114,25 @@ describe('md-input-container directive', function() {
 
   it('should set has-value class on container for non-ng-model input', function() {
     var el = setup();
-    expect(el).not.toHaveClass('md-input-has-value');
+    expect(el).not.toHaveClass('_md-input-has-value');
 
     el.find('input').val('123').triggerHandler('input');
-    expect(el).toHaveClass('md-input-has-value');
+    expect(el).toHaveClass('_md-input-has-value');
 
     el.find('input').val('').triggerHandler('input');
-    expect(el).not.toHaveClass('md-input-has-value');
+    expect(el).not.toHaveClass('_md-input-has-value');
   });
 
   it('should set has-value class on container for ng-model input', function() {
     pageScope.value = 'test';
     var el = setup('ng-model="value"');
-    expect(el).toHaveClass('md-input-has-value');
+    expect(el).toHaveClass('_md-input-has-value');
 
     pageScope.$apply('value = "3"');
-    expect(el).toHaveClass('md-input-has-value');
+    expect(el).toHaveClass('_md-input-has-value');
 
     pageScope.$apply('value = null');
-    expect(el).not.toHaveClass('md-input-has-value');
+    expect(el).not.toHaveClass('_md-input-has-value');
   });
 
   it('should match label to given input id', function() {
@@ -246,7 +246,7 @@ describe('md-input-container directive', function() {
       '</md-input-container>'
     )($rootScope);
 
-    expect(el.hasClass('md-input-has-placeholder')).toBe(true);
+    expect(el.hasClass('_md-input-has-placeholder')).toBe(true);
   }));
 
   it('should put placeholder into a label element', function() {
@@ -298,7 +298,7 @@ describe('md-input-container directive', function() {
     var element = $compile(template)(scope);
     scope.$apply();
 
-    expect(element.hasClass('md-input-has-value')).toBe(true);
+    expect(element.hasClass('_md-input-has-value')).toBe(true);
   });
 
   it('adds the md-auto-hide class to messages without a visiblity directive', inject(function() {

--- a/src/components/list/demoListControls/style.css
+++ b/src/components/list/demoListControls/style.css
@@ -4,9 +4,9 @@ md-divider {
 }
 
 md-list-item > p,
-md-list-item > .md-list-item-inner > p,
-md-list-item .md-list-item-inner > p,
-md-list-item .md-list-item-inner > .md-list-item-inner > p {
+md-list-item > ._md-list-item-inner > p,
+md-list-item ._md-list-item-inner > p,
+md-list-item ._md-list-item-inner > ._md-list-item-inner > p {
     -webkit-user-select: none; /* Chrome all / Safari all */
     -moz-user-select: none; /* Firefox all */
     -ms-user-select: none; /* IE 10+ */

--- a/src/components/list/list-theme.scss
+++ b/src/components/list/list-theme.scss
@@ -8,7 +8,7 @@ md-list.md-THEME_NAME-theme {
       color: '{{foreground-2}}';
     }
   }
-  .md-proxy-focus.md-focused div.md-no-style {
+  ._md-proxy-focus._md-focused div._md-no-style {
     background-color: '{{background-100}}';
   }
 

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -107,7 +107,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         if (hasProxiedElement) {
           wrapIn('div');
         } else if (!tEl[0].querySelector('md-button:not(.md-secondary):not(.md-exclude)')) {
-          tEl.addClass('md-no-proxy');
+          tEl.addClass('_md-no-proxy');
         }
       }
       wrapSecondary();
@@ -132,11 +132,11 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       function wrapIn(type) {
         var container;
         if (type == 'div') {
-          container = angular.element('<div class="md-no-style md-list-item-inner">');
+          container = angular.element('<div class="_md-no-style _md-list-item-inner">');
           container.append(tEl.contents());
-          tEl.addClass('md-proxy-focus');
+          tEl.addClass('_md-proxy-focus');
         } else {
-          container = angular.element('<md-button class="md-no-style"><div class="md-list-item-inner"></div></md-button>');
+          container = angular.element('<md-button class="_md-no-style"><div class="_md-list-item-inner"></div></md-button>');
           copyAttributes(tEl[0], container[0]);
           container.children().eq(0).append(tEl.contents());
         }
@@ -148,7 +148,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       function wrapSecondary() {
         if (secondaryItem && !isButton(secondaryItem) && secondaryItem.hasAttribute('ng-click')) {
           $mdAria.expect(secondaryItem, 'aria-label');
-          var buttonWrapper = angular.element('<md-button class="md-secondary-container md-icon-button">');
+          var buttonWrapper = angular.element('<md-button class="_md-secondary-container md-icon-button">');
           copyAttributes(secondaryItem, buttonWrapper[0]);
           secondaryItem.setAttribute('tabindex', '-1');
           secondaryItem.classList.remove('md-secondary');
@@ -199,7 +199,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         computeProxies();
         computeClickable();
 
-        if ($element.hasClass('md-proxy-focus') && proxies.length) {
+        if ($element.hasClass('_md-proxy-focus') && proxies.length) {
           angular.forEach(proxies, function(proxy) {
             proxy = angular.element(proxy);
 
@@ -211,9 +211,9 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
               }, 100);
             })
             .on('focus', function() {
-              if ($scope.mouseActive === false) { $element.addClass('md-focused'); }
+              if ($scope.mouseActive === false) { $element.addClass('_md-focused'); }
               proxy.on('blur', function proxyOnBlur() {
-                $element.removeClass('md-focused');
+                $element.removeClass('_md-focused');
                 proxy.off('blur', proxyOnBlur);
               });
             });
@@ -243,7 +243,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
             $element.addClass('md-clickable');
 
             if (!hasClick) {
-              ctrl.attachRipple($scope, angular.element($element[0].querySelector('.md-no-style')));
+              ctrl.attachRipple($scope, angular.element($element[0].querySelector('._md-no-style')));
             }
           }
         }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -42,11 +42,11 @@ md-list-item {
   // Ensure nested dividers are properly positioned
   position: relative;
 
-  &.md-proxy-focus.md-focused .md-no-style {
+  &._md-proxy-focus._md-focused ._md-no-style {
     transition: background-color 0.15s linear;
   }
-  &.md-no-proxy,
-  .md-no-style {
+  &._md-no-proxy,
+  ._md-no-style {
     position: relative;
     padding: $list-item-padding-vertical $list-item-padding-horizontal;
     flex: 1 1 auto;
@@ -90,7 +90,7 @@ md-list-item {
   }
 }
 
-md-list-item, md-list-item .md-list-item-inner {
+md-list-item, md-list-item ._md-list-item-inner {
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -153,7 +153,7 @@ md-list-item, md-list-item .md-list-item-inner {
     margin-right: -6px;
   }
 
-  button.md-button.md-secondary-container {
+  button.md-button._md-secondary-container {
     background-color: transparent;
     align-self: center;
     border-radius: 50%;
@@ -170,7 +170,7 @@ md-list-item, md-list-item .md-list-item-inner {
     }
   }
 
-  .md-secondary-container,
+  ._md-secondary-container,
   .md-secondary {
     position: absolute;
     top: 50%;
@@ -179,12 +179,12 @@ md-list-item, md-list-item .md-list-item-inner {
     transform: translate3d(0, -50%, 0);
   }
 
-  & > .md-button.md-secondary-container > .md-secondary {
+  & > .md-button._md-secondary-container > .md-secondary {
     margin-left: 0;
     position: static;
   }
 
-  & > p, & > .md-list-item-inner > p {
+  & > p, & > ._md-list-item-inner > p {
     flex: 1;
     margin: 0;
   }
@@ -192,9 +192,9 @@ md-list-item, md-list-item .md-list-item-inner {
 
 
 md-list-item.md-2-line,
-md-list-item.md-2-line > .md-no-style,
+md-list-item.md-2-line > ._md-no-style,
 md-list-item.md-3-line,
-md-list-item.md-3-line > .md-no-style {
+md-list-item.md-3-line > ._md-no-style {
   align-items: flex-start;
   justify-content: center;
 
@@ -238,7 +238,7 @@ md-list-item.md-3-line > .md-no-style {
 }
 
 md-list-item.md-2-line,
-md-list-item.md-2-line > .md-no-style {
+md-list-item.md-2-line > ._md-no-style {
   height:auto;
   min-height: $list-item-two-line-height;
   &.md-long-text {
@@ -257,7 +257,7 @@ md-list-item.md-2-line > .md-no-style {
 }
 
 md-list-item.md-3-line,
-md-list-item.md-3-line > .md-no-style {
+md-list-item.md-3-line > ._md-no-style {
   height:auto;
   min-height: $list-item-three-line-height;
 

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -154,7 +154,7 @@ describe('mdListItem directive', function() {
       '  <md-button class="md-exclude" ng-click="sayHello()">Hello</md-button>' +
       '</md-list-item>'
     );
-    expect(listItem.hasClass('md-no-proxy')).toBeTruthy();
+    expect(listItem.hasClass('_md-no-proxy')).toBeTruthy();
   });
 
   it('should copy md-icon.md-secondary attributes to the button', function() {

--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -133,13 +133,13 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
   $scope.$watch(function() { return self.isOpen; }, function(isOpen) {
     if (isOpen) {
       menuContainer.attr('aria-hidden', 'false');
-      $element[0].classList.add('md-open');
+      $element[0].classList.add('_md-open');
       angular.forEach(self.nestedMenus, function(el) {
-        el.classList.remove('md-open');
+        el.classList.remove('_md-open');
       });
     } else {
       menuContainer.attr('aria-hidden', 'true');
-      $element[0].classList.remove('md-open');
+      $element[0].classList.remove('_md-open');
     }
     $scope.$mdMenuIsOpen = self.isOpen;
   });

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -184,7 +184,7 @@ function MenuDirective($mdUtil) {
         if (!menuEl.hasAttribute('md-position-mode')) {
           menuEl.setAttribute('md-position-mode', 'cascade');
         }
-        menuEl.classList.add('md-nested-menu');
+        menuEl.classList.add('_md-nested-menu');
         menuEl.setAttribute('md-nest-level', nestingDepth + 1);
       });
     }
@@ -196,7 +196,7 @@ function MenuDirective($mdUtil) {
     var isInMenuBar = ctrls[1] != undefined;
     // Move everything into a md-menu-container and pass it to the controller
     var menuContainer = angular.element(
-      '<div class="md-open-menu-container md-whiteframe-z2"></div>'
+      '<div class="_md-open-menu-container md-whiteframe-z2"></div>'
     );
     var menuContents = element.children()[1];
     if (!menuContents.hasAttribute('role')) {

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -87,14 +87,14 @@ function MenuProvider($$interimElementProvider) {
        * For forced closes (like $destroy events), skip the animations
        */
       function animateRemoval() {
-        return $animateCss(element, {addClass: 'md-leave'}).start();
+        return $animateCss(element, {addClass: '_md-leave'}).start();
       }
 
       /**
        * Detach the element
        */
       function detachAndClean() {
-        element.removeClass('md-active');
+        element.removeClass('_md-active');
         detachElement(element, opts);
         opts.alreadyOpen = false;
       }
@@ -133,12 +133,12 @@ function MenuProvider($$interimElementProvider) {
         return $q(function(resolve) {
           var position = calculateMenuPosition(element, opts);
 
-          element.removeClass('md-leave');
+          element.removeClass('_md-leave');
 
           // Animate the menu scaling, and opacity [from its position origin (default == top-left)]
           // to normal scale.
           $animateCss(element, {
-            addClass: 'md-active',
+            addClass: '_md-active',
             from: animator.toCss(position),
             to: animator.toCss({transform: ''})
           })
@@ -197,7 +197,7 @@ function MenuProvider($$interimElementProvider) {
        * clicks, keypresses, backdrop closing, etc.
        */
       function activateInteraction() {
-        element.addClass('md-clickable');
+        element.addClass('_md-clickable');
 
         // close on backdrop click
         if (opts.backdrop) opts.backdrop.on('click', onBackdropClick);
@@ -220,7 +220,7 @@ function MenuProvider($$interimElementProvider) {
         focusTarget && focusTarget.focus();
 
         return function cleanupInteraction() {
-          element.removeClass('md-clickable');
+          element.removeClass('_md-clickable');
           if (opts.backdrop) opts.backdrop.off('click', onBackdropClick);
           opts.menuContentEl.off('keydown', onMenuKeyDown);
           opts.menuContentEl[0].removeEventListener('click', captureClickListener, true);
@@ -321,7 +321,7 @@ function MenuProvider($$interimElementProvider) {
         opts.menuContentEl[0].addEventListener('click', captureClickListener, true);
 
         return function cleanupInteraction() {
-          element.removeClass('md-clickable');
+          element.removeClass('_md-clickable');
           opts.menuContentEl.off('keydown');
           opts.menuContentEl[0].removeEventListener('click', captureClickListener, true);
         };

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -5,7 +5,7 @@ $dense-menu-item-height: 4 * $baseline-grid;
 $max-menu-height: 2 * $baseline-grid + $max-visible-items * $menu-item-height;
 $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-item-height;
 
-.md-open-menu-container {
+._md-open-menu-container {
   position: fixed;
   left: 0;
   top: 0;
@@ -27,12 +27,12 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
   }
 
   // Don't let the user click something until it's animated
-  &:not(.md-clickable) {
+  &:not(._md-clickable) {
     pointer-events: none;
   }
 
   // enter: menu scales in, then list fade in.
-  &.md-active {
+  &._md-active {
     opacity: 1;
     transition: $swift-ease-out;
     transition-duration: 200ms;
@@ -44,7 +44,7 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
     }
   }
   // leave: the container fades out
-  &.md-leave {
+  &._md-leave {
     opacity: 0;
     transition: $swift-ease-in;
     transition-duration: 250ms;

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -7,7 +7,7 @@ describe('material.components.menu', function() {
     $mdUtil = _$mdUtil_;
     $mdMenu = _$mdMenu_;
     $timeout = _$timeout_;
-    var abandonedMenus = $document[0].querySelectorAll('.md-open-menu-container');
+    var abandonedMenus = $document[0].querySelectorAll('._md-open-menu-container');
     angular.element(abandonedMenus).remove();
   }));
   afterEach(function() {
@@ -217,7 +217,7 @@ describe('material.components.menu', function() {
     var res;
     el = (el instanceof angular.element) ? el[0] : el;
     inject(function($document) {
-      var container = $document[0].querySelector('.md-open-menu-container');
+      var container = $document[0].querySelector('._md-open-menu-container');
       if (container && container.style.display == 'none') {
         res = [];
       } else {

--- a/src/components/menuBar/js/menuBarController.js
+++ b/src/components/menuBar/js/menuBarController.js
@@ -36,8 +36,8 @@ MenuBarController.prototype.init = function() {
 
   deregisterFns.push(this.$rootScope.$on('$mdMenuOpen', function(event, el) {
     if (self.getMenus().indexOf(el[0]) != -1) {
-      $element[0].classList.add('md-open');
-      el[0].classList.add('md-open');
+      $element[0].classList.add('_md-open');
+      el[0].classList.add('_md-open');
       self.currentlyOpenMenu = el.controller('mdMenu');
       self.currentlyOpenMenu.registerContainerProxy(self.handleKeyDown);
       self.enableOpenOnHover();
@@ -47,8 +47,8 @@ MenuBarController.prototype.init = function() {
   deregisterFns.push(this.$rootScope.$on('$mdMenuClose', function(event, el, opts) {
     var rootMenus = self.getMenus();
     if (rootMenus.indexOf(el[0]) != -1) {
-      $element[0].classList.remove('md-open');
-      el[0].classList.remove('md-open');
+      $element[0].classList.remove('_md-open');
+      el[0].classList.remove('_md-open');
     }
 
     if ($element[0].contains(el[0])) {
@@ -76,8 +76,8 @@ MenuBarController.prototype.init = function() {
 };
 
 MenuBarController.prototype.setKeyboardMode = function(enabled) {
-  if (enabled) this.$element[0].classList.add('md-keyboard-mode');
-  else this.$element[0].classList.remove('md-keyboard-mode');
+  if (enabled) this.$element[0].classList.add('_md-keyboard-mode');
+  else this.$element[0].classList.remove('_md-keyboard-mode');
 };
 
 MenuBarController.prototype.enableOpenOnHover = function() {
@@ -232,7 +232,7 @@ MenuBarController.prototype.getFocusedMenuIndex = function() {
 MenuBarController.prototype.getOpenMenuIndex = function() {
   var menus = this.getMenus();
   for (var i = 0; i < menus.length; ++i) {
-    if (menus[i].classList.contains('md-open')) return i;
+    if (menus[i].classList.contains('_md-open')) return i;
   }
   return -1;
 };

--- a/src/components/menuBar/js/menuBarDirective.js
+++ b/src/components/menuBar/js/menuBarDirective.js
@@ -114,7 +114,7 @@ function MenuBarDirective($mdUtil, $mdTheming) {
           }
           var contentEls = $mdUtil.nodesToArray(menuEl.querySelectorAll('md-menu-content'));
           angular.forEach(contentEls, function(contentEl) {
-            contentEl.classList.add('md-menu-bar-menu');
+            contentEl.classList.add('_md-menu-bar-menu');
             contentEl.classList.add('md-dense');
             if (!contentEl.hasAttribute('width')) {
               contentEl.setAttribute('width', 5);

--- a/src/components/menuBar/menu-bar-theme.scss
+++ b/src/components/menuBar/menu-bar-theme.scss
@@ -4,16 +4,16 @@ md-menu-bar.md-THEME_NAME-theme {
     border-radius: 2px;
   }
 
-  md-menu.md-open > button, md-menu > button:focus {
+  md-menu._md-open > button, md-menu > button:focus {
     outline: none;
     background: '{{background-200}}';
   }
 
-  &.md-open:not(.md-keyboard-mode) md-menu:hover > button {
+  &._md-open:not(._md-keyboard-mode) md-menu:hover > button {
     background-color: '{{ background-500-0.2}}';
   }
 
-  &:not(.md-keyboard-mode):not(.md-open) {
+  &:not(._md-keyboard-mode):not(._md-open) {
     md-menu button:hover,
     md-menu button:focus {
       background: transparent;
@@ -26,7 +26,7 @@ md-menu-content.md-THEME_NAME-theme {
     color: '{{foreground-2}}';
   }
 
-  .md-menu.md-open > .md-button {
+  .md-menu._md-open > .md-button {
     background-color: '{{ background-500-0.2}}';
   }
 }

--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -31,7 +31,7 @@ md-menu-bar {
   }
 }
 
-md-menu-content.md-menu-bar-menu.md-dense {
+md-menu-content._md-menu-bar-menu.md-dense {
   max-height: none;
   padding: 2 * $baseline-grid 0;
   md-menu-item.md-indent {

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -1,40 +1,40 @@
 md-select.md-THEME_NAME-theme {
-  &[disabled] .md-select-value {
+  &[disabled] ._md-select-value {
     border-bottom-color: transparent;
     background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
     background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
   }
-  .md-select-value {
-    &.md-select-placeholder {
+  ._md-select-value {
+    &._md-select-placeholder {
       color: '{{foreground-3}}';
     }
     border-bottom-color: '{{foreground-4}}';
   }
   &.ng-invalid.ng-dirty {
-    .md-select-value {
+    ._md-select-value {
       color: '{{warn-A700}}' !important;
       border-bottom-color: '{{warn-A700}}' !important;
     }
   }
   &:not([disabled]):focus {
-    .md-select-value {
+    ._md-select-value {
       border-bottom-color: '{{primary-color}}';
       color: '{{ foreground-1 }}';
-      &.md-select-placeholder {
+      &._md-select-placeholder {
         color: '{{ foreground-1 }}';
       }
     }
-    &.md-accent .md-select-value {
+    &.md-accent ._md-select-value {
       border-bottom-color: '{{accent-color}}';
     }
-    &.md-warn .md-select-value {
+    &.md-warn ._md-select-value {
       border-bottom-color: '{{warn-color}}';
     }
   }
   &[disabled] {
-    .md-select-value {
+    ._md-select-value {
       color: '{{foreground-3}}';
-      &.md-select-placeholder {
+      &._md-select-placeholder {
         color: '{{foreground-3}}';
       }
     }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -37,7 +37,7 @@ angular.module('material.components.select', [
  * @param {string=} placeholder Placeholder hint text.
  * @param {string=} aria-label Optional label for accessibility. Only necessary if no placeholder or
  * explicit label is present.
- * @param {string=} md-container-class Class list to get applied to the `.md-select-menu-container`
+ * @param {string=} md-container-class Class list to get applied to the `._md-select-menu-container`
  * element (for custom styling).
  *
  * @usage
@@ -121,8 +121,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
   function compile(element, attr) {
     // add the select value that will hold our placeholder or selected option value
     var valueEl = angular.element('<md-select-value><span></span></md-select-value>');
-    valueEl.append('<span class="md-select-icon" aria-hidden="true"></span>');
-    valueEl.addClass('md-select-value');
+    valueEl.append('<span class="_md-select-icon" aria-hidden="true"></span>');
+    valueEl.addClass('_md-select-value');
     if (!valueEl[0].hasAttribute('id')) {
       valueEl.attr('id', 'select_value_label_' + $mdUtil.nextUid());
     }
@@ -153,7 +153,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     }
 
     if (attr.name) {
-      var autofillClone = angular.element('<select class="md-visually-hidden">');
+      var autofillClone = angular.element('<select class="_md-visually-hidden">');
       autofillClone.attr({
         'name': '.' + attr.name,
         'ng-model': attr.ngModel,
@@ -174,7 +174,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     // Use everything that's left inside element.contents() as the contents of the menu
     var multiple = angular.isDefined(attr.multiple) ? 'multiple' : '';
     var selectTemplate = '' +
-      '<div class="md-select-menu-container" aria-hidden="true">' +
+      '<div class="_md-select-menu-container" aria-hidden="true">' +
       '<md-select-menu {0}>{1}</md-select-menu>' +
       '</div>';
 
@@ -257,14 +257,14 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       mdSelectCtrl.setIsPlaceholder = function(isPlaceholder) {
         if (isPlaceholder) {
-          valueEl.addClass('md-select-placeholder');
+          valueEl.addClass('_md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.addClass('md-placeholder');
+            containerCtrl.label.addClass('_md-placeholder');
           }
         } else {
-          valueEl.removeClass('md-select-placeholder');
+          valueEl.removeClass('_md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.removeClass('md-placeholder');
+            containerCtrl.label.removeClass('_md-placeholder');
           }
         }
       };
@@ -274,7 +274,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           .on('focus', function(ev) {
             // only set focus on if we don't currently have a selected value. This avoids the "bounce"
             // on the label transition because the focus will immediately switch to the open menu.
-            if (containerCtrl && containerCtrl.element.hasClass('md-input-has-value')) {
+            if (containerCtrl && containerCtrl.element.hasClass('_md-input-has-value')) {
               containerCtrl.setFocused(true);
             }
           });
@@ -422,7 +422,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       function findSelectContainer() {
         selectContainer = angular.element(
-          element[0].querySelector('.md-select-menu-container')
+          element[0].querySelector('._md-select-menu-container')
         );
         selectScope = scope;
         if (element.attr('md-container-class')) {
@@ -752,7 +752,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
-    element.append(angular.element('<div class="md-text">').append(element.contents()));
+    element.append(angular.element('<div class="_md-text">').append(element.contents()));
 
     element.attr('tabindex', attr.tabindex || '0');
     return postLink;
@@ -864,7 +864,7 @@ function OptgroupDirective() {
       labelElement = angular.element('<label>');
       el.prepend(labelElement);
     }
-    labelElement.addClass('md-container-ignore');
+    labelElement.addClass('_md-container-ignore');
     if (attrs.label) labelElement.text(attrs.label);
   }
 }
@@ -910,7 +910,7 @@ function SelectProvider($$interimElementProvider) {
        * skip the animations
        */
       function animateRemoval() {
-        return $animateCss(element, {addClass: 'md-leave'}).start();
+        return $animateCss(element, {addClass: '_md-leave'}).start();
       }
 
       /**
@@ -918,7 +918,7 @@ function SelectProvider($$interimElementProvider) {
        */
       function cleanElement() {
 
-        element.removeClass('md-active');
+        element.removeClass('_md-active');
         element.attr('aria-hidden', 'true');
         element[0].style.display = 'none';
 
@@ -966,7 +966,7 @@ function SelectProvider($$interimElementProvider) {
 
           try {
 
-            $animateCss(element, {removeClass: 'md-leave', duration: 0})
+            $animateCss(element, {removeClass: '_md-leave', duration: 0})
               .start()
               .then(positionAndFocusMenu)
               .then(resolve);
@@ -992,7 +992,7 @@ function SelectProvider($$interimElementProvider) {
           info.dropDown.element.css(animator.toCss(info.dropDown.styles));
 
           $$rAF(function() {
-            element.addClass('md-active');
+            element.addClass('_md-active');
             info.dropDown.element.css(animator.toCss({transform: ''}));
 
             autoFocus(opts.focusedNode);
@@ -1123,7 +1123,7 @@ function SelectProvider($$interimElementProvider) {
         var dropDown = opts.selectEl;
         var selectCtrl = dropDown.controller('mdSelectMenu') || {};
 
-        element.addClass('md-clickable');
+        element.addClass('_md-clickable');
 
         // Close on backdrop click
         opts.backdrop && opts.backdrop.on('click', onBackdropClick);
@@ -1138,7 +1138,7 @@ function SelectProvider($$interimElementProvider) {
           dropDown.off('keydown', onMenuKeyDown);
           dropDown.off('click', checkCloseMenu);
 
-          element.removeClass('md-clickable');
+          element.removeClass('_md-clickable');
           opts.isRemoved = true;
         };
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -5,7 +5,7 @@ $select-container-transition-duration: 350ms;
 
 $select-max-visible-options: 5;
 
-.md-select-menu-container {
+._md-select-menu-container {
   position: fixed;
   left: 0;
   top: 0;
@@ -14,7 +14,7 @@ $select-max-visible-options: 5;
   display: none;
 
   // Don't let the user select a new choice while it's animating
-  &:not(.md-clickable) {
+  &:not(._md-clickable) {
     pointer-events: none;
   }
 
@@ -25,7 +25,7 @@ $select-max-visible-options: 5;
 
 
   // enter: md-select scales in, then options fade in.
-  &.md-active {
+  &._md-active {
     display: block;
     opacity: 1;
     md-select-menu {
@@ -41,7 +41,7 @@ $select-max-visible-options: 5;
   }
 
   // leave: the container fades out
-  &.md-leave {
+  &._md-leave {
     opacity: 0;
     transition: $swift-ease-in;
     transition-duration: 250ms;
@@ -56,7 +56,7 @@ md-input-container > md-select {
 md-select {
   display: flex;
   margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
-  &[disabled] .md-select-value {
+  &[disabled] ._md-select-value {
     background-position: 0 bottom;
     // This background-size is coordinated with a linear-gradient set in select-theme.scss
     // to create a dotted line under the input.
@@ -75,13 +75,13 @@ md-select {
       cursor: pointer
     }
     &.ng-invalid.ng-dirty {
-      .md-select-value {
+      ._md-select-value {
         border-bottom: 2px solid;
         padding-bottom: 0;
       }
     }
     &:focus {
-      .md-select-value {
+      ._md-select-value {
         border-bottom-width: 2px;
         border-bottom-style: solid;
         padding-bottom: 0;
@@ -91,7 +91,7 @@ md-select {
 }
 
 
-.md-select-value {
+._md-select-value {
   display: flex;
   align-items: center;
   padding: 2px 2px 1px;
@@ -104,7 +104,7 @@ md-select {
   min-height: 26px;
   flex-grow: 1;
 
-  .md-text {
+  ._md-text {
     display: inline;
   }
 
@@ -116,7 +116,7 @@ md-select {
     transform: translate3d(0, 2px, 0);
   }
 
-  .md-select-icon {
+  ._md-select-icon {
     display: block;
     align-items: flex-end;
     text-align: end;
@@ -125,7 +125,7 @@ md-select {
     transform: translate3d(0, 1px, 0);
   }
 
-  .md-select-icon:after {
+  ._md-select-icon:after {
     display: block;
     content: '\25BC';
     position: relative;
@@ -134,7 +134,7 @@ md-select {
     transform: scaleY(0.6) scaleX(1);
   }
 
-  &.md-select-placeholder {
+  &._md-select-placeholder {
     display: flex;
     order: 1;
     pointer-events: none;
@@ -151,7 +151,7 @@ md-select-menu {
     flex-direction: column-reverse;
   }
 
-  &:not(.md-overflow) {
+  &:not(._md-overflow) {
     md-content {
       padding-top: $baseline-grid;
       padding-bottom: $baseline-grid;
@@ -193,7 +193,7 @@ md-option {
     outline: none;
   }
 
-  .md-text {
+  ._md-text {
     @include not-selectable();
     width: auto;
     white-space: nowrap;

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -11,7 +11,7 @@ describe('<md-select>', function() {
 
   afterEach(inject(function ($document) {
     var body = $document[0].body;
-    var children = body.querySelectorAll('.md-select-menu-container');
+    var children = body.querySelectorAll('._md-select-menu-container');
     for (var i = 0; i < children.length; i++) {
       angular.element(children[i]).remove();
     }
@@ -52,7 +52,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val", md-container-class="test"').find('md-select');
     openSelect(select);
 
-    var container = $document[0].querySelector('.md-select-menu-container');
+    var container = $document[0].querySelector('._md-select-menu-container');
     expect(container).toBeTruthy();
     expect(container.classList.contains('test')).toBe(true);
   }));
@@ -61,7 +61,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val"').find('md-select');
     var ownsId = select.attr('aria-owns'); 
     expect(ownsId).toBeTruthy();
-    var containerId = select[0].querySelector('.md-select-menu-container').getAttribute('id');
+    var containerId = select[0].querySelector('._md-select-menu-container').getAttribute('id');
     expect(ownsId).toBe(containerId);
   });
 
@@ -160,11 +160,11 @@ describe('<md-select>', function() {
 
     select.triggerHandler('focus');
 
-    expect(element.hasClass('md-input-focused')).toBe(true);
+    expect(element.hasClass('_md-input-focused')).toBe(true);
 
     select.triggerHandler('blur');
 
-    expect(element.hasClass('md-input-focused')).toBe(false);
+    expect(element.hasClass('_md-input-focused')).toBe(false);
 
   }));
 
@@ -179,16 +179,16 @@ describe('<md-select>', function() {
 
       waitForSelectClose();
 
-      expect(el).toHaveClass('md-input-has-value');
+      expect(el).toHaveClass('_md-input-has-value');
     }));
 
     it('should set has-value class on container for ng-model input', inject(function($rootScope) {
       $rootScope.value = 'test';
       var el = setupSelect('ng-model="$root.value"', ['test', 'no-test']);
-      expect(el).toHaveClass('md-input-has-value');
+      expect(el).toHaveClass('_md-input-has-value');
 
       $rootScope.$apply('value = null');
-      expect(el).not.toHaveClass('md-input-has-value');
+      expect(el).not.toHaveClass('_md-input-has-value');
     }));
 
     it('should match label to given input id', function() {
@@ -209,7 +209,7 @@ describe('<md-select>', function() {
       var select = setupSelect('ng-model="someVal", placeholder="Hello world"', null, true).find('md-select');
       var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
-      expect(label.hasClass('md-select-placeholder')).toBe(true);
+      expect(label.hasClass('_md-select-placeholder')).toBe(true);
     });
 
     it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
@@ -948,9 +948,9 @@ describe('<md-select>', function() {
 
   function expectSelectClosed(element) {
     inject(function($document) {
-      var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
+      var menu = angular.element($document[0].querySelector('._md-select-menu-container'));
       if (menu.length) {
-        if (menu.hasClass('md-active') || menu.attr('aria-hidden') == 'false') {
+        if (menu.hasClass('_md-active') || menu.attr('aria-hidden') == 'false') {
           throw Error('Expected select to be closed');
         }
       }
@@ -959,8 +959,8 @@ describe('<md-select>', function() {
 
   function expectSelectOpen(element) {
     inject(function($document) {
-      var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
-      if (!(menu.hasClass('md-active') && menu.attr('aria-hidden') == 'false')) {
+      var menu = angular.element($document[0].querySelector('._md-select-menu-container'));
+      if (!(menu.hasClass('_md-active') && menu.attr('aria-hidden') == 'false')) {
         throw Error('Expected select to be open');
       }
     });

--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -84,7 +84,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil) {
      ***************/
     // Add an element and its sticky clone to this content's sticky collection
     function add(element, stickyClone) {
-      stickyClone.addClass('md-sticky-clone');
+      stickyClone.addClass('_md-sticky-clone');
 
       var item = {
         element: element,

--- a/src/components/sticky/sticky.scss
+++ b/src/components/sticky/sticky.scss
@@ -1,4 +1,4 @@
-.md-sticky-clone {
+._md-sticky-clone {
   z-index: 2;
   top: 0;
   left: 0;

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -17,7 +17,7 @@ body {
   padding: 10px;
 }
 
-button.md-no-style {
+button._md-no-style {
   font-weight: normal;
   background-color: inherit;
   text-align: left;

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -64,7 +64,7 @@ input {
   }
 }
 
-.md-visually-hidden {
+._md-visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;


### PR DESCRIPTION
**Note**: This commit will break input until it has been updated with private classes. I modified some of the classes as they interact with `md-select`. Presumably @topherfangio changes will result in the same changes as I made resulting in full compatibility between select and input.