### PR TITLE
fix(button): add aria tests to button and uses by default the text content as aria-label

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -90,10 +90,8 @@ function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
     $mdTheming(element);
     $mdButtonInkRipple.attach(scope, element);
 
-    var elementHasText = node.textContent.trim();
-    if (!elementHasText) {
-      $mdAria.expect(element, 'aria-label');
-    }
+    var elementTextContent = node.textContent.trim();
+    $mdAria.expect(element, 'aria-label', elementTextContent);
 
     // For anchor elements, we have to set tabindex manually when the
     // element is disabled

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -29,6 +29,20 @@ describe('md-button', function() {
     expect($log.warn).not.toHaveBeenCalled();
   }));
 
+  it('should properly set the aria-label attribute from the text content', inject(function($compile, $rootScope) {
+    var button = $compile('<md-button>Text Content</md-button>')($rootScope);
+    $rootScope.$apply();
+
+    expect(button.attr('aria-label')).toBe('Text Content');
+  }));
+
+  it('should keep the specified aria-label attribute', inject(function($compile, $rootScope) {
+    var button = $compile('<md-button aria-label="Test Button">Text Content</md-button>')($rootScope);
+    $rootScope.$apply();
+
+    expect(button.attr('aria-label')).toBe('Test Button');
+  }));
+
   it('should allow attribute directive syntax', inject(function($compile, $rootScope) {
     var button = $compile('<a md-button href="https://google.com">google</a>')($rootScope.$new());
     expect(button.hasClass('md-button')).toBe(true);

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -41,7 +41,7 @@ describe('<md-tooltip> directive', function() {
         '</md-button>'
       );
 
-      expect(element.attr('aria-label')).toBeUndefined();
+      expect(element.attr('aria-label')).toBe('Hello');
   });
 
   it('should label parent', function(){


### PR DESCRIPTION
Fixes #6731