### PR TITLE
fix(tabs): Change updatePagingWidth to handle subpixel tab width

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -542,9 +542,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function updatePagingWidth() {
     var width = 1;
     angular.forEach(getElements().dummies, function (element) {
-      width += Math.ceil(element.offsetWidth);
+      width += element.getBoundingClientRect().width;
     });
-    angular.element(elements.paging).css('width', width + 'px');
+    angular.element(elements.paging).css('width', Math.ceil(width) + 'px');
   }
 
   function getMaxTabWidth () {


### PR DESCRIPTION
updatePagingWidth now uses getBoundingClientRect() instead of offsetWidth
to compute total width of tabs. offsetWidth returns only the integer part
of the tab width which can cause the pagination-wrapper to be to narrow,
causing the last tab to wrap and become not visible.

Addresses https://github.com/angular/material/issues/5439