### PR TITLE
fix(util/datepicker): Remove usages of scope().

### DIFF
--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -330,7 +330,7 @@
     if (this.$attrs['ngDisabled']) {
       // The expression is to be evaluated against the directive element's scope and not
       // the directive's isolate scope.
-      var scope = this.$mdUtil.validateScope(this.$element) ? this.$element.scope() : null;
+      var scope = this.$scope.$parent;
 
       if (scope) {
         scope.$watch(this.$attrs['ngDisabled'], function(isDisabled) {

--- a/src/core/util/autofocus.js
+++ b/src/core/util/autofocus.js
@@ -1,0 +1,108 @@
+angular.module('material.core')
+  .directive('mdAutofocus', MdAutofocusDirective)
+
+  // Support the deprecated md-auto-focus and md-sidenav-focus as well
+  .directive('mdAutoFocus', MdAutofocusDirective)
+  .directive('mdSidenavFocus', MdAutofocusDirective);
+
+/**
+ * @ngdoc directive
+ * @name mdAutofocus
+ * @module material.core.util
+ *
+ * @description
+ *
+ * `[md-autofocus]` provides an optional way to identify the focused element when a `$mdDialog`,
+ * `$mdBottomSheet`, or `$mdSidenav` opens or upon page load for input-like elements.
+ *
+ * When one of these opens, it will find the first nested element with the `[md-autofocus]`
+ * attribute directive and optional expression. An expression may be specified as the directive
+ * value to enable conditional activation of the autofocus.
+ *
+ * @usage
+ *
+ * ### Dialog
+ * <hljs lang="html">
+ * <md-dialog>
+ *   <form>
+ *     <md-input-container>
+ *       <label for="testInput">Label</label>
+ *       <input id="testInput" type="text" md-autofocus>
+ *     </md-input-container>
+ *   </form>
+ * </md-dialog>
+ * </hljs>
+ *
+ * ### Bottomsheet
+ * <hljs lang="html">
+ * <md-bottom-sheet class="md-list md-has-header">
+ *  <md-subheader>Comment Actions</md-subheader>
+ *  <md-list>
+ *    <md-list-item ng-repeat="item in items">
+ *
+ *      <md-button md-autofocus="$index == 2">
+ *        <md-icon md-svg-src="{{item.icon}}"></md-icon>
+ *        <span class="md-inline-list-icon-label">{{ item.name }}</span>
+ *      </md-button>
+ *
+ *    </md-list-item>
+ *  </md-list>
+ * </md-bottom-sheet>
+ * </hljs>
+ *
+ * ### Autocomplete
+ * <hljs lang="html">
+ *   <md-autocomplete
+ *       md-autofocus
+ *       md-selected-item="selectedItem"
+ *       md-search-text="searchText"
+ *       md-items="item in getMatches(searchText)"
+ *       md-item-text="item.display">
+ *     <span md-highlight-text="searchText">{{item.display}}</span>
+ *   </md-autocomplete>
+ * </hljs>
+ *
+ * ### Sidenav
+ * <hljs lang="html">
+ * <div layout="row" ng-controller="MyController">
+ *   <md-sidenav md-component-id="left" class="md-sidenav-left">
+ *     Left Nav!
+ *   </md-sidenav>
+ *
+ *   <md-content>
+ *     Center Content
+ *     <md-button ng-click="openLeftMenu()">
+ *       Open Left Menu
+ *     </md-button>
+ *   </md-content>
+ *
+ *   <md-sidenav md-component-id="right"
+ *     md-is-locked-open="$mdMedia('min-width: 333px')"
+ *     class="md-sidenav-right">
+ *     <form>
+ *       <md-input-container>
+ *         <label for="testInput">Test input</label>
+ *         <input id="testInput" type="text"
+ *                ng-model="data" md-autofocus>
+ *       </md-input-container>
+ *     </form>
+ *   </md-sidenav>
+ * </div>
+ * </hljs>
+ **/
+function MdAutofocusDirective() {
+  return {
+    restrict: 'A',
+
+    link: postLink
+  }
+}
+
+function postLink(scope, element, attrs) {
+  var attr = attrs.mdAutoFocus || attrs.mdAutofocus || attrs.mdSidenavFocus;
+
+  // Setup a watcher on the proper attribute to update a class we can check for in $mdUtil
+  scope.$watch(attr, function(canAutofocus) {
+    element.toggleClass('_md-autofocus', canAutofocus);
+  });
+}

--- a/src/core/util/autofocus.spec.js
+++ b/src/core/util/autofocus.spec.js
@@ -1,0 +1,61 @@
+describe('_md-autofocus', function() {
+  var $rootScope, pageScope, element;
+
+  beforeEach(module('material.core'));
+  beforeEach(inject(function(_$rootScope_) {
+    $rootScope = _$rootScope_;
+  }));
+
+  describe('add/removes the proper classes', function() {
+    it('supports true', function() {
+      build('<input id="test" type="text" md-autofocus="true">');
+
+      expect(element).toHaveClass('_md-autofocus');
+    });
+
+    it('supports false', function() {
+      build('<input id="test" type="text" md-autofocus="false">');
+
+      expect(element).not.toHaveClass('_md-autofocus');
+    });
+
+    it('supports variables', function() {
+      build('<input id="test" type="text" md-autofocus="shouldAutoFocus">');
+
+      // By default, we assume an undefined value for the expression is true
+      expect(element).toHaveClass('_md-autofocus');
+
+      // Set the expression to false
+      pageScope.$apply('shouldAutoFocus=false');
+      expect(element).not.toHaveClass('_md-autofocus');
+
+      // Set the expression to true
+      pageScope.$apply('shouldAutoFocus=true');
+      expect(element).toHaveClass('_md-autofocus');
+    });
+
+    it('supports expressions', function() {
+      build('<input id="test" type="text" md-autofocus="shouldAutoFocus==1">');
+
+      // By default, the expression should be false
+      expect(element).not.toHaveClass('_md-autofocus');
+
+      // Make the expression false
+      pageScope.$apply('shouldAutoFocus=0');
+      expect(element).not.toHaveClass('_md-autofocus');
+
+      // Make the expression true
+      pageScope.$apply('shouldAutoFocus=1');
+      expect(element).toHaveClass('_md-autofocus');
+    });
+  });
+
+  function build(template) {
+    inject(function($compile) {
+      pageScope = $rootScope.$new();
+      element = $compile(template)(pageScope);
+
+      pageScope.$apply();
+    });
+  }
+});

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -95,87 +95,12 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     /**
-     * @ngdoc directive
-     * @name mdAutofocus
-     * @module material.core.util
+     * Finds the proper focus target by searching the DOM.
      *
-
-     *
-     * @description
-     * `$mdUtil.findFocusTarget()` provides an optional way to identify the focused element when a dialog, bottomsheet, sideNav
-     * or other element opens. This is optional attribute finds a nested element with the mdAutoFocus attribute and optional
-     * expression. An expression may be specified as the directive value; to enable conditional activation of the autoFocus.
-     *
-     * @usage
-     * ### Dialog
-     * <hljs lang="html">
-     * <md-dialog>
-     *   <form>
-     *     <md-input-container>
-     *       <label for="testInput">Label</label>
-     *       <input id="testInput" type="text" md-autofocus>
-     *     </md-input-container>
-     *   </form>
-     * </md-dialog>
-     * </hljs>
-     *
-     * ### Bottomsheet
-     * <hljs lang="html">
-     * <md-bottom-sheet class="md-list md-has-header">
-     *  <md-subheader>Comment Actions</md-subheader>
-     *  <md-list>
-     *    <md-list-item ng-repeat="item in items">
-     *
-     *      <md-button md-autofocus="$index == 2">
-     *        <md-icon md-svg-src="{{item.icon}}"></md-icon>
-     *        <span class="md-inline-list-icon-label">{{ item.name }}</span>
-     *      </md-button>
-     *
-     *    </md-list-item>
-     *  </md-list>
-     * </md-bottom-sheet>
-     * </hljs>
-     *
-     * ### Autocomplete
-     * <hljs lang="html">
-     *   <md-autocomplete
-     *       md-autofocus
-     *       md-selected-item="selectedItem"
-     *       md-search-text="searchText"
-     *       md-items="item in getMatches(searchText)"
-     *       md-item-text="item.display">
-     *     <span md-highlight-text="searchText">{{item.display}}</span>
-     *   </md-autocomplete>
-     * </hljs>
-     *
-     * ### Sidenav
-     * <hljs lang="html">
-     * <div layout="row" ng-controller="MyController">
-     *   <md-sidenav md-component-id="left" class="md-sidenav-left">
-     *     Left Nav!
-     *   </md-sidenav>
-     *
-     *   <md-content>
-     *     Center Content
-     *     <md-button ng-click="openLeftMenu()">
-     *       Open Left Menu
-     *     </md-button>
-     *   </md-content>
-     *
-     *   <md-sidenav md-component-id="right"
-     *     md-is-locked-open="$mdMedia('min-width: 333px')"
-     *     class="md-sidenav-right">
-     *     <form>
-     *       <md-input-container>
-     *         <label for="testInput">Test input</label>
-     *         <input id="testInput" type="text"
-     *                ng-model="data" md-autofocus>
-     *       </md-input-container>
-     *     </form>
-     *   </md-sidenav>
-     * </div>
-     * </hljs>
-     **/
+     * @param containerEl
+     * @param attributeVal
+     * @returns {*}
+     */
     findFocusTarget: function(containerEl, attributeVal) {
       var AUTO_FOCUS = '[md-autofocus]';
       var elToFocus;
@@ -203,18 +128,12 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
         // Find the last child element with the focus attribute
         if ( items && items.length ){
-          var EXP_ATTR = /\s*\[?([\-a-z]*)\]?\s*/i;
-          var matches = EXP_ATTR.exec(selector);
-          var attribute = matches ? matches[1] : null;
-
           items.length && angular.forEach(items, function(it) {
             it = angular.element(it);
 
-            // If the expression evaluates to FALSE, then it is not focusable target
-            var focusExpression = it[0].getAttribute(attribute);
-            var isFocusable = !focusExpression || !$mdUtil.validateScope(it) ? true :
-                              (it.scope().$eval(focusExpression) !== false );
-
+            // Check the element for the _md-autofocus class to ensure any associated expression
+            // evaluated to true.
+            var isFocusable = it.hasClass('_md-autofocus');
             if (isFocusable) elFound = it;
           });
         }
@@ -483,22 +402,6 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      */
     nextUid: function() {
       return '' + nextUniqueId++;
-    },
-
-    /**
-     * By default AngularJS attaches information about binding and scopes to DOM nodes,
-     * and adds CSS classes to data-bound elements. But this information is NOT available
-     * when `$compileProvider.debugInfoEnabled(false);`
-     *
-     * @see https://docs.angularjs.org/guide/production
-     */
-    validateScope : function(element) {
-      var hasScope = element && angular.isDefined(element.scope());
-      if ( !hasScope ) {
-        $log.warn("element.scope() is not available when 'debug mode' == false. @see https://docs.angularjs.org/guide/production!");
-      }
-
-      return hasScope;
     },
 
     // Stop watchers and events from firing on a scope without destroying it,

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -1,39 +1,5 @@
 describe('util', function() {
 
-  describe('validateScope',function() {
-
-    it("should not find a valid scope when debug is disabled", function() {
-      module(function($compileProvider) {
-        $compileProvider.debugInfoEnabled(false);
-      });
-
-      inject(function($compile, $rootScope, $mdUtil) {
-        var widget = angular.element($compile('<div><button><img></button></div>')($rootScope));
-        var button = angular.element(widget.children()[0]);
-
-        $rootScope.$apply();
-        expect(button.scope()).toBe(undefined);
-        expect($mdUtil.validateScope(button)).toBe(false);
-
-      });
-    });
-
-    it("should find a valid scope when debug is enabled", function() {
-      module(function($compileProvider) {
-        $compileProvider.debugInfoEnabled(true);
-      });
-
-      inject(function($compile, $rootScope, $mdUtil) {
-        var widget = angular.element($compile('<div><button><img></button></div>')($rootScope));
-        var button = angular.element(widget.children()[0]);
-
-        $rootScope.$apply();
-        expect(button.scope()).toBeDefined();
-        expect($mdUtil.validateScope(button)).toBe(true);
-      });
-    });
-  });
-
   describe('with no overrides', function() {
     beforeEach(module('material.core'));
 


### PR DESCRIPTION
A few places use `element.scope()` to retrieve the proper scope,
however, this is only available when Angular's debugging option
is enabled and thus fails in production.

Replace usages of `.scope()` in `util.js` and `datepicker.js`
with appropriate alternatives. Remove unused function
`$mdUtil.validateScope()`.

Fixes #6474.