### PR TITLE
fix(select): fix set form to pristine if ng-model for multiple select is predefined.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -228,9 +228,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         });
       }
 
-      if (formCtrl) {
+      if (formCtrl && angular.isDefined(attr.multiple)) {
         $mdUtil.nextTick(function() {
-          formCtrl.$setPristine();
+          var hasModelValue = ngModelCtrl.$modelValue || ngModelCtrl.$viewValue;
+          if (hasModelValue) {
+            formCtrl.$setPristine();
+          }
         });
       }
 

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -387,6 +387,19 @@ describe('<md-select>', function() {
         expect(selectedOptions(el).length).toBe(0);
       }));
 
+      it('should keep the form pristine when model is predefined', inject(function($rootScope, $timeout, $compile) {
+        $rootScope.model = 2;
+        $rootScope.opts = [1, 2, 3, 4];
+        $compile('<form name="testForm">' +
+          '<md-select ng-model="model" name="multiSelect">' +
+            '<md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
+          '</md-select></form>')($rootScope);
+        $rootScope.$digest();
+        $timeout.flush();
+
+        expect($rootScope.testForm.$pristine).toBe(true);
+      }));
+
     });
 
     describe('view->model', function() {
@@ -637,13 +650,25 @@ describe('<md-select>', function() {
           $rootScope.model = [];
           $rootScope.opts = [1, 2, 3, 4];
           $compile('<form name="testForm">' +
-            '<md-select ng-model="model", name="multiSelect" required="required" multiple="multiple">' +
+            '<md-select ng-model="model" name="multiSelect" required="required" multiple="multiple">' +
               '<md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
             '</md-select></form>')($rootScope);
           $rootScope.$digest();
           expect($rootScope.testForm.$valid).toBe(false);
       }));
 
+      it('should keep the form pristine when model is predefined', inject(function($rootScope, $timeout, $compile) {
+        $rootScope.model = [1, 2];
+        $rootScope.opts = [1, 2, 3, 4];
+        $compile('<form name="testForm">' +
+          '<md-select ng-model="model" name="multiSelect" multiple="multiple">' +
+            '<md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
+          '</md-select></form>')($rootScope);
+        $rootScope.$digest();
+        $timeout.flush();
+
+        expect($rootScope.testForm.$pristine).toBe(true);
+      }));
     });
 
     describe('view->model', function() {


### PR DESCRIPTION
Bug introduced in 09bd5a3b52f29dfe530192099d2c405f204ec3ad

Fixes #6556