### PR TITLE
feat(layout): Added `*-print` attributes for all layout and flex attributes

### DIFF
--- a/src/core/services/layout/layout.attributes.scss
+++ b/src/core/services/layout/layout.attributes.scss
@@ -141,10 +141,12 @@ $layout-breakpoint-lg:     1920px !default;
   // Do not use unitless flex-basis values in the flex shorthand because IE 10-11 will error.
   // Also use 0% instead of 0px since minifiers will often convert 0px to 0 (which is unitless and will have the same problem).
   // Safari, however, fails with flex-basis : 0% and requires flex-basis : 0px
-  @media screen\0 {
-      [#{$flexName}] {
-        flex: 1 1 0%;
-      }
+  @if $name != '-print' { 
+    @media screen\0 {
+        [#{$flexName}] {
+          flex: 1 1 0%;
+        }
+    }
   }
 
   [#{$flexName}-grow]        { flex: 1 1 100%;  box-sizing: border-box; }
@@ -494,6 +496,15 @@ $layout-breakpoint-lg:     1920px !default;
     }
   }
   [hide-xl]:not([show-xl]):not([show-gt-lg]):not([show]) {
+    display: none;
+  }
+}
+
+@media print {
+  // PRINT
+  @include layouts_for_breakpoint(print);
+  
+  [hide-print]:not([show-print]):not([show]) {
     display: none;
   }
 }

--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -3,7 +3,7 @@
 
   var $mdUtil, $interpolate, $log;
 
-  var SUFFIXES = /(-gt)?-(sm|md|lg)/g;
+  var SUFFIXES = /(-gt)?-(sm|md|lg|print)/g;
   var WHITESPACE = /\s+/g;
 
   var FLEX_OPTIONS = ['grow', 'initial', 'auto', 'none', 'noshrink', 'nogrow' ];
@@ -77,7 +77,7 @@
     var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
 
     // NOTE: these are also defined in constants::MEDIA_PRIORITY and constants::MEDIA
-    var BREAKPOINTS     = [ "", "xs", "gt-xs", "sm", "gt-sm", "md", "gt-md", "lg", "gt-lg", "xl" ];
+    var BREAKPOINTS     = [ "", "xs", "gt-xs", "sm", "gt-sm", "md", "gt-md", "lg", "gt-lg", "xl", "print" ];
     var API_WITH_VALUES = [ "layout", "flex", "flex-order", "flex-offset", "layout-align" ];
     var API_NO_VALUES   = [ "show", "hide", "layout-padding", "layout-margin" ];
 

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -132,10 +132,12 @@
   // Do not use unitless flex-basis values in the flex shorthand because IE 10-11 will error.
   // Also use 0% instead of 0px since minifiers will often convert 0px to 0 (which is unitless and will have the same problem).
   // Safari, however, fails with flex-basis : 0% and requires flex-basis : 0px
-  @media screen\0 {
-      .#{$flexName} {
-        flex: 1 1 0%;
-      }
+  @if $name != '-print' { 
+    @media screen\0 {
+        .#{$flexName} {
+          flex: 1 1 0%;
+        }
+    }
   }
 
 
@@ -512,6 +514,7 @@
 @media (min-width: $layout-breakpoint-lg) {
   @include layouts_for_breakpoint(gt-lg);
   @include layouts_for_breakpoint(xl);
+  @include layouts_for_breakpoint(print);
 
   // BIGGER THAN LARGE SCREEN
   .hide, .hide-gt-xs, .hide-gt-sm, .hide-gt-md, .hide-gt-lg {
@@ -525,3 +528,11 @@
 
 }
 
+@media print {
+  // PRINT
+  @include layouts_for_breakpoint(print);
+  
+  .hide-print:not(.show-print):not(.show) {
+    display: none;
+  }
+}

--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -514,7 +514,6 @@
 @media (min-width: $layout-breakpoint-lg) {
   @include layouts_for_breakpoint(gt-lg);
   @include layouts_for_breakpoint(xl);
-  @include layouts_for_breakpoint(print);
 
   // BIGGER THAN LARGE SCREEN
   .hide, .hide-gt-xs, .hide-gt-sm, .hide-gt-md, .hide-gt-lg {

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -1,5 +1,5 @@
 describe('layout directives', function() {
-  var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl'],
+  var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl', 'print'],
     $mdUtil, $compile, pageScope;
 
   beforeEach(module('material.core', 'material.core.layout'));

--- a/src/core/util/constant.js
+++ b/src/core/util/constant.js
@@ -63,7 +63,8 @@ function MdConstantFactory($sniffer) {
       'gt-md' : '(min-width: 1280px)'                        ,
       'lg'    : '(min-width: 1280px) and (max-width: 1919px)',
       'gt-lg' : '(min-width: 1920px)'                        ,
-      'xl'    : '(min-width: 1920px)'
+      'xl'    : '(min-width: 1920px)'                        ,
+      'print' : 'print'
     },
     MEDIA_PRIORITY: [
       'xl',
@@ -74,7 +75,8 @@ function MdConstantFactory($sniffer) {
       'gt-sm',
       'sm',
       'gt-xs',
-      'xs'
+      'xs',
+      'print'
     ]
   };
 }

--- a/src/core/util/media.js
+++ b/src/core/util/media.js
@@ -57,6 +57,10 @@ angular.module('material.core')
  *      <td>xl</td>
  *      <td>(min-width: 1920px)</td>
  *    </tr>
+ *    <tr>
+ *      <td>print</td>
+ *      <td>print</td>
+ *    </tr>
  *    </tbody>
  *  </table>
  *


### PR DESCRIPTION
This adds support for controlling `flex` and `layout` attributes when printing. Previously printing would use your layout for the `sm` breakpoint. Now you can override this by using attributes like `layout-print="row"` or `flex-offset-print="2"` etc.

I'm suspecting this will primarily be of use for enterprise apps as enterprise users tend to print a lot of things.

@ThomasBurleson Can you take a look? I really needed this for a while now as my users print a lot. It reduced my primary view from 3-4 pages of paper down to 2.