### PR TITLE
fix(tabs): fix dynamic height demo for tabs

### DIFF
--- a/src/components/tabs/demoDynamicHeight/script.js
+++ b/src/components/tabs/demoDynamicHeight/script.js
@@ -1,0 +1,1 @@
+angular.module('tabsDemoDynamicHeight', ['ngMaterial']);


### PR DESCRIPTION
This issue was introduced in d8602747f597879532ff2d1bb23c7a9bec6e6b88.

Because of the new `svg-asset-cache` script, we need to init the module ourself.
The tabs demo was always working, because the `asset cache` initialized the module (unintentional).

Fixes #6780