### PR TITLE
fix(speedDial): Ensure closed scale animation actions are invisible.

### DIFF
--- a/src/components/fabSpeedDial/demoMoreOptions/style.scss
+++ b/src/components/fabSpeedDial/demoMoreOptions/style.scss
@@ -41,10 +41,12 @@ md-fab-speed-dial {
 
   // Note: you MUST use an existing CSS class for the animation to fire properly
   &.md-scale, &.md-fling {
-    &.ng-hide {
+    &.ng-hide-add.ng-hide-add-active {
       // Use !important to override ng-hide's `display: none !important`
       display: flex !important;
+    }
 
+    &.ng-hide {
       md-fab-trigger {
         transform: scale(0);
       }

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -223,7 +223,7 @@
           offsetDelay = index * delay;
 
         styles.opacity = ctrl.isOpen ? 1 : 0;
-        styles.transform = styles.webkitTransform = ctrl.isOpen ? 'scale(1)' : 'scale(0.1)';
+        styles.transform = styles.webkitTransform = ctrl.isOpen ? 'scale(1)' : 'scale(0)';
         styles.transitionDelay = (ctrl.isOpen ? offsetDelay : (items.length - offsetDelay)) + 'ms';
 
         // Make the items closest to the trigger have the highest z-index

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -134,7 +134,7 @@ md-fab-speed-dial {
 
   &.md-scale {
     .md-fab-action-item {
-      transform: scale(0.1);
+      transform: scale(0);
       transition: $swift-ease-in;
 
       // Make the scale animation a bit faster since we are delaying each item


### PR DESCRIPTION
When using the `scale` animation, the FAB Speed Dial's action items could
sometimes appear as small dots on the screen even when the component was
closed.

This was due to an old bug where closing a dialog from a hidden action
item was throwing an issue. This has since been fixed so we can revert
this back to the original code that used `scale(0)` instead of
`scale(0.1)` which ensured that the dialog always had a button to animate
to when closing.

Also fix an issue with the `ng-hide` animation in the "More Options" demo.

Fixes #6344. Fixes #6670.