### PR TITLE
fix(autocomplete, select, virtualrepeat, input): correctly validate attribute values

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -856,6 +856,55 @@ describe('<md-autocomplete>', function() {
 
       element.remove();
     });
+
+    it('should validate an empty `required` as true', function() {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              md-min-length="0" \
+              required\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+
+      expect(ctrl.isRequired).toBe(true);
+    });
+
+    it('should correctly validate an interpolated `ng-required` value', function() {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              md-min-length="0" \
+              ng-required="interpolateRequired"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+
+      expect(ctrl.isRequired).toBe(false);
+
+      scope.interpolateRequired = false;
+      scope.$apply();
+
+      expect(ctrl.isRequired).toBe(false);
+
+      scope.interpolateRequired = true;
+      scope.$apply();
+
+      expect(ctrl.isRequired).toBe(true);
+    });
+
   });
 
   describe('md-highlight-text', function() {

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -164,8 +164,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    */
   function configureWatchers () {
     var wait = parseInt($scope.delay, 10) || 0;
-    $attrs.$observe('disabled', function (value) { ctrl.isDisabled = !!value; });
-    $attrs.$observe('required', function (value) { ctrl.isRequired = !!value; });
+    $attrs.$observe('disabled', function (value) { ctrl.isDisabled = $mdUtil.parseAttributeBoolean(value, false); });
+    $attrs.$observe('required', function (value) { ctrl.isRequired = $mdUtil.parseAttributeBoolean(value, false); });
     $scope.$watch('searchText', wait ? $mdUtil.debounce(handleSearchText, wait) : handleSearchText);
     $scope.$watch('selectedItem', selectedItemChange);
     angular.element($window).on('resize', positionDropdown);

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -264,8 +264,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     var hasNgModel = !!ctrls[1];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
     var isReadonly = angular.isDefined(attr.readonly);
-    var isRequired = angular.isDefined(attr.required);
-    var mdNoAsterisk = angular.isDefined(attr.mdNoAsterisk);
+    var mdNoAsterisk = $mdUtil.parseAttributeBoolean(attr.mdNoAsterisk);
 
 
     if (!containerCtrl) return;
@@ -274,6 +273,8 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     }
     containerCtrl.input = element;
 
+    setupAttributeWatchers();
+
     // Add an error spacer div after our input to provide space for the char counter and any ng-messages
     var errorsSpacer = angular.element('<div class="md-errors-spacer">');
     // element.after appending the div before the icon (if exist) which cause a problem with calculating which class to apply
@@ -281,8 +282,6 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
 
     if (!containerCtrl.label) {
       $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
-    } else if (isRequired && !mdNoAsterisk) {
-      containerCtrl.label.addClass('md-required');
     }
 
     element.addClass('md-input');
@@ -346,6 +345,16 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     function ngModelPipelineCheckValue(arg) {
       containerCtrl.setHasValue(!ngModelCtrl.$isEmpty(arg));
       return arg;
+    }
+
+    function setupAttributeWatchers() {
+      if (containerCtrl.label) {
+        attr.$observe('required', function (value) {
+          // We don't need to parse the required value, it's always a boolean because of angular's
+          // required directive.
+          containerCtrl.label.toggleClass('md-required', value && !mdNoAsterisk);
+        });
+      }
     }
 
     function inputCheckValue() {

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -174,20 +174,6 @@ describe('md-input-container directive', function() {
     expect(el).not.toHaveClass('md-input-has-value');
   });
 
-  it('should append an asterisk to the required label', function() {
-    var el = setup('required');
-    var label = el.find('label');
-
-    expect(label).toHaveClass('md-required');
-  });
-
-  it('should not show asterisk on required label if disabled', function() {
-    var el = setup('md-no-asterisk');
-    var ctrl = el.controller('mdInputContainer');
-
-    expect(ctrl.label).not.toHaveClass('md-required');
-  });
-
   it('should match label to given input id', function() {
     var el = setup('id="foo"');
     expect(el.find('label').attr('for')).toBe('foo');
@@ -198,6 +184,31 @@ describe('md-input-container directive', function() {
     var el = setup();
     expect(el.find('input').attr('id')).toBeTruthy();
     expect(el.find('label').attr('for')).toBe(el.find('input').attr('id'));
+  });
+
+  describe('md-no-asterisk', function() {
+
+    it('should not show asterisk on required label if disabled', function() {
+      var el = setup('md-no-asterisk required');
+      var ctrl = el.controller('mdInputContainer');
+
+      expect(ctrl.label).not.toHaveClass('md-required');
+    });
+
+    it('should not show an asterisk when attribute value is `true`', function() {
+      var el = setup('md-no-asterisk="true" required');
+      var ctrl = el.controller('mdInputContainer');
+
+      expect(ctrl.label).not.toHaveClass('md-required');
+    });
+
+    it('should show an asterisk when attribute value is `false`', function() {
+      var el = setup('md-no-asterisk="false" required');
+      var ctrl = el.controller('mdInputContainer');
+
+      expect(ctrl.label).toHaveClass('md-required');
+    });
+
   });
 
   describe('md-maxlength', function() {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -173,14 +173,16 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       element.parent().append(autofillClone);
     }
 
+    var isMultiple = $mdUtil.parseAttributeBoolean(attr.multiple);
+
     // Use everything that's left inside element.contents() as the contents of the menu
-    var multiple = angular.isDefined(attr.multiple) ? 'multiple' : '';
+    var multipleContent = isMultiple ? 'multiple' : '';
     var selectTemplate = '' +
       '<div class="md-select-menu-container" aria-hidden="true">' +
       '<md-select-menu {0}>{1}</md-select-menu>' +
       '</div>';
 
-    selectTemplate = $mdUtil.supplant(selectTemplate, [multiple, element.html()]);
+    selectTemplate = $mdUtil.supplant(selectTemplate, [multipleContent, element.html()]);
     element.empty().append(valueEl);
     element.append(selectTemplate);
 
@@ -392,7 +394,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       var ariaAttrs = {
         role: 'listbox',
         'aria-expanded': 'false',
-        'aria-multiselectable': attr.multiple !== undefined && !attr.ngMultiple ? 'true' : 'false'
+        'aria-multiselectable': isMultiple && !attr.ngMultiple ? 'true' : 'false'
       };
 
       if (!element[0].hasAttribute('id')) {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -751,6 +751,16 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([1,3]);
       }));
 
+      it('should not be multiple if attr.multiple == `false`', inject(function($document) {
+        var el = setupSelect('multiple="false" ng-model="$root.model"').find('md-select');
+        openSelect(el);
+        expectSelectOpen(el);
+
+        var selectMenu = $document.find('md-select-menu')[0];
+
+        expect(selectMenu.hasAttribute('multiple')).toBe(false);
+      }));
+
     });
   });
 

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -440,7 +440,7 @@ function VirtualRepeatDirective($parse) {
 
 /** @ngInject */
 function VirtualRepeatController($scope, $element, $attrs, $browser, $document, $rootScope,
-    $$rAF) {
+    $$rAF, $mdUtil) {
   this.$scope = $scope;
   this.$element = $element;
   this.$attrs = $attrs;
@@ -450,7 +450,7 @@ function VirtualRepeatController($scope, $element, $attrs, $browser, $document, 
   this.$$rAF = $$rAF;
 
   /** @type {boolean} Whether we are in on-demand mode. */
-  this.onDemand = $attrs.hasOwnProperty('mdOnDemand');
+  this.onDemand = $mdUtil.parseAttributeBoolean($attrs.mdOnDemand);
   /** @type {!Function} Backup reference to $browser.$$checkUrlChange */
   this.browserCheckUrlChange = $browser.$$checkUrlChange;
   /** @type {number} Most recent starting repeat index (based on scroll offset) */

--- a/src/components/virtualRepeat/virtual-repeater.spec.js
+++ b/src/components/virtualRepeat/virtual-repeater.spec.js
@@ -631,6 +631,33 @@ describe('<md-virtual-repeat>', function() {
     expect(getTransform(offsetter)).toBe('translateY(880px)');
   });
 
+  describe('md-on-demand', function() {
+
+    it('should validate an empty md-on-demand attribute value correctly', inject(function() {
+      repeater.attr('md-on-demand', '');
+      createRepeater();
+
+      var containerCtrl = component.controller('mdVirtualRepeatContainer');
+      expect(containerCtrl.repeater.onDemand).toBe(true);
+    }));
+
+    it('should validate md-on-demand attribute with `true` correctly', inject(function() {
+      repeater.attr('md-on-demand', 'true');
+      createRepeater();
+
+      var containerCtrl = component.controller('mdVirtualRepeatContainer');
+      expect(containerCtrl.repeater.onDemand).toBe(true);
+    }));
+
+    it('should validate md-on-demand attribute with `false` correctly', inject(function() {
+      repeater.attr('md-on-demand', 'false');
+      createRepeater();
+
+      var containerCtrl = component.controller('mdVirtualRepeatContainer');
+      expect(containerCtrl.repeater.onDemand).toBe(false);
+    }));
+  });
+
   /**
    * Facade to access transform properly even when jQuery is used;
    * since jQuery's css function is obtaining the computed style (not wanted)

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -642,6 +642,19 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       return current;
     },
 
+    /**
+     * Parses an attribute value, mostly a string.
+     * By default checks for negated values and returns `false´ if present.
+     * Negated values are: (native falsy) and negative strings like:
+     * `false` or `0`.
+     * @param value Attribute value which should be parsed.
+     * @param negatedCheck When set to false, won't check for negated values.
+     * @returns {boolean}
+     */
+    parseAttributeBoolean: function(value, negatedCheck) {
+      return value === '' || !!value && (negatedCheck === false || value !== 'false' && value !== '0');
+},
+
     hasComputedStyle: hasComputedStyle
   };
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -286,6 +286,45 @@ describe('util', function() {
       });
     });
 
+    describe('parseAttributeBoolean', function() {
+
+      it('should validate `1` string to be true', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('1')).toBe(true);
+      }));
+
+      it('should validate an empty value to be true', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('')).toBe(true);
+      }));
+
+      it('should validate `false` text to be false', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('false')).toBe(false);
+      }));
+
+      it('should validate `true` text to be true', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('true')).toBe(true);
+      }));
+
+      it('should validate a random text to be true', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('random-string')).toBe(true);
+      }));
+
+      it('should validate `0` text to be false', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('0')).toBe(false);
+      }));
+
+      it('should validate true boolean to be true', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean(true)).toBe(true);
+      }));
+
+      it('should validate false boolean to be false', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean(false)).toBe(false);
+      }));
+
+      it('should validate `false` text to be true when ignoring negative values', inject(function($mdUtil) {
+        expect($mdUtil.parseAttributeBoolean('false', false)).toBe(true);
+      }));
+    });
+
     describe('getParentWithPointerEvents', function () {
       describe('with wrapper with pointer events style element', function () {
         it('should find the parent element and return it', inject(function($window, $mdUtil) {


### PR DESCRIPTION
Fixes the validation of the boolean attributes.

### Autocomplete
**Attributes:**
<table>
  <td>required</td>
  <td>disabled</td>
</table>

- `required` ignored an empty attribute value (`<md-autocomplete required>`)
- `disabled` ignored an empty attribute value (`<md-autocomplete disabled>`)

---
### Input
**Attributes:**
<table>
  <td>md-no-asterisk</td>
</table>
- `md-no-asterisk` is ignoring false attribute value (`<input md-no-asterisk="false">`)

**Extra Changes:**
- `required` is not updating the `md-required` class (now observing for `ng-required`)
- Wrong test-case for `md-no-asterisk`

---
### Select
**Attributes:**
<table>
  <td>multiple</td>
</table>
- `multiple` is ignoring false attribute value (`<md-select multiple="false">`)

---
### Virtual Repeat
**Attributes**
<table>
  <td>md-on-demand</td>
</table>
- `md-on-demand` is ignoring false attribute value (`<md-virtual-repeat md-on-demand="false">`)

**Extra Changes:**
- Missing attribute test for `md-on-demand`

---

### Notes
- Validating `negative` attribute values for `required`, `readonly`, `disabled` will be ignored. 
- Validating `0` as falsy value is also a useful feature and should be implemented too, because sometimes your backend will return a `boolean` in numeric style (See [here](https://en.wikipedia.org/wiki/Boolean_data_type)). 

Fixes #5831 Fixes #7063 Fixes #6415 Fixes #6393 Fixes #5896 Fixes #6698 Fixes #7105