### PR TITLE
fix(input): check if parent form is undefined before checking if it's…

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -273,7 +273,11 @@ function inputTextareaDirective($mdUtil, $window, $mdAria) {
     var isParentFormSubmitted = function () {
       var parent = $mdUtil.getClosest(element, 'form');
 
-      return parent ? angular.element(parent).controller('form').$submitted : false;
+      if (parent) {
+        var form = angular.element(parent).controller('form');
+        return form ? form.$submitted : false;
+      }
+      return false;
     };
 
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);


### PR DESCRIPTION
… submitted

This fixes an issue I had with requiring inputs in form dialogs causing errors when you close the dialog. It should also fix the same issue in other situations as this is a fix for `md-input-container`. It was just triggered with a dialog in my case.

Fixes #6807