### PR TITLE
fix(radio, divider): support all layout classes

### DIFF
--- a/src/components/divider/divider-theme.scss
+++ b/src/components/divider/divider-theme.scss
@@ -2,7 +2,12 @@ md-divider.md-THEME_NAME-theme {
   border-top-color: '{{foreground-4}}';
 }
 
-.layout-row {
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
   & > md-divider.md-THEME_NAME-theme {
     border-right-color: '{{foreground-4}}';
   }

--- a/src/components/divider/divider.scss
+++ b/src/components/divider/divider.scss
@@ -9,7 +9,12 @@ md-divider {
   }
 }
 
-.layout-row {
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
   & > md-divider {
     border-top-width: 0;
     border-right-width: 1px;

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -115,13 +115,23 @@ md-radio-button {
 }
 
 md-radio-group {
-  md-radio-button {
-    &:not(:first-child) {
-      margin-top: $radio-margin;
+  &.layout-column,
+  &.layout-xs-column, &.layout-gt-xs-column,
+  &.layout-sm-column, &.layout-gt-sm-column,
+  &.layout-md-column, &.layout-gt-md-column,
+  &.layout-lg-column, &.layout-gt-lg-column,
+  &.layout-xl-column {
+    md-radio-button {
+      margin-bottom: $radio-margin;
     }
   }
 
-  &.layout-row {
+  &.layout-row,
+  &.layout-xs-row, &.layout-gt-xs-row,
+  &.layout-sm-row, &.layout-gt-sm-row,
+  &.layout-md-row, &.layout-gt-md-row,
+  &.layout-lg-row, &.layout-gt-lg-row,
+  &.layout-xl-row {
     md-radio-button {
       margin-top: 0;
       margin-bottom: 0;


### PR DESCRIPTION
Style was not applied when the row/column was defined by `layout-XX` and `layout-gt-XX` (xs, sm, md ...) attribute, fixed by adding the edge cases to the selector.

fixes #6387