### PR TITLE
fix(menu): prevent container scaling if still animating

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -118,6 +118,7 @@ function MenuProvider($$interimElementProvider) {
       // Return the promise for when our menu is done animating in
       return showMenu()
         .then(function(response) {
+          opts.isAnimating = false;
           opts.alreadyOpen = true;
           opts.cleanupInteraction = activateInteraction();
           return response;
@@ -134,6 +135,9 @@ function MenuProvider($$interimElementProvider) {
           var position = calculateMenuPosition(element, opts);
 
           element.removeClass('md-leave');
+
+          // Prevent container scaling while running animation
+          opts.isAnimating = true;
 
           // Animate the menu scaling, and opacity [from its position origin (default == top-left)]
           // to normal scale.
@@ -476,7 +480,7 @@ function MenuProvider($$interimElementProvider) {
         top: Math.round(position.top),
         left: Math.round(position.left),
         // Animate a scale out if we aren't just repositioning
-        transform: !opts.alreadyOpen ? $mdUtil.supplant('scale({0},{1})', [scaleX, scaleY]) : undefined,
+        transform: !opts.alreadyOpen && !opts.isAnimating ? $mdUtil.supplant('scale({0},{1})', [scaleX, scaleY]) : undefined,
         transformOrigin: transformOrigin
       };
 


### PR DESCRIPTION
This fixes issues with minimal UI for Safari / IOS

*Already tested, but this needs more manual testing*

Fixes #6806