### PR TITLE
fix(slider): clamp md-slider's initialisation

### DIFF
--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -291,6 +291,9 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
      * @param percent 0-1
      */
     function setSliderPercent(percent) {
+
+        percent = clamp(percent);
+
         var percentStr = (percent * 100) + '%';
 
         activeTrack.css('width', percentStr);
@@ -378,6 +381,15 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       var closestVal = minMaxValidator( stepValidator(exactVal) );
       setSliderPercent( positionToPercent(x) );
       thumbText.text( closestVal );
+    }
+
+    /**
+    * Clamps the value to be between 0 and 1.
+    * @param {number} value The value to clamp.
+    * @returns {number}
+    */
+    function clamp(value) {
+      return Math.max(0, Math.min(value || 0, 1));
     }
 
     /**

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -30,6 +30,18 @@ describe('md-slider', function() {
     return slider;
   }
 
+  it('should not set model below the min', function() {
+    var slider = setup('ng-model="value" min="0" max="100"');
+    pageScope.$apply('value = -50');
+    expect(slider.attr('aria-valuenow')).toEqual('0');
+  });
+
+  it('should not set model above the max', function() {
+    var slider = setup('ng-model="value" min="0" max="100"');
+    pageScope.$apply('value = 150');
+    expect(slider.attr('aria-valuenow')).toEqual('100');
+  });
+
   it('should set model on press', function() {
     var slider = setup('ng-model="value" min="0" max="100"');
     pageScope.$apply('value = 50');
@@ -238,7 +250,6 @@ describe('md-slider', function() {
     $timeout.flush();
     expect(slider).not.toHaveClass('md-max');
   });
-
 
   it('should increment at a predictable step', function() {
 


### PR DESCRIPTION
Previously when a model was set with a value outside of the `min` or
the `max` of the slider, it would call `setSliderPercent` with the
initial value and no check would occur to make sure that the value of
the model could not extend the range of the slider.

The below screenshot demonstrates what the slider looks like when it has
been initialised with a value of `-1`.

![screenshot](http://i.imgur.com/BxBpz2J.png)

As you can see, the thumb is floating way off to the left. This is due
to the `left: -25%` style that has been applied to the element. It is
worth noting that the `min` and `max` are `0` and `4` respectively.