### PR TITLE
fix(autocomplete): do not use .then() for $http promise

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -639,9 +639,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     } else if (items) {
       setLoading(true);
       $mdUtil.nextTick(function () {
-        if (items.success) items.success(handleResults);
-        if (items.then)    items.then(handleResults);
-        if (items.finally) items.finally(function () {
+        if (items.success)   items.success(handleResults);
+        else if (items.then) items.then(handleResults);
+        if (items.finally)   items.finally(function () {
           setLoading(false);
         });
       },true, $scope);


### PR DESCRIPTION
$http returns promise with both .then() and .success() methods :
- `.then()` : calls back with http response object with following properties : data, status, config, headers, statusText (cf https://docs.angularjs.org/api/ng/service/$http#general-usage)
- `.success()` : calls back with data coming from server

currently, autocomplete use both methods, and when `handleResults` is called from `.then(...)`, items are replaced by http response object