### PR TITLE
fix(input): fix  invalid animation for input.

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -599,6 +599,8 @@ function mdInputInvalidMessagesAnimation($q, $animateCss) {
 
       if (className == "md-input-invalid" && messages.hasClass('md-auto-hide')) {
         showInputMessages(element, $animateCss, $q).finally(done);
+      } else {
+        done();
       }
     }
 


### PR DESCRIPTION
At the moment the animation will stuck if there is no `md-auto-hide` class or the class isn't `md-input-invalid`.
That's because we not trigger the callback if we finish the animation.

Fixes #6822