### PR TITLE
<fix(datepicker)>: change mdDateUtil.isDateWithinRange to ignore the …

### DIFF
--- a/src/components/datepicker/dateUtil.js
+++ b/src/components/datepicker/dateUtil.js
@@ -204,8 +204,9 @@
      * Creates a date with the time set to midnight.
      * Drop-in replacement for two forms of the Date constructor:
      * 1. No argument for Date representing now.
-     * 2. Single-argument value representing number of seconds since Unix Epoch.
-     * @param {number=} opt_value
+     * 2. Single-argument value representing number of seconds since Unix Epoch
+     * or a Date object.
+     * @param {number|Date=} opt_value
      * @return {Date} New date with time set to midnight.
      */
     function createDateAtMidnight(opt_value) {
@@ -220,15 +221,18 @@
     }
 
      /**
-      * Checks if a date is within a min and max range.
+      * Checks if a date is within a min and max range, ignoring the time component.
       * If minDate or maxDate are not dates, they are ignored.
       * @param {Date} date
       * @param {Date} minDate
       * @param {Date} maxDate
       */
      function isDateWithinRange(date, minDate, maxDate) {
-       return (!angular.isDate(minDate) || minDate <= date) &&
-           (!angular.isDate(maxDate) || maxDate >= date);
+       var dateAtMidnight = createDateAtMidnight(date);
+       var minDateAtMidnight = isValidDate(minDate) ? createDateAtMidnight(minDate) : null;
+       var maxDateAtMidnight = isValidDate(maxDate) ? createDateAtMidnight(maxDate) : null;
+       return (!minDateAtMidnight || minDateAtMidnight <= dateAtMidnight) &&
+           (!maxDateAtMidnight || maxDateAtMidnight >= dateAtMidnight);
      }
   });
 })();

--- a/src/components/datepicker/dateUtil.spec.js
+++ b/src/components/datepicker/dateUtil.spec.js
@@ -324,4 +324,53 @@ describe('$$mdDateUtil', function() {
 
     expect(dateUtil.isValidDate(new Date())).toBe(true);
   });
+
+  it('should return true when a date is in range', function() {
+    var date = new Date('2015-05-02');
+    var minDate = new Date('2015-05-01');
+    var maxDate = new Date('2015-05-03');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeTruthy();
+  });
+
+  it('should return false when a date is before the range', function() {
+    var date = new Date('2015-04-29');
+    var minDate = new Date('2015-05-01');
+    var maxDate = new Date('2015-05-03');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeFalsy();
+  });
+
+  it('should return false when a date is after the range', function() {
+    var date = new Date('2015-05-05');
+    var minDate = new Date('2015-05-01');
+    var maxDate = new Date('2015-05-03');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeFalsy();
+  });
+
+  it('should set the time to midnight before checking the min date', function() {
+    var date = new Date('2015-05-01T11:00:00');
+    var minDate = new Date('2015-05-01T12:00:00');
+    var maxDate = new Date('2015-05-03');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeTruthy();
+  });
+
+  it('should set the time to midnight before checking the max date', function() {
+    var date = new Date('2015-05-03T13:00:00');
+    var minDate = new Date('2015-05-01');
+    var maxDate = new Date('2015-05-03T12:00:00');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeTruthy();
+  });
+
+  it('should ignore an invalid minDate when checking if the date is in range', function() {
+    var date = new Date('2015-05-02');
+    var minDate = null;
+    var maxDate = new Date('2015-05-03');
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeTruthy();
+  });
+
+  it('should ignore an invalid maxDate when checking if the date is in range', function() {
+    var date = new Date('2015-05-02');
+    var minDate = new Date('2015-05-01');
+    var maxDate = null;
+    expect(dateUtil.isDateWithinRange(date, minDate, maxDate)).toBeTruthy();
+  });
 });


### PR DESCRIPTION
…time component of the date

Previously, mdDateUtil.isDateWithinRange did a simple comparison on the given dates. Since this
component is used for dates (and not times or datetimes), this leads to inconsistent behavior.

Fixes #6887