### PR TITLE
Fix menu not open when linking a page within the menu.

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -485,8 +485,8 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
           },
           function (open) {
             var $ul = $element.find('ul');
-            var targetHeight = open ? getTargetHeight() : 0;
             $timeout(function () {
+              var targetHeight = open ? getTargetHeight() : 0;
               $ul.css({ height: targetHeight + 'px' });
             }, 0, false);
 


### PR DESCRIPTION
The menu was "opened", but the height was computed at the wrong time
and so it ended up being set to 0.

Fixes #6861

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/angular/material/6899)
<!-- Reviewable:end -->
