### PR TITLE
fix(mdSelect): Add error message spacing. Allow placeholder and label text to display like md-input

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -206,6 +206,11 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         }
 
         containerCtrl.input = element;
+
+        // Add an error spacer div after our input to provide space for the char counter and any ng-messages
+        var errorsSpacer = angular.element('<div class="md-errors-spacer">');
+        element.after(errorsSpacer);
+
         if (!containerCtrl.label) {
           $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
         }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -263,7 +263,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       mdSelectCtrl.setIsPlaceholder = function(isPlaceholder) {
         if (isPlaceholder) {
           valueEl.addClass('md-select-placeholder');
-          if (containerCtrl && containerCtrl.label) {
+          if (containerCtrl && containerCtrl.label && !attr.placeholder) {
             containerCtrl.label.addClass('md-placeholder');
           }
         } else {


### PR DESCRIPTION
Fixes #6903. Fixes #6902.

> #breaking