### PR TITLE
layoutNowrap: Inconsistency in directive/css implementation

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -105,7 +105,7 @@
       .directive('ngCloak'      ,  buildCloakInterceptor('ng-cloak'))
 
       .directive('layoutWrap'   , attributeWithoutValue('layout-wrap'))
-      .directive('layoutNoWrap' , attributeWithoutValue('layout-no-wrap'))
+      .directive('layoutNowrap' , attributeWithoutValue('layout-nowrap'))
       .directive('layoutFill'   , attributeWithoutValue('layout-fill'))
 
       // !! Deprecated attributes: use the `-lt` (aka less-than) notations
@@ -406,7 +406,7 @@
         case 'layout-margin'  :
         case 'layout-fill'    :
         case 'layout-wrap'    :
-        case 'layout-no-wrap' :
+        case 'layout-nowrap' :
           value = '';
           break;
       }

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -220,7 +220,7 @@ describe('layout directives', function() {
       "layout-margin",
       "layout-fill",
       "layout-wrap",
-      "layout-no-wrap"
+      "layout-nowrap"
     ];
 
     angular.forEach(allowedAttrsNoValues, function(name) {


### PR DESCRIPTION
Updated layout-no-wrap to layout-nowrap (which is what's in the documentation). Previously, using layout-nowrap-gt-sm didn't work because the directive was layout-no-wrap, whereas the CSS was layout-nowrap (without the second hyphen).