### PR TITLE
fix(docs): fix animation for menu-toggle

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -464,7 +464,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
   };
 })
 
-.directive('menuToggle', [ '$timeout', function($timeout) {
+.directive('menuToggle', [ '$timeout', '$mdUtil', function($timeout, $mdUtil) {
   return {
     scope: {
       section: '='
@@ -479,20 +479,21 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
       $scope.toggle = function() {
         controller.toggleOpen($scope.section);
       };
-      $scope.$watch(
+
+      $mdUtil.nextTick(function() {
+        $scope.$watch(
           function () {
             return controller.isOpen($scope.section);
           },
           function (open) {
             var $ul = $element.find('ul');
 
-            $timeout(function updateHeight() {
-              $timeout(function () {
-                $ul.css({ height: (open ? getTargetHeight() : 0) + 'px' });
-              }, 0, false);
+            var targetHeight = open ? getTargetHeight() : 0;
+            $timeout(function () {
+              $ul.css({height: targetHeight + 'px'});
             }, 0, false);
 
-            function getTargetHeight () {
+            function getTargetHeight() {
               var targetHeight;
               $ul.addClass('no-transition');
               $ul.css('height', '');
@@ -502,8 +503,8 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
               return targetHeight;
             }
           }
-      );
-
+        );
+      });
 
       var parentNode = $element[0].parentNode.parentNode.parentNode;
       if(parentNode.classList.contains('parent-list-item')) {


### PR DESCRIPTION
Little explanation: 
> - When opening demo through link (example: http://127.0.0.1:8080/#/demo/bottomSheet), we need to wait for the `ul` being rendered. (using the next tick) 
- So I register the complete watcher in the next tick without affecting the current code.
- The current problem for the open animation is, that we read the height in the timeout, so we need to move that out -> but then it won't wait for the `ul` to be rendered on opening through link. So as I did, we need to delay the watcher registration - and everything works.

Refrences #6579 References #6572 Fixes #6262 Fixes #6936