### PR TITLE
fix(button): fixed wrong md-icon selector and changed raised icon color to hue-900

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -73,8 +73,8 @@ a.md-button.md-THEME_NAME-theme,
     color: '{{background-900}}';
     background-color: '{{background-50}}';
     &:not([disabled]) {
-      .md-icon {
-        color: '{{background-contrast}}';
+      md-icon {
+        color: '{{background-900}}';
       }
       &:hover {
         background-color: '{{background-50}}';


### PR DESCRIPTION
There is currently a wrong `md-icon` selector and a old color, which should be changed to hue-900 as already done in 38812e7791a92ccdaf64970942921e681e398a8e

Fixes #6944