### PR TITLE
docs(select): remove fixed height for select demo

### DIFF
--- a/src/components/select/demoOptionsWithAsyncSearch/index.html
+++ b/src/components/select/demoOptionsWithAsyncSearch/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="SelectAsyncController" layout="column" layout-align="center center" style="padding:40px" ng-cloak>
   <p>Select can call an arbitrary function on show. If this function returns a promise, it will display a loading indicator while it is being resolved:</p>
-  <div layout="column" layout-align="center center" style="height: 100px;">
+  <div layout="column" layout-align="center center">
     <md-select placeholder="Assign to user" ng-model="user" md-on-open="loadUsers()" style="min-width: 200px;">
       <md-option ng-value="user" ng-repeat="user in users">{{user.name}}</md-option>
     </md-select>


### PR DESCRIPTION
At the moment we are fixing the height, which will caught issues with the select because it provides the content and a margin of `20px 0 26px`, plus the message which will be shown when the user selects one option. 

That mean's that won't fit in, and the clickable area will be shrinked.
Better remove that fixed height and use the margin of `26px`.

Fixes #6943