### PR TITLE
fix(demo): fix demo interpolating at controller startup

### DIFF
--- a/docs/app/js/demo.js
+++ b/docs/app/js/demo.js
@@ -1,9 +1,7 @@
 DocsApp
 .directive('layoutAlign', function() { return angular.noop; })
 .directive('layout', function() { return angular.noop; })
-.directive('docsDemo', [
-  '$mdUtil',
-function() {
+.directive('docsDemo', [function() {
   return {
     restrict: 'E',
     scope: true,
@@ -14,10 +12,12 @@ function() {
     bindToController: true
   };
 
-  function DocsDemoCtrl($scope, $element, $attrs, codepen) {
+  function DocsDemoCtrl($scope, $element, $attrs, $interpolate, codepen) {
     var self = this;
 
     self.interpolateCode = angular.isDefined($attrs.interpolateCode);
+
+    self.demoModule = $interpolate($attrs.demoModule || '')($scope.$parent);
 
     $attrs.$observe('demoTitle', function(value) {
       self.demoTitle = value;


### PR DESCRIPTION
Issue introduced in 82625cf by myself. Sorry for that :-1: 

The actual problem is the `demoInclude` directive, because it's not observing the `module` attribute. 
See [here](https://github.com/angular/material/blob/0412152e9ea76387b8e4f474283ed369e88c65c9/docs/app/js/demoInclude.js#L18-L18). 
So we need to interpolate the module on controller startup to prevent an error, when evaling the module.

#6958