### PR TITLE
fix(autocomplete): fix autocomplete tabindex support

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -163,6 +163,49 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should forward the tabindex to the input', inject(function() {
+      var scope = createScope(null, {inputId: 'custom-input-id'});
+      var template =
+        '<md-autocomplete ' +
+            'md-input-id="{{inputId}}" ' +
+            'md-selected-item="selectedItem" ' +
+            'md-search-text="searchText" ' +
+            'md-items="item in match(searchText)" ' +
+            'md-item-text="item.display" ' +
+            'tabindex="3"' +
+            'placeholder="placeholder">' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+      var input = element.find('input');
+
+      expect(input.attr('tabindex')).toBe('3');
+
+      element.remove();
+    }));
+
+    it('should always set the tabindex of the autcomplete to `-1`', inject(function() {
+      var scope = createScope(null, {inputId: 'custom-input-id'});
+      var template =
+        '<md-autocomplete ' +
+            'md-input-id="{{inputId}}" ' +
+            'md-selected-item="selectedItem" ' +
+            'md-search-text="searchText" ' +
+            'md-items="item in match(searchText)" ' +
+            'md-item-text="item.display" ' +
+            'tabindex="3"' +
+            'placeholder="placeholder">' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+
+      expect(element.attr('tabindex')).toBe('-1');
+
+      element.remove();
+    }));
+
     it('should clear value when hitting escape', inject(function($mdConstant, $timeout) {
       var scope = createScope();
       var template = '\

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -156,7 +156,9 @@ function MdAutocomplete () {
       // Set our variable for the link function above which runs later
       element.hasNotFoundTemplate = !!noItemsTemplate;
 
-      if (!attr.hasOwnProperty('tabindex')) element.attr('tabindex', '-1');
+      // Always set our tabindex of the autocomplete directive to -1, because our input
+      // will hold the actual tabindex.
+      element.attr('tabindex', '-1');
 
       return '\
         <md-autocomplete-wrap\


### PR DESCRIPTION
- We should always apply to the root directive a tabindex of `-1`
- We should direct the tabindex to the input (if tabindex is specified)
- Added accompanying tests

Fixes #6999