### PR TITLE
docs(): overwrite fill color too.

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -452,6 +452,7 @@ a.docs-logo {
 }
 .docs-toolbar-tools .md-button md-icon {
   color: #666 !important;
+  fill: #666 !important;
 }
 @media (max-width: 400px) {
   .docs-tools {


### PR DESCRIPTION
Since we are setting the fill color for the icons too, we need to overwrite the fill attribute too.