### PR TITLE
fix(interim-element): cancel was emitted as list and not as stack

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -360,7 +360,7 @@ function InterimElementProvider() {
        *
        */
       function cancel(reason, options) {
-        var interim = stack.shift();
+        var interim = stack.pop();
         if ( !interim ) return $q.when(reason);
 
         interim


### PR DESCRIPTION
* Cancel called shift which slices the first element in the Array instead of pop who take the last and also happens on `hide`

fixes #6912