### PR TITLE
md-menu: add handling for 'data-' prefix of HTML attributes 

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -23,7 +23,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
     opts = opts || {};
     menuContainer = setMenuContainer;
     // Default element for ARIA attributes has the ngClick or ngMouseenter expression
-    triggerElement = $element[0].querySelector('[ng-click],[ng-mouseenter]');
+    triggerElement = $element[0].querySelector('[ng-click], [data-ng-click], [ng-mouseenter], [data-ng-mouseenter]');
     triggerElement.setAttribute('aria-expanded', 'false');
 
     this.isInMenuBar = opts.isInMenuBar;

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -160,8 +160,8 @@ function MenuDirective($mdUtil) {
   function compile(templateElement) {
     templateElement.addClass('md-menu');
     var triggerElement = templateElement.children()[0];
-    if (!triggerElement.hasAttribute('ng-click')) {
-      triggerElement = triggerElement.querySelector('[ng-click],[ng-mouseenter]') || triggerElement;
+    if (!triggerElement.hasAttribute('ng-click') || !triggerElement.hasAttribute('data-ng-click')) {
+      triggerElement = triggerElement.querySelector('[ng-click], [data-ng-click], [ng-mouseenter], [data-ng-mouseenter]') || triggerElement;
     }
     if (triggerElement && (
       triggerElement.nodeName == 'MD-BUTTON' ||

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -160,8 +160,8 @@ function MenuDirective($mdUtil) {
   function compile(templateElement) {
     templateElement.addClass('md-menu');
     var triggerElement = templateElement.children()[0];
-    if (!triggerElement.hasAttribute('ng-click') || !triggerElement.hasAttribute('data-ng-click')) {
-      triggerElement = triggerElement.querySelector('[ng-click], [data-ng-click], [ng-mouseenter], [data-ng-mouseenter]') || triggerElement;
+    if (!triggerElement.hasAttribute('ng-click'))
+      triggerElement = triggerElement.querySelector('[ng-click],[ng-mouseenter]') || triggerElement;
     }
     if (triggerElement && (
       triggerElement.nodeName == 'MD-BUTTON' ||

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -160,8 +160,8 @@ function MenuDirective($mdUtil) {
   function compile(templateElement) {
     templateElement.addClass('md-menu');
     var triggerElement = templateElement.children()[0];
-    if (!triggerElement.hasAttribute('ng-click'))
-      triggerElement = triggerElement.querySelector('[ng-click],[ng-mouseenter]') || triggerElement;
+    if (!triggerElement.hasAttribute('ng-click') || !triggerElement.hasAttribute('data-ng-click')) {
+      triggerElement = triggerElement.querySelector('[ng-click], [data-ng-click], [ng-mouseenter], [data-ng-mouseenter]') || triggerElement;
     }
     if (triggerElement && (
       triggerElement.nodeName == 'MD-BUTTON' ||


### PR DESCRIPTION
- md-menu caused error when using 'data-' prefixed ng-click directive.

Fixes: #6659

Version:
```javascript
/*!
 * Angular Material Design
 * https://github.com/angular/material
 * @license MIT
 * v1.0.5
 */
```