### PR TITLE
fix(datepicker): style demo ngMessage as same as input messages.

### DIFF
--- a/src/components/datepicker/demoBasicUsage/style.css
+++ b/src/components/datepicker/demoBasicUsage/style.css
@@ -4,7 +4,7 @@ md-content {
 }
 
 .validation-messages {
-  font-size: 11px;
-  color: darkred;
+  font-size: 12px;
+  color: #dd2c00;
   margin: 10px 0 0 25px;
 }


### PR DESCRIPTION
At the moment there was just some randomly picked color for the ngMessage in the datepicker demo.
We should use a color which looks as same as the actual input ngMessages (to have a flat ngMessages design),
and even the font-size should be the same.

References #6941