### PR TITLE
fix(checkbox): fix IE11 focus for checkbox

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -59,6 +59,10 @@ md-checkbox {
     @include rtl(left, 0, auto);
     @include rtl(right, auto, 0);
 
+    // Disable pointer events, because IE11 is always focusing the child elements instead of the
+    // md-checkbox element.
+    pointer-events: none;
+    
     &:before {
       box-sizing: border-box;
       background-color: transparent;


### PR DESCRIPTION
At the moment IE11 is always selecting the div.md-container, but that will cause issues with the ngModel (options).
- So we need to block pointer events for the container, because we will manage all from actual `<md-checkbox>`

Fixes #7086