### PR TITLE
fix(autocomplete): only handle results if it's an array or a promise

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -206,6 +206,36 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should not show a loading progress when the items object is invalid', inject(function() {
+      var scope = createScope(null, {
+        match: function() {
+          // Return an invalid object, which is not an array, neither a promise.
+          return {}
+        }
+      });
+
+      var template =
+        '<md-autocomplete ' +
+        'md-input-id="{{inputId}}" ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'tabindex="3"' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+
+      scope.$apply('searchText = "test"');
+
+      expect(ctrl.loading).toBe(false);
+
+      element.remove();
+    }));
+
     it('should clear value when hitting escape', inject(function($mdConstant, $timeout) {
       var scope = createScope();
       var template = '\

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -635,10 +635,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function fetchResults (searchText) {
     var items = $scope.$parent.$eval(itemExpr),
         term  = searchText.toLowerCase(),
-        isList = angular.isArray(items);
+        isList = angular.isArray(items),
+        isPromise = !!items.then; // Every promise should contain a `then` property
 
-    if ( isList ) handleResults(items);
-    else          handleAsyncResults(items);
+    if (isList) handleResults(items);
+    else if (isPromise) handleAsyncResults(items);
 
     function handleAsyncResults(items) {
       if ( !items ) return;


### PR DESCRIPTION
At the moment the autocomplete will handle the results wrong.
So if we specify for example an empty JSON-Object, the autocomplete will handle the results as an async promise.

Fixes #7074