### PR TITLE
update(panel): Sets up SCSS for the panel.

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -9,9 +9,9 @@ angular
     .service('$mdPanel', MdPanelService);
 
 
-/***************************************************************************************
- *                              PUBLIC DOCUMENTATION                                   *
- ***************************************************************************************/
+/*****************************************************************************
+ *                            PUBLIC DOCUMENTATION                           *
+ *****************************************************************************/
 
 /**
  * @ngdoc service
@@ -109,7 +109,6 @@ angular
  *     used for configuring the number of open panels and identifying specific
  *     behaviors for groups. For instance, all tooltips will be identified
  *     using the same groupName.
- *
  *   - `position` - `{$mdPanelPosition=}`: An $mdPanelPosition object that
  *     specifies the alignment of the panel. For more information, see
  *     `$mdPanelPosition`.
@@ -168,9 +167,9 @@ angular
  */
 
 
-/***************************************************************************************
- *                                       MdPanelRef                                    *
- ***************************************************************************************/
+/*****************************************************************************
+ *                                 MdPanelRef                                *
+ *****************************************************************************/
 
 
 /**
@@ -218,9 +217,9 @@ angular
  */
 
 
-/***************************************************************************************
- *                                 $mdPanelPosition                                    *
- ***************************************************************************************/
+/*****************************************************************************
+ *                               $mdPanelPosition                            *
+ *****************************************************************************/
 
 
 /**
@@ -243,9 +242,9 @@ angular
  * @ngdoc method
  * @name $mdPanelPosition#absolute
  * @description
- * Positions the panel absolutely relative to the parent element. If the parent is
- * document.body, this is equivalent to positioning the panel absolutely within the
- * viewport.
+ * Positions the panel absolutely relative to the parent element. If the parent
+ * is document.body, this is equivalent to positioning the panel absolutely
+ * within the viewport.
  * @returns {$mdPanelPosition}
  */
 
@@ -254,7 +253,8 @@ angular
  * @name $mdPanelPosition#relativeTo
  * @description
  * Positions the panel relative to a specific element.
- * @param {!angular.JQLite} element Element to position the panel with respect to.
+ * @param {!angular.JQLite} element Element to position the panel with
+ *     respect to.
  * @returns {$mdPanelPosition}
  */
 
@@ -313,9 +313,9 @@ angular
  */
 
 
-/***************************************************************************************
- *                                   IMPLEMENTATION                                    *
- ***************************************************************************************/
+/*****************************************************************************
+ *                                 IMPLEMENTATION                            *
+ *****************************************************************************/
 
 
 /**
@@ -332,8 +332,9 @@ function MdPanelService($rootElement, $rootScope, $injector) {
    */
   this._defaultConfigOptions = {
     attachTo: $rootElement,
+    bindToController: true,
     scope: $rootScope.$new(true),
-    bindToController: true
+    transformTemplate: angular.bind(this, this.wrapTemplate_)
   };
 
   /** @private {!Object} */
@@ -370,6 +371,27 @@ MdPanelService.prototype.open = function(opt_config) {
   var panelRef = this.create(opt_config);
   panelRef.open();
   return panelRef;
+};
+
+
+/**
+ * Wraps the users template in two elements, md-panel-container, which covers
+ * the entire attachTo element, and md-panel, which contains only the
+ * template. This allows the panel control over positioning, animations,
+ * and similar properties.
+ *
+ * @param {string} origTemplate The original template.
+ * @returns {string} The wrapped template.
+ * @private
+ */
+MdPanelService.prototype.wrapTemplate_ = function(origTemplate) {
+  var template = origTemplate || '';
+
+  return '<div class="md-panel-outer-wrapper">' +
+            '<div class="md-panel">' +
+              template +
+            '</div>' +
+         '</div>';
 };
 
 

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -1,0 +1,19 @@
+.md-panel-outer-wrapper {
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  overflow: hidden;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: $z-index-dialog; // TODO(ErinCoughlan): Set z-index in config.
+}
+
+
+.md-panel {
+  overflow: auto;
+  position: relative; // TODO(ErinCoughlan): Set position from config values.
+}
+

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2,6 +2,7 @@ describe('$mdPanel', function() {
   var $mdPanel, $rootScope, $rootEl, $templateCache, $q;
   var panelRef;
   var attachedElements = [];
+  var PANEL_EL = '.md-panel-outer-wrapper';
 
   /**
    * @param {!angular.$injector} $injector
@@ -63,93 +64,86 @@ describe('$mdPanel', function() {
   });
 
   it('should create and open a basic panel', function() {
-    var template = '<div id="panel">Hello World!</div>';
+    var template = '<div>Hello World!</div>';
     var config = { template: template };
 
-    panelRef = $mdPanel.open(config);
-    $rootScope.$apply();
+    openPanel(config);
 
-    expect('#panel').toExist();
+    expect(PANEL_EL).toExist();
     expect(panelRef.isOpen).toEqual(true);
 
-    panelRef.close();
-    $rootScope.$apply();
+    closePanel();
 
-    expect('#panel').not.toExist();
+    expect(PANEL_EL).not.toExist();
     expect(panelRef.isOpen).toEqual(false);
   });
 
   it('should add and remove a panel from the DOM', function() {
-    var template = '<div id="panel">Hello World!</div>';
+    var template = '<div>Hello World!</div>';
     var config = { template: template };
 
     panelRef = $mdPanel.create(config);
 
-    expect('#panel').not.toExist();
+    expect(PANEL_EL).not.toExist();
 
-    panelRef.open();
-    $rootScope.$apply();
+    openPanel();
 
-    expect('#panel').toExist();
+    expect(PANEL_EL).toExist();
 
-    panelRef.close();
-    $rootScope.$apply();
+    closePanel();
 
-    expect('#panel').not.toExist();
+    expect(PANEL_EL).not.toExist();
   });
 
-  it('should attach panel to a specific element', function() {
-    var parentEl = document.createElement('div');
-    parentEl.id = 'parent';
-    attachToBody(parentEl);
+  describe('config options:', function() {
+    it('should attach panel to a specific element', function() {
+      var parentEl = document.createElement('div');
+      parentEl.id = 'parent';
+      attachToBody(parentEl);
 
-    var template = '<div id="panel">Hello World!</div>';
-    var config = {
-      attachTo: angular.element(parentEl),
-      template: template
-    };
+      var template = '<div>Hello World!</div>';
+      var config = {
+        attachTo: angular.element(parentEl),
+        template: template
+      };
 
-    panelRef = $mdPanel.create(config);
-    panelRef.open();
-    $rootScope.$apply();
+      openPanel(config);
 
-    var panelEl = document.querySelector('#panel');
-    expect(panelEl.parentElement).toBe(parentEl);
+      var panelEl = document.querySelector(PANEL_EL);
+      expect(panelEl.parentElement).toBe(parentEl);
 
-    panelRef.close();
-    $rootScope.$apply();
+      closePanel();
 
-    expect(parentEl.childElementCount).toEqual(0);
+      expect(parentEl.childElementCount).toEqual(0);
+    });
   });
 
   describe('component logic: ', function() {
     it('should allow templateUrl to specify content', function() {
       var htmlContent = 'Puppies and Unicorns';
-      var template = '<div id="panel">' + htmlContent + '</div>';
+      var template = '<div>' + htmlContent + '</div>';
       $templateCache.put('template.html', template);
 
       var config = { templateUrl: 'template.html' };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should allow template to specify content', function() {
       var htmlContent = 'Ice cream';
-      var template = '<div id="panel">' + htmlContent + '</div>';
+      var template = '<div>' + htmlContent + '</div>';
       var config = { template: template };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should allow a controller to be specified', function() {
       var htmlContent = 'Cotton candy';
-      var template = '<div id="panel">{{ content }}</div>';
+      var template = '<div>{{ content }}</div>';
 
       var config = {
         template: template,
@@ -158,15 +152,14 @@ describe('$mdPanel', function() {
         }
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should allow controllerAs syntax', function() {
       var htmlContent = 'Cupcakes';
-      var template = '<div id="panel">{{ ctrl.content }}</div>';
+      var template = '<div>{{ ctrl.content }}</div>';
 
       var config = {
         template: template,
@@ -176,15 +169,14 @@ describe('$mdPanel', function() {
         controllerAs: 'ctrl'
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should wait for resolve before creating the panel', function() {
       var htmlContent = 'Cheesecake';
-      var template = '<div id="panel">{{ ctrl.content }}</div>';
+      var template = '<div>{{ ctrl.content }}</div>';
 
       var deferred = $q.defer();
 
@@ -203,21 +195,20 @@ describe('$mdPanel', function() {
         }
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').not.toExist();
+      expect(PANEL_EL).not.toExist();
 
       deferred.resolve(htmlContent);
       $rootScope.$apply();
 
-      expect('#panel').toExist();
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toExist();
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should bind resolve to the controller', function() {
       var htmlContent = 'Gummy bears';
-      var template = '<div id="panel">{{ ctrl.content }}</div>';
+      var template = '<div>{{ ctrl.content }}</div>';
 
       var config = {
         template: template,
@@ -232,15 +223,14 @@ describe('$mdPanel', function() {
         }
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should allow locals to be injected in the controller', function() {
       var htmlContent = 'Tiramisu';
-      var template = '<div id="panel">{{ ctrl.content }}</div>';
+      var template = '<div>{{ ctrl.content }}</div>';
 
       var config = {
         template: template,
@@ -252,15 +242,14 @@ describe('$mdPanel', function() {
         bindToController: false,
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
 
     it('should bind locals to the controller', function() {
       var htmlContent = 'Apple Pie';
-      var template = '<div id="panel">{{ ctrl.content }}</div>';
+      var template = '<div>{{ ctrl.content }}</div>';
 
       var config = {
         template: template,
@@ -271,10 +260,9 @@ describe('$mdPanel', function() {
         locals: { content: htmlContent }
       };
 
-      panelRef = $mdPanel.open(config);
-      $rootScope.$apply();
+      openPanel(config);
 
-      expect('#panel').toContainHtml(htmlContent);
+      expect(PANEL_EL).toContainHtml(htmlContent);
     });
   });
 
@@ -287,5 +275,28 @@ describe('$mdPanel', function() {
     var element = angular.element(el);
     angular.element(document.body).append(element);
     attachedElements.push(element);
+  }
+
+  /**
+   * Opens the panel. If a config value is passed, creates a new panelRef
+   * using $mdPanel.open(config); Otherwise, called open on the panelRef,
+   * assuming one has already been created.
+   * @param {!Object=} opt_config
+   */
+  function openPanel(opt_config) {
+    if (opt_config) {
+      panelRef = $mdPanel.open(opt_config);
+    } else {
+      panelRef && panelRef.open();
+    }
+    $rootScope.$apply();
+  }
+
+  /**
+   * Closes the panel using an already created panelRef.
+   */
+  function closePanel() {
+    panelRef && panelRef.close();
+    $rootScope.$apply();
   }
 });


### PR DESCRIPTION
Also wraps the user-provided template in an md-panel-container, which will allow us to control positioning, animations, and similar panel properties. I came up with a few ways to implement this, so if you have a better solution, let me know.

@ThomasBurleson @jelbourn @gmoothart @KarenParker @DerekLouie Please review.