### PR TITLE
fix(card): flex-size 0px didn't worked well on IE

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -71,7 +71,7 @@ md-card {
   md-card-title {
     padding: 3 * $card-padding / 2 $card-padding $card-padding;
     display: flex;
-    flex: 1;
+    flex: 1 1 auto;
     flex-direction: row;
 
     & + md-card-content {


### PR DESCRIPTION
* Defined as `auto` solved the problem and preserved functionality on Chrome

fixes #7061