### PR TITLE
feat(media): add media directive as $mdMedia wrapper for classes

### DIFF
--- a/src/components/media/demoBasicUsage/index.html
+++ b/src/components/media/demoBasicUsage/index.html
@@ -1,0 +1,9 @@
+<div layout="column" ng-cloak>
+
+  <md-content layout-padding>
+    <div class="box red" md-media-gt-sm="blue">
+      I'm changing my color on different screen sizes.
+    </div>
+  </md-content>
+
+</div>

--- a/src/components/media/demoBasicUsage/script.js
+++ b/src/components/media/demoBasicUsage/script.js
@@ -1,0 +1,1 @@
+angular.module('mediaBasicUsage', ['ngMaterial']);

--- a/src/components/media/demoBasicUsage/style.css
+++ b/src/components/media/demoBasicUsage/style.css
@@ -1,0 +1,17 @@
+.box {
+    width: 100%;
+    max-width: 350px;
+    height: 150px;
+    margin: 0 auto;
+    text-align: center;
+}
+
+.red {
+    background-color: rgba(255, 0, 0, 0.55);
+    color: black;
+}
+
+.blue {
+    background-color: rgba(0, 0, 255, 0.6);
+    color: white;
+}

--- a/src/components/media/media.js
+++ b/src/components/media/media.js
@@ -1,0 +1,141 @@
+(function() {
+
+  var PREFIX_REGEXP = /^((?:x|data)[\:\-_])/i;
+  var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
+  var DIRECTIVE_PREFIX = "md-media-";
+  var BREAKPOINTS = ["xs", "gt-xs", "sm", "gt-sm", "md", "gt-md", "lg", "gt-lg", "xl", "print"];
+
+  /**
+   * @ngdoc module
+   * @name material.components.media
+   * @description
+   * Media module
+   */
+  registerMediaDirectives(angular.module('material.components.media', ['material.core']));
+
+  function registerMediaDirectives(module) {
+
+    angular.forEach(BREAKPOINTS, function (breakpoint) {
+      var directiveName = directiveNormalize(DIRECTIVE_PREFIX + breakpoint);
+      module.directive(directiveName, registerBreakpointDirective(breakpoint));
+    });
+  }
+
+  /**
+   * @ngdoc directive
+   * @name mdMedia
+   * @module material.components.media
+   *
+   * @restrict A
+   *
+   * @description
+   * The `md-media` directive is a wrapper for the `$mdMedia` service.</br>
+   * It allows you to add classes on a specific screen size using breakpoints.
+   *
+   * <h3>Available breakpoints</h3>
+   <table class="md-api-table">
+   *    <thead>
+   *    <tr>
+   *      <th>Attribute</th>
+   *      <th>Media Query</th>
+   *    </tr>
+   *    </thead>
+   *    <tbody>
+   *    <tr>
+   *      <td>md-media-xs</td>
+   *      <td>(max-width: 599px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-gt-xs</td>
+   *      <td>(min-width: 600px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-sm</td>
+   *      <td>(min-width: 600px) and (max-width: 959px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-gt-sm</td>
+   *      <td>(min-width: 960px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-md</td>
+   *      <td>(min-width: 960px) and (max-width: 1279px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-gt-md</td>
+   *      <td>(min-width: 1280px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-lg</td>
+   *      <td>(min-width: 1280px) and (max-width: 1919px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-gt-lg</td>
+   *      <td>(min-width: 1920px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-xl</td>
+   *      <td>(min-width: 1920px)</td>
+   *    </tr>
+   *    <tr>
+   *      <td>md-media-print</td>
+   *      <td>print</td>
+   *    </tr>
+   *    </tbody>
+   *  </table>
+   *
+   * @usage
+   * <hljs lang="html">
+   *   <div class="red" md-media-sm="blue" md-media-gt-sm="orange">
+   *     This Box changes its color on specific screen sizes.
+   *   </div>
+   * </hljs>
+   */
+  function registerBreakpointDirective(breakpoint) {
+
+    return ['$mdMedia', function ($mdMedia) {
+      return {
+        restrict: 'A',
+        link: postLink
+      };
+
+      function postLink(scope, element, attr) {
+        var classes = [];
+
+        attr.$observe(directiveNormalize(DIRECTIVE_PREFIX + breakpoint), function (value) {
+          classes = parseClasses(value);
+        });
+
+        scope.$watch(function () {
+          return $mdMedia(breakpoint);
+        }, function (value) {
+          toggleClasses(value);
+        });
+
+        function toggleClasses(value) {
+          for (var i = 0; i < classes.length; i++) {
+            element.toggleClass(classes[i], value);
+          }
+        }
+
+        function parseClasses(value) {
+          return value.split(/ /g);
+        }
+      }
+    }];
+  }
+
+  /**
+   * Converts snake_case to camelCase.
+   * Also there is special case for Moz prefix starting with upper case letter.
+   * @param name Name to normalize
+   */
+  function directiveNormalize(name) {
+    return name
+      .replace(PREFIX_REGEXP, '')
+      .replace(SPECIAL_CHARS_REGEXP, function (_, separator, letter, offset) {
+        return offset ? letter.toUpperCase() : letter;
+      });
+  }
+
+})();

--- a/src/components/media/media.spec.js
+++ b/src/components/media/media.spec.js
@@ -1,0 +1,21 @@
+describe('mdMedia directive', function() {
+
+  beforeEach(module('material.components.media'));
+
+  it('should register the directives correctly', inject(function($injector) {
+
+    // Manually check all breakpoints, because using a dynamic test with a loop is not recommended.
+    expect($injector.has('mdMediaXsDirective')).toBe(true);
+    expect($injector.has('mdMediaGtXsDirective')).toBe(true);
+    expect($injector.has('mdMediaSmDirective')).toBe(true);
+    expect($injector.has('mdMediaGtSmDirective')).toBe(true);
+    expect($injector.has('mdMediaMdDirective')).toBe(true);
+    expect($injector.has('mdMediaGtMdDirective')).toBe(true);
+    expect($injector.has('mdMediaLgDirective')).toBe(true);
+    expect($injector.has('mdMediaGtLgDirective')).toBe(true);
+    expect($injector.has('mdMediaXlDirective')).toBe(true);
+    expect($injector.has('mdMediaPrintDirective')).toBe(true);
+
+  }));
+
+});


### PR DESCRIPTION
This directive allows the user to add specific classes on specific screen-sizes / breakpoints.

**Notes**
- Tests are currently manually (not dynamic using a loop - I can change that if desired)
- mdMedia directive is currently listed under directives / components (Is that the right way?) 

@EladBezalel @ThomasBurleson - Please correct me if the directive should be located where-else (and about the dynamic tests)

PS: Work in progress :+1: 