### PR TITLE
docs(input): document numeric input md-maxlength validation

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -157,7 +157,9 @@ function labelDirective() {
  *   specified, a character counter will be shown underneath the input.<br/><br/>
  *   The purpose of **`md-maxlength`** is exactly to show the max length counter text. If you don't
  *   want the counter text and only need "plain" validation, you can use the "simple" `ng-maxlength`
- *   or maxlength attributes.
+ *   or maxlength attributes.<br/><br/>
+ *   **Note:** Only valid for text/string inputs (not numeric).
+ *
  * @param {string=} aria-label Aria-label is required when no label is present.  A warning message
  *   will be logged in the console if not present.
  * @param {string=} placeholder An alternative approach to using aria-label when the label is not


### PR DESCRIPTION
As discussed with @EladBezalel, we should not parse the numeric model to a string but mention  it in the docs.

Fixes #5321