### PR TITLE
fix(theming): theming should also watch for controller changes.

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -341,6 +341,8 @@ function ThemingProvider($mdColorPalette) {
       var attrThemeValue = el.attr('md-theme-watch');
       if ( (alwaysWatchTheme || angular.isDefined(attrThemeValue)) && attrThemeValue != 'false') {
         var deregisterWatch = $rootScope.$watch(function() {
+          // As a few components (dialog) add their controllers later, we should also watch for a controller init.
+          ctrl = parent.controller('mdTheme');
           return ctrl && ctrl.$mdTheme || (defaultTheme == 'default' ? '' : defaultTheme);
         }, changeTheme);
         el.on('$destroy', deregisterWatch);


### PR DESCRIPTION
As the dialog inherits the controllers not at link time, the theming won't work.
Tried a few possibilities:
- Walking through the DOM after show and re-theme the elements
- Recompile the template after show

But the most elegant and performant solution is definitely watching for the controller change.

Fixes #5899