### PR TITLE
fix(tabs): remove inline css width if tabs should stretch

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -537,13 +537,28 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * Updates whether or not pagination should be displayed.
    */
   function updatePagination () {
-    if (!shouldStretchTabs()) updatePagingWidth();
+    updatePagingWidth();
     ctrl.maxTabWidth = getMaxTabWidth();
     ctrl.shouldPaginate = shouldPaginate();
   }
 
+  /**
+   * Sets or clears fixed width for md-pagination-wrapper depending on if tabs should stretch.
+   */
   function updatePagingWidth() {
+    if (shouldStretchTabs()) {
+      angular.element(elements.paging).css('width', '');
+    } else {
+      angular.element(elements.paging).css('width', calcPagingWidth() + 'px');
+    }
+  }
+
+  /**
+   * @returns {number}
+   */
+  function calcPagingWidth () {
     var width = 1;
+
     angular.forEach(getElements().dummies, function (element) {
       //-- Uses the larger value between `getBoundingClientRect().width` and `offsetWidth`.  This
       //   prevents `offsetWidth` value from being rounded down and causing wrapping issues, but
@@ -551,7 +566,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       //   of a dialog)
       width += Math.max(element.offsetWidth, element.getBoundingClientRect().width);
     });
-    angular.element(elements.paging).css('width', Math.ceil(width) + 'px');
+
+    return Math.ceil(width);
   }
 
   function getMaxTabWidth () {

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -39,7 +39,7 @@ describe('<md-tabs>', function () {
   function setup (template, scope) {
     var el;
     inject(function ($compile, $rootScope) {
-      newScope = $rootScope.$new();
+      var newScope = $rootScope.$new();
       for (var key in scope || {}) newScope[key] = scope[key];
       el = $compile(template)(newScope);
       newScope.$apply();
@@ -355,6 +355,36 @@ describe('<md-tabs>', function () {
       expect(element.find('md-tab-item').eq(0).text()).toBe('one');
       // first item in nested tabs should be 'a'
       expect(element.find('md-tabs').find('md-tab-item').eq(0).text()).toBe('a');
+    }));
+  });
+
+  describe('md-pagination-wrapper', function () {
+    var template =  '<md-tabs md-stretch-tabs="{{stretch}}">' +
+                    '  <md-tab label="label!">content!</md-tab>' +
+                    '</md-tabs>';
+
+    it('should have inline width if md-stretch-tabs="never"',
+      inject(function ($timeout, $document) {
+      var scope = { 'stretch': 'never' };
+      var element = setup(template, scope);
+      // Appending to body is required for style checks
+      angular.element($document.body).append(element);
+      // $timeout.flush required to run nextTick inside init();
+      $timeout.flush();
+      expect(element.find('md-pagination-wrapper').attr('style').indexOf('width')).toBeGreaterThan(-1);
+      element.remove();
+    }));
+
+    it('should not have inline width if md-stretch-tabs="always"',
+      inject(function ($timeout, $document) {
+      var scope = { 'stretch': 'always' };
+      var element = setup(template, scope);
+      // Appending to body is required for style checks
+      angular.element($document.body).append(element);
+      // $timeout.flush required to run nextTick inside init();
+      $timeout.flush();
+      expect(element.find('md-pagination-wrapper').attr('style').indexOf('width')).toBe(-1);
+      element.remove();
     }));
   });
 });


### PR DESCRIPTION
There is an issue when dynamically setting md-stretch-tabs. If shouldStretchTabs() evaluates to false at any time then a fixed width is added and never removed. This fix removes a fixed inline width from `<md-pagination-wrapper>` if shoulStretchTabs() returns true.