### PR TITLE
fix(list): fix converted space when target is content editable.

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -282,7 +282,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
         if (!hasClick && !proxies.length) {
           firstChild && firstChild.addEventListener('keypress', function(e) {
-            if (e.target.nodeName != 'INPUT' && e.target.nodeName != 'TEXTAREA') {
+            if (e.target.nodeName != 'INPUT' && e.target.nodeName != 'TEXTAREA' && !e.target.isContentEditable) {
               var keyCode = e.which || e.keyCode;
               if (keyCode == $mdConstant.KEY_CODE.SPACE) {
                 if (firstChild) {

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -88,6 +88,30 @@ describe('mdListItem directive', function() {
     expect($rootScope.modelVal).toBeFalsy();
   }));
 
+  it('should not convert spacebar keypress for editable elements', inject(function($mdConstant) {
+    var listItem = setup('<md-list-item><div contenteditable="true"></div></md-list-item>');
+    var editableEl = listItem.find('div');
+    var onClickSpy = jasmine.createSpy('onClickSpy');
+
+    // We need to append our element to the DOM because the browser won't detect `contentEditable` when the element
+    // is hidden in the DOM. See the related issue for chromium:
+    // https://code.google.com/p/chromium/issues/detail?id=313082
+    document.body.appendChild(listItem[0]);
+
+    editableEl.on('click', onClickSpy);
+
+    // We need to dispatch the keypress natively, because otherwise the `keypress` won't be triggered in the list.
+    var event = document.createEvent('Event');
+    event.keyCode = $mdConstant.KEY_CODE.SPACE;
+    event.initEvent('keypress', true, true);
+
+    editableEl[0].dispatchEvent(event);
+
+    expect(onClickSpy).not.toHaveBeenCalled();
+
+    document.body.removeChild(listItem[0]);
+  }));
+
   xit('should not convert spacebar keypress for text inputs', inject(function($mdConstant) {
 
     var listItem = setup('<md-list-item><input ng-keypress="pressed = true" type="text"></md-list-item>');


### PR DESCRIPTION
As this is a feature which is depending on the browsers behaviour, we need to dispatch native events to the editable element, otherwise the test won't fail when the `editableContent` check is removed.

If you don't trust me :), checkout the PR and use jqLite for triggering the event and remove the `isContentEditable` check.

Fixes #5406