### PR TITLE
Removed text-shadow for inputs with -webkit-autofill

### DIFF
--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -62,6 +62,9 @@ input {
       -webkit-appearance: none;
     }
   }
+  &:-webkit-autofill {
+    text-shadow: none;
+  }
 }
 
 .md-visually-hidden {


### PR DESCRIPTION
`input` contents with `-webkit-autofill` applied looks blurry in `.dark()` mode because of `.text-shadow` applied. This commit fixes this issue.