### PR TITLE
fix(handleMenuItemHover): allow any mdButton to be a focusableTarget

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -92,7 +92,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
         nestedMenu.open();
       }
     }, nestedMenu ? 100 : 250);
-    var focusableTarget = event.currentTarget.querySelector('button:not([disabled])');
+    var focusableTarget = event.currentTarget.querySelector('.md-button:not([disabled])');
     focusableTarget && focusableTarget.focus();
   };
 


### PR DESCRIPTION
Allow any mdButton element (`<button>` or `<a>` tag) to take focus when it is hovered over.
Previously, only a non-disabled button could be a focusable target when being hovered over.
Now, any non-disabled element with the md-button class can be a focusable target and take focus.

Closes issue #7220 