### PR TITLE
fix(docs): stretched icon button will interfere with ripple

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -430,10 +430,6 @@ a.docs-logo {
   margin: 0 24px;
   width: auto;
 }
-.docs-tools .md-button {
-  padding: 0;
-  margin: 0 0 0 8px;
-}
 .docs-tools .md-button,
 .docs-tools .md-button md-icon {
   color: #666 !important;


### PR DESCRIPTION
As there is the icon button in the toolbar currently stretched, the ripple isn't working anymore.
This can be fixed by removing that stretching.
- Everything will work still the same, except the button won't be moved `8px` right (but that still looks fine)

Line introduced in https://github.com/angular/material/commit/bd9bbdbb95675d7371c01908bb1da43fa65331c2#diff-272b77251b74dd4fbf020ac40c529c11R396

@robertmesserle Can you remember why you added this line?