### PR TITLE
docs(contactChips): Add demo of searching with a promise

### DIFF
--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -32,5 +32,18 @@
       </md-list-item>
     </md-list>
 
+    <br>
+    <h2 class="md-title">Searching asynchronously.</h2>
+    <md-contact-chips
+        ng-model="ctrl.asyncContacts"
+        md-contacts="ctrl.delayedQuerySearch($query)"
+        md-contact-name="name"
+        md-contact-image="image"
+        md-contact-email="email"
+        md-require-match="true"
+        md-highlight-flags="i"
+        filter-selected="ctrl.filterSelected"
+        placeholder="To">
+    </md-contact-chips>
   </md-content>
 </div>

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -8,8 +8,10 @@
     var self = this;
 
     self.querySearch = querySearch;
+    self.delayedQuerySearch = delayedQuerySearch;
     self.allContacts = loadContacts();
     self.contacts = [self.allContacts[0]];
+    self.asyncContacts = [];
     self.filterSelected = true;
 
     /**
@@ -19,6 +21,15 @@
       var results = query ?
           self.allContacts.filter(createFilterFor(query)) : [];
       return results;
+    }
+
+    /**
+     * Search for contacts after a random delay.
+     */
+    function delayedQuerySearch(query) {
+      return $timeout(function() {
+        return self.querySearch(query);
+      }, Math.random() * 1000, false);
     }
 
     /**

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -30,9 +30,8 @@ angular
  *    contact's image.
  *
  *
- * // The following attribute has been removed but may come back.
  * @param {expression=} filter-selected Whether to filter selected contacts from the list of
- *    suggestions shown in the autocomplete.
+ *    suggestions shown in the autocomplete. This attribute has been removed but may come back.
  *
  *
  *

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -21,7 +21,8 @@ angular
  * @param {string=} secondary-placeholder Placeholder text that will be forwarded to the input,
  *    displayed when there is at least on item in the list
  * @param {expression} md-contacts An expression expected to return contacts matching the search
- *    test, `$query`.
+ *    test, `$query`. If this expression involves a promise, a loading bar is displayed while
+ *    for it to resolve.
  * @param {string} md-contact-name The field name of the contact object representing the
  *    contact's name.
  * @param {string} md-contact-email The field name of the contact object representing the


### PR DESCRIPTION
Append a demo of searching with a delayed promise for contacts matching the query string to the existing contacts chip demo.

Closes #4661 