### PR TITLE
fix(sidenav, backdrop): fill the backdrop with its parents height

### DIFF
--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -19,50 +19,69 @@
 
 angular
   .module('material.components.backdrop', ['material.core'])
-  .directive('mdBackdrop', function BackdropDirective($mdTheming, $animate, $rootElement, $window, $log, $$rAF, $document) {
-    var ERROR_CSS_POSITION = "<md-backdrop> may not work properly in a scrolled, static-positioned parent container.";
+  .directive('mdBackdrop', MdBackdropDirective)
+  .controller('$mdBackdropController', MdBackdropController);
 
-    return {
-      restrict: 'E',
-      link: postLink
-    };
 
-    function postLink(scope, element, attrs) {
+function MdBackdropDirective($mdTheming, $animate, $rootElement, $window, $log, $$rAF, $document) {
+  var ERROR_CSS_POSITION = "<md-backdrop> may not work properly in a scrolled, static-positioned parent container.";
 
-      // If body scrolling has been disabled using mdUtil.disableBodyScroll(),
-      // adjust the 'backdrop' height to account for the fixed 'body' top offset
-      var body = $window.getComputedStyle($document[0].body);
-      if (body.position == 'fixed') {
-        var hViewport = parseInt(body.height, 10) + Math.abs(parseInt(body.top, 10));
-        element.css({
-          height: hViewport + 'px'
-        });
-      }
+  return {
+    restrict: 'E',
+    link: postLink,
+    controller: '$mdBackdropController'
+  };
 
-      // backdrop may be outside the $rootElement, tell ngAnimate to animate regardless
-      if ($animate.pin) $animate.pin(element, $rootElement);
+  function postLink(scope, element, attrs) {
 
-      $$rAF(function () {
-
-        // Often $animate.enter() is used to append the backDrop element
-        // so let's wait until $animate is done...
-        var parent = element.parent()[0];
-        if (parent) {
-
-          if ( parent.nodeName == 'BODY' ) {
-            element.css({position : 'fixed'});
-          }
-
-          var styles = $window.getComputedStyle(parent);
-          if (styles.position == 'static') {
-            // backdrop uses position:absolute and will not work properly with parent position:static (default)
-            $log.warn(ERROR_CSS_POSITION);
-          }
-        }
-
-        $mdTheming.inherit(element, element.parent());
+    // If body scrolling has been disabled using mdUtil.disableBodyScroll(),
+    // adjust the 'backdrop' height to account for the fixed 'body' top offset
+    var body = $window.getComputedStyle($document[0].body);
+    if (body.position == 'fixed') {
+      var hViewport = parseInt(body.height, 10) + Math.abs(parseInt(body.top, 10));
+      element.css({
+        height: hViewport + 'px'
       });
-
     }
 
-  });
+    // backdrop may be outside the $rootElement, tell ngAnimate to animate regardless
+    if ($animate.pin) $animate.pin(element, $rootElement);
+
+    $$rAF(function () {
+      // Often $animate.enter() is used to append the backDrop element
+      // so let's wait until $animate is done...
+      var parent = element.parent()[0];
+      if (parent) {
+
+        if (parent.nodeName == 'BODY') {
+          element.css({position: 'fixed'});
+        }
+
+        var styles = $window.getComputedStyle(parent);
+        if (styles.position == 'static') {
+          // backdrop uses position:absolute and will not work properly with parent position:static (default)
+          $log.warn(ERROR_CSS_POSITION);
+        }
+      }
+
+      $mdTheming.inherit(element, element.parent());
+    });
+
+  }
+}
+
+function MdBackdropController($element) {
+
+  /**
+   * Fills the backdrop's parent with the parent's height.
+   * This needs to be a controller function, because at postLink the backdrop isn't mostly
+   * added to the DOM yet
+   */
+  this.fillParentHeight = function () {
+    var clientHeight = $element.parent().prop('clientHeight');
+    $element.css({
+      height: clientHeight + 'px'
+    });
+  }
+
+}

--- a/src/components/backdrop/backdrop.spec.js
+++ b/src/components/backdrop/backdrop.spec.js
@@ -1,0 +1,23 @@
+describe('mdBackdrop directive', function() {
+
+    beforeEach(module('material.components.backdrop'));
+
+    it('should set the backdrops height to the same as its parent', inject(function($rootScope, $mdUtil) {
+        var parent = angular.element('<div style="height: 1000px"></div>');
+        var backdrop = $mdUtil.createBackdrop($rootScope);
+        var backdropCtrl = backdrop.controller('mdBackdrop');
+
+        parent.append(backdrop);
+
+        // We need to add the parent to the DOM, otherwise we can't measure the clientHeight`
+        document.body.appendChild(parent[0]);
+
+        backdropCtrl.fillParentHeight();
+
+        expect(backdrop.css('height')).toBe('1000px');
+
+        // Remove the element from the DOM to prevent issues with other tests
+        document.body.removeChild(parent[0]);
+    }));
+
+});

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -241,6 +241,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
       });
     };
     var backdrop = $mdUtil.createBackdrop(scope, "md-sidenav-backdrop md-opaque ng-enter");
+    var backdropCtrl = backdrop.controller('mdBackdrop');
 
     $mdTheming.inherit(backdrop, element);
 
@@ -298,6 +299,13 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
                 $animate[isOpen ? 'removeClass' : 'addClass'](element, 'md-closed')
               ])
               .then(function() {
+                // Fill the backdrop with the parents height, only if the backdrop is added to the DOM.
+                // This is needed, because we don't disable body scrolling so we need to trigger the `parent fill`
+                // manually. As the backdrop is added dynamically to the DOM we need to fill it from our directive.
+                if (backdrop.parent().length && backdropCtrl) {
+                  backdropCtrl.fillParentHeight();
+                }
+
                 // Perform focus when animations are ALL done...
                 if (scope.isOpen) {
                   focusEl && focusEl.focus();


### PR DESCRIPTION
> As there is the fixed height on the second parent, everything works as expected, except that the backdrop should fill its parent, when we are not locking the whole body

@topherfangio Can you take a look?

Fixes #5861