### PR TITLE
update(sticky): only compile the self-cloned element in the given scope.

### DIFF
--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -20,7 +20,9 @@ angular
  * @description
  * The `$mdSticky`service provides a mixin to make elements sticky.
  *
- * By default the `$mdSticky` service compiles the cloned element in the same scope as the actual element lives.
+ * By default the `$mdSticky` service compiles the cloned element, when not specified through the `elementClone`
+ * parameter, in the same scope as the actual element lives.
+ *
  *
  * <h3>Notes</h3>
  * When using an element which is containing a compiled directive, which changed its DOM structure during compilation,
@@ -64,7 +66,7 @@ angular
  *   - `element`: The element that will be 'sticky'
  *   - `elementClone`: A clone of the element, that will be shown
  *     when the user starts scrolling past the original element.
- *     If not provided, it will use the result of `element.clone()`.
+ *     If not provided, it will use the result of `element.clone()` and compiles it in the given scope.
  */
 function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
 
@@ -90,9 +92,8 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
         contentCtrl.$element.data('$$sticky', $$sticky);
       }
 
-      // Compile our clone element in the given scope if the stickyClone has no scope predefined.
-      var cloneElement = stickyClone && stickyClone.scope && stickyClone.scope() ?
-          stickyClone : $compile(stickyClone || element.clone())(scope);
+      // Compile our cloned element, when cloned in this service, into the given scope.
+      var cloneElement = stickyClone || $compile(element.clone())(scope);
 
       var deregister = $$sticky.add(element, cloneElement);
       scope.$on('$destroy', deregister);

--- a/src/components/sticky/sticky.spec.js
+++ b/src/components/sticky/sticky.spec.js
@@ -1,3 +1,87 @@
+describe('$mdSticky service', function() {
+
+  beforeEach(module('material.components.sticky'));
+
+  it('should compile our cloned element in the same scope', function(done) {
+    inject(function($compile, $rootScope, $mdSticky, $timeout) {
+      var scope = $rootScope.$new();
+      var contentEl = $compile(angular.element(
+        '<md-content>' +
+        '<sticky-directive>Sticky Element</sticky-directive>' +
+        '</md-content>'
+      ))(scope);
+
+      document.body.appendChild(contentEl[0]);
+
+      var stickyEl = contentEl.children().eq(0);
+      $mdSticky(scope, stickyEl);
+
+      // Flush the `$$sticky.add()` timeout.
+      $timeout.flush();
+
+      // When the current browser, which executes that spec, supports the sticky position, then we will always succeed
+      // the test, because otherwise our test will fail.
+      if (stickyEl.css('position')) {
+        expect(true).toBe(true);
+      } else {
+        expect(contentEl.children().length).toBe(2);
+
+        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        expect(stickyClone).toBeTruthy();
+
+        expect(angular.element(stickyClone).scope()).toBe(scope);
+      }
+
+      contentEl.remove();
+
+      done();
+    });
+  });
+
+  it('should not compile our self specified clone in the given scope', function(done) {
+    inject(function($compile, $rootScope, $mdSticky, $timeout) {
+      var scope = $rootScope.$new();
+      var cloneScope = $rootScope.$new();
+
+      var contentEl = $compile(angular.element(
+        '<md-content>' +
+          '<sticky-directive>Sticky Element</sticky-directive>' +
+        '</md-content>'
+      ))(scope);
+
+      var cloneEl = $compile(angular.element(
+        '<sticky-directive>Self-cloned Element</sticky-directive>'
+      ))(cloneScope);
+
+      document.body.appendChild(contentEl[0]);
+
+      var stickyEl = contentEl.children().eq(0);
+      $mdSticky(scope, stickyEl, cloneEl);
+
+      // Flush the `$$sticky.add()` timeout.
+      $timeout.flush();
+
+      // When the current browser, which executes that spec, supports the sticky position, then we will always succeed
+      // the test, because otherwise our test will fail.
+      if (stickyEl.css('position')) {
+        expect(true).toBe(true);
+      } else {
+        expect(contentEl.children().length).toBe(2);
+
+        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        expect(stickyClone).toBeTruthy();
+
+        expect(angular.element(stickyClone).scope()).toBe(cloneScope);
+      }
+
+      contentEl.remove();
+
+      done();
+    });
+  });
+
+});
+
 /*
  * TODO: adjust to work properly with refactors of original code
  */


### PR DESCRIPTION
As discussed with @topherfangio, we should not take advantage of the `scope()` method, because these will be only available in Angular's debug mode.
So we both agreed, with removing that and just compiling the cloned element from service into the given scope.