### PR TITLE
fix(list): multi-line inner-text-container should not overflow

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -229,6 +229,7 @@ md-list-item.md-3-line > .md-no-style {
     flex: 1;
     margin: auto;
     text-overflow: ellipsis;
+    overflow: hidden;
 
     &.md-offset {
       margin-left: $list-item-primary-width;


### PR DESCRIPTION
At the moment in a multi line list, the text content will always break the layout when a text is overflowing.
- That's why the ellipsis indicator wasn't working too

This can be fixed by keeping the initial inner-list container in place, by ignoring overflow.
Now the list design won't break and the ellipsis will show as expected.

Fixes #7065 