### PR TITLE
fix(select) trim option text value like a vanilla html select element.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -780,7 +780,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
       setOptionValue(attr.value);
     } else {
       scope.$watch(function() {
-        return element.text();
+        return element.text().trim();
       }, setOptionValue);
     }
 


### PR DESCRIPTION
In case where ngValue and value attribute is missing, ngModel of mdSelect get a string value surrounded by whitespaces, depending on HTML formatting. Vanilla select and option trim is whitespaces and so should mdSelect.