### PR TITLE
docs(autocomplete): better describe the `md-autofocus` attribute

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -49,7 +49,9 @@ angular
  *     make suggestions
  * @param {number=} md-delay Specifies the amount of time (in milliseconds) to wait before looking
  *     for results
- * @param {boolean=} md-autofocus If true, will immediately focus the input element
+ * @param {boolean=} md-autofocus If true, the autocomplete will be automatically focused when a `$mdDialog`,
+ *     `$mdBottomsheet` or `$mdSidenav`, which contains the autocomplete, is opening. <br/><br/>
+ *     Also the autocomplete will immediately focus the input element.
  * @param {boolean=} md-autoselect If true, the first item will be selected by default
  * @param {string=} md-menu-class This will be applied to the dropdown menu for styling
  * @param {string=} md-floating-label This will add a floating label to autocomplete and wrap it in


### PR DESCRIPTION
The current description for the autocomplete attribute was really confusing, and the user was wondering why the autocomplete wasn't retrieving focus automatically.
But they didn't know about the other behaviour of the actual `md-autofocus` directive.
The autocomplete attribute "wrap" is just a little addition which focus the related input instead of the element.

Fixes #7283