### PR TITLE
chore(package.json): Add style and scss fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "type": "git",
     "url": "git://github.com/angular/material.git"
   },
+  "style": "./dist/angular-material.css",
+  "scss": "./dist/angular-material.scss",
   "devDependencies": {
     "angular": "^1.5.0",
     "angular-animate": "^1.5.0",


### PR DESCRIPTION
chore(package.json): Add style and scss fields to package.json

This allows tools like npm-css,  rework-npm, and node-sass to import angular material from the node_modules directory.

Closes #7204 