### PR TITLE
fix(contactChipsDirective): Remplement the filter-selected attribute

### DIFF
--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -83,7 +83,7 @@ describe('<md-contact-chips>', function() {
     });
 
     describe('filtering selected items', function() {
-      it('should filter', inject(function() {
+      it('should filter by default', inject(function() {
         scope.querySearch = jasmine.createSpy('querySearch').and.callFake(function(q) {
           return scope.allContacts;
         });
@@ -101,29 +101,34 @@ describe('<md-contact-chips>', function() {
         });
 
         var matches = autocompleteCtrl.matches;
-        expect(matches.length).toBe(3);
+        expect(matches.length).toBe(2);
       }));
 
-      /* it('should not filter when disabled', inject(function($timeout) {
-       scope.querySearch = jasmine.createSpy('querySearch').and.callFake(function(q) {
-       return scope.allContacts;
-       });
-       scope.contacts.push(scope.allContacts[2]);
-       scope.filterSelected = false;
-       var element = buildChips(CONTACT_CHIPS_TEMPLATE);
-       var ctrl = element.controller('mdContactChips');
-       $timeout.flush();
+      it('should not filter when disabled', inject(function($timeout) {
+        scope.querySearch = jasmine.createSpy('querySearch').and.callFake(function(q) {
+          return scope.allContacts;
+        });
+        scope.contacts.push(scope.allContacts[2]);
 
-       var autocompleteElement = element.find('md-autocomplete');
-       var autocompleteCtrl = autocompleteElement.controller('mdAutocomplete');
-       element.scope().$apply(function() {
-       autocompleteCtrl.scope.searchText = 'NAME';
-       autocompleteCtrl.keydown({});
-       });
+        var template = CONTACT_CHIPS_TEMPLATE.replace(
+          '<md-contact-chips',
+          '<md-contact-chips filter-selected="false"'
+        );
+        var element = buildChips(template);
+        var ctrl = element.controller('mdContactChips');
+        $timeout.flush();
 
-       var matches = autocompleteCtrl.matches;
-       expect(matches.length).toBe(3);
-       }));*/
+        var autocompleteElement = element.find('md-autocomplete');
+        var autocompleteCtrl = autocompleteElement.controller('mdAutocomplete');
+
+        element.scope().$apply(function() {
+          autocompleteCtrl.scope.searchText = 'NAME';
+          autocompleteCtrl.keydown({});
+        });
+
+        var matches = autocompleteCtrl.matches;
+        expect(matches.length).toBe(3);
+      }));
     });
 
   });

--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -13,6 +13,8 @@
         placeholder="To">
     </md-contact-chips>
 
+    <md-checkbox ng-model="ctrl.filterSelected">Filter selected contacts from options</md-checkbox>
+    <br />
     <md-list class="fixedRows">
       <md-subheader class="md-no-sticky">Contacts</md-subheader>
       <md-list-item class="md-2-line contact-item" ng-repeat="(index, contact) in ctrl.allContacts"

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -29,10 +29,8 @@ angular
  *    contact's email address.
  * @param {string} md-contact-image The field name of the contact object representing the
  *    contact's image.
- *
- *
  * @param {expression=} filter-selected Whether to filter selected contacts from the list of
- *    suggestions shown in the autocomplete. This attribute has been removed but may come back.
+ *    suggestions shown in the autocomplete.
  *
  *
  *
@@ -44,6 +42,7 @@ angular
  *       md-contact-name="name"
  *       md-contact-image="image"
  *       md-contact-email="email"
+ *       filter-selected="ctrl.filterSelected"
  *       placeholder="To">
  *   </md-contact-chips>
  * </hljs>
@@ -62,7 +61,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-search-text="$mdContactChipsCtrl.searchText"\
               md-items="item in $mdContactChipsCtrl.queryContact($mdContactChipsCtrl.searchText)"\
               md-item-text="$mdContactChipsCtrl.itemName(item)"\
-              md-no-cache="true"\
+              md-no-cache="$mdContactChipsCtrl.filterSelected"\
               md-autoselect\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\
@@ -118,7 +117,8 @@ function MdContactChips($mdTheming, $mdUtil) {
       contactEmail: '@mdContactEmail',
       contacts: '=ngModel',
       requireMatch: '=?mdRequireMatch',
-      highlightFlags: '@?mdHighlightFlags'
+      highlightFlags: '@?mdHighlightFlags',
+      filterSelected: '=?'
     }
   };
 


### PR DESCRIPTION
- Reimplement the `filter-selected` as an optional attribute on mdContactChips.
  The value of `filter-selected` is also used as the value for the `md-no-cache` attribute on the
  autocomplete inside the directive so that when filtering is enabled, caching is disabled,
  and vice versa.
  This was the behaviour before the attribute was disabled [here](https://github.com/angular/material/commit/48c7c448fc100540af8cd2b27bd710825be0346e#diff-a49333b5f28f4db760c64a42a04866fcL60)
- Add checkbox to the contact chips demo to enable/disable filtering.
- Update contact chips unit tests
  - There are two tests that involve filtering, the first one expected 3 matches when it should
    have expected 2 ([changed here](https://github.com/angular/material/commit/786b0ed3652b7460c2c802efa1aa79972bd96f5d#diff-26f31de42de579310d01694fc34904bbL63)).
    The second one was commented out as filtering was previously unable to be turned off.

Note: In the demo, the behaviour of the `filter-selected` checkbox is a little funky:
Any searches while the checkbox is selected, will be cached without the selected contacts in the results. When the checkbox is unselected these cached searches will be used and therefore, selected contacts will still not appear even though they are not being filtered out. Even though this is unintuitive I thought it wasn't a big problem as it is very unlikely the `filter-selected` setting will be changed while the directive is in use.

Closes #4313