### PR TITLE
UX Enhancement - multiple select check icon

### DIFF
--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -70,18 +70,24 @@ md-select-menu.md-THEME_NAME-theme {
 
 }
 
-md-select-menu[multiple] md-option[selected] .md-text:before {
-   box-sizing: border-box;
-    -webkit-transform: rotate(45deg);
-    transform: rotate(45deg);
-    position: absolute;
-    left: 14px;
-    display: table;
-    width: 6.67px;
-    height: 13.33px;
-    border-width: 2px;
-    border-style: solid;
-    border-top: 0;
-    border-left: 0;
-    content: '';
+
+md-select-menu[multiple] md-option[selected] .md-text {
+    padding-left:32px;padding-right: 32px;
+    :before {
+        box-sizing: border-box;
+         -webkit-transform: rotate(45deg);
+         transform: rotate(45deg);
+         position: absolute;
+         left: 14px;
+         display: table;
+         width: 6.67px;
+         height: 13.33px;
+         border-width: 2px;
+         border-style: solid;
+         border-top: 0;
+         border-left: 0;
+         content: '';
+     }
 }
+
+md-select-menu[mulitple] md-optgroup md-option .md-text {padding-left:0;padding-right:0}

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -71,9 +71,10 @@ md-select-menu.md-THEME_NAME-theme {
 }
 
 
-md-select-menu[multiple] md-option[selected] .md-text {
+md-select-menu[multiple] md-option {
     padding-left:32px;padding-right: 32px;
-    :before {
+    &[selected] .md-text:before {
+            
         box-sizing: border-box;
          -webkit-transform: rotate(45deg);
          transform: rotate(45deg);
@@ -87,7 +88,6 @@ md-select-menu[multiple] md-option[selected] .md-text {
          border-top: 0;
          border-left: 0;
          content: '';
-     }
+    }
 }
 
-md-select-menu[mulitple] md-optgroup md-option .md-text {padding-left:0;padding-right:0}

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -69,3 +69,19 @@ md-select-menu.md-THEME_NAME-theme {
   }
 
 }
+
+md-select-menu[multiple] md-option[selected] .md-text:before {
+   box-sizing: border-box;
+    -webkit-transform: rotate(45deg);
+    transform: rotate(45deg);
+    position: absolute;
+    left: 14px;
+    display: table;
+    width: 6.67px;
+    height: 13.33px;
+    border-width: 2px;
+    border-style: solid;
+    border-top: 0;
+    border-left: 0;
+    content: '';
+}


### PR DESCRIPTION
This is a minor CSS change that adds the check tick to the dropdown select list when using multiple mode. 

Found the original dropdown to be initially a little confusing; until you realise what you have is a multiple select in front of you it seems as if the dropdown has gotten stuck open. 

scss involved: 

```
md-select-menu[multiple] md-option {
    padding-left:32px;padding-right: 32px;
    &[selected] .md-text:before {
            
        box-sizing: border-box;
         -webkit-transform: rotate(45deg);
         transform: rotate(45deg);
         position: absolute;
         left: 14px;
         display: table;
         width: 6.67px;
         height: 13.33px;
         border-width: 2px;
         border-style: solid;
         border-top: 0;
         border-left: 0;
         content: '';
    }
}
```