### PR TITLE
fix(sticky): tests relaid on private classes

### DIFF
--- a/src/components/sticky/sticky.spec.js
+++ b/src/components/sticky/sticky.spec.js
@@ -26,7 +26,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(scope);
@@ -68,7 +68,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(cloneScope);


### PR DESCRIPTION
- Tests was using `md-sticky-clone` instead of `_md-sticky-clone`