### PR TITLE
fix(sticky): fix travis unit test failure

### DIFF
--- a/src/components/sticky/sticky.spec.js
+++ b/src/components/sticky/sticky.spec.js
@@ -26,7 +26,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(scope);
@@ -68,7 +68,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(cloneScope);


### PR DESCRIPTION
After 78ccef6354cbe8898bfe3c489e3b7ea1d43bbffc we missed to update the `sticky` test
- The test failed because it used a CSS class from `$mdSticky` service, which was changed in 78ccef6354cbe8898bfe3c489e3b7ea1d43bbffc