### PR TITLE
fix(icon): disable e11 focus for SVG icons

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -473,7 +473,8 @@ describe('mdIcon service', function() {
       'height': '100%',
       'width' : '100%',
       'preserveAspectRatio': 'xMidYMid meet',
-      'viewBox' : svg.getAttribute('viewBox') || '0 0 24 24'
+      'viewBox' : svg.getAttribute('viewBox') || '0 0 24 24',
+      'focusable': false
     }, function(val, attr) {
       svg.setAttribute(attr, val);
     }, this);

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -523,7 +523,8 @@
            'height': '100%',
            'width' : '100%',
            'preserveAspectRatio': 'xMidYMid meet',
-           'viewBox' : this.element.getAttribute('viewBox') || ('0 0 ' + viewBoxSize + ' ' + viewBoxSize)
+           'viewBox' : this.element.getAttribute('viewBox') || ('0 0 ' + viewBoxSize + ' ' + viewBoxSize),
+           'focusable': false // Disable IE11s default behavior to make SVGs focusable
          }, function(val, attr) {
            this.element.setAttribute(attr, val);
          }, this);


### PR DESCRIPTION
Currently IE11 always sets the SVG icons focusable.
This can be reproduced by tabbing through the `Getting Started` section of the docs.
There will be always two tab-steps when iterating through the icon button in IE11.

@programmist Can you take a look?

Fixes #7250