### PR TITLE
fix(demo, radioButton): get user by id instead of index  …

### DIFF
--- a/src/components/radioButton/demoMultiColumn/index.html
+++ b/src/components/radioButton/demoMultiColumn/index.html
@@ -2,7 +2,7 @@
   <h2>Contact List</h2>
     <md-divider></md-divider>
 
-    <md-radio-group ng-model="cc.selectedIndex" >
+    <md-radio-group ng-model="cc.selectedId" >
       <div ng-repeat='person in cc.contacts' class="row">
         <div flex layout='row' layout-padding layout-align="start center" >
 

--- a/src/components/radioButton/demoMultiColumn/script.js
+++ b/src/components/radioButton/demoMultiColumn/script.js
@@ -1,6 +1,6 @@
 angular
   .module('radioDemo2', ['ngMaterial'])
-  .controller('ContactController', function($scope) {
+  .controller('ContactController', function($scope, $filter) {
     var self = this;
 
     self.contacts = [{
@@ -24,8 +24,8 @@ angular
       'lastName': 'Castel',
       'title': "Security"
     }];
-    self.selectedIndex = 2;
+    self.selectedId = 2;
     self.selectedUser = function() {
-      return self.contacts[self.selectedIndex].lastName;
+      return $filter('filter')(self.contacts, { id: self.selectedId })[0].lastName;
     }
   });


### PR DESCRIPTION
fix(radioButton, demoMultiColumn): #5250 #5292 

1. Add `$filter` as an injector
2. Update `selectedUser()` to fetch user by id.

BREAKING CHANGE: `self.selectedIndex` is now `self.selectedId`

Change code from this:

```html
<md-radio-group ng-model="cc.selectedIndex" >
```

```javascript
.controller('ContactController', function($scope) {

self.selectedUser = function() {
  return self.contacts[self.selectedIndex].lastName;
}
```

To this:

```html
<md-radio-group ng-model="cc.selectedId" >
```

```javascript
.controller('ContactController', function($scope, $filter) {

self.selectedUser = function() {
  return $filter('filter')(self.contacts, { id: self.selectedId })[0].lastName;
}
```