### PR TITLE
fix(mdFabSpeedDial): styles on nested speed dials

### DIFF
--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -129,13 +129,13 @@
 
       var el = element[0];
       var ctrl = element.controller('mdFabSpeedDial');
-      var items = el.querySelectorAll('.md-fab-action-item');
+      var items = findDirectChildren(findDirectChild(el, 'md-fab-actions'), '.md-fab-action-item');
 
       // Grab our trigger element
-      var triggerElement = el.querySelector('md-fab-trigger');
+      var triggerElement = findDirectChild(el, 'md-fab-trigger');
 
       // Grab our element which stores CSS variables
-      var variablesElement = el.querySelector('._md-css-variables');
+      var variablesElement = findDirectChild(el, '._md-css-variables');
 
       // Setup JS variables based on our CSS variables
       var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);
@@ -217,10 +217,10 @@
     function runAnimation(element) {
       var el = element[0];
       var ctrl = element.controller('mdFabSpeedDial');
-      var items = el.querySelectorAll('.md-fab-action-item');
+      var items = findDirectChildren(findDirectChild(el, 'md-fab-actions'), '.md-fab-action-item');
 
       // Grab our element which stores CSS variables
-      var variablesElement = el.querySelector('._md-css-variables');
+      var variablesElement = findDirectChild(el, '._md-css-variables');
 
       // Setup JS variables based on our CSS variables
       var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);
@@ -250,5 +250,20 @@
         delayDone(done);
       }
     }
+  }
+
+  function findDirectChild(element, selector) {
+    var nodesList = element.childNodes;
+
+    for (var i = 0; i < nodesList.length; ++i) {
+      if (nodesList[i].nodeType === nodesList[i].ELEMENT_NODE && nodesList[i].matches(selector))
+        return nodesList[i];
+    }
+  }
+
+  function findDirectChildren(element, selector) {
+    return [].filter.call(element.childNodes, function (node) {
+      return node.nodeType === node.ELEMENT_NODE && node.matches(selector);
+    });
   }
 })();

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -49,11 +49,11 @@ md-fab-speed-dial {
   &.md-down {
     flex-direction: column;
 
-    md-fab-trigger {
+    & > md-fab-trigger {
       order: 1;
     }
 
-    md-fab-actions {
+    & > md-fab-actions {
       flex-direction: column;
       order: 2;
     }
@@ -62,11 +62,11 @@ md-fab-speed-dial {
   &.md-up {
     flex-direction: column;
 
-    md-fab-trigger {
+    & > md-fab-trigger {
       order: 2;
     }
 
-    md-fab-actions {
+    & > md-fab-actions {
       flex-direction: column-reverse;
       order: 1;
     }
@@ -75,11 +75,11 @@ md-fab-speed-dial {
   &.md-left {
     flex-direction: row;
 
-    md-fab-trigger {
+    & > md-fab-trigger {
       order: 2;
     }
 
-    md-fab-actions {
+    & > md-fab-actions {
       flex-direction: row-reverse;
       order: 1;
 
@@ -92,11 +92,11 @@ md-fab-speed-dial {
   &.md-right {
     flex-direction: row;
 
-    md-fab-trigger {
+    & > md-fab-trigger {
       order: 1;
     }
 
-    md-fab-actions {
+    & > md-fab-actions {
       flex-direction: row;
       order: 2;
 
@@ -119,21 +119,21 @@ md-fab-speed-dial {
    * Handle the animations
    */
   &.md-fling {
-    .md-fab-action-item {
+    & > md-fab-actions > .md-fab-action-item {
       opacity: 1;
     }
   }
 
   // For the initial animation, set the duration to be instant
   &.md-fling._md-animations-waiting {
-    .md-fab-action-item {
+    & > md-fab-actions > .md-fab-action-item {
       opacity: 0;
       transition-duration: 0s;
     }
   }
 
   &.md-scale {
-    .md-fab-action-item {
+    & > md-fab-actions > .md-fab-action-item {
       transform: scale(0);
       transition: $swift-ease-in;
 

--- a/src/components/fabSpeedDial/fabSpeedDial.spec.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.spec.js
@@ -129,7 +129,7 @@ describe('<md-fab-speed-dial> directive', function() {
 
   it('properly finishes the scale animation', inject(function(mdFabSpeedDialScaleAnimation) {
     build(
-      '<md-fab-speed-dial md-open="isOpen" class="md-fling">' +
+      '<md-fab-speed-dial md-open="isOpen" class="md-scale">' +
       '  <md-fab-trigger><button></button></md-fab-trigger>' +
       '  <md-fab-actions><button></button></md-fab-actions>' +
       '</md-fab-speed-dial>'


### PR DESCRIPTION
fixes #7356
The `md-fab-actions` component should always be a direct child of the `md-fab-speed-dial` component anyways.