### PR TITLE
Extreme long layout thrashing in IE11

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -28,8 +28,9 @@ md-input-container.md-THEME_NAME-theme {
   ng-message, data-ng-message, x-ng-message,
   [ng-message], [data-ng-message], [x-ng-message],
   [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
-    :not(.md-char-counter) {
-      color: '{{warn-A700}}';
+    color: '{{warn-A700}}';
+    .md-char-counter {
+      color: '{{foreground-1}}';
     }
   }
 


### PR DESCRIPTION
Ok.. this is way too general but i think this bug left unnoticed and gave path to many bugs that related to IE11 regarding performance.

to prove my point we can reproduce this very easily using `UI Responsivess` tab in IE11 developer tools.
Duplicate the amount of ` :not` selectors prefixed with space and measure the time it takes for IE to calculate layout(in green).