### PR TITLE
fix(dialog): moved bottom focus trap to be a sibling

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -934,7 +934,7 @@ function MdDialogProvider($$interimElementProvider) {
       // The top focus trap inserted immeidately before the md-dialog element (as a sibling).
       // The bottom focus trap is inserted at the very end of the md-dialog element (as a child).
       element[0].parentNode.insertBefore(topFocusTrap, element[0]);
-      element.append(bottomFocusTrap);
+      element.after(bottomFocusTrap);
     }
 
     /**


### PR DESCRIPTION
- bottomFocusTrap was appended to the dialog, in FF it seems like it didn't trapped the focus, ,moving it to be a sibling solves it.

@jelbourn please take a look 

fixes #7407