### PR TITLE
perf(input): Reduce input/message CSS complexity.

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -24,10 +24,7 @@ md-input-container.md-THEME_NAME-theme {
     color: '{{foreground-2}}';
   }
 
-  ng-messages, [ng-messages],
-  ng-message, data-ng-message, x-ng-message,
-  [ng-message], [data-ng-message], [x-ng-message],
-  [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
+  .md-input-messages-animation, .md-input-message-animation {
     color: '{{warn-A700}}';
     .md-char-counter {
       color: '{{foreground-1}}';
@@ -75,10 +72,7 @@ md-input-container.md-THEME_NAME-theme {
     label {
       color: '{{warn-A700}}';
     }
-    ng-message, data-ng-message, x-ng-message,
-    [ng-message], [data-ng-message], [x-ng-message],
-    [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
-    .md-char-counter {
+    .md-input-message-animation, .md-char-counter {
       color: '{{warn-A700}}';
     }
   }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -822,8 +822,6 @@ function getInputElement(element) {
 
 function getMessagesElement(element) {
   var input = getInputElement(element);
-  var selector = 'ng-messages,data-ng-messages,x-ng-messages,' +
-    '[ng-messages],[data-ng-messages],[x-ng-messages]';
 
-  return angular.element(input[0].querySelector(selector));
+  return angular.element(input[0].querySelector('.md-input-messages-animation'));
 }

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -201,8 +201,7 @@ md-input-container {
   //
   // ngMessage base styles - animations moved to input.js
   //
-  ng-messages, data-ng-messages, x-ng-messages,
-  [ng-messages], [data-ng-messages], [x-ng-messages] {
+  .md-input-messages-animation {
     position: relative;
     order: 4;
     overflow: hidden;
@@ -210,19 +209,14 @@ md-input-container {
 
     &.ng-enter {
       // Upon entering the DOM, messages should be hidden
-      ng-message, data-ng-message, x-ng-message,
-      [ng-message], [data-ng-message], [x-ng-message],
-      [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp] {
+      .md-input-message-animation {
         opacity: 0;
         margin-top: -100px;
       }
     }
   }
 
-  ng-message, data-ng-message, x-ng-message,
-  [ng-message], [data-ng-message], [x-ng-message],
-  [ng-message-exp], [data-ng-message-exp], [x-ng-message-exp],
-  .md-char-counter {
+  .md-input-message-animation, .md-char-counter {
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
     overflow: hidden;


### PR DESCRIPTION
Previously, the complexity of some of the generated CSS was very high which caused greater than 50ms of load time for some input elements.

Reduce complexity by using internal classes for the `ng-messages` and `ng-message` directives.

Fixes #7405.