### PR TITLE
fix(dialog, bottom-sheet) fix focus trap for dialog when clicking outside and fix escape to close for dialog and bottom-sheet.

### DIFF
--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -175,7 +175,7 @@ function MdBottomSheetProvider($$interimElementProvider) {
         options.restoreScroll = $mdUtil.disableScrollAround(bottomSheet.element, options.parent);
       }
 
-      return $animate.enter(bottomSheet.element, options.parent)
+      return $animate.enter(bottomSheet.element, options.parent, backdrop)
         .then(function() {
           var focusable = $mdUtil.findFocusTarget(element) || angular.element(
             element[0].querySelector('button') ||
@@ -190,7 +190,13 @@ function MdBottomSheetProvider($$interimElementProvider) {
                 $mdUtil.nextTick($mdBottomSheet.cancel,true);
               }
             };
+
             $rootElement.on('keyup', options.rootElementKeyupCallback);
+
+            // Make backdrop focusable, because otherwise the focus will be always redirected to
+            // an element outside of the $rootElement, and this will prevent the keyup event to
+            // be triggered.
+            backdrop[0].tabIndex = -1;
           }
         });
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -572,7 +572,11 @@ function MdDialogProvider($$interimElementProvider) {
       autoWrap: true,
       fullscreen: false,
       transformTemplate: function(template, options) {
-        return '<div class="_md-dialog-container">' + validatedTemplate(template) + '</div>';
+        // Make the dialog container focusable, because otherwise the focus will be always redirected to
+        // an element outside of the container, and the focus trap won't work probably..
+        // Also the tabindex is needed for the `escapeToClose` functionality, because
+        // the keyDown event can't be triggered when the focus is outside of the container.
+        return '<div class="_md-dialog-container" tabindex="-1">' + validatedTemplate(template) + '</div>';
 
         /**
          * The specified template should contain a <md-dialog> wrapper element....


### PR DESCRIPTION

- When `clickOutsideToClose` is disabled and you click outside, the focus will move to another element which is over of the actual interim element.
- This will prevent the `escapeToClose` feature from work. <br/>The solution is, to make the backdrop or container focusable (only through mouse click), so the focus will stay inside the interim element.

- This fixes also a issue with the focus trap of the dialog, because when `clickOutsideToClose` is disabled and you click outside, the focus will move outside of the focus trap. (Like the buttons, which opened the dialog)

Fixes #7387