### PR TITLE
fix(progressCircular) aria in indeterminate, timestamp polyfill, IE10 visibility, test cleanup

### DIFF
--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -9,89 +9,92 @@ describe('mdProgressCircular', function() {
   }));
 
   afterEach(function() {
-    element.remove();
+    if (element) {
+      element.remove();
+    }
   });
 
-  it('should auto-set the md-mode to "indeterminate" if not specified', inject(function($compile, $rootScope, $mdConstant) {
-    element = $compile('<div>' +
-          '<md-progress-circular></md-progress-circular>' +
-          '</div>')($rootScope);
+  it('should auto-set the md-mode to "indeterminate" if not specified', function() {
+    var progress = buildIndicator('<md-progress-circular></md-progress-circular>');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
       $rootScope.mode = "";
     });
 
-    var progress = element.find('md-progress-circular');
     expect(progress.attr('md-mode')).toEqual('indeterminate');
-  }));
+  });
 
-  it('should trim the md-mode value', inject(function($compile, $rootScope, $mdConstant) {
-    element = $compile('<div>' +
-          '<md-progress-circular md-mode=" indeterminate"></md-progress-circular>' +
-          '</div>')($rootScope);
+  it('should trim the md-mode value', function() {
+    var progress = buildIndicator('<md-progress-circular md-mode=" indeterminate"></md-progress-circular>');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
     });
 
-    var progress = element.find('md-progress-circular');
     expect(progress.attr('md-mode')).toEqual('indeterminate');
-  }));
+  });
 
-  it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-circular value="{{progress}}"></md-progress-circular>' +
-      '</div>')($rootScope);
+  it('should auto-set the md-mode to "determinate" if not specified but has value', function() {
+    var progress = buildIndicator('<md-progress-circular value="{{progress}}"></md-progress-circular>');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
       $rootScope.mode = "";
     });
 
-    var progress = element.find('md-progress-circular');
     expect(progress.attr('md-mode')).toEqual('determinate');
-  }));
+  });
 
-
-
-  it('should update aria-valuenow', inject(function($compile, $rootScope) {
-    element = $compile('<div>' +
-      '<md-progress-circular value="{{progress}}">' +
-      '</md-progress-circular>' +
-      '</div>')($rootScope);
+  it('should update aria-valuenow', function() {
+    var progress = buildIndicator('<md-progress-circular value="{{progress}}"></md-progress-circular>');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
     });
 
-    var progress = element.find('md-progress-circular');
-    expect(progress.eq(0).attr('aria-valuenow')).toEqual('50');
-  }));
+    expect(progress.attr('aria-valuenow')).toEqual('50');
+  });
+
+  it('should\'t set aria-valuenow in indeterminate mode', function() {
+    var progress = buildIndicator('<md-progress-circular md-mode="indeterminate" value="100"></md-progress-circular>');
+
+    expect(progress.attr('aria-valuenow')).toBeUndefined();
+  });
 
   it('should set the size using percentage values',function() {
     var progress = buildIndicator('<md-progress-circular md-diameter="50%"></md-progress-circular>');
-    var expectedSize = config.progressSize/2 + 'px';
+    var expectedSize = config.progressSize / 2 + 'px';
 
     expect(progress.css('width')).toBe(expectedSize);
     expect(progress.css('height')).toBe(expectedSize);
   });
 
-  it('should set scaling using pixel values', function() {
+  it('should set the size using pixel values', function() {
     var progress = buildIndicator('<md-progress-circular md-diameter="37px"></md-progress-circular>');
 
     expect(progress.css('width')).toBe('37px');
     expect(progress.css('height')).toBe('37px');
   });
 
+  it('should scale the stroke width as a percentage of the diameter', function() {
+    var ratio = config.strokeWidth;
+    var diameter = 25;
+    var path = buildIndicator(
+      '<md-progress-circular md-diameter="' + diameter + '"></md-progress-circular>'
+    ).find('path').eq(0);
+
+    expect(path.css('stroke-width')).toBe(diameter / ratio + 'px');
+  });
+
   /**
    * Build a progressCircular
    */
   function buildIndicator(template) {
-    element = $compile('<div>' + template + '</div>')($rootScope);
-        $rootScope.$digest();
+    element = $compile(template)($rootScope);
+    $rootScope.$digest();
 
-    return element.find('md-progress-circular');
+    return element;
   }
 
 });


### PR DESCRIPTION
* Adds a polyfill for `performance.now`.
* Doesn't set the `aria-valuenow` attribute in indeterminate mode.
* Fixes the circle being invisible in IE10.
* Cleans up the `progressCircular` testing setup and adds a test for the stroke width.