### PR TITLE
fix(rtl-mixin): changed ltr override to initial

### DIFF
--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -114,7 +114,12 @@
 @mixin rtl-prop($ltr-prop, $rtl-prop, $value) {
   #{$ltr-prop}: $value;
   [dir=rtl] & {
+    // fallback for auto
+    #{$ltr-prop}: 0;
+    // fallback for IE
     #{$ltr-prop}: auto;
+    #{$ltr-prop}: initial;
+
     #{$rtl-prop}: $value;
   }
 }


### PR DESCRIPTION
- Changed ltr override to `initial` as most of the properties doesn't support `auto`
- Added `auto` fallback for IE as it doesn't support [initial](http://caniuse.com/#feat=css-initial-value)

related #7409