### PR TITLE
fix(chips): apply right theme styles

### DIFF
--- a/src/components/chips/chips-theme.scss
+++ b/src/components/chips/chips-theme.scss
@@ -1,16 +1,32 @@
 md-chips.md-THEME_NAME-theme {
+
   .md-chips {
-    box-shadow: 0 1px '{{background-300}}';
+    box-shadow: 0 1px '{{foreground-4}}';
+
     &.md-focused {
       box-shadow: 0 2px '{{primary-color}}';
     }
+
+    ._md-chip-input-container {
+      input {
+        @include input-placeholder-color('{{foreground-3}}');
+        color: '{{foreground-1}}';
+      }
+    }
   }
+
   md-chip {
     background: '{{background-300}}';
     color: '{{background-800}}';
+
+    md-icon {
+      color: '{{background-700}}';
+    }
+
     &.md-focused {
       background: '{{primary-color}}';
       color: '{{primary-contrast}}';
+
       md-icon {
         color: '{{primary-contrast}}';
       }


### PR DESCRIPTION
Currently there is incorrect theming on the chips component.
- Wrong Border Shadow Color
- No Theming for the Icon (`delete`)
- Input had no theming

Fixes #7104