### PR TITLE
fix(list): ui-sref support for md-secondary

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -192,7 +192,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
         // Check for a secondary item and move it outside
         if ( secondaryItem && (
-                secondaryItem.hasAttribute('ng-click') ||
+                (secondaryItem.hasAttribute('ng-click') || secondaryItem.hasAttribute('ui-sref')) ||
                 ( tAttrs.ngClick &&
                 isProxiedElement(secondaryItem) )
             )) {


### PR DESCRIPTION
md-secondary using ui-sref wasn't being moved outside the primary container