### PR TITLE
fix(input, mixing): fix input placeholder mixing and fix label theming.

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -3,7 +3,6 @@ md-input-container.md-THEME_NAME-theme {
     @include input-placeholder-color('{{foreground-3}}');
     color: '{{foreground-1}}';
     border-color: '{{foreground-4}}';
-    text-shadow: '{{foreground-shadow}}';
   }
 
   > md-icon {
@@ -12,7 +11,6 @@ md-input-container.md-THEME_NAME-theme {
 
   label,
   ._md-placeholder {
-    text-shadow: '{{foreground-shadow}}';
     color: '{{foreground-3}}';
   }
 

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -15,12 +15,16 @@
 }
 
 @mixin input-placeholder-color($color) {
-  &::-webkit-input-placeholder,
-    &::-moz-placeholder,
-    &:-moz-placeholder,
-    &:-ms-input-placeholder {
-      color: $color;
+  $pseudos: '::-webkit-input-placeholder', ':-moz-placeholder', '::-moz-placeholder',
+            ':-ms-input-placeholder',  '::-webkit-input-placeholder';
+
+  // It is important to export every pseudo within its own block, because otherwise the placeholder
+  // won't be set on the most browsers.
+  @each $pseudo in $pseudos {
+    &#{$pseudo} {
+      color: unquote($color);
     }
+  }
 }
 
 @mixin pie-clearfix {


### PR DESCRIPTION
At the moment the placeholder mixing isn't working, so the the placeholder is always using the browsers default color (`darkgrey`).

This commit fixes the invalid mixin for the placeholder, so the floating label and normal placeholder won't look different anymore.

Also removed the `text-shadow`, because in the specs is no inset shadow, this makes the label look weird.

So now the labels will look as same as in the specs, except that the `foreground-3` color is currently not correct. (in the specs - because it has a opacity of 0.26, but it should have 0.38)

Fixes #7429