### PR TITLE
fix(md-icon): accessibility issue with unique ids

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -464,8 +464,14 @@ describe('mdIcon service', function() {
     });
   });
 
+
   function updateDefaults(svg) {
     svg = angular.element(svg)[0];
+
+    svg.removeAttribute('id');
+    angular.forEach(svg.querySelectorAll('[id]'), function(item) {
+      item.removeAttribute('id');
+    });
 
     angular.forEach({
       'xmlns' : 'http://www.w3.org/2000/svg',

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -104,7 +104,7 @@
     * @param {string} id Icon name/id used to register the iconset
     * @param {string} url specifies the external location for the data file. Used internally by `$http` to load the
     * data or as part of the lookup in `$templateCache` if pre-loading was configured.
-    * @param {number=} viewBoxSize Sets the width and height of the viewBox of all icons in the set. 
+    * @param {number=} viewBoxSize Sets the width and height of the viewBox of all icons in the set.
     * It is ignored for icons with an existing viewBox. All icons in the icon set should be the same size.
     * Default value is 24.
     *
@@ -134,7 +134,7 @@
     *
     * @param {string} url specifies the external location for the data file. Used internally by `$http` to load the
     * data or as part of the lookup in `$templateCache` if pre-loading was configured.
-    * @param {number=} viewBoxSize Sets the width and height of the viewBox of all icons in the set. 
+    * @param {number=} viewBoxSize Sets the width and height of the viewBox of all icons in the set.
     * It is ignored for icons with an existing viewBox. All icons in the icon set should be the same size.
     * Default value is 24.
     *
@@ -247,7 +247,7 @@
      config.defaultViewBoxSize = viewBoxSize;
      return this;
    },
-   
+
    /**
     * Register an alias name associated with a font-icon library style ;
     */
@@ -422,8 +422,25 @@
     */
    function cacheIcon( id ) {
 
-     return function updateCache( icon ) {
-       iconCache[id] = isIcon(icon) ? icon : new Icon(icon, config[id]);
+     return function updateCache( _icon ) {
+       var icon = isIcon(_icon) ? _icon : new Icon(_icon, config[id]);
+
+       //clear id attributes to prevent aria issues
+       var elem = icon.element;
+       elem.removeAttribute('id');
+
+       var children = elem.childNodes;
+
+       for (var i=0; i<children.length;i++) {
+         var child = children[i];
+         if(child.nodeName==='path') {
+           child.removeAttribute('id');
+         }
+
+       }
+
+       iconCache[id] = icon;
+
 
        return iconCache[id].clone();
      };

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -429,15 +429,9 @@
        var elem = icon.element;
        elem.removeAttribute('id');
 
-       var children = elem.childNodes;
-
-       for (var i=0; i<children.length;i++) {
-         var child = children[i];
-         if(child.nodeName==='path') {
-           child.removeAttribute('id');
-         }
-
-       }
+       angular.forEach(elem.querySelectorAll('[id]'), function(item) {
+         item.removeAttribute('id');
+       });
 
        iconCache[id] = icon;
 


### PR DESCRIPTION
fix(md-icon): accessibility issue with unique ids

When the same svg icon is placed multiple times in the same page, it raises an aria warning that every element should have an  [unique id](https://www.w3.org/TR/WCAG20-TECHS/F77).
The solution is to remove the id from the svg and the path children.

closes: #6796