### PR TITLE
fix(progress-circular): removed dependency on `ng-hide` class

### DIFF
--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -91,7 +91,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdUti
     }
   };
 
-  function MdProgressCircularLink(scope, element) {
+  function MdProgressCircularLink(scope, element, attrs) {
     var svg = angular.element(element[0].querySelector('svg'));
     var path = angular.element(element[0].querySelector('path'));
     var startIndeterminate = $mdProgressCircular.startIndeterminate;
@@ -104,21 +104,20 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdUti
       var mode = newValues[1];
 
       if (mode !== MODE_DETERMINATE && mode !== MODE_INDETERMINATE) {
-        cleanupIndeterminateAnimation();
-        element.addClass('ng-hide');
-      } else {
-        element.removeClass('ng-hide');
-
-        if (mode === MODE_INDETERMINATE) {
-          startIndeterminateAnimation();
-        } else {
-          var newValue = clamp(newValues[0]);
-
-          cleanupIndeterminateAnimation();
-          element.attr('aria-valuenow', newValue);
-          renderCircle(clamp(oldValues[0]), newValue);
-        }
+        mode = MODE_INDETERMINATE;
+        attrs.$set('mdMode', mode);
       }
+
+      if (mode === MODE_INDETERMINATE) {
+        startIndeterminateAnimation();
+      } else {
+        var newValue = clamp(newValues[0]);
+
+        cleanupIndeterminateAnimation();
+        element.attr('aria-valuenow', newValue);
+        renderCircle(clamp(oldValues[0]), newValue);
+      }
+
     });
 
     // This is in a separate watch in order to avoid layout, unless

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -25,6 +25,17 @@ describe('mdProgressCircular', function() {
     expect(progress.attr('md-mode')).toEqual('indeterminate');
   });
 
+  it('should auto-set the md-mode to "indeterminate" if specified not as "indeterminate" or "determinate"', function() {
+    var progress = buildIndicator('<md-progress-circular md-mode="test"></md-progress-circular>');
+
+    $rootScope.$apply(function() {
+      $rootScope.progress = 50;
+      $rootScope.mode = "";
+    });
+
+    expect(progress.attr('md-mode')).toEqual('indeterminate');
+  });
+
   it('should trim the md-mode value', function() {
     var progress = buildIndicator('<md-progress-circular md-mode=" indeterminate"></md-progress-circular>');
 


### PR DESCRIPTION
- If the progress mode wasn't indeterminate or determinate it would use `ng-hide` class to hide it, and if it's a valid mode, `ng-hide` was removed, what caused `ng-hide` not to preform as wanted.
Now when mode is not indeterminate or determinate set it default to indeterminate

fixes #7454