### PR TITLE
fix(icon): rename nodes id's from cache to prevent duplicates.

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -435,7 +435,7 @@ describe('mdIcon service', function() {
       it('should return correct SVG markup', function() {
         $mdIcon('android.svg').then(function(el) {
           expect(el.outerHTML).toEqual( updateDefaults('<svg><g id="android"></g></svg>') );
-        })
+        });
         $scope.$digest();
       });
 
@@ -480,6 +480,41 @@ describe('mdIcon service', function() {
       });
     });
 
+    describe('icon is cached', function() {
+
+      it('should prevent duplicate ids', function() {
+        var firstId;
+
+        $mdIcon('android.svg').then(function(el) {
+          // First child is in our case always the node with an id.
+          firstId = el.firstChild.id;
+        });
+
+        $scope.$digest();
+
+        $mdIcon('android.svg').then(function(el) {
+          expect(el.firstChild.id).not.toBe(firstId);
+        });
+
+        $scope.$digest();
+
+      });
+
+      it('should suffix duplicated ids', function() {
+        // Just request the icon to be stored in the cache.
+        $mdIcon('android.svg');
+
+        $scope.$digest();
+
+        $mdIcon('android.svg').then(function(el) {
+          expect(el.firstChild.id).toMatch(/.+_cache[0-9]+/g);
+        });
+
+        $scope.$digest();
+      });
+
+    });
+
     describe('icon group is not found', function() {
       it('should log Error', function() {
         var msg;
@@ -510,11 +545,6 @@ describe('mdIcon service', function() {
 
   function updateDefaults(svg) {
     svg = angular.element(svg)[0];
-
-    svg.removeAttribute('id');
-    angular.forEach(svg.querySelectorAll('[id]'), function(item) {
-      item.removeAttribute('id');
-    });
 
     angular.forEach({
       'xmlns' : 'http://www.w3.org/2000/svg',


### PR DESCRIPTION
Currently we always rename the icons id's on cache initialization, but that causes problems, when using the cached icon multiple times in the app.
A super elegant solution, is to transform the ids, when the icon is requested from the cache.

Referencing #7467

@david-gang Ping.