### PR TITLE
feat(sidenav): add attribute to disable escape to close

### DIFF
--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -42,6 +42,24 @@ describe('mdSidenav', function() {
       expect($rootScope.show).toBe(false);
     }));
 
+    it('should not close on escape when escapeToClose is disabled',
+      inject(function($rootScope, $material, $mdConstant, $timeout) {
+        var el = setup('md-is-open="show" md-escape-to-close="false"');
+        $rootScope.$apply('show = true');
+
+        $material.flushOutstandingAnimations();
+
+        el.parent().triggerHandler({
+          type: 'keydown',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+
+        $timeout.flush();
+
+        expect($rootScope.show).toBe(true);
+      })
+    );
+
     it('should close on backdrop click', inject(function($rootScope, $material, $timeout) {
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
@@ -52,18 +70,18 @@ describe('mdSidenav', function() {
       expect($rootScope.show).toBe(false);
     }));
 
-    it('should show no backdrop if disabled', inject(function($rootScope, $material, $timeout) {
-      var el = setup('md-disable-backdrop="true"');
+    it('should show backdrop if md-disable-backdrop="false"', inject(function($rootScope, $material) {
+      var el = setup('md-is-open="show" md-disable-backdrop="false"');
       $rootScope.$apply('show = true');
 
       $material.flushOutstandingAnimations();
 
       var backdrop = el.parent().find('md-backdrop');
-      expect(backdrop.length).toBe(0);
+      expect(backdrop.length).toBe(1);
     }));
 
-    it('should show no backdrop if disabled', inject(function($rootScope, $material, $timeout) {
-      var el = setup('md-disable-backdrop');
+    it('should not show a backdrop if md-disable-backdrop is set', inject(function($rootScope, $material) {
+      var el = setup('md-is-open="show" md-disable-backdrop');
       $rootScope.$apply('show = true');
 
       $material.flushOutstandingAnimations();


### PR DESCRIPTION
- Fixes tests for `md-disable-backdrop`
- Adds attribute to disable the escapeToClose action.

I decided to use `md-escape-to-close` instead of `md-disable-escape-to-close`, because it seems more user-friendly.

If you have any suggestions about the attribute name, let me know ;)

Fixes #7022