### PR TITLE
docs(toast): toasts will be always positioned at the bottom if `sm` breakpoint matches.

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -34,6 +34,8 @@ function MdToastDirective($mdToast) {
   * `$mdToast` is a service to build a toast notification on any position
   * on the screen with an optional duration, and provides a simple promise API.
   *
+  * The toast will be always positioned at the `bottom`, when the screen size is
+  * between `600px` and `959px` (`sm` breakpoint)
   *
   * ## Restrictions on custom toasts
   * - The toast's template must have an outer `<md-toast>` element.


### PR DESCRIPTION
We should mention that the toast will be always positioned at the bottom, when the `sm` breakpoint is matched by the current device.

Fixes #7332