### PR TITLE
fix(chips): Fix readonly hiding and other issues.

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -60,6 +60,10 @@ $contact-chip-name-width: rem(12) !default;
   @include rtl(padding, $chip-wrap-padding, rtl-value($chip-wrap-padding));
   vertical-align: middle;
 
+  &.md-readonly ._md-chip-input-container {
+    min-height: $chip-height;
+  }
+
   &:not(.md-readonly) {
     cursor: text;
 

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -14,6 +14,8 @@ describe('<md-chips>', function() {
     '<md-chips ng-model="items" md-on-remove="removeChip($chip, $index)"></md-chips>';
   var CHIP_SELECT_TEMPLATE =
     '<md-chips ng-model="items" md-on-select="selectChip($chip)"></md-chips>';
+  var CHIP_READONLY_TEMPLATE =
+    '<md-chips ng-model="items" readonly="isReadonly"></md-chips>';
   var CHIP_READONLY_AUTOCOMPLETE_TEMPLATE =
     '<md-chips ng-model="items" readonly="true">' +
     '  <md-autocomplete md-items="item in [\'hi\', \'ho\', \'he\']"></md-autocomplete>' +
@@ -254,12 +256,53 @@ describe('<md-chips>', function() {
         expect(scope.items[3].uppername).toBe('GRAPE');
       });
 
-      it('should not throw an error when using readonly with an autocomplete', function() {
-        var element = buildChips(CHIP_READONLY_AUTOCOMPLETE_TEMPLATE);
+      describe('when readonly', function() {
+        var element, ctrl;
 
-        $timeout.flush();
+        it("properly toggles the controller's readonly property", function() {
+          element = buildChips(CHIP_READONLY_TEMPLATE);
+          ctrl = element.controller('mdChips');
 
-        expect($exceptionHandler.errors).toEqual([]);
+          expect(ctrl.readonly).toBeFalsy();
+
+          scope.$apply('isReadonly = true');
+
+          expect(ctrl.readonly).toBeTruthy();
+        });
+
+        it("properly toggles the wrapper's .md-readonly class", function() {
+          element = buildChips(CHIP_READONLY_TEMPLATE);
+          ctrl = element.controller('mdChips');
+
+          expect(element.find('md-chips-wrap')).not.toHaveClass('md-readonly');
+
+          scope.$apply('isReadonly = true');
+
+          expect(element.find('md-chips-wrap')).toHaveClass('md-readonly');
+        });
+
+        it('is false with empty items should not hide the chips wrapper', function() {
+          scope.isReadonly = false;
+          scope.items = [];
+          element = buildChips(CHIP_READONLY_TEMPLATE);
+
+          expect(element.find('md-chips-wrap').length).toBe(1);
+        });
+
+        it('is true with empty items should not hide the chips wrapper', function() {
+          scope.isReadonly = true;
+          scope.items = [];
+          element = buildChips(CHIP_READONLY_TEMPLATE);
+
+          expect(element.find('md-chips-wrap').length).toBe(1);
+        });
+
+        it('is true should not throw an error when used with an autocomplete', function() {
+          element = buildChips(CHIP_READONLY_AUTOCOMPLETE_TEMPLATE);
+          $timeout.flush();
+
+          expect($exceptionHandler.errors).toEqual([]);
+        });
       });
 
       it('should disallow duplicate object chips', function() {

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -66,7 +66,8 @@
    * @param {string=} secondary-placeholder Placeholder text that will be forwarded to the input,
    *    displayed when there is at least on item in the list
    * @param {boolean=} readonly Disables list manipulation (deleting or adding list items), hiding
-   *    the input and delete buttons
+   *    the input and delete buttons. If no `ng-model` is provided, the chips will automatically be
+   *    marked as readonly.
    * @param {number=} md-max-chips The maximum number of chips allowed to add through user input.
    *    <br/><br/>The validation property `md-max-chips` can be used when the max chips
    *    amount is reached.
@@ -119,13 +120,12 @@
 
   var MD_CHIPS_TEMPLATE = '\
       <md-chips-wrap\
-          ng-if="!$mdChipsCtrl.readonly || $mdChipsCtrl.items.length > 0"\
           ng-keydown="$mdChipsCtrl.chipKeydown($event)"\
-          ng-class="{ \'md-focused\': $mdChipsCtrl.hasFocus(), \'md-readonly\': !$mdChipsCtrl.ngModelCtrl }"\
+          ng-class="{ \'md-focused\': $mdChipsCtrl.hasFocus(), \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly}"\
           class="md-chips">\
         <md-chip ng-repeat="$chip in $mdChipsCtrl.items"\
             index="{{$index}}"\
-            ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': $mdChipsCtrl.readonly}">\
+            ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly}">\
           <div class="_md-chip-content"\
               tabindex="-1"\
               aria-hidden="true"\
@@ -135,9 +135,9 @@
                class="_md-chip-remove-container"\
                md-chip-transclude="$mdChipsCtrl.chipRemoveTemplate"></div>\
         </md-chip>\
-        <div ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl"\
-            class="_md-chip-input-container"\
-            md-chip-transclude="$mdChipsCtrl.chipInputTemplate"></div>\
+        <div class="_md-chip-input-container">\
+          <div ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl"\
+               md-chip-transclude="$mdChipsCtrl.chipInputTemplate"></div>\
         </div>\
       </md-chips-wrap>';
 


### PR DESCRIPTION
The chips components was not properly setting the `md-readonly` class
when the `readonly` flag was true. Additionally, if there were no
chips available and the component was in readonly mode, the entire
component disappeared causing a page reflow.

Fixes #7136. References #7390.