### PR TITLE
fix(button): Fix icon opacity in themed toolbar disabled buttons.

### DIFF
--- a/src/components/toolbar/demoBasicUsage/index.html
+++ b/src/components/toolbar/demoBasicUsage/index.html
@@ -5,13 +5,13 @@
 
     <br>
 
-    <md-toolbar>
+    <md-toolbar class="md-hue-2">
       <div class="md-toolbar-tools">
-        <md-button class="md-icon-button" aria-label="Settings">
+        <md-button class="md-icon-button" aria-label="Settings" ng-disabled="true">
           <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
         </md-button>
         <h2>
-          <span>Toolbar with Icon Buttons</span>
+          <span>Toolbar with Disabled/Enabled Icon Buttons</span>
         </h2>
         <span flex></span>
         <md-button class="md-icon-button" aria-label="Favorite">

--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -7,6 +7,11 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     fill: '{{primary-contrast}}';
   }
 
+  .md-button[disabled] md-icon {
+    color: '{{primary-contrast-0.26}}';
+    fill: '{{primary-contrast-0.26}}';
+  }
+
   &.md-accent {
     background-color: '{{accent-color}}';
     color: '{{accent-contrast}}';
@@ -18,6 +23,11 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     md-icon {
       color: '{{accent-contrast}}';
       fill: '{{accent-contrast}}';
+    }
+
+    .md-button[disabled] md-icon {
+      color: '{{accent-contrast-0.26}}';
+      fill: '{{accent-contrast-0.26}}';
     }
   }
 


### PR DESCRIPTION
The icons in disabled buttons which were part of a themed toolbar
did not have the correct opacity set.

Fixes #5815.