### PR TITLE
fix(autocomplete): fix incorrect height for progress-bar

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -82,7 +82,7 @@ md-autocomplete {
         left: 2px;
         width: auto;
       }
-      .md-mode-indeterminate {
+      ._md-mode-indeterminate {
         position: absolute;
         top: 0;
         left: 0;


### PR DESCRIPTION
The current indeterminate class wasn't privatized and that caused the progress bar to have a height of 5px, instead of 3px

@topherfangio Seems like you forgot to privatize the indeterminate class here. Can you review this PR?

Fixes #7497