### PR TITLE
Fix(select): layout issue

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -104,16 +104,18 @@ md-select {
   min-height: 26px;
   flex-grow: 1;
 
-  ._md-text {
-    display: inline;
-  }
 
-  *:first-child {
-    flex: 1 0 auto;
+  > span:not(._md-select-icon) {
+    max-width: 100%;
+    flex: 1 1 auto;
+    transform: translate3d(0, 2px, 0);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
-    transform: translate3d(0, 2px, 0);
+
+    ._md-text {
+      display: inline;
+    }
   }
 
   ._md-select-icon {


### PR DESCRIPTION
- Make selector less aggressive restricting it to the text span only
- Add a max width, so the overflow rule will go in effect if we reach the width of the container
- Allow span to shrink if width is greater than that of the input container

Closes #6200 and #6312