### PR TITLE
fix(mixins): unquote is causing issues with module compilation.

### DIFF
--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -22,7 +22,7 @@
   // won't be set on the most browsers.
   @each $pseudo in $pseudos {
     &#{$pseudo} {
-      color: unquote($color);
+      color: $color;
     }
   }
 }


### PR DESCRIPTION
`unquote` caused issues with theming and module compilation.

Fixes #7514