### PR TITLE
fix(list): item-inner shouldn't be wider than the container

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -138,11 +138,13 @@ md-list-item {
       align-items: center;
       justify-content: flex-start;
 
-      padding: 0;
+      padding: 0 16px;
       margin: 0;
 
+      // The button should not inherit the parents background color.
+      background-color: initial;
+
       font-weight: 400;
-      background-color: inherit;
       @include rtl(text-align, left, right);
       border: medium none;
 
@@ -151,16 +153,16 @@ md-list-item {
         position: absolute;
         top: 0;
         left: 0;
+        height: 100%;
 
         margin: 0;
         padding: 0;
-        height: 100%;
       }
 
       ._md-list-item-inner {
         // The list item content should fill the complete width.
-        flex: 1 1 auto;
-        padding: 0 16px;
+        width: 100%;
+        height: 100%;
       }
 
     }


### PR DESCRIPTION
This fixes a overflow issue - when being in a flex layout.

![image](https://cloud.githubusercontent.com/assets/4987015/13711130/3a7cd730-e7bd-11e5-8eae-8b2dce1af6d4.png)

![image](https://cloud.githubusercontent.com/assets/4987015/13711152/531e9710-e7bd-11e5-9bbe-03a64b50b94d.png)

* Also fixes the issue, when using  a custom background color on the list-item.

Fixes #7551 Fixes #7525