### PR TITLE
fix(select): Fix NPE by checking for controller existence.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1280,7 +1280,7 @@ function SelectProvider($$interimElementProvider) {
       var mdSelect = opts.selectCtrl;
       if (mdSelect) {
         var menuController = opts.selectEl.controller('mdSelectMenu');
-        mdSelect.setLabelText(menuController.selectedLabels());
+        mdSelect.setLabelText(menuController ? menuController.selectedLabels() : '');
         mdSelect.triggerClose();
       }
     }


### PR DESCRIPTION
In some cases, the select could be removed from the DOM before some
of the cleanup code was executed. This caused a `.controller()` call
to return `null`, but we did not check for existence before using
the controller which resulted in null pointer exception.

Fixes #7079.