### PR TITLE
chore(travis): travis cache phantomjs2 binary.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,12 @@ cache:
   directories:
   - node_modules
   - "$HOME/.pub-cache"
+  - "$HOME/travis-phantomjs"
 branches:
   only:
   - master
 before_install:
-- mkdir travis-phantomjs
-- wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
-  -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
-- tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
-- export PHANTOMJS_BIN=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin/phantomjs
+- "source ./scripts/travis-install-phantomjs2.sh"
 install:
 - npm install
 - npm rebuild node-sass

--- a/scripts/travis-install-phantomjs2.sh
+++ b/scripts/travis-install-phantomjs2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+PHANTOMSJS2_PACKAGE="phantomjs-2.1.1-linux-x86_64.tar.bz2"
+PHANTOMJS2_OUTPUT="phantomjs-2.1.1-linux-x86_64"
+
+mkdir -p $HOME/travis-phantomjs
+
+if [ ! -d $HOME/travis-phantomjs/${PHANTOMJS2_OUTPUT} ]; then
+  wget https://bitbucket.org/ariya/phantomjs/downloads/${PHANTOMSJS2_PACKAGE} -O $HOME/travis-phantomjs/${PHANTOMSJS2_PACKAGE}
+
+  tar -xvf ~/travis-phantomjs/${PHANTOMSJS2_PACKAGE} -C $HOME/travis-phantomjs
+fi
+
+export PHANTOMJS_BIN=$HOME/travis-phantomjs/${PHANTOMJS2_OUTPUT}/bin/phantomjs


### PR DESCRIPTION
This caches the `phantomjs2` installation. There appeared problems, with too many requests on Travis, while downloading the installation on each change.

I decided to use two variables on top of the script, to be able to update the version easily.