### PR TITLE
perf(progress-circular): fire off indeterminate animation before the first digest

### DIFF
--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -97,6 +97,12 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
 
     $mdTheming(element);
 
+    // If the mode is indeterminate, it doesn't need to
+    // wait for the next digest. It can start right away.
+    if(scope.mdMode === MODE_INDETERMINATE){
+      startIndeterminateAnimation();
+    }
+
     scope.$watchGroup(['value', 'mdMode'], function(newValues, oldValues) {
       var mode = newValues[1];
 


### PR DESCRIPTION
The indeterminate animation doesn't have to wait for the first digest in order
to start animating. Should help with issues similar to #7577.