### PR TITLE
fix(menu): typo in @ngInject annotation

### DIFF
--- a/src/components/menuBar/js/menuBarDirective.js
+++ b/src/components/menuBar/js/menuBarDirective.js
@@ -92,10 +92,7 @@ angular
   .module('material.components.menuBar')
   .directive('mdMenuBar', MenuBarDirective);
 
-/**
- *
- * @ngInjdect
- */
+/* @ngInject */
 function MenuBarDirective($mdUtil, $mdTheming) {
   return {
     restrict: 'E',

--- a/src/components/menuBar/js/menuItemDirective.js
+++ b/src/components/menuBar/js/menuItemDirective.js
@@ -3,10 +3,7 @@ angular
   .module('material.components.menuBar')
   .directive('mdMenuItem', MenuItemDirective);
 
- /**
-  *
-  * @ngInjdect
-  */
+ /* @ngInject */
 function MenuItemDirective() {
   return {
     require: ['mdMenuItem', '?ngModel'],


### PR DESCRIPTION
It was labeled as `@ngInjdect` instead of `@ngInject`.

Relates to #7610.