### PR TITLE
fix(checkbox): duplicate demo module name.

### DIFF
--- a/src/components/checkbox/demoSyncing/script.js
+++ b/src/components/checkbox/demoSyncing/script.js
@@ -1,5 +1,5 @@
 
-angular.module('checkboxDemo1', ['ngMaterial'])
+angular.module('checkboxDemo2', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope) {
 


### PR DESCRIPTION
* The demo uses the same module name as the basic demo uses, this caused problems with the demo.

Fixes #7590.