### PR TITLE
fix(dialog): dialog should support skipCompile from interim element.

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -891,6 +891,11 @@ function MdDialogProvider($$interimElementProvider) {
      * Inject ARIA-specific attributes appropriate for Dialogs
      */
     function configureAria(element, options) {
+      // If the element is undefined, then there was no <md-dialog> element present.
+      // This can be caused by using the options.skipCompile and options.element properties.
+      // In this case, the template processing and compilation will be skipped and wont
+      // add the <md-dialog> automatically.
+      if (!element.length) return;
 
       var role = (options.$type === 'alert') ? 'alertdialog' : 'dialog';
       var dialogContent = element.find('md-dialog-content');

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -725,6 +725,33 @@ describe('$mdDialog', function() {
       expect(closing).toBe(true);
     }));
 
+    it('should support a self provided element', inject(function($mdDialog, $rootScope) {
+      var dialogTemplate =
+        '<div class="md-dialog-container" tabindex="-1">' +
+          '<md-dialog>' +
+            'My Custom Node' +
+          '</md-dialog>' +
+        '</div>';
+
+      var parent = angular.element('<div>');
+      var dialogNode = angular.element(dialogTemplate);
+
+      $mdDialog.show({
+        skipCompile: true,
+        element: dialogNode,
+        parent: parent
+      });
+
+      $rootScope.$apply();
+
+      runAnimation();
+
+      var container = angular.element(parent[0].querySelector('.md-dialog-container'));
+      expect(container.length).toBe(1);
+
+      expect(container[0]).toBe(dialogNode[0]);
+    }));
+
     it('should support specifying a parent using a string selector', inject(function($mdDialog, $rootScope, $document) {
       var body = angular.element($document[0].querySelector("body"));
       var nodes = angular.element(''+


### PR DESCRIPTION
* Makes dialog compatible with `options.skipCompile` from the interim element service.

Fixes #7566.