### PR TITLE
fix(mdInput): Fix md-maxlength validation

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -531,7 +531,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
         if (!angular.isNumber(maxlength) || maxlength < 0) {
           return true;
         }
-        return ( modelValue || element.val() || viewValue || '' ).length <= maxlength;
+        return ( element.val() || viewValue || '' ).length <= maxlength;
       };
     });
 

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -300,6 +300,25 @@ describe('md-input-container directive', function() {
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
       expect(getCharCounter(el).length).toBe(0);
     });
+
+    it('should not show an error on inputs with type="number" and a valid number value', function() {
+      var el = $compile('<form name="form">' +
+        ' <md-input-container>' +
+        '   <input type="number" md-maxlength="5" ng-model="foo" name="foo">' +
+        ' </md-input-container>' +
+        '</form>')(pageScope);
+
+      pageScope.$apply();
+      el.find('input').val('123').triggerHandler('input');
+      expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
+      expect(getCharCounter(el).length).toBe(1);
+      expect(getCharCounter(el).text()).toBe('3/5');
+
+      el.find('input').val('123456').triggerHandler('input');
+      expect(pageScope.form.foo.$error['md-maxlength']).toBeTruthy();
+      expect(getCharCounter(el).length).toBe(1);
+      expect(getCharCounter(el).text()).toBe('6/5');
+    });
   });
 
   it('should not add the md-input-has-placeholder class when the placeholder is transformed into a label', inject(function($rootScope, $compile) {


### PR DESCRIPTION
Re-opening this PR as requested by @ThomasBurleson. See below for the original description.

`mdMaxlength` currently doesn't validate properly on inputs with `type="number"`. When the `$modelValue` returns a number, its `length` property is `undefined`. This change parses the `$modelValue` to a string when it's appropriate to do so.

Fix md-maxlength validation to use $viewValue

Add a test to validate the changes to md-maxlength