### PR TITLE
feat(chips): add `md-static` class to hide input styling and display set of chips as tags

### DIFF
--- a/src/components/chips/chips-theme.scss
+++ b/src/components/chips/chips-theme.scss
@@ -1,5 +1,9 @@
 md-chips.md-THEME_NAME-theme {
 
+  &.md-static .md-chips {
+    box-shadow: none;
+  }
+
   .md-chips {
     box-shadow: 0 1px '{{foreground-4}}';
 

--- a/src/components/chips/demoStaticChips/index.html
+++ b/src/components/chips/demoStaticChips/index.html
@@ -16,5 +16,21 @@
       If no <code>ng-model</code> is provided, there are no input elements in <code>md-chips</code>.
     </p>
 
+
+    <br/>
+    <h2 class="md-title">Display as static tags.</h2>
+
+    <div layout="row" layout-align="start center">
+
+      <div class="md-subhead" style="padding-right: 15px;">Tags: </div>
+
+      <md-chips class="md-static" ng-model="ctrl.chips" readonly="true"></md-chips>
+
+    </div>
+    <p class="note">
+      Input styling may be removed by using the <code>md-static</code> class on <code>md-chips</code>.<br/>
+      If using <code>ng-model</code>, use in conjunction with <code>readonly="true"</code>.
+    </p>
+
   </md-content>
 </div>

--- a/src/components/chips/demoStaticChips/script.js
+++ b/src/components/chips/demoStaticChips/script.js
@@ -6,5 +6,7 @@
 
   function DemoCtrl ($timeout, $q) {
     this.chipText = 'Football';
+
+    this.chips = ['XL', 'Orange', 'Cotton'];
   }
 })();

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -9,7 +9,7 @@
    *
    * @description
    * `<md-chips>` is an input component for building lists of strings or objects. The list items are
-   * displayed as 'chips'. This component can make use of an `<input>` element or an 
+   * displayed as 'chips'. This component can make use of an `<input>` element or an
    * `<md-autocomplete>` element.
    *
    * ### Custom templates
@@ -56,6 +56,10 @@
    *   </ul>
    * </ul>
    *
+   * ### CSS
+   *
+   * `md-static` remove input container styling, use in conjunction with `readonly="true"` if using `ng-model`.
+   *
    *  <span style="font-size:.8em;text-align:center">
    *    Warning: This component is a WORK IN PROGRESS. If you use it now,
    *    it will probably break on you in the future.
@@ -68,7 +72,7 @@
    * @param {boolean=} readonly Disables list manipulation (deleting or adding list items), hiding
    *    the input and delete buttons. If no `ng-model` is provided, the chips will automatically be
    *    marked as readonly.
-   * @param {string=} md-enable-chip-edit Set this to "true" to enable editing of chip contents. The user can 
+   * @param {string=} md-enable-chip-edit Set this to "true" to enable editing of chip contents. The user can
    *    go into edit mode with pressing "space", "enter", or double clicking on the chip. Chip edit is only
    *    supported for chips with basic template.
    * @param {number=} md-max-chips The maximum number of chips allowed to add through user input.


### PR DESCRIPTION
- Display chips as tags using class `md-static` to hide the box-shadow suggesting the component has an input field

Closes #7601