### PR TITLE
fix(input): prevent the label from overflowing the parent

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -127,6 +127,10 @@ md-input-container {
     transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
     transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
 
+    // The max-width is necessary, because in some browsers, using this together with
+    // a calc might cause it to overflow the parent. See #7403
+    max-width: 100%;
+
     @include rtl(transform-origin, left top, right top);
   }
   ._md-placeholder {


### PR DESCRIPTION
When an mdInput was focused in IE, the calc was causing the label to overflow it's parent.

Closes #7403.