### PR TITLE
fix(select): Fixes Oxford comma logic in md-select-demo.

### DIFF
--- a/src/components/select/demoOptionGroups/script.js
+++ b/src/components/select/demoOptionGroups/script.js
@@ -18,13 +18,20 @@ angular
         { category: 'veg', name: 'Green Olives' }
       ];
       $scope.selectedToppings = [];
-      $scope.printSelectedToppings = function printSelectedToppings(){
-        // If there is more than one topping, we add an 'and' and an oxford
-        // comma to be gramatically correct.
-        if (this.selectedToppings.length > 1) {
-          var lastTopping = ', and ' + this.selectedToppings.slice(-1)[0];
-          return this.selectedToppings.slice(0,-1).join(', ') + lastTopping;
+      $scope.printSelectedToppings = function printSelectedToppings() {
+        var numberOfToppings = this.selectedToppings.length;
+
+        // If there is more than one topping, we add an 'and'
+        // to be gramatically correct. If there are 3+ toppings
+        // we also add an oxford comma.
+        if (numberOfToppings > 1) {
+          var needsOxfordComma = numberOfToppings > 2;
+          var lastToppingConjunction = (needsOxfordComma ? ',' : '') + ' and ';
+          var lastTopping = lastToppingConjunction +
+              this.selectedToppings[this.selectedToppings.length - 1];
+          return this.selectedToppings.slice(0, -1).join(', ') + lastTopping;
         }
+
         return this.selectedToppings.join('');
       };
     });


### PR DESCRIPTION
The function in the example previously added a comma when it shouldn't have (in cases where there are less than 3 toppings). This fixes the oxford comma logic.