### PR TITLE
fix(mdSelect): fix flickering of ngMessages on mdSelect opening

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -299,19 +299,19 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
             }
           });
 
-        // Wait until postDigest so that we attach after ngModel's
-        // blur listener so we can set untouched.
-        $mdUtil.nextTick(function () {
-          element.on('blur', function() {
-            if (untouched) {
-              untouched = false;
-              ngModelCtrl.$setUntouched();
+        // Attach before ngModel's blur listener to stop propagation of blur event
+        // to prevent from setting $touched.
+        element.on('blur', function(event) {
+          if (untouched) {
+            untouched = false;
+            if (selectScope.isOpen) {
+              event.stopImmediatePropagation();
             }
+          }
 
-            if (selectScope.isOpen) return;
-            containerCtrl && containerCtrl.setFocused(false);
-            inputCheckValue();
-          });
+          if (selectScope.isOpen) return;
+          containerCtrl && containerCtrl.setFocused(false);
+          inputCheckValue();
         });
       }
 

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -158,6 +158,23 @@ describe('<md-select>', function() {
     expect($rootScope.myForm.select.$touched).toBe(true);
   }));
 
+  it('should remain untouched during opening', inject(function($compile, $rootScope) {
+    var form = $compile('<form name="myForm">' +
+                        '<md-select name="select" ng-model="val">' +
+                        '<md-option>1</md-option>' +
+                        '</md-select>' +
+                        '</form>')($rootScope);
+    var unwatch = $rootScope.$watch('myForm.select.$touched',
+      function(touched) {
+        expect(touched).toBe(false);
+      });
+    var select = form.find('md-select');
+    openSelect(select);
+    unwatch();
+    closeSelect();
+    expect($rootScope.myForm.select.$touched).toBe(true);
+  }));
+
   it('restores focus to select when the menu is closed', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);


### PR DESCRIPTION
To properly prevent ngMessages from showing up on select opening,
we have to set untouched, in the $apply triggered by ngModel, after ngModel sets touched.
To be close to mdInput behaviour, we set untouched only, when mdSelect was opened.

closes #7636