### PR TITLE
fix(list): make secondary items static

### DIFF
--- a/src/components/list/demoListControls/style.css
+++ b/src/components/list/demoListControls/style.css
@@ -15,8 +15,3 @@ md-list-item ._md-list-item-inner > ._md-list-item-inner > p {
     -ms-user-select: none; /* IE 10+ */
     user-select: none; /* Likely future */
 }
-
-/* Add some right padding so that the text doesn't overlap the buttons */
-.secondary-button-padding p {
-    padding-right: 100px;
-}

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -88,10 +88,12 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
     restrict: 'E',
     controller: 'MdListController',
     compile: function(tEl, tAttrs) {
+
       // Check for proxy controls (no ng-click on parent, and a control inside)
       var secondaryItems = tEl[0].querySelectorAll('.md-secondary');
       var hasProxiedElement;
       var proxyElement;
+      var itemContainer = tEl;
 
       tEl[0].setAttribute('role', 'listitem');
 
@@ -130,14 +132,13 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       }
 
       function wrapIn(type) {
-        var container;
         if (type == 'div') {
-          container = angular.element('<div class="_md-no-style _md-list-item-inner">');
-          container.append(tEl.contents());
+          itemContainer = angular.element('<div class="_md-no-style _md-list-item-inner">');
+          itemContainer.append(tEl.contents());
           tEl.addClass('_md-proxy-focus');
         } else {
           // Element which holds the default list-item content.
-          container = angular.element(
+          itemContainer = angular.element(
             '<div class="md-button _md-no-style">'+
             '   <div class="_md-list-item-inner"></div>'+
             '</div>'
@@ -152,58 +153,48 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           copyAttributes(tEl[0], buttonWrap[0]);
 
           // Append the button wrap before our list-item content, because it will overlay in relative.
-          container.prepend(buttonWrap);
-          container.children().eq(1).append(tEl.contents());
+          itemContainer.prepend(buttonWrap);
+          itemContainer.children().eq(1).append(tEl.contents());
           
           tEl.addClass('_md-button-wrap');
         }
 
         tEl[0].setAttribute('tabindex', '-1');
-        tEl.append(container);
+        tEl.append(itemContainer);
       }
 
       function wrapSecondaryItems() {
-        if (secondaryItems.length === 1) {
-          wrapSecondaryItem(secondaryItems[0], tEl);
-        } else if (secondaryItems.length > 1) {
-          var secondaryItemsWrapper = angular.element('<div class="_md-secondary-container">');
-          angular.forEach(secondaryItems, function(secondaryItem) {
-            wrapSecondaryItem(secondaryItem, secondaryItemsWrapper, true);
-          });
-          tEl.append(secondaryItemsWrapper);
-        }
+        var secondaryItemsWrapper = angular.element('<div class="_md-secondary-container">');
+
+        angular.forEach(secondaryItems, function(secondaryItem) {
+          wrapSecondaryItem(secondaryItem, secondaryItemsWrapper);
+        });
+
+        // Since the secondary item container is static we need to fill the remaing space.
+        var spaceFiller = angular.element('<div class="flex"></div>');
+        itemContainer.append(spaceFiller);
+
+        itemContainer.append(secondaryItemsWrapper);
       }
 
-      function wrapSecondaryItem(secondaryItem, container, hasSecondaryItemsWrapper) {
+      function wrapSecondaryItem(secondaryItem, container) {
         if (secondaryItem && !isButton(secondaryItem) && secondaryItem.hasAttribute('ng-click')) {
           $mdAria.expect(secondaryItem, 'aria-label');
-          var buttonWrapper;
-          if (hasSecondaryItemsWrapper) {
-            buttonWrapper = angular.element('<md-button class="md-icon-button">');
-          } else {
-            buttonWrapper = angular.element('<md-button class="_md-secondary-container md-icon-button">');
-          }
+          var buttonWrapper = angular.element('<md-button class="md-secondary md-icon-button">');
           copyAttributes(secondaryItem, buttonWrapper[0]);
           secondaryItem.setAttribute('tabindex', '-1');
-          secondaryItem.classList.remove('md-secondary');
           buttonWrapper.append(secondaryItem);
           secondaryItem = buttonWrapper[0];
         }
 
-        // Check for a secondary item and move it outside
-        if ( secondaryItem && (
-                secondaryItem.hasAttribute('ng-click') ||
-                ( tAttrs.ngClick &&
-                isProxiedElement(secondaryItem) )
-            )) {
-          // When using multiple secondary items we need to remove their secondary class to be
-          // orderd correctly in the list-item
-          if (hasSecondaryItemsWrapper) {
-            secondaryItem.classList.remove('md-secondary');
-          }
-          tEl.addClass('md-with-secondary');
-          container.append(secondaryItem);
+        if (secondaryItem && (!hasClickEvent(secondaryItem) || (!tAttrs.ngClick && isProxiedElement(secondaryItem)))) {
+          // In this case we remove the secondary class, so we can identify it later, when we searching for the
+          // proxy items.
+          angular.element(secondaryItem).removeClass('md-secondary');
         }
+
+        tEl.addClass('md-with-secondary');
+        container.append(secondaryItem);
       }
 
       function copyAttributes(item, wrapper) {
@@ -227,14 +218,23 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         return nodeName == "MD-BUTTON" || nodeName == "BUTTON";
       }
 
+      function hasClickEvent (element) {
+        var attr = element.attributes;
+        for (var i = 0; i < attr.length; i++) {
+          if (tAttrs.$normalize(attr[i].name) === 'ngClick') return true;
+        }
+        return false;
+      }
+
       return postLink;
 
       function postLink($scope, $element, $attr, ctrl) {
 
-        var proxies    = [],
-            firstChild = $element[0].firstElementChild,
-            hasClick   = firstChild && firstChild.firstElementChild &&
-                         hasClickEvent(firstChild.firstElementChild);
+        var proxies       = [],
+            firstElement  = $element[0].firstElementChild,
+            isButtonWrap  = $element.hasClass('_md-button-wrap'),
+            clickChild    = isButtonWrap ? firstElement.firstElementChild : firstElement,
+            hasClick      = clickChild && hasClickEvent(clickChild);
 
         computeProxies();
         computeClickable();
@@ -260,22 +260,19 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           });
         }
 
-        function hasClickEvent (element) {
-          var attr = element.attributes;
-          for (var i = 0; i < attr.length; i++) {
-            if ($attr.$normalize(attr[i].name) === 'ngClick') return true;
-          }
-          return false;
-        }
 
         function computeProxies() {
-          var children = $element.children();
-          if (children.length && !children[0].hasAttribute('ng-click')) {
+          if (firstElement && firstElement.children && !hasClick) {
+
             angular.forEach(proxiedTypes, function(type) {
-              angular.forEach(firstChild.querySelectorAll(type), function(child) {
+
+              // All elements which are not capable for being used a proxy have the .md-secondary class
+              // applied. These items had been sorted out in the secondary wrap function.
+              angular.forEach(firstElement.querySelectorAll(type + ':not(.md-secondary)'), function(child) {
                 proxies.push(child);
               });
             });
+
           }
         }
         function computeClickable() {
@@ -288,12 +285,12 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           }
         }
 
-        var firstChildKeypressListener = function(e) {
+        var clickChildKeypressListener = function(e) {
           if (e.target.nodeName != 'INPUT' && e.target.nodeName != 'TEXTAREA' && !e.target.isContentEditable) {
             var keyCode = e.which || e.keyCode;
             if (keyCode == $mdConstant.KEY_CODE.SPACE) {
-              if (firstChild) {
-                firstChild.click();
+              if (clickChild) {
+                clickChild.click();
                 e.preventDefault();
                 e.stopPropagation();
               }
@@ -302,16 +299,16 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         };
 
         if (!hasClick && !proxies.length) {
-          firstChild && firstChild.addEventListener('keypress', firstChildKeypressListener);
+          clickChild && clickChild.addEventListener('keypress', clickChildKeypressListener);
         }
 
         $element.off('click');
         $element.off('keypress');
 
-        if (proxies.length == 1 && firstChild) {
+        if (proxies.length == 1 && clickChild) {
           $element.children().eq(0).on('click', function(e) {
             var parentButton = $mdUtil.getClosest(e.target, 'BUTTON');
-            if (!parentButton && firstChild.contains(e.target)) {
+            if (!parentButton && clickChild.contains(e.target)) {
               angular.forEach(proxies, function(proxy) {
                 if (e.target !== proxy && !proxy.contains(e.target)) {
                   angular.element(proxy).triggerHandler('click');
@@ -322,7 +319,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         }
 
         $scope.$on('$destroy', function () {
-          firstChild && firstChild.removeEventListener('keypress', firstChildKeypressListener);
+          clickChild && clickChild.removeEventListener('keypress', clickChildKeypressListener);
         });
       }
     }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -213,9 +213,6 @@ md-list-item {
       outline: none
     }
   }
-  &.md-with-secondary {
-    position: relative;
-  }
   &.md-clickable:hover {
     cursor: pointer;
   }
@@ -263,12 +260,7 @@ md-list-item {
     & > md-icon:first-child:not(.md-avatar-icon) {
       @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-primary-icon-width);
     }
-    & > md-checkbox {
-      width: 3 * $baseline-grid;
-      @include rtl(margin-left, 3px, 29px);
-      @include rtl(margin-right, 29px,3px);
-      margin-top: 16px;
-    }
+
     & .md-avatar, .md-avatar-icon {
       margin-top: $baseline-grid;
       margin-bottom: $baseline-grid;
@@ -284,57 +276,47 @@ md-list-item {
       padding: 8px;
     }
 
-    md-checkbox.md-secondary,
-    md-switch.md-secondary {
-      margin-top: 0;
-      margin-bottom: 0;
-    }
-
-    md-checkbox.md-secondary {
-      @include rtl-prop(margin-right, margin-left, 0);
-    }
-
-    md-switch.md-secondary {
-      @include rtl-prop(margin-right, margin-left, -6px);
-    }
-
-    button.md-button._md-secondary-container {
-      background-color: transparent;
-      align-self: center;
-      border-radius: 50%;
-      margin: 0px;
-      min-width: 0px;
-
-      .md-ripple,
-      .md-ripple-container {
-        border-radius: 50%;
-      }
+    & > md-checkbox {
+      width: 3 * $baseline-grid;
+      @include rtl(margin-left, 3px, 29px);
+      @include rtl(margin-right, 29px, 3px);
+      margin-top: 16px;
     }
 
     ._md-secondary-container {
-      @include rtl-prop(margin-right, margin-left, -12px);
+      display: flex;
+      align-items: center;
 
-      &.md-icon-button {
+      height: 100%;
+      margin: auto;
+
+      .md-button, .md-icon-button {
+        &:last-of-type {
+          // Reset 6px margin for the button.
+          @include rtl-prop(margin-right, margin-left, 0px);
+        }
+      }
+
+      md-checkbox {
+        margin-top: 0;
+        margin-bottom: 0;
+
+        &:last-child {
+          width: 3 * $baseline-grid;
+          @include rtl-prop(margin-right, margin-left, 0);
+        }
+      }
+
+      md-switch {
+        margin-top: 0;
+        margin-bottom: 0;
+
         @include rtl-prop(margin-right, margin-left, -6px);
       }
     }
 
-    ._md-secondary-container,
-    .md-secondary {
-      position: absolute;
-      top: 50%;
-      margin: 0;
-      @include rtl-prop(right, left, $list-item-padding-horizontal);
-      transform: translate3d(0, -50%, 0);
-    }
-
-    & > .md-button._md-secondary-container > .md-secondary {
-      @include rtl-prop(margin-left, margin-right, 0);
-      position: static;
-    }
-
     & > p, & > ._md-list-item-inner > p {
-      flex: 1;
+      flex: 1 1 auto;
       margin: 0;
     }
   }
@@ -351,7 +333,7 @@ md-list-item {
       }
 
       .md-list-item-text {
-        flex: 1;
+        flex: 1 1 auto;
         margin: auto;
         text-overflow: ellipsis;
         overflow: hidden;
@@ -405,7 +387,7 @@ md-list-item {
         align-self: flex-start;
       }
       .md-list-item-text {
-        flex: 1;
+        flex: 1 1 auto;
       }
     }
   }

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -26,70 +26,79 @@ describe('mdListItem directive', function() {
     return el;
   }
 
-  it('supports empty list items', function() {
-    var list = setup('\
-                 <md-list>\
-                   <md-list-item></md-list-item>\
-                 </md-list>'
-    );
-
-    var cntr = list[0].querySelector('div');
-
-    if (cntr && cntr.click) {
-      cntr.click();
-      expect($rootScope.modelVal).toBe(false);
-    }
-
-  });
-
   it('forwards click events for md-checkbox', function() {
-    var listItem = setup('<md-list-item><md-checkbox ng-model="modelVal"></md-checkbox></md-list-item>');
+    var listItem = setup(
+      '<md-list-item>' +
+        '<md-checkbox ng-model="modelVal"></md-checkbox>' +
+      '</md-list-item>');
+
     var cntr = listItem[0].querySelector('div');
 
-    if (cntr && cntr.click) {
-      cntr.click();
-      expect($rootScope.modelVal).toBe(true);
-    }
+    cntr.click();
+    expect($rootScope.modelVal).toBe(true);
+
+    cntr.click();
+    expect($rootScope.modelVal).toBe(false);
 
   });
 
   it('forwards click events for md-switch', function() {
-    var listItem = setup('<md-list-item><md-switch ng-model="modelVal"></md-switch></md-list-item>');
+    var listItem = setup(
+      '<md-list-item>' +
+        '<md-switch ng-model="modelVal"></md-switch>' +
+      '</md-list-item>');
+
     var cntr = listItem[0].querySelector('div');
 
-    if (cntr && cntr.click) {
-      cntr.click();
-      expect($rootScope.modelVal).toBe(true);
-    }
+    cntr.click();
+    expect($rootScope.modelVal).toBe(true);
 
+    cntr.click();
+    expect($rootScope.modelVal).toBe(false);
   });
 
   it('should convert spacebar keypress events as clicks', inject(function($mdConstant) {
-    var listItem = setup('<md-list-item><md-checkbox ng-model="modelVal"></md-checkbox></md-list-item>');
+    var listItem = setup(
+      '<md-list-item>' +
+        '<md-checkbox ng-model="modelVal"></md-checkbox>' +
+      '</md-list-item>');
+
     var checkbox = angular.element(listItem[0].querySelector('md-checkbox'));
 
     expect($rootScope.modelVal).toBeFalsy();
+
     checkbox.triggerHandler({
       type: 'keypress',
       keyCode: $mdConstant.KEY_CODE.SPACE
     });
+
     expect($rootScope.modelVal).toBe(true);
   }));
 
   it('should not convert spacebar keypress for text areas', inject(function($mdConstant) {
-    var listItem = setup('<md-list-item><textarea ng-model="modelVal"></md-list-item>');
+    var listItem = setup(
+      '<md-list-item>' +
+        '<textarea ng-model="modelVal">' +
+      '</md-list-item>');
+
     var inputEl = angular.element(listItem[0].querySelector('textarea')[0]);
 
     expect($rootScope.modelVal).toBeFalsy();
+
     inputEl.triggerHandler({
       type: 'keypress',
       keyCode: $mdConstant.KEY_CODE.SPACE
     });
+
     expect($rootScope.modelVal).toBeFalsy();
   }));
 
   it('should not convert spacebar keypress for editable elements', inject(function($mdConstant) {
-    var listItem = setup('<md-list-item><div contenteditable="true"></div></md-list-item>');
+    var listItem = setup(
+      '<md-list-item>' +
+        '<div contenteditable="true"></div>' +
+      '</md-list-item>');
+
     var editableEl = listItem.find('div');
     var onClickSpy = jasmine.createSpy('onClickSpy');
 
@@ -113,69 +122,145 @@ describe('mdListItem directive', function() {
   }));
 
   it('creates buttons when used with ng-click', function() {
-    var listItem = setup('<md-list-item ng-click="sayHello()" ng-disabled="true"><p>Hello world</p></md-list-item>');
-    var buttonChild = listItem.children().children()[0];
-    var innerChild = listItem.children().children()[1];
-    expect(buttonChild.nodeName).toBe('MD-BUTTON');
-    expect(buttonChild.hasAttribute('ng-disabled')).toBeTruthy();
-    expect(innerChild.nodeName).toBe('DIV');
-    expect(innerChild.childNodes[0].nodeName).toBe('P');
+    var listItem = setup(
+      '<md-list-item ng-click="sayHello()" ng-disabled="true">' +
+        '<p>Hello world</p>' +
+      '</md-list-item>');
+
+    // List items, which are clickable always contain a button wrap at the top level.
+    var buttonWrap = listItem.children().eq(0);
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // The button wrap should contain the button executor, the inner content, flex filler and the
+    // secondary item container as children.
+    expect(buttonWrap.children().length).toBe(4);
+
+    var buttonExecutor = buttonWrap.children()[0];
+
+    // The list item should forward the click and disabled attributes.
+    expect(buttonExecutor.hasAttribute('ng-click')).toBe(true);
+    expect(buttonExecutor.hasAttribute('ng-disabled')).toBe(true);
+
+    var innerContent = buttonWrap.children()[1];
+
+    expect(innerContent.nodeName).toBe('DIV');
+    expect(innerContent.firstElementChild.nodeName).toBe('P');
   });
 
   it('creates buttons when used with ui-sref', function() {
-    var listItem = setup('<md-list-item ui-sref="somestate"><p>Hello world</p></md-list-item>');
-    var firstChild = listItem.children().children()[0];
-    expect(firstChild.nodeName).toBe('MD-BUTTON');
-    expect(firstChild.hasAttribute('ui-sref')).toBeTruthy();
+    var listItem = setup(
+      '<md-list-item ui-sref="somestate">' +
+        '<p>Hello world</p>' +
+      '</md-list-item>');
+
+    // List items, which are clickable always contain a button wrap at the top level.
+    var buttonWrap = listItem.children().eq(0);
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // The button wrap should contain the button executor, the inner content, flex filler and the
+    // secondary item container as children.
+    expect(buttonWrap.children().length).toBe(4);
+
+    var buttonExecutor = buttonWrap.children()[0];
+
+    // The list item should forward the ui-sref attribute.
+    expect(buttonExecutor.hasAttribute('ui-sref')).toBe(true);
+
+    var innerContent = buttonWrap.children()[1];
+
+    expect(innerContent.nodeName).toBe('DIV');
+    expect(innerContent.firstElementChild.nodeName).toBe('P');
   });
 
   it('creates buttons when used with href', function() {
-    var listItem = setup('<md-list-item href="/somewhere"><p>Hello world</p></md-list-item>');
-    var firstChild = listItem.children().children()[0];
-    expect(firstChild.nodeName).toBe('MD-BUTTON');
-    expect(firstChild.hasAttribute('href')).toBeTruthy();
+    var listItem = setup(
+      '<md-list-item href="/somewhere">' +
+        '<p>Hello world</p>' +
+      '</md-list-item>');
+
+    // List items, which are clickable always contain a button wrap at the top level.
+    var buttonWrap = listItem.children().eq(0);
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // The button wrap should contain the button executor, the inner content, flex filler and the
+    // secondary item container as children.
+    expect(buttonWrap.children().length).toBe(4);
+
+    var buttonExecutor = buttonWrap.children()[0];
+
+    // The list item should forward the href attribute.
+    expect(buttonExecutor.hasAttribute('href')).toBe(true);
+
+    var innerContent = buttonWrap.children()[1];
+
+    expect(innerContent.nodeName).toBe('DIV');
+    expect(innerContent.firstElementChild.nodeName).toBe('P');
   });
 
   it('moves aria-label to primary action', function() {
     var listItem = setup('<md-list-item ng-click="sayHello()" aria-label="Hello"></md-list-item>');
-    var listButtonWrap = listItem.children();
-    // The actual click button will be a child of the button.md-no-style wrapper.
-    var listItemButton = listButtonWrap.children();
 
-    expect(listButtonWrap).toHaveClass('md-button');
-    expect(listItemButton[0].nodeName).toBe('MD-BUTTON');
-    expect(listItemButton[0].getAttribute('aria-label')).toBe('Hello');
+    var buttonWrap = listItem.children().eq(0);
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // The actual click button will be a child of the button.md-no-style wrapper.
+    var buttonExecutor = buttonWrap.children()[0];
+    
+    expect(buttonExecutor.nodeName).toBe('MD-BUTTON');
+    expect(buttonExecutor.getAttribute('aria-label')).toBe('Hello');
   });
 
-  it('moves md-secondary items outside of the button', function() {
-    var listItem = setup('<md-list-item ng-click="sayHello()"><p>Hello World</p><md-icon class="md-secondary" ng-click="goWild()"></md-icon></md-list-item>');
-    // First child is our button and content holder
+  it('moves secondary items outside of the button', function() {
+    var listItem = setup(
+      '<md-list-item ng-click="sayHello()">' +
+        '<p>Hello World</p>' +
+        '<md-icon class="md-secondary" ng-click="goWild()"></md-icon>' +
+      '</md-list-item>');
+
+    // First child is our button wrap
     var firstChild = listItem.children().eq(0);
     expect(firstChild[0].nodeName).toBe('DIV');
-    // It should contain two elements, the button overlay and the actual content
-    expect(firstChild.children().length).toBe(2);
-    var secondChild = listItem.children().eq(1);
-    expect(secondChild[0].nodeName).toBe('MD-BUTTON');
-    expect(secondChild.hasClass('_md-secondary-container')).toBeTruthy();
+
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // It should contain three elements, the button overlay, inner content, flex filler
+    // and the secondary container.
+    expect(firstChild.children().length).toBe(4);
+
+    var secondaryContainer = firstChild.children().eq(3);
+    expect(secondaryContainer).toHaveClass('_md-secondary-container');
+
+    // The secondary container should contain the md-icon,
+    // which has been transformed to an icon button.
+    expect(secondaryContainer.children()[0].nodeName).toBe('MD-BUTTON');
   });
 
   it('moves multiple md-secondary items outside of the button', function() {
-    var listItem = setup('<md-list-item ng-click="sayHello()"><p>Hello World</p><md-icon class="md-secondary" ng-click="goWild()"><md-icon class="md-secondary" ng-click="goWild2()"></md-icon></md-list-item>');
-    // First child is our button and content holder
+    var listItem = setup(
+      '<md-list-item ng-click="sayHello()">' +
+        '<p>Hello World</p>' +
+        '<md-icon class="md-secondary" ng-click="goWild()"></md-icon>' +
+        '<md-icon class="md-secondary" ng-click="goWild2()"></md-icon>' +
+      '</md-list-item>');
+
+    // First child is our button wrap
     var firstChild = listItem.children().eq(0);
     expect(firstChild[0].nodeName).toBe('DIV');
-    // It should contain two elements, the button overlay and the actual content
-    expect(firstChild.children().length).toBe(2);
-    var secondChild = listItem.children().eq(1);
-    expect(secondChild[0].nodeName).toBe('DIV');
-    expect(secondChild.hasClass('_md-secondary-container')).toBeTruthy();
-    expect(secondChild.children().length).toBe(2);
-    var secondaryBtnOne = secondChild.children().eq(0);
-    expect(secondaryBtnOne[0].nodeName).toBe('MD-BUTTON');
-    expect(secondaryBtnOne.hasClass('_md-secondary-container')).toBeFalsy();
-    var secondaryBtnTwo = secondChild.children().eq(1);
-    expect(secondaryBtnTwo[0].nodeName).toBe('MD-BUTTON');
-    expect(secondaryBtnTwo.hasClass('_md-secondary-container')).toBeFalsy();
+
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // It should contain three elements, the button overlay, inner content, flex filler
+    // and the secondary container.
+    expect(firstChild.children().length).toBe(4);
+
+    var secondaryContainer = firstChild.children().eq(3);
+    expect(secondaryContainer).toHaveClass('_md-secondary-container');
+
+    // The secondary container should hold the two secondary items.
+    expect(secondaryContainer.children().length).toBe(2);
+
+    expect(secondaryContainer.children()[0].nodeName).toBe('MD-BUTTON');
+    expect(secondaryContainer.children()[1].nodeName).toBe('MD-BUTTON');
   });
 
   it('should detect non-compiled md-buttons', function() {


### PR DESCRIPTION
* The secondary items always had an absolute position, which causes issues with overflowing.
* This commit refactors the list to make the secondary items static.
* Fixes multiple secondary padding (as in specs - consistent)
* Fixes Proxy Scan for secondary items container
* Improved tests for the list component (more clear and more safe)

@crisbeto Maybe you can also review

Fixes #7500. Fixes #2759.