### PR TITLE
fix(md-tabs): fix mdEnableDisconnect flag by inverting some booleans

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -395,7 +395,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
           isActive:     function () { return this.getIndex() === ctrl.selectedIndex; },
           isLeft:       function () { return this.getIndex() < ctrl.selectedIndex; },
           isRight:      function () { return this.getIndex() > ctrl.selectedIndex; },
-          shouldRender: function () { return !ctrl.noDisconnect || this.isActive(); },
+          shouldRender: function () { return ctrl.noDisconnect || this.isActive(); },
           hasFocus:     function () {
             return !ctrl.lastClick
                 && ctrl.hasFocus && this.getIndex() === ctrl.focusIndex;

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -30,7 +30,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   defineBooleanAttribute('dynamicHeight', handleDynamicHeight);
   defineBooleanAttribute('noPagination');
   defineBooleanAttribute('swipeContent');
-  defineBooleanAttribute('noDisconnect');
   defineBooleanAttribute('autoselect');
   defineBooleanAttribute('noSelectClick');
   defineBooleanAttribute('centerTabs', handleCenterTabs, false);
@@ -395,7 +394,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
           isActive:     function () { return this.getIndex() === ctrl.selectedIndex; },
           isLeft:       function () { return this.getIndex() < ctrl.selectedIndex; },
           isRight:      function () { return this.getIndex() > ctrl.selectedIndex; },
-          shouldRender: function () { return ctrl.noDisconnect || this.isActive(); },
+          shouldRender: function () { return this.isActive(); },
           hasFocus:     function () {
             return !ctrl.lastClick
                 && ctrl.hasFocus && this.getIndex() === ctrl.focusIndex;

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -191,7 +191,7 @@ function MdTabs () {
                 'md-tabs-template="::tab.template" ' +
                 'md-connected-if="tab.isActive()" ' +
                 'md-scope="::tab.parent" ' +
-                'ng-if="$mdTabsCtrl.enableDisconnect || tab.shouldRender()"></div> ' +
+                'ng-if="!$mdTabsCtrl.enableDisconnect || tab.shouldRender()"></div> ' +
           '</md-tab-content> ' +
         '</md-tabs-content-wrapper>';
     },

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -61,7 +61,7 @@
  * @param {boolean=} md-center-tabs When enabled, tabs will be centered provided there is no need for pagination
  * @param {boolean=} md-no-pagination When enabled, pagination will remain off
  * @param {boolean=} md-swipe-content When enabled, swipe gestures will be enabled for the content area to jump between tabs
- * @param {boolean=} md-enable-disconnect When enabled, scopes will be disconnected for tabs that are not being displayed.  This provides a performance boost, but may also cause unexpected issues and is not recommended for most users.
+ * @param {boolean=} md-enable-disconnect When enabled, scopes will be disconnected for tabs that are not being displayed. When a scope is disconnected it is removed from the scope hierarchy so that its events and watches are not fired, but its state is not destroyed. This can result in a performance boost but may have unexpected behaviour.
  * @param {boolean=} md-autoselect When present, any tabs added after the initial load will be automatically selected
  * @param {boolean=} md-no-select-click When enabled, click events will not be fired when selecting tabs
  *


### PR DESCRIPTION
The md-enable-disconnect flag, designed to allow tab content scope to be destroyed when the tab is not displayed, was not working because the logic for hiding the tab content in ngIf was incorrect.

Fixes issue #6342