### PR TITLE
Select All feature for Multi Select component.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -119,7 +119,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
     controller: function($scope) {
-      $scope.checkAll=false; // Select all binding
+      $scope.checkAll = false; // Select all binding
       $scope.checkClass='';  // toggle class for the check box     
     } // empty placeholder controller to be initialized in link
   };


### PR DESCRIPTION
The multi select component of angular material does not have the below

- Select All
- When there are more than 1 selected then it keeps adding all of them to the selected label hence growing the component in size. Missing a label saying XX +n more as selected.

This commit adds the above functionality to the select component.

The below code shows how a md select can be written the feature of check all

`
      <md-input-container style="width:200px;">
        <label>State</label>
        <md-select ng-model="userState1" multiple id="hello" select-all>
          <md-option ng-repeat="state in states" value="{{state.abbrev}}" select-all>
            {{state.abbrev}}
          </md-option>
        </md-select>
      </md-input-container>
`

If you notice there is a attribute **select-all** which is added to the md-select which would add the check all option. Further you can see that the same attribute is added to the md-option to just display the check box for all the options. Adding to the md-option is optional where are adding to the md-select is required. The output would be as below

![selectall-1](https://cloud.githubusercontent.com/assets/5701291/13928726/4d730986-efb0-11e5-917e-0d80d5a7096a.png)

![selectall-2](https://cloud.githubusercontent.com/assets/5701291/13928899/16970cea-efb1-11e5-85b6-4560fa1cb754.png)

