### PR TITLE
feat(list): add ui-sref-opts attribute to button executor.

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -208,7 +208,8 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
       function copyAttributes(item, wrapper) {
         var copiedAttrs = ['ng-if', 'ng-click', 'aria-label', 'ng-disabled',
-          'ui-sref', 'href', 'ng-href', 'ng-attr-ui-sref'];
+          'ui-sref', 'href', 'ng-href', 'ng-attr-ui-sref', 'ui-sref-opts'];
+
         angular.forEach(copiedAttrs, function(attr) {
           if (item.hasAttribute(attr)) {
             wrapper.setAttribute(attr, item.getAttribute(attr));


### PR DESCRIPTION
* The list item supports the ui-sref-opts attribute now as well.

Fixes #7658