### PR TITLE
feat(select): changed md-select to have select all feature

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -118,7 +118,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     restrict: 'E',
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
     compile: compile,
-    controller: function() {
+    controller: function($scope) {
+      $scope.checkAll = false; // Select all binding
+      $scope.checkClass='';  // toggle class for the check box     
     } // empty placeholder controller to be initialized in link
   };
 
@@ -155,6 +157,19 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         .find('md-option')
         .attr('ng-show', '$$loadingAsyncDone');
     }
+
+   // add the select all option
+
+    var showCheckAll = angular.isDefined(attr.selectAll)?true:false;
+
+    if(showCheckAll){
+      element.find('md-content')
+      .prepend(angular.element('<div class="ng-scope md-ink-ripple" tabindex="0" aria-selected="false" id="chk_all" style="border-bottom: solid 1px lightgrey;" ng-click="checkAll = !checkAll">'+
+        '<div class="md-text ng-binding" style="text-align:right;margin-top:15px;margin-right:0px;cursor:pointer">Check All  <md-checkbox ng-class="checkClass" class="md-primary" ng-model="checkall" aria-label="check all"></md-checkbox></div></div>'))
+      ;
+    }
+
+    // end of adding the select all
 
     if (attr.name) {
       var autofillClone = angular.element('<select class="_md-visually-hidden">');
@@ -555,6 +570,37 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     // and values matching every option's controller.
     self.options = {};
 
+    // Watching the checkAll binding 
+    var isSelectAll = $element.parent().parent()[0].attributes['select-all']?true:false;
+
+    if(isSelectAll){
+      $element[0].setAttribute('select-all','');
+    }
+
+    $scope.$watch('checkAll',function(nv,ov){
+        var values = [];
+        if(nv){
+          angular.forEach(self.options,function(key,value){
+            key && key.setSelected(true);
+            self.selected[key] = value;
+            values.push(value);
+          });
+          $scope.checkClass='md-checked';
+        }else{
+          angular.forEach(self.options,function(key,value){
+            key && key.setSelected(false);
+            delete self.selected[key];
+          });
+          values=[];
+          $scope.checkClass='';
+        }
+
+        self.ngModel.$setViewValue(values);
+        self.ngModel.$render();
+    });
+
+    //--
+
     $scope.$watchCollection(function() {
       return self.options;
     }, function() {
@@ -660,7 +706,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
           // Map the given element to its innerHTML string. If the element has a child ripple
           // container remove it from the HTML string, before returning the string.
           mapFn = function(el) {
-            var html = el.innerHTML;
+            // check if its the select all kind if so then just get only
+            // the text 
+            if(isSelectAll)
+              var html = angular.element(el).text();
+            else
+              var html = el.innerHTML;
             // Remove the ripple container from the selected option, copying it would cause a CSP violation.
             var rippleContainer = el.querySelector('.md-ripple-container');
             return rippleContainer ? html.replace(rippleContainer.outerHTML, '') : html;
@@ -668,7 +719,13 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
         } else if (mode == 'aria') {
           mapFn = function(el) { return el.hasAttribute('aria-label') ? el.getAttribute('aria-label') : el.textContent; };
         }
-        return selectedOptionEls.map(mapFn).join(', ');
+        // check if the selected length is greater than 1
+        // wrap to show + n more. 
+        if (selectedOptionEls.map(mapFn).length > 1 && isSelectAll){
+          return selectedOptionEls.map(mapFn)[0]+" [+ "+(selectedOptionEls.map(mapFn).length-1)+" more ]";
+        }
+        else        
+          return selectedOptionEls.map(mapFn).join(', ');
       } else {
         return '';
       }
@@ -768,7 +825,11 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
-    element.append(angular.element('<div class="_md-text">').append(element.contents()));
+    // Adding the check box to all the md options. This would not be visible if the md options
+    // does not have the select-all attribute. it would then look normal options. 
+    var showCheckBox = angular.isDefined(attr.selectAll)?true:false;
+    var cbox = '<md-checkbox aria-label="check" class="md-primary" style="position:absolute;right:0;" ng-model="isChecked"></md-checkbox>';
+    element.append(angular.element('<div class="md-text">').append(element.contents()).append(showCheckBox?cbox:''));
 
     element.attr('tabindex', attr.tabindex || '0');
     return postLink;


### PR DESCRIPTION
@gmoothart @ErinCoughlan @jelbourn @ThomasBurleson , Please review.

The multi select component of angular material does not have the below

- Select All
- When there are more than 1 selected then it keeps adding all of them to the selected label hence growing the component in size. Missing a label saying XX +n more as selected.

This commit adds the above functionality to the select component.

The below code shows how a md select can be written the feature of check all

```html
      <md-input-container style="width:200px;">
        <label>State</label>
        <md-select ng-model="userState1" multiple id="hello" select-all>
          <md-option ng-repeat="state in states" value="{{state.abbrev}}" select-all>
            {{state.abbrev}}
          </md-option>
        </md-select>
      </md-input-container>
```

If you notice there is a attribute **select-all** which is added to the md-select which would add the check all option. Further you can see that the same attribute is added to the md-option to just display the check box for all the options. Adding to the md-option is optional where are adding to the md-select is required. The output would be as below

![selectall-1](https://cloud.githubusercontent.com/assets/5701291/13930843/088a9532-efba-11e5-9e01-71d3d54faa79.png)

![selectall-2](https://cloud.githubusercontent.com/assets/5701291/13930849/112f7f22-efba-11e5-8330-1379d1690add.png)

