### PR TITLE
feat(datepicker): md-hide-button, md-readonly, md-floating-label

### DIFF
--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -6,35 +6,51 @@ md-datepicker.md-THEME_NAME-theme {
 
 .md-THEME_NAME-theme {
 
-  .md-datepicker-input {
-    @include input-placeholder-color('\'{{foreground-3}}\'');
-    color: '{{foreground-1}}';
-    background: '{{background-color}}';
-  }
-
-  .md-datepicker-input-container {
-    border-bottom-color: '{{background-300}}';
-
-    &.md-datepicker-focused {
-      border-bottom-color: '{{primary-500}}'
+//  .md-datepicker-input {
+//    @include input-placeholder-color('\'{{foreground-3}}\'');
+//    color: '{{foreground-1}}';
+//    background: '{{background-color}}';
+//  }
+//
+//  .md-datepicker-input-container {
+//    border-bottom-color: '{{background-300}}';
+//
+//    &.md-datepicker-focused {
+//      border-bottom-color: '{{primary-500}}'
+//    }
+//
+//    &.md-datepicker-invalid {
+//      border-bottom-color: '{{warn-A700}}';
+//    }
+//  }
+  md-datepicker {
+    md-input-container {
+      &.md-datepicker-invalid {
+        .md-input {
+          border-bottom-color: '{{warn-A700}}';
+        }
+      }
     }
-
-    &.md-datepicker-invalid {
-      border-bottom-color: '{{warn-A700}}';
-    }
   }
-
   .md-datepicker-calendar-pane {
     border-color: '{{background-hue-1}}';
   }
 
-  .md-datepicker-triangle-button {
-    .md-datepicker-expand-triangle {
-      border-top-color: '{{foreground-3}}';
-    }
-
-    &:hover .md-datepicker-expand-triangle {
-      border-top-color: '{{foreground-2}}';
+//  .md-datepicker-triangle-button {
+//    .md-datepicker-expand-triangle {
+//      border-top-color: '{{foreground-3}}';
+//    }
+//
+//    &:hover .md-datepicker-expand-triangle {
+//      border-top-color: '{{foreground-2}}';
+//    }
+//  }
+  span {
+    &.md-datepicker-triangle {
+      color: '{{ foreground-3 }}';
+      &::after {
+        color: '{{ foreground-3 }}';
+      }
     }
   }
 

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -43,11 +43,11 @@ md-datepicker {
   }
 }
 
-.md-inline-form {
-  md-datepicker {
-    margin-top: 12px;
-  }
-}
+//.md-inline-form {
+//  md-datepicker {
+//    margin-top: 12px;
+//  }
+//}
 
 // The calendar icon button used to open the calendar pane.
 .md-datepicker-button {

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -4,16 +4,43 @@ $md-datepicker-border-bottom-gap: 5px !default;  // Space between input and the 
 $md-datepicker-open-animation-duration: 0.2s !default;
 $md-datepicker-triangle-button-width: 36px !default;
 
+$input-container-padding: 2px !default;
+$input-label-float-offset: 6px !default;
+$input-label-float-scale: 0.75 !default;
+$input-label-float-width: $input-container-padding + 16px;
+
 md-datepicker {
   // Don't let linebreaks happen between the open icon-button and the input.
   white-space: nowrap;
   overflow: hidden;
 
   // Leave room for the down-triangle button to "overflow" it's parent without modifying scrollLeft
-  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2);
-  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2);
+//  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2);
+//  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2);
 
   vertical-align: middle;
+  
+  input {
+    min-width: 120px;
+  }
+  input[readonly] {
+    min-width: 120px;
+    cursor: pointer;
+  }
+  input[disabled] {
+    cursor: auto;
+  }
+  &.ng-not-empty {
+    md-input-container {
+      label {
+        transition: none !important;
+        transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale) !important;
+        transition: transform $swift-ease-out-timing-function $swift-ease-out-duration,
+                    width $swift-ease-out-timing-function $swift-ease-out-duration !important;
+        width: calc((100% - #{$input-label-float-width}) / #{$input-label-float-scale}) !important;
+      }
+    }
+  }
 }
 
 .md-inline-form {
@@ -27,32 +54,35 @@ md-datepicker {
   display: inline-block;
   box-sizing: border-box;
   background: none;
+  md-icon {
+    vertical-align: baseline;
+  }
 }
 
 // The input into which the user can type the date.
-.md-datepicker-input {
-  @include md-flat-input();
-  min-width: 120px;
-  max-width: $md-calendar-width - $md-datepicker-button-gap;
-}
+//.md-datepicker-input {
+//  @include md-flat-input();
+//  min-width: 120px;
+//  max-width: $md-calendar-width - $md-datepicker-button-gap;
+//}
 
 // Container for the datepicker input.
-.md-datepicker-input-container {
-  // Position relative in order to absolutely position the down-triangle button within.
-  position: relative;
-
-  padding-bottom: $md-datepicker-border-bottom-gap;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-
-  display: inline-block;
-  width: auto;
-  @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
-
-  &.md-datepicker-focused {
-    border-bottom-width: 2px;
-  }
-}
+//.md-datepicker-input-container {
+//  // Position relative in order to absolutely position the down-triangle button within.
+//  position: relative;
+//
+//  padding-bottom: $md-datepicker-border-bottom-gap;
+//  border-bottom-width: 1px;
+//  border-bottom-style: solid;
+//
+//  display: inline-block;
+//  width: auto;
+//  @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
+//
+//  &.md-datepicker-focused {
+//    border-bottom-width: 2px;
+//  }
+//}
 
 
 // Floating pane that contains the calendar at the bottom of the input.
@@ -130,50 +160,88 @@ $md-date-arrow-size: 5px;
   border-top: $md-date-arrow-size solid;
 }
 
-// Button containing the down "disclosure" triangle/arrow.
-.md-datepicker-triangle-button {
-  position: absolute;
-  @include rtl-prop(right, left, 0);
-  top: 0;
-
-  // TODO(jelbourn): This position isn't great on all platforms.
-  @include rtl(transform, translateY(-25%) translateX(45%), translateY(-25%) translateX(-45%));
+span {
+  &.md-datepicker-triangle {
+    display: block;
+    align-items: flex-end;
+    text-align: end;
+    width: 3 * $baseline-grid;
+    margin: 0 .5 * $baseline-grid;
+    transform: translate3d(0, 1px, 0);
+    position: absolute;
+    right: 4px;
+    top: 7px;
+    &::after {
+      cursor: pointer;
+      display: block;
+      content: '\25BC';
+      position: relative;
+      top: 2px;
+      speak: none;
+      transform: scaleY(0.6) scaleX(1);
+    }
+  }
 }
+input[disabled] + div + span {
+  &.md-datepicker-triangle {
+    &::after {
+      cursor: auto;
+    }
+  }
+}
+// Button containing the down "disclosure" triangle/arrow.
+//.md-datepicker-triangle-button {
+//  position: absolute;
+//  @include rtl-prop(right, left, 0);
+//  top: 0;
+//
+//  // TODO(jelbourn): This position isn't great on all platforms.
+//  @include rtl(transform, translateY(-25%) translateX(45%), translateY(-25%) translateX(-45%));
+//}
 
 // Need crazy specificity to override .md-button.md-icon-button.
 // Only apply this high specifiy to the property we need to override.
-.md-datepicker-triangle-button.md-button.md-icon-button {
-  height: 100%;
-  width: $md-datepicker-triangle-button-width;
-  position: absolute;
-}
+//.md-datepicker-triangle-button.md-button.md-icon-button {
+//  height: 100%;
+//  width: $md-datepicker-triangle-button-width;
+//  position: absolute;
+//}
 
 // Disabled state for all elements of the picker.
-md-datepicker[disabled] {
-  .md-datepicker-input-container {
-    border-bottom-color: transparent;
-  }
-
-  .md-datepicker-triangle-button {
-    display: none;
-  }
-}
+//md-datepicker[disabled] {
+//  .md-datepicker-input-container {
+//    border-bottom-color: transparent;
+//  }
+//
+//  .md-datepicker-triangle-button {
+//    display: none;
+//  }
+//}
 
 // Open state for all of the elements of the picker.
 .md-datepicker-open {
-  .md-datepicker-input-container {
-    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
+  .md-input {
     border: none;
   }
-
-  .md-datepicker-input {
-    @include rtl-prop(margin-left, margin-right, 24px);
-    height: 40px;
-  }
-
-  .md-datepicker-triangle-button {
+  .md-datepicker-triangle {
     display: none;
+    &::after {
+      content: '';
+    }
   }
+  //.md-datepicker-input-container {
+  //  @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
+  //  border: none;
+  //}
+  //
+  //.md-datepicker-input {
+  //  @include rtl-prop(margin-left, margin-right, 24px);
+  //  height: 40px;
+  //}
+  //
+  //.md-datepicker-triangle-button {
+  //  display: none;
+  //}
 }
 
 // When the position of the floating calendar pane is adjusted to remain inside

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -3,7 +3,16 @@
 
     <h4>Standard date-picker</h4>
     <md-datepicker ng-model="myDate" md-placeholder="Enter date"></md-datepicker>
-
+    
+    <h4>Date-picker without the button</h4>
+    <md-datepicker ng-model="myDate" md-placeholder="Enter date" md-hide-button="true"></md-datepicker>
+    
+    <h4>Date-picker with a floating label</h4>
+    <md-datepicker ng-model="myDate" md-floating-label="Enter date"></md-datepicker>
+    
+    <h4>Date-picker readonly</h4>
+    <md-datepicker ng-model="myDate" md-placeholder="Enter date" md-readonly="true"></md-datepicker>
+    
     <h4>Disabled date-picker</h4>
     <md-datepicker ng-model="myDate" md-placeholder="Enter date" disabled></md-datepicker>
 


### PR DESCRIPTION
Hello,
since the datepicker directive doesn't allow the developer to customize the template, I added some parameters that allow to better adapt the module to different situations.
These are the parameters:
```
    @param {boolean=} md-hide-button Whether to hide the datepicker button or not.
    @param {boolean=} md-readonly Whether the datepicker is readonly (The datapicker will be opened on focus automatically).
    @param {String=} md-floating-label This will add a floating label to datepicker
```

![demo](https://cloud.githubusercontent.com/assets/3505087/13931972/2ec98b68-efa6-11e5-8d15-f689db87ec31.png)

I also refactored the htmls structure of the module in order to make it equal to other input directives.
The input field of the datepicker had different size than the other fields, worsening the UX. Now it have the same look of the other modules.

I hope It was helpful.
Simone