### PR TITLE
fix(sidenav): fix incorrect disable-backdrop tests

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -228,6 +228,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
    */
   function postLink(scope, element, attr, sidenavCtrl) {
     var lastParentOverFlow;
+    var backdrop;
     var triggeringElement = null;
     var promise = $q.when(true);
     var isLockedOpenParsed = $parse(attr.mdIsLockedOpen);
@@ -240,7 +241,11 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
         $mdMedia: $mdMedia
       });
     };
-    var backdrop = !angular.isDefined(attr.mdDisableBackdrop) ? $mdUtil.createBackdrop(scope, "_md-sidenav-backdrop md-opaque ng-enter") : undefined;
+
+    // Only create the backdrop if the backdrop isn't disabled.
+    if (!angular.isDefined(attr.mdDisableBackdrop)) {
+      backdrop = $mdUtil.createBackdrop(scope, "_md-sidenav-backdrop md-opaque ng-enter");
+    }
 
     $mdTheming(element);
 

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -52,18 +52,18 @@ describe('mdSidenav', function() {
       expect($rootScope.show).toBe(false);
     }));
 
-    it('should show no backdrop if disabled', inject(function($rootScope, $material, $timeout) {
-      var el = setup('md-disable-backdrop="true"');
+    it('should show a backdrop by default', inject(function($rootScope, $material) {
+      var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');
 
       $material.flushOutstandingAnimations();
 
       var backdrop = el.parent().find('md-backdrop');
-      expect(backdrop.length).toBe(0);
+      expect(backdrop.length).toBe(1);
     }));
 
-    it('should show no backdrop if disabled', inject(function($rootScope, $material, $timeout) {
-      var el = setup('md-disable-backdrop');
+    it('should not show a backdrop if md-disable-backdrop is set to true', inject(function($rootScope, $material) {
+      var el = setup('md-is-open="show" md-disable-backdrop');
       $rootScope.$apply('show = true');
 
       $material.flushOutstandingAnimations();


### PR DESCRIPTION
The tests for the `md-disable-backdrop` attribute are currently really useless, because the sidenav is actually never opening. 