### PR TITLE
fix(button): reduce selector length

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -1,4 +1,3 @@
-a.md-button.md-THEME_NAME-theme,
 .md-button.md-THEME_NAME-theme {
 
   &:not([disabled]) {


### PR DESCRIPTION
The `a.md-button.md-THEME_NAME-theme` in the button theme didn't really do anything, however
because there's quite a lot of nesting going on, it almost doubled the amount of selectors.

This was introduced in https://github.com/angular/material/commit/0178b8955f6bf2120a3a32fa8c51398557c9c059.