### PR TITLE
docs(progressCircular): missing Provider typo

### DIFF
--- a/src/components/progressCircular/js/progressCircularProvider.js
+++ b/src/components/progressCircular/js/progressCircularProvider.js
@@ -14,19 +14,19 @@
  *
  * @property {number} durationIndeterminate Duration of the indeterminate animation.
  * @property {number} startIndeterminate Indeterminate animation start point.
- * @param {number} endIndeterminate Indeterminate animation end point.
- * @param {number} rotationDurationIndeterminate Duration of the indeterminate rotating animation.
- * @param {function} easeFnIndeterminate Easing function to be used when animating
+ * @property {number} endIndeterminate Indeterminate animation end point.
+ * @property {number} rotationDurationIndeterminate Duration of the indeterminate rotating animation.
+ * @property {function} easeFnIndeterminate Easing function to be used when animating
  * between the indeterminate values.
  *
  * @property {(function(object): object)} configure Used to modify the default options.
  *
  * @usage
  * <hljs lang="js">
- *   myAppModule.config(function($mdProgressCircular) {
+ *   myAppModule.config(function($mdProgressCircularProvider) {
  *
  *     // Example of changing the default progress options.
- *     $mdProgressCircular.configure({
+ *     $mdProgressCircularProvider.configure({
  *       progressSize: 100,
  *       strokeWidth: 20,
  *       duration: 800


### PR DESCRIPTION
typo: `$mdProgressCircular` ->  `$mdProgressCircularProvider`
otherwise angular can not find the module named `$mdProgressCircular`