### PR TITLE
fix(mdDialog): fix issue #7725

### DIFF
--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -1,4 +1,4 @@
-$dialog-padding: $baseline-grid * 3;
+$dialog-padding: 0 ($baseline-grid * 3) ($baseline-grid * 3);
 
 .md-dialog-is-showing {
   max-height: 100%;
@@ -50,6 +50,14 @@ md-dialog {
 
   .md-dialog-content {
     padding: $dialog-padding;
+
+    &.md-not-last {
+      padding-bottom: 0;
+    }
+  }
+
+  md-dialog-title {
+    padding: 24px 24px 20px;
   }
 
   md-dialog-content {


### PR DESCRIPTION
Fix the padding of custom dialogs and add title tag to seperate title and content.
Custom dialogs use a md-dialog-title tag to wrap the title.
Use the `md-dialog-content` class with in combination with the `md-not-last` class to remove the bottom padding,
e.g. to insert a table.

change your code from this:

```html
<md-dialog>
  <md-dialog-content>
    everything goes here
  </md-dialog-content>
</md-dialog>
```

to this:

```html
<md-dialog>
  <md-dialog-title>
    title goes here
  </md-dialog-title>
  <md-dialog-content>
    content goes here
  </md-dialog-content>
</md-dialog>
```