### PR TITLE
feat(mdDialog): add custom value support to clickOutsideToClose and escapeToClose

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -771,25 +771,12 @@ function MdDialogProvider($$interimElementProvider) {
       }, 60);
 
       var removeListeners = [];
-      var smartClose = function(optionParam) {
+      var smartClose = function(key) {
         // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
         // cancel or fallback to hide.
-        var closeFn, tickFn;
-        if( options.$type == 'alert' ) {
-          closeFn = $mdDialog.hide;
-        }
-        else {
-          closeFn = $mdDialog.cancel;
-        }
-
-        if( options[optionParam] !== true ) {
-          tickFn = function() {
-            return closeFn(options[optionParam])
-          };
-        }
-        else {
-          tickFn = closeFn;
-        }
+        var closeFn = (options.$type == 'alert') ? $mdDialog.hide : $mdDialog.cancel;
+        var curriedCloseFn = angular.bind(this, closeFn, options[key]);
+        var tickFn  = (angular.isDefined(options[key]) && options[key]!== true) ?  curriedCloseFn : closeFn;
 
         $mdUtil.nextTick(tickFn, true);
       };

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -771,12 +771,33 @@ function MdDialogProvider($$interimElementProvider) {
       }, 60);
 
       var removeListeners = [];
-      var smartClose = function() {
-        // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
-        // cancel or fallback to hide.
-        var closeFn = ( options.$type == 'alert' ) ? $mdDialog.hide : $mdDialog.cancel;
-        $mdUtil.nextTick(closeFn, true);
+      var smartClose = function(optionParam) {
+        return function() {
+          // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
+          // cancel or fallback to hide.
+          var closeFn, tickFn;
+          if( options.$type == 'alert' ) {
+            closeFn = $mdDialog.hide;
+          }
+          else {
+            closeFn = $mdDialog.cancel;
+          }
+
+          if( options[optionParam] !== true ) {
+            tickFn = function() {
+              return closeFn(options[optionParam])
+            };
+          }
+          else {
+            tickFn = closeFn;
+          }
+
+          $mdUtil.nextTick(tickFn, true);
+        }
       };
+
+      var smartCloseEscape = smartClose('escapeToClose');
+      var smartCloseOutside = smartClose('clickOutsideToClose');
 
       if (options.escapeToClose) {
         var parentTarget = options.parent;
@@ -785,7 +806,7 @@ function MdDialogProvider($$interimElementProvider) {
             ev.stopPropagation();
             ev.preventDefault();
 
-            smartClose();
+            smartCloseEscape();
           }
         };
 
@@ -829,7 +850,7 @@ function MdDialogProvider($$interimElementProvider) {
             ev.stopPropagation();
             ev.preventDefault();
 
-            smartClose();
+            smartCloseOutside();
           }
         };
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -774,9 +774,9 @@ function MdDialogProvider($$interimElementProvider) {
       var smartClose = function(key) {
         // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
         // cancel or fallback to hide.
-        var closeFn = (options.$type == 'alert') ? $mdDialog.hide : $mdDialog.cancel;
+        var closeFn = options.$type == 'alert' ? $mdDialog.hide : $mdDialog.cancel;
         var curriedCloseFn = angular.bind(this, closeFn, options[key]);
-        var tickFn  = (angular.isDefined(options[key]) && options[key]!== true) ?  curriedCloseFn : closeFn;
+        var tickFn = angular.isDefined(options[key]) && options[key] !== true ? curriedCloseFn : closeFn;
 
         $mdUtil.nextTick(tickFn, true);
       };

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -772,32 +772,27 @@ function MdDialogProvider($$interimElementProvider) {
 
       var removeListeners = [];
       var smartClose = function(optionParam) {
-        return function() {
-          // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
-          // cancel or fallback to hide.
-          var closeFn, tickFn;
-          if( options.$type == 'alert' ) {
-            closeFn = $mdDialog.hide;
-          }
-          else {
-            closeFn = $mdDialog.cancel;
-          }
-
-          if( options[optionParam] !== true ) {
-            tickFn = function() {
-              return closeFn(options[optionParam])
-            };
-          }
-          else {
-            tickFn = closeFn;
-          }
-
-          $mdUtil.nextTick(tickFn, true);
+        // Only 'confirm' dialogs have a cancel button... escape/clickOutside will
+        // cancel or fallback to hide.
+        var closeFn, tickFn;
+        if( options.$type == 'alert' ) {
+          closeFn = $mdDialog.hide;
         }
-      };
+        else {
+          closeFn = $mdDialog.cancel;
+        }
 
-      var smartCloseEscape = smartClose('escapeToClose');
-      var smartCloseOutside = smartClose('clickOutsideToClose');
+        if( options[optionParam] !== true ) {
+          tickFn = function() {
+            return closeFn(options[optionParam])
+          };
+        }
+        else {
+          tickFn = closeFn;
+        }
+
+        $mdUtil.nextTick(tickFn, true);
+      };
 
       if (options.escapeToClose) {
         var parentTarget = options.parent;
@@ -806,7 +801,7 @@ function MdDialogProvider($$interimElementProvider) {
             ev.stopPropagation();
             ev.preventDefault();
 
-            smartCloseEscape();
+            smartClose('escapeToClose');
           }
         };
 
@@ -850,7 +845,7 @@ function MdDialogProvider($$interimElementProvider) {
             ev.stopPropagation();
             ev.preventDefault();
 
-            smartCloseOutside();
+            smartClose('clickOutsideToClose')
           }
         };
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1246,6 +1246,79 @@ describe('$mdDialog', function() {
     });
   });
 
+  it('should reject the show promise with a custom cancel value after mousedown mouseup and remove', inject(function($mdDialog, $timeout) {
+    jasmine.mockElementFocus(this);
+    var container, parent = angular.element('<div>');
+    var rejectCorrect = false;
+
+    $mdDialog.show(
+      $mdDialog.confirm({
+        template: '<md-dialog>' +
+        '<md-dialog-content tabIndex="0">' +
+        '<p>Muppets are the best</p>' +
+        '</md-dialog-content>' +
+        '</md-dialog>',
+        parent: parent,
+        clickOutsideToClose: 'test'
+      })
+    ).catch(function(rejectVal){
+        if(rejectVal === 'test') {
+          rejectCorrect = true;
+        }
+      });
+
+    runAnimation();
+
+    container = angular.element(parent[0].querySelector('.md-dialog-container'));
+    container.triggerHandler({
+      type: 'mousedown',
+      target: container[0]
+    });
+    container.triggerHandler({
+      type: 'mouseup',
+      target: container[0]
+    });
+
+    $timeout.flush();
+    runAnimation();
+
+    expect(rejectCorrect).toBe(true);
+  }));
+
+  it('should reject the show promise with a custom cancel value after ESCAPE key', inject(function($mdDialog, $rootScope, $timeout, $mdConstant) {
+    jasmine.mockElementFocus(this);
+    var container, parent = angular.element('<div>');
+    var response;
+
+    $mdDialog.show(
+      $mdDialog.confirm({
+        template: '<md-dialog>' +
+        '<md-dialog-content tabIndex="0">' +
+        '<p>Muppets are the best</p>' +
+        '</md-dialog-content>' +
+        '</md-dialog>',
+        parent: parent,
+        clickOutsideToClose: 'outside',
+        escapeToClose: 'escape',
+        ok: 'OK',
+        cancel: 'CANCEL'
+      })
+    ).catch(function(reason) {
+        response = reason;
+      });
+    runAnimation();
+
+    parent.triggerHandler({
+      type: 'keydown',
+      keyCode: $mdConstant.KEY_CODE.ESCAPE
+    });
+    runAnimation();
+    runAnimation();
+
+
+    expect(response).toBe('escape');
+  }));
+
   function hasConfigurationMethods(preset, methods) {
     angular.forEach(methods, function(method) {
       return it('supports config method #' + method, inject(function($mdDialog) {


### PR DESCRIPTION
This changes dialog.js to support custom values for the clickOutsideToClose and escapeToClose
parameters. This allows users of the library to distinguish the different situations that can resolve
or reject the promise returned by $mdDialog and provide specific handling for each way the dialog
can be closed.

Closes issue #7731, which I opened.