### PR TITLE
feat(): add $$mdAPI factory

### DIFF
--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -57,58 +57,41 @@ angular
  * $mdSidenav(componentId).isLockedOpen();
  * </hljs>
  */
-function SidenavService($mdComponentRegistry, $q) {
-  return function(handle) {
+function SidenavService($$mdAPI, $q) {
 
-    // Lookup the controller instance for the specified sidNav instance
-    var self;
-    var errorMsg = "SideNav '" + handle + "' is not available!";
-    var instance = $mdComponentRegistry.get(handle);
+  return $$mdAPI()
+    .onError(onError)
+    .addMethod('isOpen', isOpen)
+    .addMethod('isLockedOpen', isLockedOpen)
+    .addMethod('toggle', toggle)
+    .addMethod('open', open)
+    .addMethod('close', close)
+    .create();
 
-    if(!instance) {
-      $mdComponentRegistry.notFoundError(handle);
-    }
+  function onError(registryName) {
+    return $q.reject("SideNav '" + registryName + "' is not available!");
+  }
 
-    return self = {
-      // -----------------
-      // Sync methods
-      // -----------------
-      isOpen: function() {
-        return instance && instance.isOpen();
-      },
-      isLockedOpen: function() {
-        return instance && instance.isLockedOpen();
-      },
-      // -----------------
-      // Async methods
-      // -----------------
-      toggle: function() {
-        return instance ? instance.toggle() : $q.reject(errorMsg);
-      },
-      open: function() {
-        return instance ? instance.open() : $q.reject(errorMsg);
-      },
-      close: function() {
-        return instance ? instance.close() : $q.reject(errorMsg);
-      },
-      then : function( callbackFn ) {
-        var promise = instance ? $q.when(instance) : waitForInstance();
-        return promise.then( callbackFn || angular.noop );
-      }
-    };
+  function isOpen() {
+   return this.instance.isOpen();
+  }
 
-    /**
-     * Deferred lookup of component instance using $component registry
-     */
-    function waitForInstance() {
-      return $mdComponentRegistry
-                .when(handle)
-                .then(function( it ){
-                  instance = it;
-                  return it;
-                });
-    }
-  };
+  function isLockedOpen() {
+    return this.instance.isLockedOpen();
+  }
+
+  function toggle() {
+    return this.instance.toggle();
+  }
+
+  function open() {
+    return this.instance.open();
+  }
+
+  function close() {
+    return this.instance.close();
+  }
+
 }
 /**
  * @ngdoc directive
@@ -396,7 +379,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
  * @module material.components.sidenav
  *
  */
-function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
+function SidenavController($scope, $attrs, $$mdAPI, $q) {
 
   var self = this;
 
@@ -412,5 +395,5 @@ function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
   self.toggle = function() { return self.$toggleOpen( !$scope.isOpen );  };
   self.$toggleOpen = function(value) { return $q.when($scope.isOpen = value); };
 
-  self.destroy = $mdComponentRegistry.register(self, $attrs.mdComponentId);
+  self.destroy = $$mdAPI.register(self, $attrs.mdComponentId);
 }

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -57,40 +57,11 @@ angular
  * $mdSidenav(componentId).isLockedOpen();
  * </hljs>
  */
-function SidenavService($$mdAPI, $q) {
+function SidenavService($$mdAPI) {
 
   return $$mdAPI()
-    .onError(onError)
-    .addMethod('isOpen', isOpen)
-    .addMethod('isLockedOpen', isLockedOpen)
-    .addMethod('toggle', toggle)
-    .addMethod('open', open)
-    .addMethod('close', close)
+    .load()
     .create();
-
-  function onError(registryName) {
-    return $q.reject("SideNav '" + registryName + "' is not available!");
-  }
-
-  function isOpen() {
-   return this.instance.isOpen();
-  }
-
-  function isLockedOpen() {
-    return this.instance.isLockedOpen();
-  }
-
-  function toggle() {
-    return this.instance.toggle();
-  }
-
-  function open() {
-    return this.instance.open();
-  }
-
-  function close() {
-    return this.instance.close();
-  }
 
 }
 /**
@@ -243,7 +214,6 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     scope.$watch(isLocked, updateIsLocked);
     scope.$watch('isOpen', updateIsOpen);
 
-
     // Publish special accessor for the Controller instance
     sidenavCtrl.$toggleOpen = toggleOpen;
 
@@ -383,17 +353,42 @@ function SidenavController($scope, $attrs, $$mdAPI, $q) {
 
   var self = this;
 
-  // Use Default internal method until overridden by directive postLink
+  self.isOpen = function() {
+    return !!$scope.isOpen;
+  };
 
-  // Synchronous getters
-  self.isOpen = function() { return !!$scope.isOpen; };
-  self.isLockedOpen = function() { return !!$scope.isLockedOpen; };
+  self.isLockedOpen = function() {
+    return !!$scope.isLockedOpen;
+  };
 
-  // Async actions
-  self.open   = function() { return self.$toggleOpen( true );  };
-  self.close  = function() { return self.$toggleOpen( false ); };
-  self.toggle = function() { return self.$toggleOpen( !$scope.isOpen );  };
-  self.$toggleOpen = function(value) { return $q.when($scope.isOpen = value); };
+  self.open   = function() {
+    return self.$toggleOpen(true);
+  };
 
-  self.destroy = $$mdAPI.register(self, $attrs.mdComponentId);
+  self.close  = function() {
+    return self.$toggleOpen(false);
+  };
+
+  self.toggle = function() {
+    return self.$toggleOpen(!$scope.isOpen);
+  };
+
+  self.$toggleOpen = function(value) {
+    return $q.when($scope.isOpen = value);
+  };
+
+  function onError(registryName) {
+    return $q.reject("SideNav '" + registryName + "' is not available!");
+  }
+
+  // This registers our public API.
+  self.destroy = $$mdAPI()
+    .onError(onError)
+    .addMethod('isOpen', self.isOpen)
+    .addMethod('isLockedOpen', self.isLockedOpen)
+    .addMethod('toggle', self.toggle)
+    .addMethod('open', self.open)
+    .addMethod('close', self.close)
+    .store($attrs.mdComponentId);
+
 }

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -341,13 +341,20 @@ describe('mdSidenav', function() {
           var instance;
 
           // Lookup deferred (not existing) instance
-          $mdSidenav('left').then( function(inst) { instance = inst; });
+          $mdSidenav('left').then(function(inst) {
+            // The instance will be not the controller, because we are creating our public API with
+            // the stored configuration approach. That means that the instance is actually the set of
+            // the registered methods of the configuration.
+            instance = inst;
+          });
+
           expect(instance).toBeUndefined();
 
           // Instantiate `left` sidenav component
           var el = setup('md-component-id="left"');
 
           $timeout.flush();
+
           expect(instance).toBeTruthy();
           expect(instance.isOpen()).toBeFalsy();
 

--- a/src/core/services/apiFactory/apiFactory.js
+++ b/src/core/services/apiFactory/apiFactory.js
@@ -1,0 +1,201 @@
+angular
+  .module('material.core')
+  .factory('$$mdAPI', mdAPIFactory);
+
+/**
+ * @ngdoc service
+ * @name $$mdAPI
+ * @module material.core
+ *
+ * @description
+ *
+ * Factory that constructs a public API.
+ * Used internally by ngMaterial to provide a public interface with restricted methods.
+ * Once the factory generated the service, the service will allow an async lookup for instances and more.
+ *
+ * ### Basics
+ * When creating a public API, then there must be an instance, which is stored into the `$mdComponentRegistry`.
+ * It is recommended, to register the instance by using the `$$mdAPI` function, instead of the native
+ * `$mdComponentRegistry`.
+ *
+ * ### Error Handling
+ * An `$$mdAPI` generated service can also hold a `onError` function, which will be called when there is no instance
+ * present yet.
+ *
+ * For example, when the user calls a registered method, but there is no instance found yet, then `onError` will be
+ * called, and when a return value is present, then it will be used for the registered method's return value.
+ *
+ * **Notice**: The `onError` function is not working when using a stored configuration.
+ *
+ * ### Stored Configuration
+ * When using a stored configuration, then the `$$mdAPI` factory will register the current configuration in the
+ * component registry.
+ *
+ * That means, that the following variables will have another value:
+ * - `this.instance`: The previous stored configuration
+ *
+ * ### Inside of provided functions
+ * Every provided function will be called within a special context, which provides the following variables:
+ *
+ * - `this.instance`: The previous loaded instance
+ * - `this.registryName`: The unique id of the instance.
+ *
+ * @usage
+ * <hljs lang="js">
+ *   function MdSidenavFactory($$mdAPI) {
+ *     return $$mdAPI()
+ *       .addMethod('open', openFn)
+ *       .create();
+ *
+ *     function openFn() {
+ *       // This call the instanceFn function, which is defined in the instance for the current componnent id.
+ *       this.instance.instanceFn();
+ *     }
+ *   }
+ * </hljs>
+ *
+ * This is how an instance object can be registered in the `$mdComponentRegistry`.
+ * <hljs lang="js">
+ *   function postLink(scope, element, attrs) {
+ *     $$mdAPI.register({
+ *       instanceFn: $scope.instanceFn
+ *     }, 'leftSidenav');
+ *   }
+ * </hljs>
+ *
+ * The `$$mdAPI` factory can be also used without an instance object.
+ * <hljs lang="js">
+ *   function postLink($$mdAPI) {
+ *     $$mdAPI()
+ *       .addMethod('open', $scope.instanceFn)
+ *       .store('leftSidenav')
+ *   }
+ *
+ *   function $mdSidenavFactory($$mdAPI) {
+ *     return $$mdAPI()
+ *       // This loads the stored configuration which is responsible for the current component id.
+ *       .load()
+ *       .create()
+ * </hljs>
+ *
+ */
+function mdAPIFactory($mdComponentRegistry, $q) {
+
+  function MdAPIService() {
+    var API;
+    var loadStoredConfig = false;
+    var config = {
+      methods: {}
+    };
+
+    return API = {
+      onError: _setOnError,
+      addMethod: _addMethod,
+      create: _createFactory,
+      store: _storeAsInstance,
+      load: _setLoadStoredConfig
+    };
+
+    function _setOnError(fn) {
+      config.onError = fn;
+      return API;
+    }
+
+    function _addMethod(name, fn) {
+      if (typeof fn !== 'function') {
+        throw new Error('$$mdAPI: Error while registering the method ' + name + '. The value is not a function');
+      }
+
+      config.methods[name] = fn;
+      return API;
+    }
+
+    function _storeAsInstance(componentId) {
+      return $mdComponentRegistry.register(config, componentId);
+    }
+
+    function _setLoadStoredConfig() {
+      loadStoredConfig = true;
+      return API;
+    }
+
+    function _createFactory() {
+      return function(registryName) {
+
+        function FactoryFunction() {
+          this.registryName = registryName;
+          this.instance = $mdComponentRegistry.get(registryName);
+
+          if (!this.instance && !loadStoredConfig) {
+            $mdComponentRegistry.notFoundError(registryName);
+
+          } else if (this.instance && loadStoredConfig) {
+            if (!this.instance.methods) {
+              throw new Error('$$mdAPI: No stored configuration found for name: ' + registryName);
+            }
+
+            applyConfigMethods(this.instance.methods);
+          }
+        }
+
+        // This is a default function for every factory function.
+        // It allows the user to asynchronously lookup for the instance.
+        FactoryFunction.prototype.then = function(resolveFn) {
+          var self = this;
+
+          var result = this.instance ? $q.when(this.instance) :
+            $mdComponentRegistry
+              .when(this.registryName)
+              .then(function(val) {
+                self.instance = val;
+
+                if (loadStoredConfig) {
+                  applyConfigMethods(self.instance.methods);
+
+                  // We return the configuration methods, because otherwise the async lookup
+                  // is only returning the stored configuration. This allows the user to easily access
+                  // the methods through the async instance.
+                  return self.instance.methods;
+                }
+
+                return val;
+              });
+
+          return result.then(resolveFn || angular.noop);
+        };
+
+        // This registers our custom provided methods and applies them to the prototype of our
+        // factory function.
+        applyConfigMethods(config.methods);
+
+        // This creates our object, we are not using a simple JSON object here, because we wan't to to take
+        // advantage of the function context.
+        return new FactoryFunction();
+
+        function applyConfigMethods(methods) {
+          angular.forEach(methods, function(value, key) {
+
+            FactoryFunction.prototype[key] = function() {
+              if (!this.instance) {
+                var res = config.onError(this.registryName);
+                // When the onError function returns a value, then it should be returned.
+                if (res) return res;
+              }
+
+              return value.apply(this, arguments);
+            };
+
+          });
+        }
+      };
+    }
+  }
+
+  // This is a public function, which allows the user to register its instance directly
+  // by using the $$mdAPI service. This provides a flat API for creating public interfaces.
+  MdAPIService.register = function(instance, id) {
+    return $mdComponentRegistry.register(instance, id);
+  };
+
+  return MdAPIService;
+}

--- a/src/core/services/apiFactory/apiFactory.spec.js
+++ b/src/core/services/apiFactory/apiFactory.spec.js
@@ -1,0 +1,300 @@
+describe('$$mdAPI factory', function() {
+  var $$mdAPI;
+
+  beforeEach(module('material.core'));
+
+  beforeEach(inject(function(_$$mdAPI_) {
+    $$mdAPI = _$$mdAPI_;
+  }));
+
+  it('should register the registered methods', function() {
+    $$mdAPI.register({}, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('closePane', angular.noop)
+      .addMethod('openPane', angular.noop)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['closePane']).toBe('function');
+    expect(typeof service['openPane']).toBe('function');
+  });
+  
+  it('should register the async lookup method by default', function() {
+    $$mdAPI.register({}, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('closePane', angular.noop)
+      .addMethod('openPane', angular.noop)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['then']).toBe('function');
+    expect(typeof service['closePane']).toBe('function');
+    expect(typeof service['openPane']).toBe('function');
+  });
+
+  it('should call the onError method probably', function() {
+    // We don't register an instance here, because we wan't to trigger
+    // the onError method, which will be always called when no instance
+    // couldn't be found.
+
+    var onErrorSpy = jasmine.createSpy('onErrorSpy');
+
+    var factory = $$mdAPI()
+      .onError(onErrorSpy)
+      .addMethod('testMethod', angular.noop)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['testMethod']).toBe('function');
+
+    service['testMethod']();
+
+    expect(onErrorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should overwrite the return value when onError is called', function() {
+    var onErrorFn = function() {
+      return 'Overwrote!';
+    };
+
+    var factory = $$mdAPI()
+      .onError(onErrorFn)
+      .addMethod('testMethod', angular.noop)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['testMethod']).toBe('function');
+
+    // When the onError function returns a value, then it will be forwarded to the actual call.
+    // This is useful when rejecting a value, when no instance is present yet.
+    expect(service['testMethod']()).toBe('Overwrote!');
+  });
+
+  it('should return the values of the registered methods probably', function() {
+    $$mdAPI.register({}, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('sayHello', sayHello)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['sayHello']).toBe('function');
+    expect(service['sayHello']()).toBe('Hello');
+
+    function sayHello() {
+      return 'Hello';
+    }
+  });
+
+  it('should forward the instance correctly', function() {
+    var instanceSpy = jasmine.createSpy('instanceSpy');
+
+    $$mdAPI.register({
+      triggerSpy: instanceSpy
+    }, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('executeSpy', executeSpy)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['executeSpy']).toBe('function');
+
+    service['executeSpy']();
+
+    expect(instanceSpy).toHaveBeenCalledTimes(1);
+
+    function executeSpy() {
+      this.instance.triggerSpy();
+    }
+  });
+
+  it('should apply the registry name correctly', function() {
+    var registryName = null;
+
+    $$mdAPI.register({}, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('loadRegistryName', loadRegistryName)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['loadRegistryName']).toBe('function');
+
+    service['loadRegistryName']();
+
+    expect(registryName).toBe('testInstance');
+
+    function loadRegistryName() {
+      registryName = this.registryName;
+    }
+  });
+
+  it('should register the instance correctly', function() {
+    var instance = null;
+
+    $$mdAPI.register({
+      correct: true
+    }, 'testInstance');
+
+    var factory = $$mdAPI()
+      .addMethod('loadInstance', loadInstance)
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['loadInstance']).toBe('function');
+
+    service['loadInstance']();
+
+    expect(instance['correct']).toBe(true);
+
+    function loadInstance() {
+      instance = this.instance;
+    }
+  });
+
+  it('should correctly wait for the instance', inject(function($timeout) {
+    var loadedInstance = null;
+
+    var factory = $$mdAPI().create();
+    var service = factory('testInstance');
+
+    expect(typeof service['then']).toBe('function');
+
+    service['then'](function(instance) {
+      // This callback will be resolved with the instance, when the async lookup completed.
+      loadedInstance = instance;
+    });
+
+    $$mdAPI.register({
+      correct: true
+    }, 'testInstance');
+
+    // Flush the timeout of the $mdComponentRegistry.
+    $timeout.flush();
+
+    expect(loadedInstance['correct']).toBe(true);
+  }));
+
+  it('should log an error when no instance is present', inject(function($log) {
+    spyOn($log, 'error');
+
+    var factory = $$mdAPI().create();
+
+    factory('testInstance');
+
+    expect($log.error).toHaveBeenCalledTimes(1);
+  }));
+
+  it('should correctly store the configuration', function() {
+
+    $$mdAPI()
+      .addMethod('testMethod', angular.noop)
+      // We store our current config, so we can reuse it later.
+      .store('testInstance');
+
+    var factory = $$mdAPI()
+      // This loads our previous stored configuration into the current API
+      .load()
+      .create();
+
+    var service = factory('testInstance');
+
+    expect(typeof service['testMethod']).toBe('function');
+  });
+
+  it('should correctly load the configuration asynchronously', inject(function($timeout) {
+    var loadedInstance = null;
+
+    var factory = $$mdAPI()
+      // This loads our previous stored configuration into the current API
+      .load()
+      .create();
+
+    var service = factory('testComponentId');
+
+    service.then(function(instance) {
+      loadedInstance = instance;
+    });
+
+    expect(service['testMethod']).toBeUndefined();
+
+    $$mdAPI()
+      .addMethod('testMethod', angular.noop)
+      .store('testComponentId');
+
+    $timeout.flush();
+
+    expect(typeof service['testMethod']).toBe('function');
+    expect(loadedInstance).toBeTruthy();
+  }));
+
+  it('should return a deregister function when storing the configuration', function() {
+    var deregisterFn = $$mdAPI()
+      .addMethod('testMethod', angular.noop)
+      .store('testComponentId');
+
+    expect(typeof deregisterFn).toBe('function');
+  });
+
+  it('should return the methods when using async lookup for a stored configuration', inject(function($timeout) {
+    var loadedInstance = null;
+
+    var factory = $$mdAPI()
+      // This loads our previous stored configuration into the current API
+      .load()
+      .create();
+
+    var service = factory('testComponentId');
+
+    service.then(function(instance) {
+      loadedInstance = instance;
+    });
+
+    expect(service['testMethod']).toBeUndefined();
+
+    $$mdAPI()
+      .addMethod('testMethod', angular.noop)
+      .store('testComponentId');
+
+    $timeout.flush();
+
+    expect(typeof service['testMethod']).toBe('function');
+    expect(loadedInstance).toBeTruthy();
+    expect(typeof loadedInstance['testMethod']).toBe('function');
+  }));
+
+  it('should correctly deregister the stored configuration', inject(function($mdComponentRegistry) {
+
+    var deregisterFn = $$mdAPI()
+      .addMethod('testMethod', angular.noop)
+      .store('testComponentId');
+
+    expect(typeof deregisterFn).toBe('function');
+
+    var factory = $$mdAPI()
+      .load()
+      .create();
+
+    var service = factory('testComponentId');
+
+    expect(typeof service['testMethod']).toBe('function');
+    expect($mdComponentRegistry.get('testComponentId')).toBeTruthy();
+
+    deregisterFn();
+
+    expect($mdComponentRegistry.get('testComponentId')).toBeFalsy();
+
+  }));
+
+});

--- a/src/core/services/registry/componentRegistry.js
+++ b/src/core/services/registry/componentRegistry.js
@@ -4,7 +4,7 @@
    *
    * @description
    * A component instance registration service.
-   * Note: currently this as a private service in the SideNav component.
+   * Note: This is currently used by the $$mdAPI factory, which provides public interfaces like `$mdSidenav`.
    */
   angular.module('material.core')
     .factory('$mdComponentRegistry', ComponentRegistry);


### PR DESCRIPTION
`$$mdAPI factory`
---
`$$mdAPI` is a factory, which simplifies creating of public interfaces for ngMaterial components.

The `$$mdAPI` factory will be used in future for the following components (PR's will follow - #3520)
- [x] `$mdSidenav`
- `$mdAutocomplete`
- `$mdSelect`

### Usage
The `$$mdAPI` factory offers a few different possibilities to create a public interface.

**Basic Usage**
```js
function MdSidenavFactory($$mdAPI) {
  return $$mdAPI()
    // Will be called, when no instance is present, and overwrites the return value. 
    .onError(errorFn)
    .addMethod('open', openSidenav)
    .create();

  function openSidenav() {
    // The instance will be passed into the current context.
    this.instance.open();
  }
  ...
}

// Sidenav postLink function
function postLink(scope, element, attrs) {
  $$mdAPI.register({
    // Just an example mock
    open: $scope.open 
  }, attrs.mdComponentId);
}
```

**Stored Configuration Usage (Recommended)**
```js
function MdSidenavFactory($$mdAPI) {
  return $$mdAPI
    .load()
    .create();
}

function postLink(scope, element, attrs) {
  $$mdAPI()
    .addMethod('open', $scope.open)
    .store(attrs.mdComponentId);
}
```

You may have noticed, that the stored configuration usage is **extremely** powerful.

**More coming soon** - 

cc. @jelbourn (because of #3520) - @EladBezalel  - @topherfangio 

- Reviewing can be started yet, but please notice, that this is still in progress.