### PR TITLE
fix(build): add @ngInject annotations everywhere

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -7,6 +7,7 @@ var ITEM_HEIGHT   = 41,
     MENU_PADDING  = 8,
     INPUT_PADDING = 2; // Padding provided by `md-input-container`
 
+/* @ngInject */
 function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming, $window,
                              $animate, $rootElement, $attrs, $q) {
   //-- private variables

--- a/src/components/autocomplete/js/autocompleteParentScopeDirective.js
+++ b/src/components/autocomplete/js/autocompleteParentScopeDirective.js
@@ -2,6 +2,7 @@ angular
   .module('material.components.autocomplete')
   .directive('mdAutocompleteParentScope', MdAutocompleteItemScopeDirective);
 
+/* @ngInject */
 function MdAutocompleteItemScopeDirective($compile, $mdUtil) {
   return {
     restrict: 'AE',

--- a/src/components/autocomplete/js/highlightController.js
+++ b/src/components/autocomplete/js/highlightController.js
@@ -2,6 +2,7 @@ angular
     .module('material.components.autocomplete')
     .controller('MdHighlightCtrl', MdHighlightCtrl);
 
+/* @ngInject */
 function MdHighlightCtrl ($scope, $element, $attrs) {
   this.init = init;
 

--- a/src/components/autocomplete/js/highlightDirective.js
+++ b/src/components/autocomplete/js/highlightDirective.js
@@ -31,6 +31,7 @@ angular
  * </hljs>
  */
 
+/* @ngInject */
 function MdHighlight ($interpolate, $parse) {
   return {
     terminal: true,

--- a/src/components/backdrop/backdrop.js
+++ b/src/components/backdrop/backdrop.js
@@ -19,6 +19,8 @@
 
 angular
   .module('material.components.backdrop', ['material.core'])
+
+  /* @ngInject */
   .directive('mdBackdrop', function BackdropDirective($mdTheming, $animate, $rootElement, $window, $log, $$rAF, $document) {
     var ERROR_CSS_POSITION = "<md-backdrop> may not work properly in a scrolled, static-positioned parent container.";
 

--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -125,6 +125,7 @@ function MdBottomSheetDirective($mdBottomSheet) {
  *
  */
 
+/* @ngInject */
 function MdBottomSheetProvider($$interimElementProvider) {
   // how fast we need to flick down to close the sheet, pixels/ms
   var CLOSING_VELOCITY = 0.5;
@@ -165,7 +166,7 @@ function MdBottomSheetProvider($$interimElementProvider) {
         // Prevent mouse focus on backdrop; ONLY programatic focus allowed.
         // This allows clicks on backdrop to propogate to the $rootElement and
         // ESC key events to be detected properly.
-        
+
         backdrop[0].tabIndex = -1;
 
         if (options.clickOutsideToClose) {

--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -62,6 +62,8 @@ angular
  *  </md-button>
  * </hljs>
  */
+
+/* @ngInject */
 function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
 
   return {

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -119,6 +119,8 @@ angular.module('material.components.card', [
  * </md-card>
  * </hljs>
  */
+
+/* @ngInject */
 function mdCardDirective($mdTheming) {
   return {
     restrict: 'E',

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -46,6 +46,8 @@ angular
  * </hljs>
  *
  */
+
+/* @ngInject */
 function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $mdUtil, $timeout) {
   inputDirective = inputDirective[0];
   var CHECKED_CSS = 'md-checked';
@@ -55,7 +57,7 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
     transclude: true,
     require: '?ngModel',
     priority: 210, // Run before ngAria
-    template: 
+    template:
       '<div class="_md-container" md-ink-ripple md-ink-ripple-checkbox>' +
         '<div class="_md-icon"></div>' +
       '</div>' +

--- a/src/components/chips/js/chipController.js
+++ b/src/components/chips/js/chipController.js
@@ -13,6 +13,8 @@ angular
  * @param $mdUtil
  * @constructor
  */
+
+/* @ngInject */
 function MdChipCtrl ($scope, $element, $mdConstant, $timeout, $mdUtil) {
   /**
    * @type {$scope}

--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -31,8 +31,9 @@ var DELETE_HINT_TEMPLATE = '\
  *
  * @param $mdTheming
  * @param $mdUtil
- * @ngInject
  */
+
+/* @ngInject */
 function MdChip($mdTheming, $mdUtil) {
   var hintTemplate = $mdUtil.processTemplate(DELETE_HINT_TEMPLATE);
 

--- a/src/components/chips/js/chipRemoveDirective.js
+++ b/src/components/chips/js/chipRemoveDirective.js
@@ -21,12 +21,14 @@ angular
 
 /**
  * MdChipRemove Directive Definition.
- * 
+ *
  * @param $compile
  * @param $timeout
  * @returns {{restrict: string, require: string[], link: Function, scope: boolean}}
  * @constructor
  */
+
+/* @ngInject */
 function MdChipRemove ($timeout) {
   return {
     restrict: 'A',

--- a/src/components/chips/js/chipTranscludeDirective.js
+++ b/src/components/chips/js/chipTranscludeDirective.js
@@ -2,6 +2,7 @@ angular
     .module('material.components.chips')
     .directive('mdChipTransclude', MdChipTransclude);
 
+/* @ngInject */
 function MdChipTransclude ($compile) {
   return {
     restrict: 'EA',

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -14,6 +14,8 @@ angular
  * @param $mdUtil
  * @constructor
  */
+
+/* @ngInject */
 function MdChipsCtrl ($scope, $mdConstant, $log, $element, $timeout, $mdUtil) {
   /** @type {$timeout} **/
   this.$timeout = $timeout;
@@ -180,7 +182,7 @@ MdChipsCtrl.prototype.isEditingChip = function(){
 MdChipsCtrl.prototype.chipKeydown = function (event) {
   if (this.getChipBuffer()) return;
   if (this.isEditingChip()) return;
-  
+
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.BACKSPACE:
     case this.$mdConstant.KEY_CODE.DELETE:

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -9,7 +9,7 @@
    *
    * @description
    * `<md-chips>` is an input component for building lists of strings or objects. The list items are
-   * displayed as 'chips'. This component can make use of an `<input>` element or an 
+   * displayed as 'chips'. This component can make use of an `<input>` element or an
    * `<md-autocomplete>` element.
    *
    * ### Custom templates
@@ -68,7 +68,7 @@
    * @param {boolean=} readonly Disables list manipulation (deleting or adding list items), hiding
    *    the input and delete buttons. If no `ng-model` is provided, the chips will automatically be
    *    marked as readonly.
-   * @param {string=} md-enable-chip-edit Set this to "true" to enable editing of chip contents. The user can 
+   * @param {string=} md-enable-chip-edit Set this to "true" to enable editing of chip contents. The user can
    *    go into edit mode with pressing "space", "enter", or double clicking on the chip. Chip edit is only
    *    supported for chips with basic template.
    * @param {number=} md-max-chips The maximum number of chips allowed to add through user input.
@@ -176,6 +176,7 @@
   /**
    * MDChips Directive Definition
    */
+  /* @ngInject */
   function MdChips ($mdTheming, $mdUtil, $compile, $log, $timeout) {
     // Run our templates through $mdUtil.processTemplate() to allow custom start/end symbols
     var templates = getTemplates();

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -97,8 +97,9 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
  *
  * @param $mdTheming
  * @returns {*}
- * @ngInject
  */
+
+/* @ngInject */
 function MdContactChips($mdTheming, $mdUtil) {
   return {
     template: function(element, attrs) {

--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -44,6 +44,7 @@ angular.module('material.components.content', [
  *
  */
 
+/* @ngInject */
 function mdContentDirective($mdTheming) {
   return {
     restrict: 'E',

--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -75,6 +75,7 @@
    *
    */
 
+  /* @ngInject */
   angular.module('material.components.datepicker').config(function($provide) {
     // TODO(jelbourn): Assert provided values are correctly formatted. Need assertions.
 

--- a/src/components/datepicker/datePicker.js
+++ b/src/components/datepicker/datePicker.js
@@ -385,7 +385,7 @@
         var maxDate = this.dateUtil.createDateAtMidnight(this.maxDate);
         this.ngModelCtrl.$setValidity('maxdate', date <= maxDate);
       }
-      
+
       if (angular.isFunction(this.dateFilter)) {
         this.ngModelCtrl.$setValidity('filtered', this.dateFilter(date));
       }
@@ -441,17 +441,17 @@
 
     this.updateErrorState(parsedDate);
   };
-  
+
   /**
    * Check whether date is in range and enabled
    * @param {Date=} opt_date
    * @return {boolean} Whether the date is enabled.
    */
   DatePickerCtrl.prototype.isDateEnabled = function(opt_date) {
-    return this.dateUtil.isDateWithinRange(opt_date, this.minDate, this.maxDate) && 
+    return this.dateUtil.isDateWithinRange(opt_date, this.minDate, this.maxDate) &&
           (!angular.isFunction(this.dateFilter) || this.dateFilter(opt_date));
   };
-  
+
   /** Position and attach the floating calendar to the document. */
   DatePickerCtrl.prototype.attachCalendarPane = function() {
     var calendarPane = this.calendarPane;

--- a/src/components/datepicker/dateUtil.js
+++ b/src/components/datepicker/dateUtil.js
@@ -5,6 +5,8 @@
    * Utility for performing date calculations to facilitate operation of the calendar and
    * datepicker.
    */
+
+  /* @ngInject */
   angular.module('material.components.datepicker').factory('$$mdDateUtil', function() {
     return {
       getFirstDateOfMonth: getFirstDateOfMonth,

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -482,6 +482,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * @returns {promise} A promise that is resolved when the dialog has been closed.
  */
 
+/* @ngInject */
 function MdDialogProvider($$interimElementProvider) {
   // Elements to capture and redirect focus when the user presses tab at the dialog boundary.
   var topFocusTrap, bottomFocusTrap;

--- a/src/components/divider/divider.js
+++ b/src/components/divider/divider.js
@@ -26,6 +26,8 @@ angular.module('material.components.divider', [
  * </hljs>
  *
  */
+
+/* @ngInject */
 function MdDividerDirective($mdTheming) {
   return {
     restrict: 'E',

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -4,6 +4,7 @@
   angular.module('material.components.fabShared', ['material.core'])
     .controller('MdFabController', MdFabController);
 
+  /* @ngInject */
   function MdFabController($scope, $element, $animate, $mdUtil, $mdConstant, $timeout) {
     var vm = this;
 

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -118,6 +118,7 @@
     }
   }
 
+  /* @ngInject */
   function MdFabSpeedDialFlingAnimation($timeout) {
     function delayDone(done) { $timeout(done, cssAnimationDuration, false); }
 
@@ -209,6 +210,7 @@
     }
   }
 
+  /* @ngInject */
   function MdFabSpeedDialScaleAnimation($timeout) {
     function delayDone(done) { $timeout(done, cssAnimationDuration, false); }
 

--- a/src/components/gridList/grid-list.js
+++ b/src/components/gridList/grid-list.js
@@ -93,6 +93,8 @@ angular.module('material.components.gridList', ['material.core'])
  * </md-grid-list>
  * </hljs>
  */
+
+/* @ngInject */
 function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
   return {
     restrict: 'E',
@@ -705,6 +707,8 @@ function GridLayoutFactory($mdUtil) {
  * </md-grid-tile>
  * </hljs>
  */
+
+/* @ngInject */
 function GridTileDirective($mdMedia) {
   return {
     restrict: 'E',

--- a/src/components/icon/js/iconDirective.js
+++ b/src/components/icon/js/iconDirective.js
@@ -166,6 +166,8 @@ angular
  * </hljs>
  *
  */
+
+/* @ngInject */
 function mdIconDirective($mdIcon, $mdTheming, $mdAria ) {
 
   return {

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -316,10 +316,11 @@
 
    },
 
-   $get : ['$http', '$q', '$log', '$templateCache', function($http, $q, $log, $templateCache) {
+   /* @ngInject */
+   $get : function($http, $q, $log, $templateCache) {
      this.preloadIcons($templateCache);
      return MdIconService(config, $http, $q, $log, $templateCache);
-   }]
+   }
  };
 
    /**

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -63,6 +63,8 @@ angular.module('material.components.input', [
  *
  * </hljs>
  */
+
+/* @ngInject */
 function mdInputContainerDirective($mdTheming, $parse) {
 
   var INPUT_TAGS = ['INPUT', 'TEXTAREA', 'SELECT', 'MD-SELECT'];
@@ -250,6 +252,7 @@ function labelDirective() {
  *
  */
 
+/* @ngInject */
 function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout) {
   return {
     restrict: 'E',
@@ -483,6 +486,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout) {
   }
 }
 
+/* @ngInject */
 function mdMaxlengthDirective($animate, $mdUtil) {
   return {
     restrict: 'A',
@@ -549,6 +553,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
   }
 }
 
+/* @ngInject */
 function placeholderDirective($log) {
   return {
     restrict: 'A',
@@ -618,6 +623,8 @@ function placeholderDirective($log) {
  *
  * </hljs>
  */
+
+/* @ngInject */
 function mdSelectOnFocusDirective($timeout) {
 
   return {
@@ -700,6 +707,7 @@ function ngMessagesDirective() {
   }
 }
 
+/* @ngInject */
 function ngMessageDirective($mdUtil) {
   return {
     restrict: 'EA',
@@ -720,6 +728,7 @@ function ngMessageDirective($mdUtil) {
   }
 }
 
+/* @ngInject */
 function mdInputInvalidMessagesAnimation($q, $animateCss) {
   return {
     addClass: function(element, className, done) {
@@ -736,6 +745,7 @@ function mdInputInvalidMessagesAnimation($q, $animateCss) {
   };
 }
 
+/* @ngInject */
 function ngMessagesAnimation($q, $animateCss) {
   return {
     enter: function(element, done) {
@@ -764,6 +774,7 @@ function ngMessagesAnimation($q, $animateCss) {
   }
 }
 
+/* @ngInject */
 function ngMessageAnimation($animateCss) {
   return {
     enter: function(element, done) {
@@ -784,6 +795,7 @@ function ngMessageAnimation($animateCss) {
   }
 }
 
+/* @ngInject */
 function showInputMessages(element, $animateCss, $q) {
   var animators = [], animator;
   var messages = getMessagesElement(element);
@@ -797,6 +809,7 @@ function showInputMessages(element, $animateCss, $q) {
   return $q.all(animators);
 }
 
+/* @ngInject */
 function hideInputMessages(element, $animateCss, $q) {
   var animators = [], animator;
   var messages = getMessagesElement(element);
@@ -810,6 +823,7 @@ function hideInputMessages(element, $animateCss, $q) {
   return $q.all(animators);
 }
 
+/* @ngInject */
 function showMessage(element, $animateCss) {
   var height = element[0].offsetHeight;
 
@@ -822,6 +836,7 @@ function showMessage(element, $animateCss) {
   });
 }
 
+/* @ngInject */
 function hideMessage(element, $animateCss) {
   var height = element[0].offsetHeight;
   var styles = window.getComputedStyle(element[0]);

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -35,6 +35,7 @@ angular.module('material.components.list', [
  * </hljs>
  */
 
+/* @ngInject */
 function mdListDirective($mdTheming) {
   return {
     restrict: 'E',
@@ -82,6 +83,8 @@ function mdListDirective($mdTheming) {
  * and you can include a class of `class="md-exclude"` if you need to use a non-secondary button
  * that is inside the list, but does not wrap the contents._
  */
+
+/* @ngInject */
 function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
   var proxiedTypes = ['md-checkbox', 'md-switch'];
   return {
@@ -154,7 +157,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
           // Append the button wrap before our list-item content, because it will overlay in relative.
           container.prepend(buttonWrap);
           container.children().eq(1).append(tEl.contents());
-          
+
           tEl.addClass('_md-button-wrap');
         }
 
@@ -337,6 +340,8 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
  * @module material.components.list
  *
  */
+
+/* @ngInject */
 function MdListController($scope, $element, $mdListInkRipple) {
   var ctrl = this;
   ctrl.attachRipple = attachRipple;

--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -4,9 +4,7 @@ angular
     .module('material.components.menu')
     .controller('mdMenuCtrl', MenuController);
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $rootScope, $q) {
 
   var menuContainer;

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -108,7 +108,7 @@
  * Sometimes you would like to be able to click on a menu item without having the menu
  * close. To do this, ngMaterial exposes the `md-prevent-menu-close` attribute which
  * can be added to a button inside a menu to stop the menu from automatically closing.
- * You can then close the menu programatically by injecting `$mdMenu` and calling 
+ * You can then close the menu programatically by injecting `$mdMenu` and calling
  * `$mdMenu.hide()`.
  *
  * <hljs lang="html">
@@ -144,9 +144,7 @@ angular
     .module('material.components.menu')
     .directive('mdMenu', MenuDirective);
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MenuDirective($mdUtil) {
   var INVALID_PREFIX = 'Invalid HTML for md-menu: ';
   return {

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -12,6 +12,7 @@ angular
  *
  */
 
+/* @ngInject */
 function MenuProvider($$interimElementProvider) {
   var MENU_EDGE_MARGIN = 8;
 
@@ -442,7 +443,7 @@ function MenuProvider($$interimElementProvider) {
       }
 
       var rtl = ($mdUtil.bidi() == 'rtl');
-      
+
       switch (positionMode.left) {
         case 'target':
           position.left = existingOffsets.left + originNodeRect.left - alignTargetRect.left;

--- a/src/components/menuBar/js/menuBarController.js
+++ b/src/components/menuBar/js/menuBarController.js
@@ -5,9 +5,7 @@ angular
 
 var BOUND_MENU_METHODS = ['handleKeyDown', 'handleMenuHover', 'scheduleOpenHoveredMenu', 'cancelScheduledOpen'];
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MenuBarController($scope, $rootScope, $element, $attrs, $mdConstant, $document, $mdUtil, $timeout) {
   this.$element = $element;
   this.$attrs = $attrs;

--- a/src/components/menuBar/js/menuItemController.js
+++ b/src/components/menuBar/js/menuItemController.js
@@ -4,9 +4,7 @@ angular
   .controller('MenuItemController', MenuItemController);
 
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MenuItemController($scope, $element, $attrs) {
   this.$element = $element;
   this.$attrs = $attrs;

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -56,6 +56,8 @@ angular.module('material.components.progressLinear', [
  * <md-progress-linear md-mode="query"></md-progress-linear>
  * </hljs>
  */
+
+/* @ngInject */
 function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
   var MODE_DETERMINATE = "determinate",
       MODE_INDETERMINATE = "indeterminate",
@@ -71,7 +73,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
       '</div>',
     compile: compile
   };
-  
+
   function compile(tElement, tAttrs, transclude) {
     tElement.attr('aria-valuemin', 0);
     tElement.attr('aria-valuemax', 100);

--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -49,6 +49,8 @@ angular.module('material.components.radioButton', [
  * </hljs>
  *
  */
+
+/* @ngInject */
 function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
   RadioGroupController.prototype = createRadioGroupControllerProto();
 
@@ -239,6 +241,8 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
  * </hljs>
  *
  */
+
+/* @ngInject */
 function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
 
   var CHECKED_CSS = 'md-checked';

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -113,6 +113,8 @@ angular.module('material.components.select', [
  * </div>
  * </hljs>
  */
+
+/* @ngInject */
 function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $parse) {
   return {
     restrict: 'E',
@@ -491,6 +493,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
   }
 }
 
+/* @ngInject */
 function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
   return {
@@ -546,6 +549,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     }
   }
 
+  /* @ngInject */
   function SelectMenuController($scope, $attrs, $element) {
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);
@@ -757,6 +761,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
 }
 
+/* @ngInject */
 function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   return {
@@ -890,6 +895,7 @@ function OptgroupDirective() {
   }
 }
 
+/* @ngInject */
 function SelectProvider($$interimElementProvider) {
   return $$interimElementProvider('$mdSelect')
     .setDefaults({

--- a/src/components/showHide/showHide.js
+++ b/src/components/showHide/showHide.js
@@ -12,7 +12,7 @@ angular.module('material.components.showHide', [
   .directive('ngShow', createDirective('ngShow', true))
   .directive('ngHide', createDirective('ngHide', false));
 
-
+/* @ngInject */
 function createDirective(name, targetValue) {
   return ['$mdUtil', function($mdUtil) {
     return {

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -57,6 +57,8 @@ angular
  * $mdSidenav(componentId).isLockedOpen();
  * </hljs>
  */
+
+/* @ngInject */
 function SidenavService($mdComponentRegistry, $q) {
   return function(handle) {
 
@@ -209,6 +211,8 @@ function SidenavFocusDirective() {
  *   - `<md-sidenav md-is-locked-open="$mdMedia('min-width: 1000px')"></md-sidenav>`
  *   - `<md-sidenav md-is-locked-open="$mdMedia('sm')"></md-sidenav>` (locks open on small screens)
  */
+
+/* @ngInject */
 function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, $compile, $parse, $log, $q, $document) {
   return {
     restrict: 'E',
@@ -396,6 +400,8 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
  * @module material.components.sidenav
  *
  */
+
+/* @ngInject */
 function SidenavController($scope, $element, $attrs, $mdComponentRegistry, $q) {
 
   var self = this;

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -123,6 +123,8 @@ function SliderContainerDirective() {
  * @param {number=} max The maximum value the user is allowed to pick. Default 100.
  * @param {number=} round The amount of numbers after the decimal point, maximum is 6 to prevent scientific notation. Default 3.
  */
+
+/* @ngInject */
 function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture, $parse, $log, $timeout) {
   return {
     scope: {},

--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -68,6 +68,8 @@ angular
  *     when the user starts scrolling past the original element.
  *     If not provided, it will use the result of `element.clone()` and compiles it in the given scope.
  */
+
+/* @ngInject */
 function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
 
   var browserStickySupport = checkStickySupport();
@@ -162,7 +164,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
         return a.top < b.top ? -1 : 1;
       });
 
-      // Find which item in the list should be active, 
+      // Find which item in the list should be active,
       // based upon the content's current scroll position
       var item;
       var currentScrollTop = contentEl.prop('scrollTop');
@@ -182,7 +184,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
     // Find the `top` of an item relative to the content element,
     // and also the height.
     function refreshPosition(item) {
-      // Find the top of an item by adding to the offsetHeight until we reach the 
+      // Find the top of an item by adding to the offsetHeight until we reach the
       // content element.
       var current = item.element[0];
       item.top = 0;
@@ -335,7 +337,7 @@ function MdSticky($document, $mdConstant, $$rAF, $mdUtil, $compile) {
 
   // Android 4.4 don't accurately give scroll events.
   // To fix this problem, we setup a fake scroll event. We say:
-  // > If a scroll or touchmove event has happened in the last DELAY milliseconds, 
+  // > If a scroll or touchmove event has happened in the last DELAY milliseconds,
   //   then send a `$scroll` event every animationFrame.
   // Additionally, we add $scrollstart and $scrollend events.
   function setupAugmentedScrollEvents(element) {

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -41,6 +41,7 @@ angular
  * </hljs>
  */
 
+/* @ngInject */
 function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
   return {
     restrict: 'E',

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -48,6 +48,8 @@ angular.module('material.components.switch', [
  *
  * </hljs>
  */
+
+/* @ngInject */
 function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdGesture) {
   var checkboxDirective = mdCheckboxDirective[0];
 

--- a/src/components/tabs/js/tabScroll.js
+++ b/src/components/tabs/js/tabScroll.js
@@ -1,6 +1,7 @@
 angular.module('material.components.tabs')
     .directive('mdTabScroll', MdTabScroll);
 
+/* @ngInject */
 function MdTabScroll ($parse) {
   return {
     restrict: 'A',

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -2,9 +2,7 @@ angular
     .module('material.components.tabs')
     .controller('MdTabsController', MdTabsController);
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple,
                            $mdUtil, $animateCss, $attrs, $compile, $mdTheming) {
   // define private properties
@@ -219,7 +217,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function handleSelectedIndexChange (newValue, oldValue) {
     if (newValue === oldValue) return;
-    
+
     ctrl.selectedIndex     = getNearestSafeIndex(newValue);
     ctrl.lastSelectedIndex = oldValue;
     ctrl.updateInkBarStyles();

--- a/src/components/tabs/js/tabsTemplateDirective.js
+++ b/src/components/tabs/js/tabsTemplateDirective.js
@@ -2,6 +2,7 @@ angular
     .module('material.components.tabs')
     .directive('mdTabsTemplate', MdTabsTemplate);
 
+/* @ngInject */
 function MdTabsTemplate ($compile, $mdUtil) {
   return {
     restrict: 'A',

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -87,7 +87,7 @@ function MdToastDirective($mdToast) {
 /**
  * @ngdoc method
  * @name $mdToast#showSimple
- * 
+ *
  * @param {string} message The message to display inside the toast
  * @description
  * Convenience method which builds and shows a simple toast.

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -60,6 +60,7 @@ angular.module('material.components.toolbar', [
  * at one fourth the rate at which the user scrolls down. Default 0.5.
  */
 
+/* @ngInject */
 function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
   var translateY = angular.bind(null, $mdUtil.supplant, 'translate3d(0,{0}px,0)');
 

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -32,6 +32,8 @@ angular
  * @param {boolean=} md-autohide If present or provided with a boolean value, the tooltip will hide on mouse leave, regardless of focus
  * @param {string=} md-direction Which direction would you like the tooltip to go?  Supports left, right, top, and bottom.  Defaults to bottom.
  */
+
+/* @ngInject */
 function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdTheming, $rootElement,
                             $animate, $q) {
 
@@ -149,7 +151,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       function windowScrollHandler() {
         setVisible(false);
       }
-      
+
       ngWindow.on('blur', windowBlurHandler);
       ngWindow.on('resize', debouncedOnResize);
       document.addEventListener('scroll', windowScrollHandler, true);

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -78,7 +78,7 @@ var MAX_ELEMENT_SIZE = 1533917;
  */
 var NUM_EXTRA = 3;
 
-/** @ngInject */
+/* @ngInject */
 function VirtualRepeatContainerController(
     $$rAF, $mdUtil, $parse, $rootScope, $window, $scope, $element, $attrs) {
   this.$rootScope = $rootScope;
@@ -423,6 +423,8 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
  *     Otherwise, return a higher number than the currently loaded items to produce an
  *     infinite-scroll behavior.
  */
+
+/* @ngInject */
 function VirtualRepeatDirective($parse) {
   return {
     controller: VirtualRepeatController,
@@ -446,7 +448,7 @@ function VirtualRepeatDirective($parse) {
 }
 
 
-/** @ngInject */
+/* @ngInject */
 function VirtualRepeatController($scope, $element, $attrs, $browser, $document, $rootScope,
     $$rAF, $mdUtil) {
   this.$scope = $scope;

--- a/src/components/whiteframe/whiteframe.js
+++ b/src/components/whiteframe/whiteframe.js
@@ -29,6 +29,8 @@ angular
  * </div>
  * </hljs>
  */
+
+/* @ngInject */
 function MdWhiteframeDirective($log) {
   var MIN_DP = 1;
   var MAX_DP = 24;

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -17,8 +17,9 @@ angular
 /**
  * Detect if the ng-Touch module is also being used.
  * Warn if detected.
- * @ngInject
  */
+
+/* @ngInject */
 function DetectNgTouch($log, $injector) {
   if ( $injector.has('$swipe') ) {
     var msg = "" +
@@ -29,9 +30,7 @@ function DetectNgTouch($log, $injector) {
   }
 }
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function MdCoreConfigure($provide, $mdThemingProvider) {
 
   $provide.decorator('$$rAF', ["$delegate", rAFDecorator]);
@@ -43,9 +42,7 @@ function MdCoreConfigure($provide, $mdThemingProvider) {
     .backgroundPalette('grey');
 }
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function rAFDecorator($delegate) {
   /**
    * Use this to throttle events that come in often.

--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -2,9 +2,7 @@
 angular.module('material.core')
   .service('$mdAria', AriaService);
 
-/*
- * @ngInject
- */
+/* @ngInject */
 function AriaService($$rAF, $log, $window, $interpolate) {
 
   return {

--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -2,6 +2,7 @@ angular
   .module('material.core')
   .service('$mdCompiler', mdCompilerService);
 
+/* @ngInject */
 function mdCompilerService($q, $http, $injector, $compile, $controller, $templateCache) {
   /* jshint validthis: true */
 

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -5,7 +5,7 @@ var HANDLERS = {};
  * It contains normalized x and y coordinates from DOM events,
  * as well as other information abstracted from the DOM.
  */
- 
+
 var pointer, lastPointer, forceSkipClickHijack = false;
 
 /**
@@ -169,7 +169,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
    * Register handlers. These listen to touch/start/move events, interpret them,
    * and dispatch gesture events depending on options & conditions. These are all
    * instances of GestureHandler.
-   * @see GestureHandler 
+   * @see GestureHandler
    */
   return self
     /*
@@ -496,7 +496,7 @@ function attachToDocument( $mdGesture, $$MdGestureHandler ) {
      * click event will be sent ~400ms after a touchend event happens.
      * The only way to know if this click is real is to prevent any normal
      * click events, and add a flag to events sent by material so we know not to prevent those.
-     * 
+     *
      * Two exceptions to click events that should be prevented are:
      *  - click events sent by the keyboard (eg form submit)
      *  - events that originate from an Ionic app

--- a/src/core/services/registry/componentRegistry.js
+++ b/src/core/services/registry/componentRegistry.js
@@ -16,6 +16,8 @@
    * @module material.core.componentRegistry
    *
    */
+
+  /* @ngInject */
   function ComponentRegistry($log, $q) {
 
     var self;

--- a/src/core/services/ripple/button_ripple.js
+++ b/src/core/services/ripple/button_ripple.js
@@ -17,6 +17,7 @@
   angular.module('material.core')
     .factory('$mdButtonInkRipple', MdButtonInkRipple);
 
+  /* @ngInject */
   function MdButtonInkRipple($mdInkRipple) {
     return {
       attach: function attachRipple(scope, element, options) {

--- a/src/core/services/ripple/checkbox_ripple.js
+++ b/src/core/services/ripple/checkbox_ripple.js
@@ -17,6 +17,7 @@
   angular.module('material.core')
     .factory('$mdCheckboxInkRipple', MdCheckboxInkRipple);
 
+  /* @ngInject */
   function MdCheckboxInkRipple($mdInkRipple) {
     return {
       attach: attach

--- a/src/core/services/ripple/list_ripple.js
+++ b/src/core/services/ripple/list_ripple.js
@@ -17,6 +17,7 @@
   angular.module('material.core')
     .factory('$mdListInkRipple', MdListInkRipple);
 
+  /* @ngInject */
   function MdListInkRipple($mdInkRipple) {
     return {
       attach: attach

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -46,6 +46,8 @@ var DURATION = 450;
  *   </ANY>
  * </hljs>
  */
+
+/* @ngInject */
 function InkRippleDirective ($mdButtonInkRipple, $mdCheckboxInkRipple) {
   return {
     controller: angular.noop,
@@ -101,6 +103,8 @@ function InkRippleDirective ($mdButtonInkRipple, $mdCheckboxInkRipple) {
  * * `colorElement` - The element the ripple should take its color from, defined by css property `color`
  * * `fitRipple` - Whether the ripple should fill the element
  */
+
+/* @ngInject */
 function InkRippleService ($injector) {
   return { attach: attach };
   function attach (scope, element, options) {
@@ -115,8 +119,9 @@ function InkRippleService ($injector) {
 
 /**
  * Controller used by the ripple service in order to apply ripples
- * @ngInject
  */
+
+/* @ngInject */
 function InkRippleCtrl ($scope, $element, rippleOptions, $window, $timeout, $mdUtil) {
   this.$window    = $window;
   this.$timeout   = $timeout;

--- a/src/core/services/ripple/tab_ripple.js
+++ b/src/core/services/ripple/tab_ripple.js
@@ -17,6 +17,7 @@
   angular.module('material.core')
     .factory('$mdTabInkRipple', MdTabInkRipple);
 
+  /* @ngInject */
   function MdTabInkRipple($mdInkRipple) {
     return {
       attach: attach

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -402,6 +402,7 @@ function ThemingProvider($mdColorPalette) {
   }
 }
 
+/* @ngInject */
 function ThemingDirective($mdTheming, $interpolate, $log) {
   return {
     priority: 100,
@@ -423,6 +424,7 @@ function ThemingDirective($mdTheming, $interpolate, $log) {
   };
 }
 
+/* @ngInject */
 function ThemableDirective($mdTheming) {
   return $mdTheming;
 }
@@ -484,6 +486,7 @@ function parseRules(theme, colorType, rules) {
 var rulesByType = {};
 
 // Generate our themes at run time given the state of THEMES and PALETTES
+/* @ngInject */
 function generateAllThemes($injector) {
   var head = document.head;
   var firstChild = head ? head.firstElementChild : null;

--- a/src/core/util/animation/animate.js
+++ b/src/core/util/animation/animate.js
@@ -1,6 +1,8 @@
 // Polyfill angular < 1.4 (provide $animateCss)
 angular
   .module('material.core')
+
+  /* @ngInject */
   .factory('$$mdAnimate', function($q, $timeout, $mdConstant, $animateCss){
 
      // Since $$mdAnimate is injected into $mdUtil... use a wrapper function
@@ -14,6 +16,8 @@ angular
 /**
  * Factory function that requires special injections
  */
+
+/* @ngInject */
 function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
   var self;
   return self = {

--- a/src/core/util/animation/animateCss.js
+++ b/src/core/util/animation/animateCss.js
@@ -15,13 +15,15 @@ if (angular.version.minor >= 4) {
   var TRANSITION_EVENTS = (WEBKIT ? 'webkitTransitionEnd ' : '') + 'transitionend';
   var ANIMATION_EVENTS = (WEBKIT ? 'webkitAnimationEnd ' : '') + 'animationend';
 
-  var $$ForceReflowFactory = ['$document', function($document) {
+  /* @ngInject */
+  var $$ForceReflowFactory = function($document) {
     return function() {
       return $document[0].body.clientWidth + 1;
     }
-  }];
+  };
 
-  var $$rAFMutexFactory = ['$$rAF', function($$rAF) {
+  /* @ngInject */
+  var $$rAFMutexFactory = function($$rAF) {
     return function() {
       var passed = false;
       $$rAF(function() {
@@ -31,9 +33,10 @@ if (angular.version.minor >= 4) {
         passed ? fn() : $$rAF(fn);
       };
     };
-  }];
+  };
 
-  var $$AnimateRunnerFactory = ['$q', '$$rAFMutex', function($q, $$rAFMutex) {
+  /* @ngInject */
+  var $$AnimateRunnerFactory = function($q, $$rAFMutex) {
     var INITIAL_STATE = 0;
     var DONE_PENDING_STATE = 1;
     var DONE_COMPLETE_STATE = 2;
@@ -133,15 +136,16 @@ if (angular.version.minor >= 4) {
     };
 
     return AnimateRunner;
-  }];
+  };
 
   angular
     .module('material.core.animate', [])
     .factory('$$forceReflow', $$ForceReflowFactory)
     .factory('$$AnimateRunner', $$AnimateRunnerFactory)
     .factory('$$rAFMutex', $$rAFMutexFactory)
-    .factory('$animateCss', ['$window', '$$rAF', '$$AnimateRunner', '$$forceReflow', '$$jqLite', '$timeout',
-                     function($window,   $$rAF,   $$AnimateRunner,   $$forceReflow,   $$jqLite,   $timeout) {
+
+    /* @ngInject */
+    .factory('$animateCss', function($window, $$rAF, $$AnimateRunner, $$forceReflow, $$jqLite, $timeout) {
 
       function init(element, options) {
 
@@ -383,7 +387,7 @@ if (angular.version.minor >= 4) {
       }
 
       return init;
-    }]);
+    });
 
   /**
    * Older browsers [FF31] expect camelCase

--- a/src/core/util/iterator.js
+++ b/src/core/util/iterator.js
@@ -1,5 +1,7 @@
   angular
     .module('material.core')
+
+    /* @ngInject */
     .config( function($provide){
        $provide.decorator('$mdUtil', ['$delegate', function ($delegate){
            /**

--- a/src/core/util/media.js
+++ b/src/core/util/media.js
@@ -84,9 +84,9 @@ angular.module('material.core')
  *   $scope.anotherCustom = $mdMedia('max-width: 300px');
  * });
  * </hljs>
- * @ngInject
  */
 
+/* @ngInject */
 function mdMediaFactory($mdConstant, $rootScope, $window) {
   var queries = {};
   var mqls = {};

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -16,9 +16,7 @@ angular
   .module('material.core')
   .factory('$mdUtil', UtilFactory);
 
-/**
- * @ngInject
- */
+/* @ngInject */
 function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $interpolate, $log, $rootElement, $window) {
   // Setup some core variables for the processTemplate method
   var startSymbol = $interpolate.startSymbol(),


### PR DESCRIPTION
* Adds @ngInject to everything that was missing it.
* Removes any instances of @ngInject that were in the doc strings.
* Makes all the @ngInject declarations consistent with each other.
* Adds newlines at the ends of files that didn't have them and trims any excess whitespace.

Closes #7610.

This doesn't really need a whole lot of reviewing, but it might be a good idea to run a build locally, just in case and see whether Closure complains. It all seems fine locally with `gulp build-all-modules --mode=closure`, but I'm not too familiar with the build setup.