### PR TITLE
fix(chips): do not trim the input model.

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -388,7 +388,58 @@ describe('<md-chips>', function() {
           expect(enterEvent.preventDefault).toHaveBeenCalled();
         }));
 
+        it('should trim the buffer when a chip will be added', inject(function($mdConstant) {
+          var element = buildChips(BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+          var input = element.find('input');
+
+          // This string contains a lot of spaces, which should be trimmed.
+          input.val('    Test    ');
+          input.triggerHandler('input');
+
+          expect(ctrl.chipBuffer).toBeTruthy();
+
+          var enterEvent = {
+            type: 'keydown',
+            keyCode: $mdConstant.KEY_CODE.ENTER,
+            which: $mdConstant.KEY_CODE.ENTER
+          };
+
+          input.triggerHandler(enterEvent);
+
+          expect(scope.items).toEqual(['Apple', 'Banana', 'Orange', 'Test']);
+        }));
+
+        it('should not trim the input text of the input', inject(function($mdConstant) {
+          var element = buildChips(BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+          var input = element.find('input');
+
+          input.val('    ');
+          input.triggerHandler('input');
+
+          expect(ctrl.chipBuffer).toBeTruthy();
+
+          var enterEvent = {
+            type: 'keydown',
+            keyCode: $mdConstant.KEY_CODE.BACKSPACE,
+            which: $mdConstant.KEY_CODE.BACKSPACE,
+            preventDefault: jasmine.createSpy('preventDefault')
+          };
+
+          input.triggerHandler(enterEvent);
+
+          expect(enterEvent.preventDefault).not.toHaveBeenCalled();
+
+          input.val('');
+          input.triggerHandler('input');
+
+          input.triggerHandler(enterEvent);
+
+          expect(enterEvent.preventDefault).toHaveBeenCalledTimes(1);
+        }));
       });
+
 
       it('focuses/blurs the component when focusing/blurring the input', inject(function() {
         var element = buildChips(BASIC_CHIP_TEMPLATE);

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -144,7 +144,7 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
     // Only append the chip and reset the chip buffer if the max chips limit isn't reached.
     if (this.hasMaxChipsReached()) return;
 
-    this.appendChip(chipBuffer);
+    this.appendChip(chipBuffer.trim());
     this.resetChipBuffer();
   }
 };

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -154,6 +154,7 @@
             ng-model="$mdChipsCtrl.chipBuffer"\
             ng-focus="$mdChipsCtrl.onInputFocus()"\
             ng-blur="$mdChipsCtrl.onInputBlur()"\
+            ng-trim="false"\
             ng-keydown="$mdChipsCtrl.inputKeydown($event)">';
 
   var CHIP_DEFAULT_TEMPLATE = '\


### PR DESCRIPTION
* The chips input should not trim the text, because otherwise the buffer will be always falsey, even when there are spaces in the input, and this would cause the backspace not to work.

Fixes #7243