### PR TITLE
Add md-autocomplete-snap="width"

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -2564,8 +2564,6 @@ describe('<md-autocomplete>', function() {
     element.remove();
   });
 
-});
-
   describe('md-autocomplete-snap', function() {
     it('should match the width of the snap element if width is set', inject(function($timeout, $material) {
       var template = '\

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -2565,3 +2565,69 @@ describe('<md-autocomplete>', function() {
   });
 
 });
+
+  describe('md-autocomplete-snap', function() {
+    it('should match the width of the snap element if width is set', inject(function($timeout, $material) {
+      var template = '\
+        <div style="width: 1000px" md-autocomplete-snap="width">\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder"\
+              style="width:200px">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>\
+        </div>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var autoEl = element.find('md-autocomplete');
+      var ctrl = autoEl.controller('mdAutocomplete');
+      var ul = element.find('ul');
+
+      angular.element(document.body).append(element);
+
+      $material.flushInterimElement();
+      ctrl.focus();
+
+      autoEl.scope().searchText = 'fo';
+      waitForVirtualRepeat(autoEl);
+
+      expect(ul[0].offsetWidth).toBe(1000);
+      element.remove();
+    }));
+
+    it('should match the width of the wrap element if width is not set', inject(function($timeout, $material) {
+      var template = '\
+        <div style="width: 1000px" md-autocomplete-snap>\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder"\
+              style="width:200px">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>\
+        </div>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var autoEl = element.find('md-autocomplete');
+      var ctrl = autoEl.controller('mdAutocomplete');
+      var ul = element.find('ul');
+
+      angular.element(document.body).append(element);
+
+      $material.flushInterimElement();
+      ctrl.focus();
+
+      autoEl.scope().searchText = 'fo';
+      waitForVirtualRepeat(autoEl);
+
+      expect(ul[0].offsetWidth).toBe(200);
+      element.remove();
+    }));
+  });
+
+});

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -257,7 +257,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       scroller: $element[0].querySelector('.md-virtual-repeat-scroller'),
       ul:    $element.find('ul')[0],
       input: $element.find('input')[0],
-      wrap:  $element.find('md-autocomplete-wrap')[0],
+      wrap:  getWrapTarget(),
       root:  document.body
     };
 
@@ -267,6 +267,17 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
 
     inputModelCtrl = elements.$.input.controller('ngModel');
   }
+
+	/**
+	 * Finds the correct element that will determine the width
+	 * @returns {*}
+	 */
+	function getWrapTarget() {
+    for (var element = $element; element.length; element = element.parent()) {
+      if (angular.isDefined(element.attr('md-autocomplete-wrap-override'))) return element[ 0 ];
+    }
+    return $element.find('md-autocomplete-wrap')[0];
+	}
 
   /**
    * Finds the element that the menu will base its position on

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -268,16 +268,16 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     inputModelCtrl = elements.$.input.controller('ngModel');
   }
 
-	/**
-	 * Finds the correct element that will determine the width
-	 * @returns {*}
-	 */
-	function getWrapTarget() {
+  /**
+   * Find the target for the wrap element which determines menu width
+   * @returns {*}
+   */
+  function getWrapTarget() {
     for (var element = $element; element.length; element = element.parent()) {
       if (angular.isDefined(element.attr('md-autocomplete-wrap-override'))) return element[ 0 ];
     }
     return $element.find('md-autocomplete-wrap')[0];
-	}
+  }
 
   /**
    * Finds the element that the menu will base its position on

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -251,43 +251,51 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Gathers all of the elements needed for this controller
    */
   function gatherElements () {
+
+    var snapWrap = gatherSnapWrap();
+
     elements = {
       main:  $element[0],
       scrollContainer: $element[0].querySelector('.md-virtual-repeat-container'),
       scroller: $element[0].querySelector('.md-virtual-repeat-scroller'),
       ul:    $element.find('ul')[0],
       input: $element.find('input')[0],
-      wrap:  getWrapTarget(),
+      wrap:  snapWrap.wrap,
+      snap:  snapWrap.snap,
       root:  document.body
     };
 
     elements.li   = elements.ul.getElementsByTagName('li');
-    elements.snap = getSnapTarget();
     elements.$    = getAngularElements(elements);
 
     inputModelCtrl = elements.$.input.controller('ngModel');
   }
 
   /**
-   * Find the target for the wrap element which determines menu width
-   * @returns {*}
+   * Gathers the snap and wrap elements
+   *
    */
-  function getWrapTarget() {
-    for (var element = $element; element.length; element = element.parent()) {
-      if (angular.isDefined(element.attr('md-autocomplete-wrap-override'))) return element[ 0 ];
+  function gatherSnapWrap() {
+    var element;
+    var value;
+    for (element = $element; element.length; element = element.parent()) {
+      value = element.attr('md-autocomplete-snap');
+      if (angular.isDefined(value)) break;
     }
-    return $element.find('md-autocomplete-wrap')[0];
-  }
 
-  /**
-   * Finds the element that the menu will base its position on
-   * @returns {*}
-   */
-  function getSnapTarget () {
-    for (var element = $element; element.length; element = element.parent()) {
-      if (angular.isDefined(element.attr('md-autocomplete-snap'))) return element[ 0 ];
+    if (element.length) {
+      var snapWidth = value.toLowerCase() === 'width';
+      return {
+        snap: element[0],
+        wrap: snapWidth ? element[0] : $element.find('md-autocomplete-wrap')[0]
+      };
     }
-    return elements.wrap;
+
+    var wrap = $element.find('md-autocomplete-wrap')[0];
+    return {
+      snap: wrap,
+      wrap: wrap
+    };
   }
 
   /**

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -284,10 +284,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     }
 
     if (element.length) {
-      var snapWidth = value.toLowerCase() === 'width';
       return {
         snap: element[0],
-        wrap: snapWidth ? element[0] : $element.find('md-autocomplete-wrap')[0]
+        wrap: (value.toLowerCase() === 'width') ? element[0] : $element.find('md-autocomplete-wrap')[0]
       };
     }
 

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -34,7 +34,15 @@ angular
  *
  * There is an example below of how this should look.
  *
+ * ### Snapping Drop-Down
+ *
+ * You can cause the autocomplete drop-down to snap to an ancestor element by applying the
+ *     `md-autocomplete-snap` attribute to that element. You can also snap to the width of
+ *     the `md-autocomplete-snap` element by setting the attribute's value to `width`
+ *     (ie. `md-autocomplete-snap="width"`).
+ *
  * ### Notes
+ *
  * **Autocomplete Dropdown Items Rendering**
  *
  * The `md-autocomplete` uses the the <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeat</a>


### PR DESCRIPTION
This allows a `md-autocomplete-wrap` to be applied to an ancestor of a `md-autocomplete` and cause that element to be used for evaluating the width of the autocomplete instead of the the `md-autocomplete-wrap` element. This addresses #4450 which constrains the width of the menu that pops up to the width of the auto complete wrapper.
![autocomplete](https://cloud.githubusercontent.com/assets/4137562/14049549/8f234314-f27b-11e5-8649-40fa704bc10b.gif)
When using chips and possibly in other situations it would be desirable to have the menu be the width of the chips component.
![autocompleteoverride](https://cloud.githubusercontent.com/assets/4137562/14049561/b1c62788-f27b-11e5-9d0f-5a48d679c443.gif)
Adding support for this attribute would allow for this and other similar behavior.

A working version of this change can be seen at https://codepen.io/allenperl/pen/KzmQwr.
