### PR TITLE
feat(navBar): add mdNavBar component for page navigation

### DIFF
--- a/src/components/navBar/demoBasicUsage/index.html
+++ b/src/components/navBar/demoBasicUsage/index.html
@@ -1,0 +1,11 @@
+<div ng-controller="AppCtrl" ng-cloak>
+  <md-content class="md-padding">
+    <md-nav-bar selected-link-name="currentLink" nav-bar-aria-label="navigation links">
+      <md-nav-link nav-click="goto('page1')" link-name="page1">Page One</md-nav-link>
+      <md-nav-link nav-click="goto('page2')" link-name="page2">Page Two</md-nav-link>
+      <md-nav-link nav-click="goto('page3')" link-name="page3">Page Three</md-nav-link>
+      <!-- these require actual routing with ui-router or ng-route, so they won't work in the demo -->
+      <md-nav-link nav-sref="app.page4" link-name="page4">Page Four</md-nav-link>
+      <md-nav-link nav-href="#page5" link-name="page5">Page Five</md-nav-link>
+    </md-nav-bar>
+  </md-content>

--- a/src/components/navBar/demoBasicUsage/index.html
+++ b/src/components/navBar/demoBasicUsage/index.html
@@ -1,11 +1,13 @@
 <div ng-controller="AppCtrl" ng-cloak>
   <md-content class="md-padding">
-    <md-nav-bar selected-link-name="currentLink" nav-bar-aria-label="navigation links">
-      <md-nav-link nav-click="goto('page1')" link-name="page1">Page One</md-nav-link>
-      <md-nav-link nav-click="goto('page2')" link-name="page2">Page Two</md-nav-link>
-      <md-nav-link nav-click="goto('page3')" link-name="page3">Page Three</md-nav-link>
-      <!-- these require actual routing with ui-router or ng-route, so they won't work in the demo -->
-      <md-nav-link nav-sref="app.page4" link-name="page4">Page Four</md-nav-link>
-      <md-nav-link nav-href="#page5" link-name="page5">Page Five</md-nav-link>
+    <md-nav-bar md-selected-nav-item="currentNavItem" nav-bar-aria-label="navigation links">
+      <md-nav-item md-nav-click="goto('page1')" name="page1">Page One</md-nav-item>
+      <md-nav-item md-nav-click="goto('page2')" name="page2">Page Two</md-nav-item>
+      <md-nav-item md-nav-click="goto('page3')" name="page3">Page Three</md-nav-item>
+      <!-- these require actual routing with ui-router or ng-route, so they won't work in the demo
+      <md-nav-item md-nav-sref="app.page4" name="page4">Page Four</md-nav-item>
+      <md-nav-item md-nav-href="#page5" name="page5">Page Five</md-nav-item>
+      -->
     </md-nav-bar>
+    <span>{{currentNavItem}}</span>
   </md-content>

--- a/src/components/navBar/demoBasicUsage/script.js
+++ b/src/components/navBar/demoBasicUsage/script.js
@@ -5,7 +5,6 @@
       .controller('AppCtrl', AppCtrl);
 
   function AppCtrl($scope) {
-    $scope.currentLink = 'page1';
-    $scope.goto = function(hash) { $scope.currentLink = hash; };
+    $scope.currentNavItem = 'page1';
   }
 })();

--- a/src/components/navBar/demoBasicUsage/script.js
+++ b/src/components/navBar/demoBasicUsage/script.js
@@ -1,0 +1,11 @@
+(function() {
+  'use strict';
+
+  angular.module('navBarDemoBasicUsage', ['ngMaterial'])
+      .controller('AppCtrl', AppCtrl);
+
+  function AppCtrl($scope) {
+    $scope.currentLink = 'page1';
+    $scope.goto = function(hash) { $scope.currentLink = hash; };
+  }
+})();

--- a/src/components/navBar/navBar-theme.scss
+++ b/src/components/navBar/navBar-theme.scss
@@ -5,7 +5,7 @@ md-nav-bar.md-THEME_NAME-theme {
     border-color: '{{foreground-4}}';
   }
 
-  .md-button.md-nav-button.md-unselected {
+  .md-button._md-nav-button.md-unselected {
     color: '{{foreground-2}}';
   }
 

--- a/src/components/navBar/navBar-theme.scss
+++ b/src/components/navBar/navBar-theme.scss
@@ -1,0 +1,16 @@
+md-nav-bar.md-THEME_NAME-theme {
+
+  .md-nav-bar {
+    background-color: transparent;
+    border-color: '{{foreground-4}}';
+  }
+
+  .md-button.md-nav-button.md-unselected {
+    color: '{{foreground-2}}';
+  }
+
+  md-nav-ink-bar {
+    color: '{{accent-color}}';
+    background: '{{accent-color}}';
+  }
+}

--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -1,0 +1,509 @@
+/**
+ * @ngdoc module
+ * @name material.components.navBar
+ */
+
+
+angular.module('material.components.navBar', ['material.core'])
+    .controller('MdNavBarController', MdNavBarController)
+    .directive('mdNavBar', MdNavBar)
+    .controller('MdNavLinkController', MdNavLinkController)
+    .directive('mdNavLink', MdNavLink);
+
+
+/*****************************************************************************
+ *                            PUBLIC DOCUMENTATION                           *
+ *****************************************************************************/
+/**
+ * @ngdoc directive
+ * @name mdNavBar
+ * @module material.components.navBar
+ *
+ * @restrict E
+ *
+ * @description
+ * The `<md-nav-bar>` directive renders a list of material tabs that can be used
+ * for top-level page navigation. Unlike `<md-tabs>`, it has no concept of a tab
+ * body.
+ *
+ * Because it deals with page navigation, certain routing concepts are built-in.
+ * Route changes via via ng-href, ui-sref, or ng-click events are supported.
+ *
+ * Accessibility functionality is implemented as a site navigator with a
+ * listbox, according to
+ * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
+ *
+ * @param {string=} selectedLinkName The name of the current tab; this must
+ * match the link-name attribute of `<md-nav-link>`
+ * @param {string=} navBarAriaLabel An aria-label for the nav-bar
+ *
+ * @usage
+ * <hljs lang="html">
+ *  <md-nav-bar selected-link-name="currentLink">
+ *    <md-nav-link nav-click="goto('page1')" link-name="page1">Page One</md-nav-link>
+ *    <md-nav-link nav-sref="app.page2" link-name="page2">Page Two</md-nav-link>
+ *    <md-nav-link nav-href="#page3" link-name="page3">Page Three</md-nav-link>
+ *  </md-nav-bar>
+ *</hljs>
+ * <hljs lang="js">
+ * (function() {
+ *   ‘use strict’;
+ *
+ *    $rootScope.$on('$routeChangeSuccess', function(event, current) {
+ *      $scope.currentLink = getCurrentLinkFromRoute(current);
+ *    });
+ * });
+ * </hljs>
+ */
+
+/*****************************************************************************
+ *                            mdNavLink                                      *
+ *****************************************************************************/
+/**
+ * @ngdoc directive
+ * @name mdNavLink
+ * @module material.components.navBar
+ *
+ * @restrict E
+ *
+ * @description
+ * `<md-nav-link>` describes a page navigation link within the `<md-nav-bar>`
+ * component. It renders an md-button as the actual link.
+ *
+ * Exactly one of the navClick, navHref, navSref attributes are required to be
+ * specified.
+ *
+ * @param {Function=} navClick Function which will be called when the
+ * link is clicked to change the page. Renders as an `ng-click`.
+ * @param {string=} navHref url to transition to when this link is clicked.
+ * Renders as an `ng-href`.
+ * @param {string=} navSref Ui-router state to transition to when this link is
+ * clicked. Renders as a `ui-sref`.
+ * @param {string=} linkName The name of this link. Used by the nav bar to know
+ * which link is currently selected.
+ *
+ * @usage
+ * See `<md-nav-bar>` for usage.
+ */
+
+
+/*****************************************************************************
+ *                                IMPLEMENTATION                             *
+ *****************************************************************************/
+
+function MdNavBar($mdAria) {
+  return {
+    restrict: 'E',
+    transclude: true,
+    controller: MdNavBarController,
+    controllerAs: 'ctrl',
+    bindToController: true,
+    scope: {
+      'selectedLinkName': '=?',
+      'navBarAriaLabel': '@?',
+    },
+    template:
+      '<div class="md-nav-bar">' +
+        '<nav role="navigation">' +
+          '<ul class="md-nav-bar-list" layout="row" ng-transclude role="listbox"' +
+            'tabindex="0"' +
+            'ng-focus="ctrl.onFocus()"' +
+            'ng-blur="ctrl.onBlur()"' +
+            'ng-keydown="ctrl.onKeydown($event)"' +
+            'aria-label="{{ctrl.navBarAriaLabel}}">' +
+          '</ul>' +
+        '</nav>' +
+        '<md-nav-ink-bar></md-nav-ink-bar>' +
+      '</div>',
+    link: function(scope, element, attrs, ctrl) {
+      if (!ctrl.navBarAriaLabel) {
+        $mdAria.expectAsync(element, 'aria-label', angular.noop);
+      }
+    }
+  };
+}
+
+/**
+ * Controller for the nav-bar component.
+ *
+ * Accessibility functionality is implemented as a site navigator with a
+ * listbox, according to
+ * https://www.w3.org/TR/wai-aria-practices/#Site_Navigator_Tabbed_Style
+ * @param {!angular.JQLite} $element
+ * @param {!angular.Scope} $scope
+ * @param {!angular.Timeout} $timeout
+ * @param {!Object} $mdConstant
+ * @constructor
+ * @final
+ * @ngInject
+ */
+function MdNavBarController($element, $scope, $timeout, $mdConstant) {
+  // Injected variables
+  /** @private @const {!angular.Timeout} */
+  this._$timeout = $timeout;
+
+  /** @private @const {!angular.Scope} */
+  this._$scope = $scope;
+
+  /** @private @const {!Object} */
+  this._$mdConstant = $mdConstant;
+
+  // Data-bound variables.
+  /** @type {string} */
+  this.selectedLinkName;
+
+  /** @type {string} */
+  this.navBarAriaLabel;
+
+  // State variables.
+
+  /** @type {?angular.JQLite} */
+  this._navBarEl = $element[0];
+
+  /** @type {?angular.JQLite} */
+  this._inkbar;
+
+  var self = this;
+  // need to wait for transcluded content to be available
+  var deregisterTabWatch = this._$scope.$watch(function() {
+    return self._navBarEl.querySelectorAll('.md-nav-button').length;
+  },
+  function(newLength) {
+    if (newLength > 0) {
+      self._initTabs();
+      deregisterTabWatch();
+    }
+  });
+}
+
+
+
+/**
+ * Initializes the tab components once they exist.
+ * @private
+ */
+MdNavBarController.prototype._initTabs = function() {
+  this._inkbar = angular.element(this._navBarEl.getElementsByTagName('md-nav-ink-bar')[0]);
+
+  var self = this;
+  this._$timeout(function() {
+    self._updateTabs(self.selectedLinkName, undefined);
+  });
+
+  this._$scope.$watch('ctrl.selectedLinkName', function(newValue, oldValue) {
+    // Wait a digest before update tabs for products doing
+    // anything dynamic in the template.
+    self._$timeout(function() {
+      self._updateTabs(newValue, oldValue);
+    });
+  });
+};
+
+/**
+ * Set the current tab to be selected.
+ * @param {string|undefined} newValue New current tab name.
+ * @param {string|undefined} oldValue Previous tab name.
+ * @private
+ */
+MdNavBarController.prototype._updateTabs = function(newValue, oldValue) {
+  var tabs = this._getTabs();
+
+  var oldIndex;
+  if (oldValue) {
+    var oldTab = this._getTabByName(oldValue);
+    if (oldTab) {
+      oldTab.setSelected(false);
+      oldIndex = tabs.indexOf(oldTab);
+    }
+  }
+
+  if (newValue) {
+    var tab = this._getTabByName(newValue);
+    if (tab) {
+      tab.setSelected(true);
+      var newIndex = tabs.indexOf(tab);
+      var self = this;
+      this._$timeout(function() {
+        self._updateInkBarStyles(tab, newIndex, oldIndex);
+      });
+    }
+  }
+};
+
+/**
+ * Repositions the ink bar to the selected tab.
+ * @private
+ */
+MdNavBarController.prototype._updateInkBarStyles = function(tab, newIndex, oldIndex) {
+  var tabEl = tab.getButtonEl();
+  var left = tabEl.offsetLeft;
+
+  this._inkbar.toggleClass('md-left', newIndex < oldIndex)
+      .toggleClass('md-right', newIndex > oldIndex);
+  this._inkbar.css({left: left + 'px', width: tabEl.offsetWidth + 'px'});
+};
+
+/**
+ * Returns an array of the current tabs.
+ * @return {!Array<!NavLinkController>}
+ * @private
+ */
+MdNavBarController.prototype._getTabs = function() {
+  var linkArray = Array.prototype.slice.call(
+      this._navBarEl.querySelectorAll('.md-nav-link'));
+  return linkArray.map(function(el) {
+    return angular.element(el).controller('mdNavLink')
+  });
+};
+
+/**
+ * Returns the tab with the specified name.
+ * @param {string} name The name of the tab, found in its link-name attribute.
+ * @return {!NavLinkController|undefined}
+ * @private
+ */
+MdNavBarController.prototype._getTabByName = function(name) {
+  return this._findTab(function(tab) {
+    return tab.getName() == name;
+  });
+};
+
+/**
+ * Returns the selected tab.
+ * @return {!NavLinkController|undefined}
+ * @private
+ */
+MdNavBarController.prototype._getSelectedTab = function() {
+  return this._findTab(function(tab) {
+    return tab.isSelected()
+  });
+};
+
+/**
+ * Returns the focused tab.
+ * @return {!NavLinkController|undefined}
+ */
+MdNavBarController.prototype.getFocusedTab = function() {
+  return this._findTab(function(tab) {
+    return tab.hasFocus()
+  });
+};
+
+/**
+ * Find a tab that matches the specified function.
+ * @private
+ */
+MdNavBarController.prototype._findTab = function(fn) {
+  var tabs = this._getTabs();
+  for (var i = 0; i < tabs.length; i++) {
+    if (fn(tabs[i])) {
+      return tabs[i];
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Direct focus to the selected tab when focus enters the nav bar.
+ */
+MdNavBarController.prototype.onFocus = function() {
+  var tab = this._getSelectedTab();
+  if (tab) {
+    tab.setFocused(true);
+  }
+};
+
+/**
+ * Clear tab focus when focus leaves the nav bar.
+ */
+MdNavBarController.prototype.onBlur = function() {
+  var tab = this.getFocusedTab();
+  if (tab) {
+    tab.setFocused(false);
+  }
+};
+
+/**
+ * Move focus from oldTab to newTab.
+ * @param {!NavLinkController} oldTab
+ * @param {!NavLinkController} newTab
+ * @private
+ */
+MdNavBarController.prototype._moveFocus = function(oldTab, newTab) {
+  oldTab.setFocused(false);
+  newTab.setFocused(true);
+};
+
+/**
+ * Responds to keypress events.
+ * @param {!Event} e
+ */
+MdNavBarController.prototype.onKeydown = function(e) {
+  var keyCodes = this._$mdConstant.KEY_CODE;
+  var tabs = this._getTabs();
+  var focusedTab = this.getFocusedTab();
+  if (!focusedTab) return;
+
+  var focusedTabIndex = tabs.indexOf(focusedTab);
+
+  // use arrow keys to navigate between tabs
+  switch (e.keyCode) {
+    case keyCodes.UP_ARROW:
+    case keyCodes.LEFT_ARROW:
+      if (focusedTabIndex > 0) {
+        this._moveFocus(focusedTab, tabs[focusedTabIndex - 1]);
+      }
+      break;
+    case keyCodes.DOWN_ARROW:
+    case keyCodes.RIGHT_ARROW:
+      if (focusedTabIndex < tabs.length - 1) {
+        this._moveFocus(focusedTab, tabs[focusedTabIndex + 1]);
+      }
+      break;
+    case keyCodes.SPACE:
+    case keyCodes.ENTER:
+      // timeout to avoid a "digest already in progress" console error
+      this._$timeout(function() {
+        focusedTab.getButtonEl().click();
+      });
+      break;
+  }
+};
+
+function MdNavLink() {
+  return {
+    restrict: 'E',
+    require: '^MdNavBar',
+    controller: MdNavLinkController,
+    bindToController: true,
+    controllerAs: 'ctrl',
+    replace: true,
+    transclude: true,
+    template:
+      '<li class="md-nav-link" role="option" aria-selected="{{ctrl.isSelected()}}">' +
+        '<md-button ng-if="ctrl.navSref" class="md-nav-button md-accent"' +
+          'ng-class="ctrl.getNgClassMap()"' +
+          'tabindex="-1"' +
+          'ui-sref="{{ctrl.navSref}}">' +
+          '<span ng-transclude></span>' +
+        '</md-button>' +
+        '<md-button ng-if="ctrl.navHref" class="md-nav-button md-accent"' +
+          'ng-class="ctrl.getNgClassMap()"' +
+          'tabindex="-1"' +
+          'ng-href="{{ctrl.navHref}}">' +
+          '<span ng-transclude></span>' +
+        '</md-button>' +
+        '<md-button ng-if="ctrl.navClick" class="md-nav-button md-accent"' +
+          'ng-class="ctrl.getNgClassMap()"' +
+          'tabindex="-1"' +
+          'ng-click="ctrl.navClick()">' +
+          '<span ng-transclude></span>' +
+        '</md-button>' +
+      '</li>',
+    scope: {
+      'navClick': '&?',
+      'navHref': '@?',
+      'navSref': '@?',
+      'linkName': '@',
+    }
+  };
+}
+
+/**
+ * Controller for the nav-link component.
+ * @param {!angular.JQLite} $element
+ * @constructor
+ * @final
+ * @ngInject
+ */
+function MdNavLinkController($element) {
+
+  /** @private @const {!angular.JQLite} */
+  this._$element = $element;
+
+  // Data-bound variables
+  /** @const {?Function} */
+  this.navClick;
+  /** @const {?string} */
+  this.navHref;
+  /** @const {?string} */
+  this.navSref;
+
+  // State variables
+  /** @private {boolean} */
+  this._selected = false;
+
+  /** @private {boolean} */
+  this._focused = false;
+
+
+  var hasNavClick = this.navClick != null;
+  var hasNavHref = this.navHref != null;
+  var hasNavSref = this.navSref != null;
+
+  if ((hasNavClick ? 1:0) + (hasNavHref ? 1:0) + (hasNavSref ? 1:0) != 1) {
+    throw Error(
+        'Must specify exactly one of nav-click, nav-href, ' +
+        'nav-sref for nav-link directive');
+  }
+}
+
+/**
+ * Returns a map of class names and values for use by ng-class.
+ * @return {!Object<string,boolean>}
+ */
+MdNavLinkController.prototype.getNgClassMap = function() {
+  return {
+    'md-active': this._selected,
+    'md-primary': this._selected,
+    'md-unselected': !this._selected,
+    'md-focused': this._focused,
+  };
+};
+
+/**
+ * Get the link-name attribute of the tab.
+ * @return {string}
+ */
+MdNavLinkController.prototype.getName = function() {
+  return this.linkName;
+};
+
+/**
+ * Get the button element associated with the tab.
+ * @return {!Element}
+ */
+MdNavLinkController.prototype.getButtonEl = function() {
+  return this._$element[0].querySelector('.md-nav-button');
+};
+
+/**
+ * Set the selected state of the tab.
+ * @param {boolean} isSelected
+ */
+MdNavLinkController.prototype.setSelected = function(isSelected) {
+  this._selected = isSelected;
+};
+
+/**
+ * @return {boolean}
+ */
+MdNavLinkController.prototype.isSelected = function() {
+  return this._selected;
+};
+
+/**
+ * Set the focused state of the tab.
+ * @param {boolean} isFocused
+ */
+MdNavLinkController.prototype.setFocused = function(isFocused) {
+  this._focused = isFocused;
+};
+
+/**
+ * @return {boolean}
+ */
+MdNavLinkController.prototype.hasFocus = function() {
+  return this._focused;
+};

--- a/src/components/navBar/navBar.scss
+++ b/src/components/navBar/navBar.scss
@@ -1,0 +1,61 @@
+/** Matches "md-tabs md-tabs-wrapper" style. */
+$md-nav-bar-height: 48px;
+
+.md-nav-bar {
+  border-style: solid;
+  border-width: 0 0 1px;
+  height: $md-nav-bar-height;
+  position: relative;
+}
+
+.md-nav-bar-list {
+  outline: none;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.md-nav-link:first-of-type {
+  margin-left: 8px;
+}
+
+// override button styles to look more like tabs
+.md-button.md-nav-button {
+  line-height: 24px;
+  margin: 0 4px;
+  padding: 12px 16px;
+  transition: background-color 0.35s $swift-ease-in-out-timing-function;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:hover {
+    background-color: inherit;
+  }
+}
+
+md-nav-ink-bar {
+  $duration: $swift-ease-in-out-duration * 0.5;
+  $multiplier: 0.5;
+  bottom: 0;
+  height: 2px;
+  left: auto;
+  position: absolute;
+  right: auto;
+  background-color: black;
+
+  &.md-left {
+    transition: left ($duration * $multiplier) $swift-ease-in-out-timing-function,
+        right $duration $swift-ease-in-out-timing-function;
+  }
+  &.md-right {
+    transition: left $duration $swift-ease-in-out-timing-function,
+        right ($duration * $multiplier) $swift-ease-in-out-timing-function;
+  }
+}
+
+md-nav-extra-content {
+  min-height: 48px;
+  padding-right: 12px;
+}

--- a/src/components/navBar/navBar.scss
+++ b/src/components/navBar/navBar.scss
@@ -8,19 +8,19 @@ $md-nav-bar-height: 48px;
   position: relative;
 }
 
-.md-nav-bar-list {
+._md-nav-bar-list {
   outline: none;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.md-nav-link:first-of-type {
+.md-nav-item:first-of-type {
   margin-left: 8px;
 }
 
 // override button styles to look more like tabs
-.md-button.md-nav-button {
+.md-button._md-nav-button {
   line-height: 24px;
   margin: 0 4px;
   padding: 12px 16px;
@@ -45,11 +45,11 @@ md-nav-ink-bar {
   right: auto;
   background-color: black;
 
-  &.md-left {
+  &._md-left {
     transition: left ($duration * $multiplier) $swift-ease-in-out-timing-function,
         right $duration $swift-ease-in-out-timing-function;
   }
-  &.md-right {
+  &._md-right {
     transition: left $duration $swift-ease-in-out-timing-function,
         right ($duration * $multiplier) $swift-ease-in-out-timing-function;
   }

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -1,0 +1,247 @@
+describe('mdNavBar', function() {
+  var el, $compile, $scope, $timeout, ctrl, tabContainer, $material, $mdConstant;
+
+  /** @ngInject */
+  var injectLocals = function(
+      _$compile_, $rootScope, _$timeout_, _$material_, _$mdConstant_) {
+    $compile = _$compile_;
+    $scope = $rootScope.$new();
+    $timeout = _$timeout_;
+    $material = _$material_;
+    $mdConstant = _$mdConstant_;
+  };
+
+  beforeEach(function() {
+    module('material.components.navBar', 'ngAnimateMock');
+
+    inject(injectLocals);
+  });
+
+  afterEach(function() {
+    el && el.remove();
+  });
+
+  function create(template) {
+    el = $compile(template)($scope);
+    angular.element(document.body).append(el);
+    $scope.$apply();
+    ctrl = el.controller('mdNavBar');
+    tabContainer = angular.element(el[0].querySelector('.md-nav-bar-list'));
+    $timeout.flush();
+    $material.flushOutstandingAnimations();
+  }
+
+  function createTabs() {
+    create(
+        '<md-nav-bar selected-link-name="selectedTabRoute" nav-bar-aria-label="{{ariaLabel}}">' +
+        '  <md-nav-link nav-href="#1" link-name="tab1">' +
+        '    tab1' +
+        '  </md-nav-link>' +
+        '  <md-nav-link nav-href="#2" link-name="tab2">' +
+        '    tab2' +
+        '  </md-nav-link>' +
+        '  <md-nav-link nav-href="#3" link-name="tab3">' +
+        '    tab3' +
+        '  </md-nav-link>' +
+        '</md-nav-bar>');
+  }
+
+  describe('tabs', function() {
+    it('shows current tab as selected', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      var tab1 = getTab('tab1');
+
+      expect(tab1).toHaveClass('md-active');
+      expect(tab1).toHaveClass('md-primary');
+    });
+
+    it('shows non-selected tabs as unselected', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      expect(getTab('tab2')).toHaveClass('md-unselected');
+      expect(getTab('tab3')).toHaveClass('md-unselected');
+    });
+
+    it('changes current tab when selectedTabRoute changes', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      updateSelectedTabRoute('tab2');
+
+      expect(getTab('tab2')).toHaveClass('md-active');
+      expect(getTab('tab2')).toHaveClass('md-primary');
+      expect(getTab('tab1')).not.toHaveClass('md-active');
+      expect(getTab('tab1')).not.toHaveClass('md-primary');
+    });
+
+    it('requires navigation attribute to be present', function() {
+      expect(function() {
+        create('<md-nav-link link-name="fooo">footab</md-nav-link>');
+      }).toThrow();
+    });
+
+    it('does not allow multiple navigation attributes', function() {
+      expect(function() {
+        create(
+            '<md-nav-link nav-href="a" nav-sref="b" link-name="fooo">' +
+            'footab</md-nav-link>');
+      }).toThrow();
+    });
+
+    it('allows empty navigation attribute', function() {
+      // be permissive; this helps with test writing
+      expect(function() {
+        create(
+            '<md-nav-link nav-href="" link-name="fooo">' +
+            'footab</md-nav-link>');
+      }).not.toThrow();
+    });
+  });
+
+  describe('inkbar', function() {
+    it('moves to new tab', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      // b/c there is no css in the karma test, we have to interrogate the
+      //   inkbar style property directly
+      expect(parseInt(getInkbarEl().style.left))
+          .toBeCloseTo(getTab('tab1')[0].offsetLeft, 0.1);
+
+      updateSelectedTabRoute('tab3');
+
+      expect(parseInt(getInkbarEl().style.left))
+          .toBeCloseTo(getTab('tab3')[0].offsetLeft, 0.1);
+    });
+  });
+
+  describe('a11y', function() {
+    it('sets aria-checked on the selected tab', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      expect(getTab('tab1').parent().attr('aria-selected')).toBe('true');
+      expect(getTab('tab2').parent().attr('aria-selected')).toBe('false');
+      expect(getTab('tab3').parent().attr('aria-selected')).toBe('false');
+
+      updateSelectedTabRoute('tab3');
+
+      expect(getTab('tab1').parent().attr('aria-selected')).toBe('false');
+      expect(getTab('tab2').parent().attr('aria-selected')).toBe('false');
+      expect(getTab('tab3').parent().attr('aria-selected')).toBe('true');
+    });
+
+    it('sets aria-label on the listbox', function() {
+      var label = 'top level navigation for my site';
+      $scope.ariaLabel = label;
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      expect(tabContainer[0].getAttribute('aria-label')).toBe(label);
+    });
+
+    it('sets focus on the selected tab when the navbar receives focus',
+       function() {
+         $scope.selectedTabRoute = 'tab2';
+         createTabs();
+
+         expect(getTab('tab2')).not.toHaveClass('md-focused');
+         ctrl.onFocus();
+         $scope.$apply();
+
+         expect(getTab('tab2')).toHaveClass('md-focused');
+       });
+
+    it('removes tab focus when the navbar blurs', function() {
+      $scope.selectedTabRoute = 'tab2';
+      createTabs();
+
+      tabContainer.triggerHandler('focus');
+      expect(getTab('tab2')).toHaveClass('md-focused');
+
+      tabContainer.triggerHandler('blur');
+      expect(getTab('tab2')).not.toHaveClass('md-focused');
+    });
+
+    it('up/left moves focus back', function() {
+      $scope.selectedTabRoute = 'tab3';
+      createTabs();
+
+      tabContainer.triggerHandler('focus');
+      tabContainer.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.UP_ARROW,
+      });
+      tabContainer.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.LEFT_ARROW,
+      });
+      $scope.$apply();
+
+      expect(getTab('tab1')).toHaveClass('md-focused');
+      expect(getTab('tab2')).not.toHaveClass('md-focused');
+      expect(getTab('tab3')).not.toHaveClass('md-focused');
+    });
+
+    it('down/right moves focus forward', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      tabContainer.triggerHandler('focus');
+      tabContainer.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.DOWN_ARROW,
+      });
+      tabContainer.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW,
+      });
+      $scope.$apply();
+
+      expect(getTab('tab1')).not.toHaveClass('md-focused');
+      expect(getTab('tab2')).not.toHaveClass('md-focused');
+      expect(getTab('tab3')).toHaveClass('md-focused');
+    });
+
+    it('enter selects a tab', function() {
+      $scope.selectedTabRoute = 'tab2';
+      createTabs();
+      var tab2Ctrl = getTabCtrl('tab2');
+      spyOn(tab2Ctrl.getButtonEl(), 'click');
+
+      tabContainer.triggerHandler('focus');
+      tabContainer.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.ENTER,
+      });
+
+      $scope.$apply();
+      $timeout.flush();
+
+      expect(tab2Ctrl.getButtonEl().click).toHaveBeenCalled();
+    });
+  });
+
+  function getTab(tabName) {
+    return angular.element(
+        el[0].querySelector('.md-nav-bar [link-name="' + tabName + '"]' +
+        ' .md-nav-button'));
+  }
+
+  function getTabCtrl(tabName) {
+    return getTab(tabName).controller('mdNavLink');
+  }
+
+  function getInkbarEl() {
+    return el.find('md-nav-ink-bar')[0];
+  }
+
+  function updateSelectedTabRoute(newRoute) {
+    $scope.selectedTabRoute = newRoute;
+    $scope.$apply();
+    $timeout.flush();
+  }
+});

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -26,23 +26,23 @@ describe('mdNavBar', function() {
     angular.element(document.body).append(el);
     $scope.$apply();
     ctrl = el.controller('mdNavBar');
-    tabContainer = angular.element(el[0].querySelector('.md-nav-bar-list'));
+    tabContainer = angular.element(el[0].querySelector('._md-nav-bar-list'));
     $timeout.flush();
     $material.flushOutstandingAnimations();
   }
 
   function createTabs() {
     create(
-        '<md-nav-bar selected-link-name="selectedTabRoute" nav-bar-aria-label="{{ariaLabel}}">' +
-        '  <md-nav-link nav-href="#1" link-name="tab1">' +
+        '<md-nav-bar md-selected-nav-item="selectedTabRoute" nav-bar-aria-label="{{ariaLabel}}">' +
+        '  <md-nav-item md-nav-href="#1" name="tab1">' +
         '    tab1' +
-        '  </md-nav-link>' +
-        '  <md-nav-link nav-href="#2" link-name="tab2">' +
+        '  </md-nav-item>' +
+        '  <md-nav-item md-nav-href="#2" name="tab2">' +
         '    tab2' +
-        '  </md-nav-link>' +
-        '  <md-nav-link nav-href="#3" link-name="tab3">' +
+        '  </md-nav-item>' +
+        '  <md-nav-item md-nav-href="#3" name="tab3">' +
         '    tab3' +
-        '  </md-nav-link>' +
+        '  </md-nav-item>' +
         '</md-nav-bar>');
   }
 
@@ -79,15 +79,15 @@ describe('mdNavBar', function() {
 
     it('requires navigation attribute to be present', function() {
       expect(function() {
-        create('<md-nav-link link-name="fooo">footab</md-nav-link>');
+        create('<md-nav-item name="fooo">footab</md-nav-item>');
       }).toThrow();
     });
 
     it('does not allow multiple navigation attributes', function() {
       expect(function() {
         create(
-            '<md-nav-link nav-href="a" nav-sref="b" link-name="fooo">' +
-            'footab</md-nav-link>');
+            '<md-nav-item md-nav-href="a" md-nav-sref="b" name="fooo">' +
+            'footab</md-nav-item>');
       }).toThrow();
     });
 
@@ -95,9 +95,38 @@ describe('mdNavBar', function() {
       // be permissive; this helps with test writing
       expect(function() {
         create(
-            '<md-nav-link nav-href="" link-name="fooo">' +
-            'footab</md-nav-link>');
+          '<md-nav-bar>' +
+            '<md-nav-item md-nav-href="" name="fooo">' + 'footab</md-nav-item>' +
+          '<md-nav-bar>');
       }).not.toThrow();
+    });
+
+    it('uses nav item text for name if no name supplied', function() {
+      create(
+        '<md-nav-bar md-selected-nav-item="selectedTabRoute" nav-bar-aria-label="{{ariaLabel}}">' +
+        '  <md-nav-item md-nav-href="#1">' +
+        '    footab ' +
+        '  </md-nav-item>' +
+        '  <md-nav-item md-nav-href="#2" name="tab2">' +
+        '    tab2' +
+        '  </md-nav-item>' +
+        '  <md-nav-item md-nav-href="#3" name="tab3">' +
+        '    tab3' +
+        '  </md-nav-item>' +
+        '</md-nav-bar>');
+
+      expect(getTab('footab').length).toBe(1);
+    });
+
+    it('updates md-selected-nav-item on tab change', function() {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+
+      var tab2Ctrl = getTabCtrl('tab2');
+      tab2Ctrl.getButtonEl().click();
+      $scope.$apply();
+
+      expect($scope.selectedTabRoute).toBe('tab2');
     });
   });
 
@@ -226,13 +255,11 @@ describe('mdNavBar', function() {
   });
 
   function getTab(tabName) {
-    return angular.element(
-        el[0].querySelector('.md-nav-bar [link-name="' + tabName + '"]' +
-        ' .md-nav-button'));
+    return angular.element(getTabCtrl(tabName).getButtonEl());
   }
 
   function getTabCtrl(tabName) {
-    return getTab(tabName).controller('mdNavLink');
+    return ctrl._getTabByName(tabName);
   }
 
   function getInkbarEl() {


### PR DESCRIPTION
Tabs component specifically for top-level page navigation. The UI follows md-tabs closely, but there is no concept of md-tab-body and the tabs just serve as links.

The navigation/routing method used is somewhat hard-coded but can use `ng-href`, `ui-sref` (ui-router), or `ng-click`. Because it is tied in with routing, it is hard to accurately show usage in the demo page (but I tried anyway).

This resolves #6676 , and it provides a much simpler component than md-tabs to cover a simpler use-case.

This is just a preliminary PR to get feedback on the general approach; in a final version I will add better documentation and testing

Basic API (with ui-router):
```
<md-nav-bar selected-tab-name="currentLinkName">
    <md-nav-link nav-sref="app.home" link-name="home">Home</md-nav-link>
    <md-nav-link nav-sref="app.reports" link-name="reports">Reports</md-nav-link>
    <md-nav-link nav-sref="app.admin" link-name="admin">Admin</md-nav-link>
</md-nav-bar>
...
$rootScope.$on('$stateChangeSuccess', function() {
  // currentLinkName must match one of the link-name attributes in the md-nav-link directives.
  // applications can do the route-to-linkName mapping in any convenient way
  $scope.currentLinkName = getLinkNameFromCurrentRoute();
});

```