### PR TITLE
fix(docs): $mdDateLocaleProvider.formatDate must work with invalid date

### DIFF
--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -53,7 +53,8 @@
    *     };
    *
    *     $mdDateLocaleProvider.formatDate = function(date) {
-   *       return moment(date).format('L');
+   *       var m = moment(date);
+   *       return m.isValid() ? m.format('L') : date;
    *     };
    *
    *     $mdDateLocaleProvider.monthHeaderFormatter = function(date) {

--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -54,7 +54,7 @@
    *
    *     $mdDateLocaleProvider.formatDate = function(date) {
    *       var m = moment(date);
-   *       return m.isValid() ? m.format('L') : date;
+   *       return m.isValid() ? m.format('L') : '';
    *     };
    *
    *     $mdDateLocaleProvider.monthHeaderFormatter = function(date) {


### PR DESCRIPTION
- $mdDateLocaleProvider.formatDate must check if 'date' is a valid date (ng-model could be null for example)