### PR TITLE
chore(): bower-material-release should force remove the stale layout files

### DIFF
--- a/scripts/bower-material-release.sh
+++ b/scripts/bower-material-release.sh
@@ -25,8 +25,8 @@ function run {
 
   cd bower-material
   # remove stale layout files; newer ones are in `dist/layouts/`
-  rm ./angular-material.layouts.css
-  rm ./angular-material.layouts.min.css
+  rm -f ./angular-material.layouts.css
+  rm -f ./angular-material.layouts.min.css
 
 
   echo "-- Committing and tagging..."


### PR DESCRIPTION

![image](https://cloud.githubusercontent.com/assets/4987015/14151248/4ea7e28c-f6ad-11e5-989e-aaf678821412.png)

* Currently an error occurs, when then file is not existing, using `-f` is ignoring that message and won't prevent the execution.