### PR TITLE
fix(release): adds `newVersion` value to node string

### DIFF
--- a/release.js
+++ b/release.js
@@ -356,7 +356,7 @@
         'git checkout master',
         `git pull --rebase ${origin} master --strategy=theirs`,
         `git checkout release/${newVersion} -- CHANGELOG.md`,
-        `node -e "${stringifyFunction(buildCommand)}"`,
+        `node -e "var newVersion = '${newVersion}'; ${stringifyFunction(buildCommand)}"`,
         'git add CHANGELOG.md',
         'git add package.json',
         `git commit -m "update version number in package.json to ${newVersion}"`,


### PR DESCRIPTION
Should fix `package.json` in master during future releases

@ThomasBurleson 