### PR TITLE
docs(typography): explain how the roboto font is loaded.

### DIFF
--- a/docs/content/CSS/typography.md
+++ b/docs/content/CSS/typography.md
@@ -10,6 +10,40 @@ consistency across your application.
 <section class="demo-container">
   <md-toolbar class="demo-toolbar">
     <div class="md-toolbar-tools">
+      <h3>General Typography</h3>
+    </div>
+  </md-toolbar>
+  <div class="md-whiteframe-z1 docs-list">
+    <p>
+      Angular Material is always using the [Roboto](https://www.google.com/fonts#UsePlace:use/Collection:Roboto)
+      font for its components.
+    </p>
+
+    <p>
+      The `Roboto` font will be not automatically loaded by Angular Material itself.<br/>
+      That's why the font needs to be injected manually by the user.
+    </p>
+
+    <p>Here is an example markup, which loads the `Roboto` font from a CDN.</p>
+
+    <hljs lang="html">
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
+    </hljs>
+
+    <p>
+      <h4 class="md-title">Notes</h4>
+      When `Roboto` isn't loaded, then the typography will fallback to the following fonts:
+      <p>
+        - `Helvetica Neue`<br/>
+        - `sans-serif`
+      </p>
+    </p>
+  </div>
+</section>
+
+<section class="demo-container">
+  <md-toolbar class="demo-toolbar">
+    <div class="md-toolbar-tools">
       <h3>Heading Styles</h3>
     </div>
   </md-toolbar>


### PR DESCRIPTION
Fixes #7133