### PR TITLE
fix(menu): resolve an error when going from a nested menu item to a regular one

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -87,11 +87,11 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
       if (self.currentlyOpenMenu && self.currentlyOpenMenu != nestedMenu) {
         var closeTo = self.nestLevel + 1;
         self.currentlyOpenMenu.close(true, { closeTo: closeTo });
-        self.isAlreadyOpening = true;
-        nestedMenu.open();
+        self.isAlreadyOpening = !!nestedMenu;
+        nestedMenu && nestedMenu.open();
       } else if (nestedMenu && !nestedMenu.isOpen && nestedMenu.open) {
-        self.isAlreadyOpening = true;
-        nestedMenu.open();
+        self.isAlreadyOpening = !!nestedMenu;
+        nestedMenu && nestedMenu.open();
       }
     }, nestedMenu ? 100 : 250);
     var focusableTarget = event.currentTarget.querySelector('.md-button:not([disabled])');


### PR DESCRIPTION
Fixes a JS error that was being thrown if the user goes from a menu item with a sub menu to an item that doesn't have one.
Also fixes the menu item without a sub menu staying highlighted afterwards.

Closes #7819.

@topherfangio Could you give me some feedback on this one? I believe it got introduced in https://github.com/angular/material/commit/b58343c20ac4bd3418629c29abddfe3ac3840eb5#diff-7d56e0ee8b5aa2a3434f4f53a8a66168