### PR TITLE
fix(select): prevent selectedLabels from being passed $scope by $watch

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -334,7 +334,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         $mdAria.expect(element, 'aria-label', labelText);
       }
 
-      scope.$watch(selectMenuCtrl.selectedLabels, syncLabelText);
+      scope.$watch(function() {
+          return selectMenuCtrl.selectedLabels();
+      }, syncLabelText);
 
       function syncLabelText() {
         if (selectContainer) {


### PR DESCRIPTION
Fix provided by @jelbourn for #6260