### PR TITLE
update(panel): Extends attachTo config accepted types.

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -101,8 +101,9 @@ angular
  *     with the value 3.
  *   - `resolve` - `{Object=}`: Similar to locals, except it takes promises as
  *     values. The panel will not open until all of the promises resolve.
- *   - `attachTo` - `{Element=}`: The element to attach the panel to. Defaults
- *     to appending to the root element of the application.
+ *   - `attachTo` - `{(string|!angular.JQLite|!Element)=}`: The element to
+ *     attach the panel to. Defaults to appending to the root element of the
+ *     application.
  *   - `panelClass` - `{string=}`: A css class to apply to the panel element.
  *     This class should define any borders, box-shadow, etc. for the panel.
  *   - `position` - `{MdPanelPosition=}`: An MdPanelPosition object that
@@ -1000,8 +1001,7 @@ MdPanelRef.prototype._createPanel = function() {
     self._$mdCompiler.compile(self._config)
         .then(function(compileData) {
           self._panelContainer = compileData.link(self._config['scope']);
-          angular.element(self._config['attachTo']).append(
-              self._panelContainer);
+          getElement(self._config['attachTo']).append(self._panelContainer);
 
           self._panelEl = angular.element(
               self._panelContainer[0].querySelector('.md-panel'));
@@ -1082,7 +1082,7 @@ MdPanelRef.prototype._removeEventListener = function() {
  */
 MdPanelRef.prototype._configureEscapeToClose = function() {
   if (this._config['escapeToClose']) {
-    var parentTarget = this._config['attachTo'];
+    var parentTarget = getElement(this._config['attachTo']);
     var self = this;
 
     var keyHandlerFn = function (ev) {

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -234,24 +234,64 @@ describe('$mdPanel', function() {
   });
 
   describe('config options:', function() {
-    it('should attach panel to a specific element', function() {
-      var parentEl = document.createElement('div');
-      parentEl.id = 'parent';
-      attachToBody(parentEl);
+    describe('should attach panel to a specific element', function() {
+      var parentEl;
 
-      var config = {
-        attachTo: angular.element(parentEl),
-        template: DEFAULT_TEMPLATE
-      };
+      beforeEach(function() {
+        parentEl = document.createElement('div');
+        parentEl.id = 'parent';
+        attachToBody(parentEl);
+      });
 
-      openPanel(config);
+      it('using an Element', function() {
+        var config = {
+          attachTo: parentEl,
+          template: DEFAULT_TEMPLATE
+        };
 
-      var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
-      expect(panelWrapperEl.parentElement).toBe(parentEl);
+        openPanel(config);
 
-      closePanel();
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        expect(panelWrapperEl.parentElement).toBe(parentEl);
 
-      expect(parentEl.childElementCount).toEqual(0);
+        closePanel();
+
+        expect(parentEl.childElementCount).toEqual(0);
+      });
+
+
+      it('using an JQLite Object', function() {
+        var config = {
+          attachTo: angular.element(parentEl),
+          template: DEFAULT_TEMPLATE
+        };
+
+        openPanel(config);
+
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        expect(panelWrapperEl.parentElement).toBe(parentEl);
+
+        closePanel();
+
+        expect(parentEl.childElementCount).toEqual(0);
+      });
+
+
+      it('using a query selector', function() {
+        var config = {
+          attachTo: '#parent',
+          template: DEFAULT_TEMPLATE
+        };
+
+        openPanel(config);
+
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        expect(panelWrapperEl.parentElement).toBe(parentEl);
+
+        closePanel();
+
+        expect(parentEl.childElementCount).toEqual(0);
+      });
     });
 
     it('should apply a custom css class to the panel', function() {


### PR DESCRIPTION
Allows attachTo to accept an Element, JQLite object, or a query selector.

@jelbourn @gmoothart @KarenParker @DerekLouie Please review.

Fixes #7678