### PR TITLE
feat(mdComponentRegistry) Allow Multiple .when registrations

### DIFF
--- a/src/core/services/registry/componentRegistry.js
+++ b/src/core/services/registry/componentRegistry.js
@@ -83,7 +83,9 @@
         function resolveWhen() {
           var dfd = pendings[handle];
           if ( dfd ) {
-            dfd.resolve( instance );
+            dfd.forEach(function (promise) {
+              promise.resolve(instance);
+            });
             delete pendings[handle];
           }
         }
@@ -102,7 +104,10 @@
           if ( instance )  {
             deferred.resolve( instance );
           } else {
-            pendings[handle] = deferred;
+            if (pendings[handle] === undefined) {
+              pendings[handle] = [];
+            }
+            pendings[handle].push(deferred);
           }
 
           return deferred.promise;

--- a/src/core/services/registry/componentRegistry.spec.js
+++ b/src/core/services/registry/componentRegistry.spec.js
@@ -72,6 +72,22 @@ describe('$mdComponentRegistry Service', function() {
       expect(instance).toBe(resolved);
     });
 
+    it('should allow multiple registrations', function() {
+      var promise = $mdComponentRegistry.when('left');
+      var promise1 = $mdComponentRegistry.when('left');
+      var el = setup('md-component-id="left"');
+      var instance = $mdComponentRegistry.get('left');
+      var resolved = false;
+      var resolved1 = false;
+
+      promise.then(function(inst){   resolved = inst;  });
+      promise1.then(function(inst){   resolved1 = inst;  });
+      $timeout.flush();
+
+      expect(instance).toBe(resolved);
+      expect(instance).toBe(resolved1);
+    });
+
     it('should wait for next component registration', function() {
       var resolved;
       var count = 0;


### PR DESCRIPTION
Allows mdComponentRegistry.when() to be used multiple times.  Currently the promise is overridden everytime you call .when().  This pr makes the pending[handle] and array and pushes promises.  All the promises are then resolved when the instance is ready.

Closes https://github.com/angular/material/issues/7846