### PR TITLE
fix(autocomplete): don't apply a background if the autocomplete has a floating label

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -1,6 +1,6 @@
 md-autocomplete.md-THEME_NAME-theme {
   background: '{{background-A100}}';
-  &[disabled] {
+  &[disabled]:not([md-floating-label]) {
     background: '{{background-100}}';
   }
   button {


### PR DESCRIPTION
The grey background should only be applied if the autocomplete doesn't have a floating label.

Closes #7841.