### PR TITLE
chore(): bower-material should update style modules and remove stale files

### DIFF
--- a/scripts/bower-material-release.sh
+++ b/scripts/bower-material-release.sh
@@ -24,10 +24,19 @@ function run {
   cp -Rf dist/* bower-material/
 
   cd bower-material
-  # remove stale layout files; newer ones are in `dist/layouts/`
+
+  # Remove stale files from older builds
   rm -f ./angular-material.layouts.css
   rm -f ./angular-material.layouts.min.css
+  rm -rf ./demos
 
+  # Restructure release files
+  mkdir -p ./modules/css ./modules/scss
+
+  cp ./core/services/layout/*.css ./modules/css
+  cp ./angular-material.scss ./modules/scss
+  cp ./layouts/*.css ./modules/css
+  cp ./layouts/*.scss ./modules/scss
 
   echo "-- Committing and tagging..."
   replaceJsonProp "bower.json" "version" "$VERSION"


### PR DESCRIPTION

* `angular-material.scss` copied into `modules/scss`
* `core/layout/ie_fixes.css` copied into `modules/css`
* `layouts/*.{css,scss}` copied into `modules/{css,scss}`
*  Removed stale `./demos/` folder.
* Core Modules (default + closure) should not contain layout attributes. (only classes)

Fixes #7835