### PR TITLE
fix(md-checkbox) support horizontal centering of blank md-checkbox

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -66,5 +66,9 @@ md-checkbox {
     @include rtl(margin-left, $checkbox-text-margin + $checkbox-width, 0);
     @include rtl(margin-right, 0, $checkbox-text-margin + $checkbox-width);
 
+    &:empty {
+      display: none
+    }
+
   }
 }


### PR DESCRIPTION
A blank md-checkbox will improperly be padded to 30px because md-label's margin-left attribute

With this CSS change, If md-label is empty, then it won't appear and thus, won't pad the checkbox to the right. This works together with md-checkbox:last-of-type so users might have to wrap md-checkbox in a div if it's the only element.

Here's a code pen showing how the change works:

http://codepen.io/shortfuse/pen/MyEvVm

This fixes https://github.com/angular/material/issues/3793

This follows the material design guidelines as shown here under "Column Padding"

https://www.google.com/design/spec/components/data-tables.html#data-tables-specs

Right now there is still an issue with the 16px vertical margin, but that could be reserved for another pull request/issue.