### PR TITLE
fix(icon): icons should have a minimum height.

### DIFF
--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -7,6 +7,10 @@ md-icon {
   height: $icon-size;
   width: $icon-size;
 
+  // The icons should not shrink on smaller viewports.
+  min-height: $icon-size;
+  min-width: $icon-size;
+
   svg {
     pointer-events: none;
     display: block;


### PR DESCRIPTION
* Icons should not shrink on smaller viewport. (At both axis, looks weird and is inconsistent)
* Also fixes an issue in the toolbar demo, where the icons shrink, when the viewport is to small.

As discussed with @topherfangio, icons should have a minimum height.

Fixes #7599