### PR TITLE
feat(progress): add the ability to disable the progressbars

### DIFF
--- a/src/components/progressCircular/demoBasicUsage/index.html
+++ b/src/components/progressCircular/demoBasicUsage/index.html
@@ -26,12 +26,12 @@
       colors.
     </p>
 
-    <div ng-show="vm.activated" layout="row" layout-sm="column" layout-align="space-around">
-      <md-progress-circular class="md-hue-2" md-diameter="20px"></md-progress-circular>
-      <md-progress-circular class="md-accent" md-diameter="40"></md-progress-circular>
-      <md-progress-circular class="md-accent md-hue-1" md-diameter="60"></md-progress-circular>
-      <md-progress-circular class="md-warn md-hue-3" md-diameter="70"></md-progress-circular>
-      <md-progress-circular md-diameter="96"></md-progress-circular>
+    <div layout="row" layout-sm="column" layout-align="space-around">
+      <md-progress-circular ng-disabled="!vm.activated" class="md-hue-2" md-diameter="20px"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-accent" md-diameter="40"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-accent md-hue-1" md-diameter="60"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-warn md-hue-3" md-diameter="70"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" md-diameter="96"></md-progress-circular>
     </div>
   </md-content>
 
@@ -42,12 +42,12 @@
       This is an example of the <b>&lt;md-progress-circular&gt;</b> component, with a dark theme.
     </p>
 
-    <div ng-show="vm.activated" layout="row" layout-sm="column" layout-align="space-around">
-      <md-progress-circular class="md-hue-2" md-diameter="20px"></md-progress-circular>
-      <md-progress-circular class="md-accent" md-diameter="40"></md-progress-circular>
-      <md-progress-circular class="md-accent md-hue-1" md-diameter="60"></md-progress-circular>
-      <md-progress-circular class="md-warn md-hue-3" md-diameter="70"></md-progress-circular>
-      <md-progress-circular md-diameter="96"></md-progress-circular>
+    <div layout="row" layout-sm="column" layout-align="space-around">
+      <md-progress-circular ng-disabled="!vm.activated" class="md-hue-2" md-diameter="20px"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-accent" md-diameter="40"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-accent md-hue-1" md-diameter="60"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" class="md-warn md-hue-3" md-diameter="70"></md-progress-circular>
+      <md-progress-circular ng-disabled="!vm.activated" md-diameter="96"></md-progress-circular>
     </div>
   </md-content>
 

--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -29,6 +29,8 @@
  * should be a pixel-size value (eg '100'). If this attribute is
  * not present then a default value of '50px' is assumed.
  *
+ * @param {boolean=} ng-disabled Determines whether to disable the progress element.
+ *
  * @usage
  * <hljs lang="html">
  * <md-progress-circular md-mode="determinate" value="..."></md-progress-circular>
@@ -52,6 +54,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
   var DEGREE_IN_RADIANS = $window.Math.PI / 180;
   var MODE_DETERMINATE = 'determinate';
   var MODE_INDETERMINATE = 'indeterminate';
+  var DISABLED_CLASS = '_md-progress-circular-disabled';
 
   return {
     restrict: 'E',
@@ -87,8 +90,9 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
   };
 
   function MdProgressCircularLink(scope, element, attrs) {
-    var svg = angular.element(element[0].querySelector('svg'));
-    var path = angular.element(element[0].querySelector('path'));
+    var node = element[0];
+    var svg = angular.element(node.querySelector('svg'));
+    var path = angular.element(node.querySelector('path'));
     var startIndeterminate = $mdProgressCircular.startIndeterminate;
     var endIndeterminate = $mdProgressCircular.endIndeterminate;
     var rotationIndeterminate = 0;
@@ -96,6 +100,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
     var interval;
 
     $mdTheming(element);
+    element.toggleClass(DISABLED_CLASS, attrs.hasOwnProperty('disabled'));
 
     // If the mode is indeterminate, it doesn't need to
     // wait for the next digest. It can start right away.
@@ -103,22 +108,43 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
       startIndeterminateAnimation();
     }
 
-    scope.$watchGroup(['value', 'mdMode'], function(newValues, oldValues) {
-      var mode = newValues[1];
+    scope.$watchGroup(['value', 'mdMode', function() {
+      var isDisabled = node.disabled;
 
-      if (mode !== MODE_DETERMINATE && mode !== MODE_INDETERMINATE) {
-        mode = MODE_INDETERMINATE;
-        attrs.$set('mdMode', mode);
+      // Sometimes the browser doesn't return a boolean, in
+      // which case we should check whether the attribute is
+      // present.
+      if (isDisabled === true || isDisabled === false){
+        return isDisabled;
       }
 
-      if (mode === MODE_INDETERMINATE) {
-        startIndeterminateAnimation();
-      } else {
-        var newValue = clamp(newValues[0]);
+      return angular.isDefined(element.attr('disabled'));
+    }], function(newValues, oldValues) {
+      var mode = newValues[1];
+      var isDisabled = newValues[2];
+      var wasDisabled = oldValues[2];
 
+      if (isDisabled !== wasDisabled) {
+        element.toggleClass(DISABLED_CLASS, !!isDisabled);
+      }
+
+      if (isDisabled) {
         cleanupIndeterminateAnimation();
-        element.attr('aria-valuenow', newValue);
-        renderCircle(clamp(oldValues[0]), newValue);
+      } else {
+        if (mode !== MODE_DETERMINATE && mode !== MODE_INDETERMINATE) {
+          mode = MODE_INDETERMINATE;
+          attrs.$set('mdMode', mode);
+        }
+
+        if (mode === MODE_INDETERMINATE) {
+          startIndeterminateAnimation();
+        } else {
+          var newValue = clamp(newValues[0]);
+
+          cleanupIndeterminateAnimation();
+          element.attr('aria-valuenow', newValue);
+          renderCircle(clamp(oldValues[0]), newValue);
+        }
       }
 
     });
@@ -159,7 +185,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
         path.attr('d', getSvgArc(animateTo, diameter, pathDiameter, rotation));
       } else {
         $$rAF(function animation(now) {
-          var currentTime = $window.Math.min((now || $mdUtil.now()) - startTime, animationDuration);
+          var currentTime = $window.Math.max(0, $window.Math.min((now || $mdUtil.now()) - startTime, animationDuration));
 
           path.attr('d', getSvgArc(
             ease(currentTime, animateFrom, changeInValue, animationDuration),

--- a/src/components/progressCircular/js/progressCircularProvider.js
+++ b/src/components/progressCircular/js/progressCircularProvider.js
@@ -44,7 +44,7 @@ function MdProgressCircularProvider() {
   var progressConfig = {
     progressSize: 50,
     strokeWidth: 10,
-    duration: 100,
+    duration: 1000,
     easeFn: linearEase,
 
     durationIndeterminate: 500,

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -2,6 +2,10 @@
 md-progress-circular {
     position: relative;
 
+    &._md-progress-circular-disabled {
+        visibility: hidden;
+    }
+
     svg {
         position: absolute;
         overflow: visible;

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -98,6 +98,14 @@ describe('mdProgressCircular', function() {
     expect(path.css('stroke-width')).toBe(diameter / ratio + 'px');
   });
 
+  it('should hide the element if is disabled', function() {
+    var element = buildIndicator(
+      '<md-progress-circular disabled></md-progress-circular>'
+    );
+
+    expect(element.hasClass('_md-progress-circular-disabled')).toBe(true);
+  });
+
   /**
    * Build a progressCircular
    */
@@ -108,4 +116,20 @@ describe('mdProgressCircular', function() {
     return element;
   }
 
+});
+
+describe('mdProgressCircularProvider', function() {
+    beforeEach(function() {
+        module('material.components.progressCircular', function($mdProgressCircularProvider) {
+          $mdProgressCircularProvider.configure({
+            progressSize: 1337,
+            strokeWidth: 42
+          });
+        });
+    });
+
+    it('should allow for the default options to be configured', inject(function($mdProgressCircular) {
+        expect($mdProgressCircular.progressSize).toBe(1337);
+        expect($mdProgressCircular.strokeWidth).toBe(42);
+    }));
 });

--- a/src/components/progressLinear/demoBasicUsage/index.html
+++ b/src/components/progressLinear/demoBasicUsage/index.html
@@ -26,7 +26,7 @@
   </p>
   <md-progress-linear class="md-warn" md-mode="buffer" value="{{vm.determinateValue}}"
                       md-buffer-value="{{vm.determinateValue2}}"
-                      ng-show="vm.showList[0]"></md-progress-linear>
+                      ng-disabled="!vm.showList[0]"></md-progress-linear>
 
   <h4 class="md-title">Query</h4>
 
@@ -36,7 +36,7 @@
   </p>
 
   <div class="container" ng-class="{'visible' : !vm.activated}">
-    <md-progress-linear md-mode="query" ng-show="vm.showList[1]"></md-progress-linear>
+    <md-progress-linear md-mode="query" ng-disabled="!vm.showList[1]"></md-progress-linear>
     <div class="bottom-block">
       <span>Loading application libraries...</span>
     </div>

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -42,6 +42,7 @@ angular.module('material.components.progressLinear', [
  * then `md-mode="determinate"` would be auto-injected instead.
  * @param {number=} value In determinate and buffer modes, this number represents the percentage of the primary progress bar. Default: 0
  * @param {number=} md-buffer-value In the buffer mode, this number represents the percentage of the secondary progress bar. Default: 0
+ * @param {boolean=} ng-disabled Determines whether to disable the progress element.
  *
  * @usage
  * <hljs lang="html">
@@ -57,10 +58,11 @@ angular.module('material.components.progressLinear', [
  * </hljs>
  */
 function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
-  var MODE_DETERMINATE = "determinate",
-      MODE_INDETERMINATE = "indeterminate",
-      MODE_BUFFER = "buffer",
-      MODE_QUERY = "query";
+  var MODE_DETERMINATE = "determinate";
+  var MODE_INDETERMINATE = "indeterminate";
+  var MODE_BUFFER = "buffer";
+  var MODE_QUERY = "query";
+  var DISABLED_CLASS = "_md-progress-linear-disabled";
 
   return {
     restrict: 'E',
@@ -71,7 +73,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
       '</div>',
     compile: compile
   };
-  
+
   function compile(tElement, tAttrs, transclude) {
     tElement.attr('aria-valuemin', 0);
     tElement.attr('aria-valuemax', 100);
@@ -82,12 +84,16 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
   function postLink(scope, element, attr) {
     $mdTheming(element);
 
-    var lastMode, toVendorCSS = $mdUtil.dom.animator.toCss;
-    var bar1 = angular.element(element[0].querySelector('._md-bar1')),
-        bar2 = angular.element(element[0].querySelector('._md-bar2')),
-        container = angular.element(element[0].querySelector('._md-container'));
+    var lastMode;
+    var isDisabled = attr.hasOwnProperty('disabled');
+    var toVendorCSS = $mdUtil.dom.animator.toCss;
+    var bar1 = angular.element(element[0].querySelector('._md-bar1'));
+    var bar2 = angular.element(element[0].querySelector('._md-bar2'));
+    var container = angular.element(element[0].querySelector('._md-container'));
 
-    element.attr('md-mode', mode());
+    element
+      .attr('md-mode', mode())
+      .toggleClass(DISABLED_CLASS, isDisabled);
 
     validateMode();
     watchAttributes();
@@ -105,6 +111,16 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
 
       attr.$observe('mdBufferValue', function(value) {
         animateIndicator(bar1, clamp(value));
+      });
+
+      attr.$observe('disabled', function(value) {
+        if (value === true || value === false) {
+          isDisabled = value;
+        } else {
+          isDisabled = angular.isDefined(value);
+        }
+
+        element.toggleClass(DISABLED_CLASS, !!isDisabled);
       });
 
       attr.$observe('mdMode',function(mode){
@@ -136,7 +152,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
         $log.debug( $mdUtil.supplant(info, [mode]) );
 
         element.attr("md-mode",mode);
-        attr['mdMode'] = mode;
+        attr.mdMode = mode;
       }
     }
 
@@ -165,7 +181,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
      * percentage value (0-100).
      */
     function animateIndicator(target, value) {
-      if ( !mode() ) return;
+      if ( isDisabled || !mode() ) return;
 
       var to = $mdUtil.supplant("translateX({0}%) scale({1},1)", [ (value-100)/2, value/100 ]);
       var styles = toVendorCSS({ transform : to });

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -9,6 +9,10 @@ md-progress-linear {
   padding-top: 0 !important;
   margin-bottom: 0 !important;
 
+  &._md-progress-linear-disabled {
+    visibility: hidden;
+  }
+
   ._md-container {
     display:block;
     position: relative;
@@ -83,7 +87,8 @@ md-progress-linear {
       }
     }
 
-    &.ng-hide {
+    &.ng-hide
+    ._md-progress-linear-disabled & {
       animation: none;
 
       ._md-bar1 {

--- a/src/components/progressLinear/progress-linear.spec.js
+++ b/src/components/progressLinear/progress-linear.spec.js
@@ -136,4 +136,15 @@ describe('mdProgressLinear', function() {
 
     expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toBeFalsy();
   }));
+
+  it('should hide the element if it is disabled', inject(function($compile, $rootScope) {
+    var element = $compile('<div>' +
+      '<md-progress-linear value="25" disabled>' +
+      '</md-progress-linear>' +
+      '</div>')($rootScope);
+
+    var progress = element.find('md-progress-linear').eq(0);
+
+    expect(progress.hasClass('_md-progress-linear-disabled')).toBe(true);
+  }));
 });


### PR DESCRIPTION
* Adds support for `ngDisabled` to the `progressCircular` and `progressLinear` components. Hides the element and stops all rendering if the element is disabled.
* Fixes a potential weird appearance in `progressCircular` if the animation time goes below 0.
* Adds some missing coverage for the `$mdProgressCircularProvider`.

@ThomasBurleson this is as discussed on Friday. 