### PR TITLE
perf(progress-circular): proper cleanup when the element gets destroyed or the animations are flushed

### DIFF
--- a/src/components/progressCircular/js/progressCircularProvider.js
+++ b/src/components/progressCircular/js/progressCircularProvider.js
@@ -44,7 +44,7 @@ function MdProgressCircularProvider() {
   var progressConfig = {
     progressSize: 50,
     strokeWidth: 10,
-    duration: 1000,
+    duration: 100,
     easeFn: linearEase,
 
     durationIndeterminate: 500,

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -106,6 +106,11 @@ describe('mdProgressCircular', function() {
     expect(element.hasClass('_md-progress-circular-disabled')).toBe(true);
   });
 
+  it('should not throw the browser in an infinite loop when flushing the animations', inject(function($animate) {
+    var progress = buildIndicator('<md-progress-circular md-mode="indeterminate"></md-progress-circular>');
+    $animate.flush();
+  }));
+
   /**
    * Build a progressCircular
    */

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -148,7 +148,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         .find('md-content')
         .prepend(angular.element(
           '<div>' +
-          ' <md-progress-circular md-mode="{{progressMode}}" ng-hide="$$loadingAsyncDone" md-diameter="25px"></md-progress-circular>' +
+          ' <md-progress-circular md-mode="indeterminate" ng-if="!$$loadingAsyncDone" md-diameter="25px"></md-progress-circular>' +
           '</div>'
         ));
 
@@ -1135,12 +1135,10 @@ function SelectProvider($$interimElementProvider) {
       function watchAsyncLoad() {
         if (opts.loadingAsync && !opts.isRemoved) {
           scope.$$loadingAsyncDone = false;
-          scope.progressMode = 'indeterminate';
 
           $q.when(opts.loadingAsync)
             .then(function() {
               scope.$$loadingAsyncDone = true;
-              scope.progressMode = '';
               delete opts.loadingAsync;
             }).then(function() {
               $$rAF(positionAndFocusMenu);


### PR DESCRIPTION
* Fixes the `$interval` that does the indeterminate animation not being cancelled when the element is destroyed.
* Fixes the `$$rAF` that does the indeterminate rotation being kicked into an infinite loop when calling `$animate.flush`.
* Fixes the select progressbar continuing to render while it's hidden.

@ThomasBurleson this fixes the unit test issues that @robertmesserle and @ErinCoughlan were having.