### PR TITLE
fix(a): default accent color removed

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -157,17 +157,19 @@
 }
 
 a.md-THEME_NAME-theme:not(.md-button) {
-  color: '{{accent-color}}';
-
-  &:hover {
-    color: '{{accent-700}}';
-  }
-
   &.md-primary {
     color: '{{primary-color}}';
 
     &:hover {
       color: '{{primary-700}}';
+    }
+  }
+  
+  &.md-accent {
+    color: '{{accent-color}}';
+
+    &:hover {
+      color: '{{accent-700}}';
     }
   }
 


### PR DESCRIPTION
- Moved default accent color to `md-accent` class as we don't want to force accent color on a element

fixed #7879