### PR TITLE
fix(select): md-checkbox inside md-list-item using incorrect text color.

### DIFF
--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -81,7 +81,7 @@ md-select-menu.md-THEME_NAME-theme {
   }
 }
 
-[md-checkbox-enabled].md-THEME_NAME-theme {
+._md-checkbox-enabled.md-THEME_NAME-theme {
   @include checkbox-primary('[selected]');
 
   md-option ._md-text {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -792,7 +792,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     var selectCtrl = ctrls[1];
 
     if (selectCtrl.isMultiple) {
-      element.attr('md-checkbox-enabled', '');
+      element.addClass('_md-checkbox-enabled');
       element.prepend(CHECKBOX_SELECTION_INDICATOR.clone());
     }
 

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -236,7 +236,7 @@ md-optgroup {
 }
 
 md-select-menu[multiple] {
-  md-option[md-checkbox-enabled] {
+  md-option._md-checkbox-enabled {
     @include rtl(padding-left, $select-option-padding * 2.5, $select-option-padding);
     @include rtl(padding-right, $select-option-padding, $select-option-padding * 2.5);
 


### PR DESCRIPTION
Hello,

@ThomasBurleson @DevVersion @EladBezalel.

I used an attribute selector which is not picked up by theming service which made some text miss-colored. Here is the fix + screenshot.


Fixes #7885.

Please Review.

![fixedselectcheckboxcss](https://cloud.githubusercontent.com/assets/709204/14291178/25ae79cc-fb17-11e5-8622-b9f992a6f0b0.png)
 