### PR TITLE
perf(progress-circular): switch back to keyframe animation for the rotation

### DIFF
--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -55,6 +55,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
   var MODE_DETERMINATE = 'determinate';
   var MODE_INDETERMINATE = 'indeterminate';
   var DISABLED_CLASS = '_md-progress-circular-disabled';
+  var INDETERMINATE_CLASS = '_md-mode-indeterminate';
 
   return {
     restrict: 'E',
@@ -98,7 +99,6 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
     var rotationIndeterminate = 0;
     var lastAnimationId = 0;
     var lastDrawFrame;
-    var lastRotationFrame;
     var interval;
 
     $mdTheming(element);
@@ -161,6 +161,7 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
     scope.$watch('mdDiameter', function(newValue) {
       var diameter = getSize(newValue);
       var strokeWidth = getStroke(diameter);
+      var transformOrigin = (diameter / 2) + 'px';
       var dimensions = {
         width: diameter + 'px',
         height: diameter + 'px'
@@ -173,7 +174,15 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
 
       // Usually viewBox sets the dimensions for the SVG, however that doesn't
       // seem to be the case on IE10.
-      svg.css(dimensions);
+      // Important! The transform origin has to be set from here and it has to
+      // be in the format of "Ypx Ypx Ypx", otherwise the rotation wobbles in
+      // IE and Edge, because they don't account for the stroke width when
+      // rotating. Also "center" doesn't help in this case, it has to be a
+      // precise value.
+      svg
+        .css(dimensions)
+        .css('transform-origin', transformOrigin + ' ' + transformOrigin + ' ' + transformOrigin);
+
       element.css(dimensions);
       path.css('stroke-width',  strokeWidth + 'px');
     });
@@ -231,36 +240,6 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
 
     function startIndeterminateAnimation() {
       if (!interval) {
-        var startTime = $mdUtil.now();
-        var animationDuration = $mdProgressCircular.rotationDurationIndeterminate;
-        var radius = getSize(scope.mdDiameter) / 2;
-
-        // Spares us at least a little bit of string concatenation.
-        radius = ' ' + radius + ', ' + radius;
-
-        // This animates the indeterminate rotation. This can be achieved much easier
-        // with CSS keyframes, however IE11 seems to have problems centering the rotation
-        // which causes a wobble in the indeterminate animation.
-        lastRotationFrame = $$rAF(function animation(now) {
-          var timestamp = now || $mdUtil.now();
-          var currentTime = timestamp - startTime;
-          var rotation = $mdProgressCircular.easingPresets.linearEase(currentTime, 0, 360, animationDuration);
-
-          path.attr('transform', 'rotate(' + rotation + radius + ')');
-
-          if (interval) {
-            lastRotationFrame && lastRotationFrame();
-            lastRotationFrame = $$rAF(animation);
-          } else {
-            path.removeAttr('transform');
-          }
-
-          // Reset the animation
-          if (currentTime >= animationDuration) {
-            startTime = timestamp;
-          }
-        });
-
         // Note that this interval isn't supposed to trigger a digest.
         interval = $interval(
           animateIndeterminate,
@@ -270,7 +249,10 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
         );
 
         animateIndeterminate();
-        element.removeAttr('aria-valuenow');
+
+        element
+          .addClass(INDETERMINATE_CLASS)
+          .removeAttr('aria-valuenow');
       }
     }
 
@@ -278,13 +260,12 @@ function MdProgressCircularDirective($$rAF, $window, $mdProgressCircular, $mdThe
       if (interval) {
         $interval.cancel(interval);
         interval = null;
+        element.removeClass(INDETERMINATE_CLASS);
       }
 
       if ( clearLastFrames === true ){
         lastDrawFrame && lastDrawFrame();
-        lastRotationFrame && lastRotationFrame();
-
-        lastDrawFrame = lastRotationFrame = undefined;
+        lastDrawFrame = undefined;
       }
     }
   }

--- a/src/components/progressCircular/js/progressCircularProvider.js
+++ b/src/components/progressCircular/js/progressCircularProvider.js
@@ -15,7 +15,6 @@
  * @property {number} durationIndeterminate Duration of the indeterminate animation.
  * @property {number} startIndeterminate Indeterminate animation start point.
  * @property {number} endIndeterminate Indeterminate animation end point.
- * @property {number} rotationDurationIndeterminate Duration of the indeterminate rotating animation.
  * @property {function} easeFnIndeterminate Easing function to be used when animating
  * between the indeterminate values.
  *
@@ -50,7 +49,6 @@ function MdProgressCircularProvider() {
     durationIndeterminate: 500,
     startIndeterminate: 3,
     endIndeterminate: 80,
-    rotationDurationIndeterminate: 2900,
     easeFnIndeterminate: materialEase,
 
     easingPresets: {

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -1,9 +1,20 @@
+$progress-circular-indeterminate-duration: 2.9s !default;
+
+@keyframes indeterminate-rotate {
+    0%       { transform: rotate(0deg); }
+    100%     { transform: rotate(360deg); }
+}
+
 // Used to avoid unnecessary layout
 md-progress-circular {
     position: relative;
 
     &._md-progress-circular-disabled {
         visibility: hidden;
+    }
+
+    &._md-mode-indeterminate svg {
+        animation: indeterminate-rotate $progress-circular-indeterminate-duration linear infinite;
     }
 
     svg {

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -111,6 +111,11 @@ describe('mdProgressCircular', function() {
     $animate.flush();
   }));
 
+  it('should set the transform origin in all dimensions', function() {
+    var svg = buildIndicator('<md-progress-circular md-diameter="42px"></md-progress-circular>').find('svg').eq(0);
+    expect(svg.css('transform-origin')).toBe('21px 21px 21px');
+  });
+
   /**
    * Build a progressCircular
    */


### PR DESCRIPTION
In #7402 I had to fall back to using JS to do the indeterminate rotation, because of IE and Edge which weren't accounting for the element's stroke and caused a wobble in the animation. I managed to work around this issue by specifying the `transform-origin` in all dimensions (x, y and z), as well as using the element's radius as the origin, instead of `center`.

@ThomasBurleson this also spares us one of the `$$rAF` loops that was causing problems with `$animate.flush`.