### PR TITLE
feat(menuFilter): Adding a menu filter directive.

### DIFF
--- a/src/components/menuFilter/demoBasicUsage/index.html
+++ b/src/components/menuFilter/demoBasicUsage/index.html
@@ -1,0 +1,26 @@
+<div ng-controller="menuFilterController as ctrl" class="md-padding" ng-cloak>
+  <div>
+    <h1 class="md-title">Pick a drink below</h1>
+    <div layout="row">
+      <md-input-container>
+        <label>Drinks</label>
+        <md-select ng-model="ctrl.selectedDrinks" multiple
+                   md-on-close="ctrl.clearSearch()"
+                   data-md-container-class="menuFilterdemoBasicUsage">
+          <md-select-header class="demo-select-header">
+            <md-menu-filter items="ctrl.drinks"
+                            placeholder="Select a drink.."
+                            filtered-items="ctrl.filteredDrinks"
+                            ng-model="ctrl.searchTerm"
+                            tabindex="1"
+                            class="demo-header-searchbox">
+            </md-menu-filter>
+          </md-select-header>
+          <md-optgroup label="drinks">
+            <md-option ng-value="drink" ng-repeat="drink in ctrl.filteredDrinks">{{drink}}</md-option>
+          </md-optgroup>
+        </md-select>
+      </md-input-container>
+    </div>
+ </div>
+</div>

--- a/src/components/menuFilter/demoBasicUsage/script.js
+++ b/src/components/menuFilter/demoBasicUsage/script.js
@@ -1,0 +1,49 @@
+angular
+    .module('menuFilterDemo', ['ngMaterial'])
+    .controller('menuFilterController', function($scope, $element) {
+      var menuFilter = $element.find('md-menu-filter');
+      var optGroup = $element.find('md-optgroup');
+
+      // These functions make sure we can use the up and down arrows to interact
+      // with the md-options below the md-filter-menu.
+      optGroup.on('keydown', function(ev) {
+        if (ev.keyCode == 38) {
+          var container = angular.element(ev.currentTarget).parent().parent();
+          var options = container.find('md-option');
+          switch (document.activeElement) {
+            case options[0]:
+              container.find('md-menu-filter').find('input').focus();
+              ev.stopPropagation();
+              break;
+            case options[1]:
+              container.find('md-content')[0].scrollTop = 0;
+              break;
+            default:
+              break;
+          }
+        }
+      });
+      menuFilter.on('keydown', function(ev) {
+        // The md-select eats keydown events which would otherwise disallow users to
+        // type in this directive's input unless this is present.
+        if (ev.keyCode !== 27) {
+          // We still want to close the dialog on esc
+          ev.stopPropagation();
+        }
+
+        if (ev.keyCode == 40 && document.activeElement.tagName !== "MD-OPTION") {
+          var container = angular.element(ev.currentTarget).parent().parent();
+          var options = container.find('md-option');
+          options[0] && options[0].focus();
+          // This prevents the scrolling that normally happens with a down arrow
+          // press.
+          ev.preventDefault();
+        }
+      });
+      this.drinks = ['Soda', 'Water', 'Sparkling Water', 'Juice', 'Milk'];
+      this.filteredDrinks = [];
+      this.searchTerm = '';
+      this.clearSearch = function() {
+        this.searchTerm = '';
+      };
+    });

--- a/src/components/menuFilter/demoBasicUsage/style.css
+++ b/src/components/menuFilter/demoBasicUsage/style.css
@@ -1,0 +1,42 @@
+/* Please note: All these selectors are only applied to children of elements with the 'menuFilterdemoBasicUsage' class */
+
+.demo-header-searchbox {
+  input {
+    border: none;
+    outline: none;
+    height: 100%;
+    width: 150px;
+    padding: 0;
+    border: 0;
+    padding-right: 35px;
+  }
+}
+
+.demo-select-header {
+  box-shadow: 0px 1px 0px 0px rgba(0, 0, 0, 0.1), 0px 0px 0px 0px rgba(0, 0, 0,
+  0.14), 0px 0px 0px 0px rgba(0, 0, 0, 0.12);
+  padding-left: 10.667px;
+  height: 48px;
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+md-optgroup {
+  width: 225px;
+}
+
+md-select-header.demo-select-header {
+  position: fixed;
+  background-color: white;
+  z-index: 1;
+  top: 0;
+}
+
+md-content._md {
+  overflow-x: hidden;
+  margin-top: 48px;
+  max-height: 192px;
+}

--- a/src/components/menuFilter/menu-filter.js
+++ b/src/components/menuFilter/menu-filter.js
@@ -1,0 +1,146 @@
+/**
+ * @ngdoc module
+ * @name material.components.menuFilter
+ */
+
+angular.module('material.components.menuFilter', [
+  'material.core',
+])
+  .directive('mdMenuFilter', MdMenuFilterDirective);
+
+/**
+ * @ngdoc directive
+ * @name mdMenuFilter
+ * @module material.components.menuFilter
+ * @restrict E
+ *
+ * @description
+ * The menu filter directive is used to make adding a searchbar to
+ * the top of a component quick and painless.
+ *
+ * @param {string=} aria-label Optional label for accessibility. Only necessary if no placeholder or
+ *   explicit label is present.
+ * @param {Array=} items The items to filter. This is an input, it will act as a
+ *   list of items to display when there is no search term and to filter through
+ *   when a search term is present.
+ * @param {Array=} filtered-items The variable the filtered results will be stored in.
+ *  This will be overwritten with the values in the 'items' array that substring
+ *  match the 'ng-model' every time the 'ng-model' is updated.
+ *  every time the ng-model is changed.
+ * @param {string} ng-model Assignable angular expression to data-bind the
+ *   search term to, this is the variable the directive watches and triggers
+ *   filtering on.
+ * @param {string=} placeholder Placeholder hint text.
+ * @param {string=} tabindex Optional tab-index for accessibility.
+ *
+ * @usage
+ * <hljs lang="html">
+ *  <md-menu-filter items="ctrl.items"
+ *                  placeholder="Select an item.."
+ *                  filtered-items="ctrl.filteredItems"
+ *                  ng-model="ctrl.searchTerm"
+ *                  tabindex="1"
+ *                  aria-label="search box">
+ *  </md-menu-filter>
+ * </hljs>
+ *
+ * Please Note: When using this in the context of of an md-select directive w/
+ * the 'multiple' attribute enabled - this component cannot detect when that
+ * select menu closes. If the developer does not clear the ng-model on close,
+ * the closed menu will only display the filtered results (although the actual
+ * options selected may range beyond what is currently being filtered). An
+ * example of how one might clear the ng-model on close is provided in the basic
+ * demo.
+ */
+function MdMenuFilterDirective($mdTheming, $mdAria) {
+  return {
+    restrict: 'E',
+    template: '<input ng-model="searchTerm" type="search"' +
+        'class="md-menu-filter _md-text">' +
+            '<button' +
+                ' type="button"' +
+                ' tabindex="-1"' +
+                ' ng-if="searchTerm"' +
+                ' class="_md-search-clear-button"' +
+                ' ng-click="clear()">' +
+              '<md-icon md-svg-icon="md-close"></md-icon>' +
+              '<span class="_md-visually-hidden">Clear</span>' +
+            '</button>',
+    scope: {
+      filteredItems: '=',
+      items: '=',
+      ngModel: '=',
+      ariaLabel: '@?',
+      placeholder: '@?',
+      tabindex: '@?',
+    },
+    link: link
+  };
+
+  function link(scope, element, attr) {
+    var ngModel = element.controller('ngModel');
+
+    $mdTheming(element);
+
+    init();
+
+    function init() {
+      // This is for the clear button that appears when there is a search term.
+      scope.clear = function() {
+        scope.searchTerm = '';
+      };
+
+      var tabindex = (attr.tabindex >= 0) ? attr.tabindex : '-1';
+
+      // Set our tabindex of the md-menu-filter directive to -1 by default,
+      // because the select/menu input will hold the actual tabindex.
+      element.find('input').attr('tabindex', tabindex);
+
+      initNgModel();
+      initTextAttributes();
+    }
+
+    function initNgModel() {
+      scope.$watch('searchTerm', function(item) {
+        ngModel.$setViewValue(item);
+        filterResults(item);
+      });
+
+      ngModel.$render = function() {
+        scope.searchTerm = ngModel.$modelValue;
+      };
+    }
+
+    function initTextAttributes() {
+      var labelText = element.attr('aria-label');
+      var placeholder = element.attr('placeholder');
+
+      if (placeholder) {
+        element.find('input').attr('placeholder', placeholder);
+      }
+
+      if (labelText) {
+        element.attr('aria-label', labelText);
+      } else {
+        placeholder && element.attr('aria-label', placeholder);
+        $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+      }
+    }
+
+    function filterResults(query) {
+      if (query)  {
+        var results = [];
+        query = query.toLowerCase();
+        for (var i = 0; i < scope.items.length; i++) {
+          var item = scope.items[i];
+          if (item.toString().toLowerCase().indexOf(query) > -1) {
+            results.push(item);
+          }
+        }
+        scope.filteredItems = results;
+      } else {
+        scope.filteredItems = scope.items;
+      }
+    }
+  }
+}

--- a/src/components/menuFilter/menu-filter.scss
+++ b/src/components/menuFilter/menu-filter.scss
@@ -1,0 +1,20 @@
+md-menu-filter {
+  &:focus {
+    outline: none;
+  }
+  ._md-search-clear-button {
+    cursor: pointer;
+    background: transparent;
+    border: none;
+    border-radius: 50%;
+    font-size: 12px;
+    height: 30px;
+    margin: auto 5px;
+    padding: 0;
+    position: absolute;
+    right: 5px;
+    transform: translateY(25%);
+    top: 0;
+    width: 30px;
+  }
+}

--- a/src/components/menuFilter/menu-filter.spec.js
+++ b/src/components/menuFilter/menu-filter.spec.js
@@ -1,0 +1,112 @@
+describe('<md-menu-filter>', function() {
+  var el,
+  body,
+  doc,
+  compile,
+  log,
+  rootScope,
+  scopeWithController;
+  var defaultAttrs =
+      'items="ctrl.items" filtered-items="ctrl.filteredItems" ng-model="ctrl.searchTerm" ';
+
+  beforeEach(module('material.components.input'));
+  beforeEach(module('material.components.menuFilter'));
+
+  beforeEach(inject(function($document, $rootScope, $compile, $log) {
+    body = $document[0].body;
+    compile = $compile;
+    doc = $document;
+    log = $log;
+    rootScope = $rootScope;
+    scopeWithController = $rootScope.$new();
+    scopeWithController['ctrl'] = {
+      'items': ['one', 'two', 'three'],
+      'filteredItems': [],
+      'searchTerm': ''
+    };
+  }));
+
+  afterEach(function () {
+    el && el.remove();
+  });
+
+  it('should default tabindex to -1', function() {
+    var filterMenuInput = setupFilterMenu().find('input');
+    expect(filterMenuInput.attr('tabindex')).toBe('-1');
+  });
+
+  it('should set the tabindex to 0 if specified', function() {
+    var filterMenuInput = setupFilterMenu(defaultAttrs + 'tabindex="0"').find('input');
+    expect(filterMenuInput.attr('tabindex')).toBe('0');
+  });
+
+  it('should set the correct positive integer tabindex if specified', function() {
+    var filterMenuInput = setupFilterMenu(defaultAttrs + 'tabindex="3"').find('input');
+    expect(filterMenuInput.attr('tabindex')).toBe('3');
+  });
+
+  it('should show clear search button if search term exists', function() {
+    scopeWithController.ctrl.searchTerm = 'cool beans';
+
+    var filterMenuClearButton = setupFilterMenu().find('button');
+
+    expect(filterMenuClearButton).not.toBe(null);
+  });
+
+  it('should clear search term with clear button', function() {
+    scopeWithController.ctrl.searchTerm = 'cool beans';
+
+    var filterMenuClearButton = setupFilterMenu().find('button');
+
+    filterMenuClearButton.triggerHandler('click');
+    scopeWithController.$apply();
+
+    expect(scopeWithController.ctrl.searchTerm).toBe('');
+  });
+
+  it('should filter the items depending on substring matching', function() {
+    var filterMenu = setupFilterMenu();
+
+    expect(scopeWithController.ctrl.filteredItems.length).toBe(3);
+
+    scopeWithController.ctrl.searchTerm = 'on';
+    scopeWithController.$apply();
+
+    expect(scopeWithController.ctrl.filteredItems.length).toBe(1);
+    expect(scopeWithController.ctrl.filteredItems[0]).toBe('one');
+  });
+
+  it('defaults to the aria-label to the placeholder text if none specified', function() {
+    var filterMenuInput = setupFilterMenu(defaultAttrs + 'placeholder="hello world"').find('input');
+    expect(filterMenuInput.attr('placeholder')).toBe('hello world');
+  });
+
+  it('should preserve existing aria-label', function() {
+    var filterMenu = setupFilterMenu(defaultAttrs + 'aria-label="angular rocks"');
+    expect(filterMenu.attr('aria-label')).toBe('angular rocks');
+  });
+
+  it('should expect an aria-label if none is present', function() {
+    spyOn(log, 'warn');
+
+    setupFilterMenu();
+    rootScope.$apply();
+
+    expect(log.warn).toHaveBeenCalled();
+    log.warn.calls.reset();
+
+    setupFilterMenu(defaultAttrs + 'aria-label="angular rocks"');
+
+    rootScope.$apply();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  function setupFilterMenu(attrs, scope) {
+    var src = '<md-menu-filter ' + (attrs || defaultAttrs) + ' ></md-menu-filter>';
+    var template = angular.element(src);
+    el = compile(template)(scope || scopeWithController || rootScope);
+    rootScope.$digest();
+    return el;
+  }
+
+});


### PR DESCRIPTION
@jelbourn @ErinCoughlan @gmoothart @KarenParker @ThomasBurleson 

Hello,

This is a directive which allows a developer to easily add a search bar to a component (it does substring based filtering). It is particularly keen for the select / menu components but is really a general filtering directive that can be used anywhere. This directive has an clear button that appears when there is a search term.

I tried to design it in such a way that no assumptions are made about how the developer is going to use it.

The demo has keyboard navigation and a sticky header baked in. Please note that this is not apart of the component (as no assumptions are made about where the developer is going to use this directive) but simply serves as an possible example use case.

Fixes #6643 and #7385.

This PR depends on #7782.

Please review. 

Screenshots:

![md-menu-filter1](https://cloud.githubusercontent.com/assets/709204/14547315/2194d308-0261-11e6-95eb-840e161dd848.png)

![md-menu-filter2](https://cloud.githubusercontent.com/assets/709204/14547314/217f8ce6-0261-11e6-98f8-f006c851d11a.png)
