### PR TITLE
fix(gesture): don't trigger swipe if not the main direction

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -305,18 +305,26 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
       onEnd: function (ev, pointer) {
         var eventType;
 
-        if (Math.abs(pointer.distanceX) > Math.abs(pointer.distanceY)) {
-            if (Math.abs(pointer.velocityX) > this.state.options.minVelocity &&
-              Math.abs(pointer.distanceX) > this.state.options.minDistance) {
-              eventType = pointer.directionX == 'left' ? '$md.swipeleft' : '$md.swiperight';
-              this.dispatchEvent(ev, eventType);
-            }
-        } else {
-            if (Math.abs(pointer.velocityY) > this.state.options.minVelocity &&
-              Math.abs(pointer.distanceY) > this.state.options.minDistance) {
-              eventType = pointer.directionY == 'up' ? '$md.swipeup' : '$md.swipedown';
-              this.dispatchEvent(ev, eventType);
-            }
+        if (isHorizontalSwipe(pointer, this.state.options)) {
+          eventType = pointer.directionX == 'left' ? '$md.swipeleft' : '$md.swiperight';
+          this.dispatchEvent(ev, eventType);
+        } else if (isVerticalSwipe(pointer, this.state.options)) {
+          eventType = pointer.directionY == 'up' ? '$md.swipeup' : '$md.swipedown';
+          this.dispatchEvent(ev, eventType);
+        }
+        
+        function isHorizontalSwipe(pointer, options) {
+          // In addition to metric checks, must be more horizontal than vertical
+          return Math.abs(pointer.distanceX) > Math.abs(pointer.distanceY) &&
+            Math.abs(pointer.velocityX) > options.minVelocity &&
+            Math.abs(pointer.distanceX) > options.minDistance;
+        }
+        
+        function isVerticalSwipe(pointer, options) {
+          // In addition to metric checks, must be more vertical than horizontal
+          return Math.abs(pointer.distanceY) > Math.abs(pointer.distanceX) &&
+            Math.abs(pointer.velocityY) > options.minVelocity &&
+            Math.abs(pointer.distanceY) > options.minDistance;
         }
       }
     });

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -169,7 +169,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
    * Register handlers. These listen to touch/start/move events, interpret them,
    * and dispatch gesture events depending on options & conditions. These are all
    * instances of GestureHandler.
-   * @see GestureHandler 
+   * @see GestureHandler
    */
   return self
     /*
@@ -305,15 +305,18 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
       onEnd: function (ev, pointer) {
         var eventType;
 
-        if (Math.abs(pointer.velocityX) > this.state.options.minVelocity &&
-          Math.abs(pointer.distanceX) > this.state.options.minDistance) {
-          eventType = pointer.directionX == 'left' ? '$md.swipeleft' : '$md.swiperight';
-          this.dispatchEvent(ev, eventType);
-        }
-        else if (Math.abs(pointer.velocityY) > this.state.options.minVelocity &&
-          Math.abs(pointer.distanceY) > this.state.options.minDistance) {
-          eventType = pointer.directionY == 'up' ? '$md.swipeup' : '$md.swipedown';
-          this.dispatchEvent(ev, eventType);
+        if (Math.abs(pointer.distanceX) > Math.abs(pointer.distanceY)) {
+            if (Math.abs(pointer.velocityX) > this.state.options.minVelocity &&
+              Math.abs(pointer.distanceX) > this.state.options.minDistance) {
+              eventType = pointer.directionX == 'left' ? '$md.swipeleft' : '$md.swiperight';
+              this.dispatchEvent(ev, eventType);
+            }
+        } else {
+            if (Math.abs(pointer.velocityY) > this.state.options.minVelocity &&
+              Math.abs(pointer.distanceY) > this.state.options.minDistance) {
+              eventType = pointer.directionY == 'up' ? '$md.swipeup' : '$md.swipedown';
+              this.dispatchEvent(ev, eventType);
+            }
         }
       }
     });
@@ -496,7 +499,7 @@ function attachToDocument( $mdGesture, $$MdGestureHandler ) {
      * click event will be sent ~400ms after a touchend event happens.
      * The only way to know if this click is real is to prevent any normal
      * click events, and add a flag to events sent by material so we know not to prevent those.
-     * 
+     *
      * Two exceptions to click events that should be prevented are:
      *  - click events sent by the keyboard (eg form submit)
      *  - events that originate from an Ionic app


### PR DESCRIPTION
A horizontal swipe action should not be triggered if the main direction of
the swipe was actually vertical (and vice versa).

#7911