### PR TITLE
fix(progress-circular): use a non-flushable requestAnimationFrame

### DIFF
--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -106,11 +106,6 @@ describe('mdProgressCircular', function() {
     expect(element.hasClass('_md-progress-circular-disabled')).toBe(true);
   });
 
-  it('should not throw the browser in an infinite loop when flushing the animations', inject(function($animate) {
-    var progress = buildIndicator('<md-progress-circular md-mode="indeterminate"></md-progress-circular>');
-    $animate.flush();
-  }));
-
   it('should set the transform origin in all dimensions', function() {
     var svg = buildIndicator('<md-progress-circular md-diameter="42px"></md-progress-circular>').find('svg').eq(0);
     expect(svg.css('transform-origin')).toBe('21px 21px 21px');


### PR DESCRIPTION
Reverts to using the plain `requestAnimationFrame`, instead of `$$rAF`, in order to avoid infinite loops when calling `$animate.flush`.

@ThomasBurleson this was still causing infinite loops in some of @robertmesserle's tests, so we decided that using `$$rAF` doesn't provide any benefits in this case and we can use the plain `requestAnimationFrame`, which isn't flushable by Angular.