### PR TITLE
fix(css): identify md components for global md styling

### DIFF
--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -16,7 +16,9 @@ angular
 function MdBottomSheetDirective($mdBottomSheet) {
   return {
     restrict: 'E',
-    link : function postLink(scope, element, attr) {
+    link : function postLink(scope, element) {
+      element.addClass('_md');     // private md component indicator for styling
+
       // When navigation force destroys an interimElement, then
       // listen and $destroy() that interim instance...
       scope.$on('$destroy', function() {

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -2,6 +2,19 @@ describe('$mdBottomSheet service', function () {
   beforeEach(module('material.components.bottomSheet'));
 
   describe('#build()', function () {
+    it('should have `._md` class indicator',
+      inject(function ($mdBottomSheet, $rootElement, $material) {
+        var parent = angular.element('<div>');
+        $mdBottomSheet.show({
+          template: '<md-bottom-sheet>',
+          parent: parent
+        });
+        $material.flushOutstandingAnimations();
+
+        var sheet = parent.find('md-bottom-sheet');
+        expect(sheet.hasClass('_md')).toBe(true);
+    }));
+
     it('should not close when `clickOutsideToClose == true`',
       inject(function ($mdBottomSheet, $rootElement, $material) {
         var parent = angular.element('<div>');

--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -156,7 +156,8 @@
   }
 }
 
-a.md-THEME_NAME-theme:not(.md-button) {
+a.md-THEME_NAME-theme:not(.md-button),
+._md a:not(.md-button) {
   &.md-primary {
     color: '{{primary-color}}';
 

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -122,7 +122,8 @@ angular.module('material.components.card', [
 function mdCardDirective($mdTheming) {
   return {
     restrict: 'E',
-    link: function ($scope, $element) {
+    link: function ($scope, $element, attr) {
+      $element.addClass('_md');     // private md component indicator for styling
       $mdTheming($element);
     }
   };

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -12,4 +12,10 @@ describe('mdCard directive', function() {
     $compile('<md-card></md-card>')($rootScope.$new());
     expect($mdThemingMock.called).toBe(true);
   }));
+
+  it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+    var element = $compile('<md-card></md-card>')($rootScope.$new());
+    expect(element.hasClass('_md')).toBe(true);
+  }));
+  
 });

--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -48,8 +48,8 @@ function mdContentDirective($mdTheming) {
   return {
     restrict: 'E',
     controller: ['$scope', '$element', ContentController],
-    link: function(scope, element, attr) {
-      var node = element[0];
+    link: function(scope, element) {
+      element.addClass('_md');     // private md component indicator for styling
 
       $mdTheming(element);
       scope.$broadcast('$mdContentLoaded', element);

--- a/src/components/content/content.spec.js
+++ b/src/components/content/content.spec.js
@@ -1,0 +1,10 @@
+describe('mdContent directive', function() {
+
+  beforeEach(module('material.components.content'));
+
+  it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+    var element = $compile('<md-content></md-content>')($rootScope.$new());
+    expect(element.hasClass('_md')).toBe(true);
+  }));
+  
+});

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -50,7 +50,9 @@ angular
 function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
   return {
     restrict: 'E',
-    link: function(scope, element, attr) {
+    link: function(scope, element) {
+      element.addClass('_md');     // private md component indicator for styling
+
       $mdTheming(element);
       $$rAF(function() {
         var images;

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -24,6 +24,13 @@ describe('$mdDialog', function() {
     };
   }));
 
+  describe('md-dialog', function() {
+    it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+      var element = $compile('<md-dialog></md-dialog>')($rootScope.$new());
+      expect(element.hasClass('_md')).toBe(true);
+    }));
+  });
+
   describe('#alert()', function() {
     hasConfigurationMethods('alert', [
       'title', 'htmlContent', 'textContent', 'ariaLabel',

--- a/src/components/gridList/grid-list.js
+++ b/src/components/gridList/grid-list.js
@@ -104,6 +104,8 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
   };
 
   function postLink(scope, element, attrs, ctrl) {
+    element.addClass('_md');     // private md component indicator for styling
+    
     // Apply semantics
     element.attr('role', 'list');
 

--- a/src/components/gridList/grid-list.spec.js
+++ b/src/components/gridList/grid-list.spec.js
@@ -1,11 +1,11 @@
-
 describe('md-grid-list', function() {
 
   beforeEach(module('ngAria'));
   beforeEach(module('material.components.gridList'));
 
-  it('should ', function() {
-
-  });
+  it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+    var element = $compile('<md-grid-list></md-grid-list>')($rootScope.$new());
+    expect(element.hasClass('_md')).toBe(true);
+  }));
 
 });

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -230,7 +230,8 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       return postLink;
 
       function postLink($scope, $element, $attr, ctrl) {
-
+        $element.addClass('_md');     // private md component indicator for styling
+        
         var proxies       = [],
             firstElement  = $element[0].firstElementChild,
             isButtonWrap  = $element.hasClass('_md-button-wrap'),

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -26,6 +26,13 @@ describe('mdListItem directive', function() {
     return el;
   }
 
+  describe('md-list-item', function() {
+    it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+      var element = $compile('<md-list><md-list-item></md-list-item></md-list>')($rootScope.$new());
+      expect(element.find('md-list-item').hasClass('_md')).toBe(true);
+    }));
+  });
+
   it('forwards click events for md-checkbox', function() {
     var listItem = setup(
       '<md-list-item>' +

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -191,14 +191,15 @@ function MenuDirective($mdUtil) {
     return link;
   }
 
-  function link(scope, element, attrs, ctrls) {
+  function link(scope, element, attr, ctrls) {
     var mdMenuCtrl = ctrls[0];
     var isInMenuBar = ctrls[1] != undefined;
     // Move everything into a md-menu-container and pass it to the controller
-    var menuContainer = angular.element(
-      '<div class="_md-open-menu-container md-whiteframe-z2"></div>'
-    );
+    var menuContainer = angular.element( '<div class="_md _md-open-menu-container md-whiteframe-z2"></div>');
     var menuContents = element.children()[1];
+
+    element.addClass('_md');     // private md component indicator for styling
+
     if (!menuContents.hasAttribute('role')) {
       menuContents.setAttribute('role', 'menu');
     }
@@ -211,5 +212,6 @@ function MenuDirective($mdUtil) {
     element.append(menuContainer);
     menuContainer[0].style.display = 'none';
     mdMenuCtrl.init(menuContainer, { isInMenuBar: isInMenuBar });
+
   }
 }

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -20,6 +20,11 @@ describe('material.components.menu', function() {
 
   describe('md-menu directive', function() {
 
+    it('should have `._md` class indicator', function() {
+      var element = setup();
+      expect(element.hasClass('_md')).toBe(true);
+    });
+
     it('errors on invalid markup', inject(function($compile, $rootScope) {
       function buildBadMenu() {
         $compile('<md-menu></md-menu>')($rootScope);

--- a/src/components/menuBar/js/menuBarDirective.js
+++ b/src/components/menuBar/js/menuBarDirective.js
@@ -120,7 +120,8 @@ function MenuBarDirective($mdUtil, $mdTheming) {
         }
       });
 
-      return function postLink(scope, el, attrs, ctrl) {
+      return function postLink(scope, el, attr, ctrl) {
+        el.addClass('_md');     // private md component indicator for styling
         $mdTheming(scope, el);
         ctrl.init();
       };

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -12,6 +12,12 @@ describe('material.components.menuBar', function() {
 
   describe('MenuBar', function() {
     describe('MenuBar Directive', function() {
+
+      it('should have `._md` class indicator', function() {
+        var element = setup();
+        expect(element.hasClass('_md')).toBe(true);
+      });
+
       it('sets md-position-mode to "bottom left" on nested menus', function() {
         var menuBar = setup();
         var nestedMenu = menuBar[0].querySelector('md-menu');

--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -60,7 +60,9 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
   };
 
   function linkRadioGroup(scope, element, attr, ctrls) {
+    element.addClass('_md');     // private md component indicator for styling
     $mdTheming(element);
+    
     var rgCtrl = ctrls[0];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
 

--- a/src/components/radioButton/radio-button.spec.js
+++ b/src/components/radioButton/radio-button.spec.js
@@ -3,6 +3,15 @@ describe('radioButton', function() {
 
   beforeEach(module('material.components.radioButton'));
 
+  it('should have `._md` class indicator',inject(function($compile, $rootScope) {
+    var element = $compile('<md-radio-group ng-model="color">' +
+                               '<md-radio-button value="blue"></md-radio-button>' +
+                               '<md-radio-button value="green"></md-radio-button>' +
+                             '</md-radio-group>')($rootScope);
+
+    expect(element.hasClass('_md')).toBe(true);
+  }));
+
   it('should set checked css class', inject(function($compile, $rootScope) {
     var element = $compile('<md-radio-group ng-model="color">' +
                             '<md-radio-button value="blue"></md-radio-button>' +

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -519,6 +519,8 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
   function preLink(scope, element, attr, ctrls) {
     var selectCtrl = ctrls[0];
 
+    element.addClass('_md');     // private md component indicator for styling
+    
     $mdTheming(element);
     element.on('click', clickListener);
     element.on('keypress', keyListener);

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -30,6 +30,12 @@ describe('<md-select>', function() {
     backdrops.remove();
   }));
 
+
+  it('should have `._md` class indicator', function() {
+    var element = setupSelect('ng-model="val"').find('md-select-menu');
+    expect(element.hasClass('_md')).toBe(true);
+  });
+
   it('should preserve tabindex', function() {
     var select = setupSelect('tabindex="2" ng-model="val"').find('md-select');
     expect(select.attr('tabindex')).toBe('2');

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -246,7 +246,8 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     if (!angular.isDefined(attr.mdDisableBackdrop)) {
       backdrop = $mdUtil.createBackdrop(scope, "_md-sidenav-backdrop md-opaque ng-enter");
     }
-
+    
+    element.addClass('_md');     // private md component indicator for styling
     $mdTheming(element);
 
     // The backdrop should inherit the sidenavs theme,

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -15,6 +15,13 @@ describe('mdSidenav', function() {
 
   describe('directive', function() {
 
+    it('should have `._md` class indicator', inject(function($rootScope) {
+      var element = setup('md-is-open="show"');
+
+      $rootScope.$apply('show = true');
+      expect(element.hasClass('_md')).toBe(true);
+    }));
+
     it('should bind isOpen attribute', inject(function($rootScope, $material) {
       var el = setup('md-is-open="show"');
       $rootScope.$apply('show = true');

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -27,7 +27,6 @@ function SliderContainerDirective() {
     controller: function () {},
     compile: function (elem) {
       var slider = elem.find('md-slider');
-
       if (!slider) {
         return;
       }
@@ -42,7 +41,8 @@ function SliderContainerDirective() {
         slider.attr('flex', '');
       }
 
-      return function (scope, element, attr, ctrl) {
+      return function postLink(scope, element, attr, ctrl) {
+        element.addClass('_md');     // private md component indicator for styling
 
         // We have to manually stop the $watch on ngDisabled because it exists
         // on the parent scope, and won't be automatically destroyed when
@@ -53,6 +53,7 @@ function SliderContainerDirective() {
         }
 
         var stopDisabledWatch = angular.noop;
+
         if (attr.disabled) {
           setDisable(true);
         }

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -42,7 +42,9 @@ describe('md-slider', function() {
   function getWrapper(slider) {
     return angular.element(slider[0].querySelector('._md-slider-wrapper'));
   }
-  
+
+
+
   it('should not set model below the min', function() {
     var slider = setup('ng-model="value" min="0" max="100"');
     pageScope.$apply('value = -50');
@@ -486,6 +488,12 @@ describe('md-slider', function() {
   });
 
   describe('slider container', function () {
+
+    it('should have `._md` class indicator', inject(function() {
+      var element = setupContainer('disabled="disabled"');
+      expect(element.hasClass('_md')).toBe(true);
+    }));
+
     it('should disable via the `disabled` attribute', function() {
       var container = setupContainer('disabled="disabled"');
       var slider = angular.element(container[0].querySelector('md-slider'));

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -47,7 +47,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     replace: true,
     transclude: true,
     template: (
-    '<div class="md-subheader">' +
+    '<div class="md-subheader _md">' +
     '  <div class="_md-subheader-inner">' +
     '    <span class="_md-subheader-content"></span>' +
     '  </div>' +
@@ -55,6 +55,8 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     ),
     link: function postLink(scope, element, attr, controllers, transclude) {
       $mdTheming(element);
+      element.addClass('_md');
+      
       var outerHTML = element[0].outerHTML;
 
       function getContent(el) {

--- a/src/components/subheader/subheader.spec.js
+++ b/src/components/subheader/subheader.spec.js
@@ -18,6 +18,16 @@ describe('mdSubheader', function() {
     $exceptionHandler = _$exceptionHandler_;
   }));
 
+
+  it('should have `._md` class indicator', inject(function() {
+    build('<div><md-subheader>Hello {{ to }}!</md-subheader></div>');
+    pageScope.to = 'world';
+    pageScope.$digest();
+
+    expect(element.children().hasClass('_md')).toBe(true);
+  }));
+
+
   it('preserves content', function() {
     build('<div><md-subheader>Hello {{ to }}!</md-subheader></div>');
     pageScope.to = 'world';

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -171,9 +171,10 @@ function MdTabs () {
             '</div> ' +
           '</md-tabs-canvas> ' +
         '</md-tabs-wrapper> ' +
-        '<md-tabs-content-wrapper ng-show="$mdTabsCtrl.hasContent && $mdTabsCtrl.selectedIndex >= 0"> ' +
+        '<md-tabs-content-wrapper ng-show="$mdTabsCtrl.hasContent && $mdTabsCtrl.selectedIndex >= 0" class="_md"> ' +
           '<md-tab-content ' +
               'id="tab-content-{{::tab.id}}" ' +
+              'class="_md" ' +
               'role="tabpanel" ' +
               'aria-labelledby="tab-item-{{::tab.id}}" ' +
               'md-swipe-left="$mdTabsCtrl.swipeContent && $mdTabsCtrl.incrementIndex(1)" ' +

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -57,11 +57,24 @@ describe('<md-tabs>', function () {
 
   describe('activating tabs', function () {
 
+    it('should have `._md` class indicator', inject(function() {
+      var tabs = setup(
+        '<md-tabs> ' +
+        '   <md-tab label="a">a</md-tab>' +
+        '   <md-tab label="b">b</md-tab>' +
+        '</md-tabs>'
+      );
+
+      expect(tabs.find('md-tabs-content-wrapper').hasClass('_md')).toBe(true);
+    }));
+
     it('should select first tab by default', function () {
-      var tabs = setup('<md-tabs>\
-            <md-tab label="a">a</md-tab>\
-            <md-tab label="b">b</md-tab>\
-          </md-tabs>');
+      var tabs = setup(
+              '<md-tabs> ' +
+              '   <md-tab label="a">a</md-tab>' +
+              '   <md-tab label="b">b</md-tab>' +
+              '</md-tabs>'
+          );
       expect(tabs.find('md-tab-item').eq(0)).toBeActiveTab();
     });
 

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -15,7 +15,9 @@ angular.module('material.components.toast', [
 function MdToastDirective($mdToast) {
   return {
     restrict: 'E',
-    link: function postLink(scope, element, attr) {
+    link: function postLink(scope, element) {
+      element.addClass('_md');     // private md component indicator for styling
+      
       // When navigation force destroys an interimElement, then
       // listen and $destroy() that interim instance...
       scope.$on('$destroy', function() {

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -25,7 +25,23 @@ describe('$mdToast service', function() {
   }
 
   describe('simple()', function() {
+
     hasConfigMethods(['content', 'action', 'capsule', 'highlightAction', 'theme']);
+
+    it('should have `._md` class indicator', inject(function($mdToast, $material) {
+      var parent = angular.element('<div>');
+
+      $mdToast.show(
+        $mdToast.simple({
+          parent: parent,
+          content: 'Do something',
+          theme: 'some-theme',
+          capsule: true
+      }));
+      $material.flushOutstandingAnimations();
+
+      expect(parent.find('md-toast').hasClass('_md')).toBe(true);
+    }));
 
     it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $material, $browser) {
       var openAndclosed = false;

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -65,11 +65,11 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
 
   return {
     template: '',
-
     restrict: 'E',
 
     link: function(scope, element, attr) {
 
+      element.addClass('_md');     // private md component indicator for styling
       $mdTheming(element);
 
       if (angular.isDefined(attr.mdScrollShrink)) {

--- a/src/components/toolbar/toolbar.spec.js
+++ b/src/components/toolbar/toolbar.spec.js
@@ -237,6 +237,17 @@ describe('<md-toolbar>', function() {
     expect($exceptionHandler.errors).toEqual([]);
   }));
 
+  it('should have `._md` class indicator', inject(function() {
+    build(
+      '<div>' +
+      '  <md-toolbar></md-toolbar>' +
+      '  <md-content></md-content>' +
+      '</div>'
+    );
+
+    expect(element.find('md-toolbar').hasClass('_md')).toBe(true);
+  }));
+
   it('disables scroll shrink when the attribute is not provided', inject(function() {
     build(
       '<div>' +

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -42,7 +42,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     restrict: 'E',
     transclude: true,
     priority:210, // Before ngAria
-    template: '<div class="_md-content" ng-transclude></div>',
+    template: '<div class="_md-content _md" ng-transclude></div>',
     scope: {
       delay: '=?mdDelay',
       visible: '=?mdVisible',


### PR DESCRIPTION
* add private classname "._md" to all md component containers to all global md-only stylings
* button-theme `<a>` styles now support `._md a:not(.md-button)` to style anchor tags used inside md containers