### PR TITLE
fix(menu): allow md-menu-align-target anywhere in the md-menu-content

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -412,9 +412,8 @@ function MenuProvider($$interimElementProvider) {
       if (positionMode.top == 'target' || positionMode.left == 'target' || positionMode.left == 'target-right') {
         alignTarget = firstVisibleChild();
         if ( alignTarget ) {
-          // TODO: Allow centering on an arbitrary node, for now center on first menu-item's child
           alignTarget = alignTarget.firstElementChild || alignTarget;
-          alignTarget = alignTarget.querySelector('[md-menu-align-target]') || alignTarget;
+          alignTarget = containerNode.querySelector('[md-menu-align-target]') || alignTarget;
           alignTargetRect = alignTarget.getBoundingClientRect();
 
           existingOffsets = {


### PR DESCRIPTION
There is no reason to only search the first menu item for
md-menu-align-target, as mentioned in the TODO comment. This commit
searches the entire md-menu-content for the alignment target instead.