### PR TITLE
feat(floating labels) use expressions

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -576,10 +576,10 @@ function placeholderDirective($log) {
     if (!inputContainer) return;
 
     var label = inputContainer.element.find('label');
-    var hasNoFloat = angular.isDefined(inputContainer.element.attr('md-no-float'));
+    var noFloat = inputContainer.element.attr('md-no-float');
 
     // If we have a label, or they specify the md-no-float attribute, just return
-    if ((label && label.length) || hasNoFloat) {
+    if ((label && label.length) || noFloat === '' || scope.$eval(noFloat)) {
       // Add a placeholder class so we can target it in the CSS
       inputContainer.setHasPlaceholder(true);
       return;

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -346,6 +346,49 @@ describe('md-input-container directive', function() {
     expect(label.textContent).toEqual('some placeholder');
   });
 
+  it('should not create a floating label from a placeholder if md-no-float is empty', function () {
+    var el = compile(
+      '<md-input-container md-no-float>' +
+      '  <input placeholder="Foo" ng-model="foo">' +
+      '</md-input-container>'
+    );
+
+    expect(el.find('label').length).toBe(0);
+  });
+
+  it('should not create a floating label from a placeholder if md-no-float is truthy', function () {
+    pageScope.inputs = [{
+      placeholder: 'Name',
+      model: ''
+    }, {
+      placeholder: 'Email',
+      model: ''
+    }];
+
+    var el = compile(
+      '<div>' +
+      '  <md-input-container ng-repeat="input in inputs" md-no-float="$index !== 0">' +
+      '    <input placeholder="{{input.placeholder}}" ng-model="input.model">' +
+      '  </md-input-container>' +
+      '</div>'
+    );
+
+    var labels = el.find('label');
+
+    expect(labels.length).toBe(1);
+    expect(labels[0].textContent).toEqual('Name');
+  });
+
+  it('should create a floating label from a placeholder if md-no-float is falsey', function () {
+    var el = compile(
+      '<md-input-container md-no-float="false">' +
+      '  <input placeholder="Foo" ng-model="foo">' +
+      '</md-input-container>'
+    );
+
+    expect(el.find('label').length).toBe(1);
+  });
+
   it('should ignore placeholder when a label element is present', inject(function($rootScope, $compile) {
     var el = $compile(
       '<md-input-container>' +


### PR DESCRIPTION
Use expressions to conditionally disable floating labels. Floating labels will be disabled if

1. The `md-no-float` attribute exists and is empty, or
2. The `md-no-float` attribute evaluates to true.

In the docs, `@param md-no-float {boolean=}`.