### PR TITLE
fix(list): clickable list-items should show a focus effect.

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -146,7 +146,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
           // Button which shows ripple and executes primary action.
           var buttonWrap = angular.element(
-            '<md-button class="_md-no-style" md-no-focus-style></md-button>'
+            '<md-button class="_md-no-style"></md-button>'
           );
 
           buttonWrap[0].setAttribute('aria-label', tEl[0].textContent);


### PR DESCRIPTION
* Currently the focus effect was completely disabled for clickable list-items, because there were problems with the dialog focus restore.

This focus effect, should be re-enabled on the clickable list items.
But we should also keep track of the dialog focus restore issue. (See #7963)

Fixes #7960.

cc. @robertmesserle 