### PR TITLE
feat(md-ink-explode): New directive for ink circle outside the element

### DIFF
--- a/src/core/services/ripple/explode_ripple.js
+++ b/src/core/services/ripple/explode_ripple.js
@@ -12,7 +12,7 @@ angular.module('material.core')
  * element that this directive is on is clicked. This can be used for transitions to another state.
  *
  * @param {string} md-ink-explode A DOM selector for the container to be passed to QuerySelector()
- * @param {number} md-ink-explode-dur The duration of the explode from start to finish
+ * @param {number} md-ink-explode-duration The duration of the explode from start to finish
  * @param {string} md-ink-explode-color A hex, rgb or rgba color string
  *
  * @usage
@@ -45,20 +45,18 @@ angular.module('material.core')
  *     Ripples if 'canRipple' function return value is not 'false' or '0'
  *   </ANY>
  * </hljs>
- *  Note: The container and duration will not observe changes to the Interpolated values via
- *  `md-ink-explode={{ContainerSelector}}` The initial values will be the final values.
  */
-function InkExplodeRippleDirective($mdInkRipple) {
-    return{
-        controller: angular.noop,
-        link: function(scope,element,attr){
-            $mdInkRipple.attach(scope, angular.element(element), {
-                center: false,
-                dimBackground: false,
-                fitRipple: false,
-                duration: parseInt(attr.mdInkExplodeDur) || 1000,
-                inkExplode: true
-            });
-        }
+function InkExplodeRippleDirective ($mdInkRipple) {
+  return {
+    controller: angular.noop,
+    link:       function (scope, element, attr) {
+      $mdInkRipple.attach(scope, angular.element(element), {
+        center:        false,
+        dimBackground: false,
+        fitRipple:     false,
+        duration:      parseInt(attr.mdInkExplodeDuration) || 1000,
+        inkExplode:    true
+      });
     }
+  }
 }

--- a/src/core/services/ripple/explode_ripple.js
+++ b/src/core/services/ripple/explode_ripple.js
@@ -1,0 +1,64 @@
+angular.module('material.core')
+    .directive('mdInkExplode', InkExplodeRippleDirective);
+
+
+/**
+ * @ngdoc directive
+ * @name mdInkExplode
+ * @module material.core
+ *
+ * @description
+ * The `md-ink-explode` directive allows you to specify a different container for the ripple to take place in when the
+ * element that this directive is on is clicked. This can be used for transitions to another state.
+ *
+ * @param {string} md-ink-explode A DOM selector for the container to be passed to QuerySelector()
+ * @param {number} md-ink-explode-dur The duration of the explode from start to finish
+ * @param {string} md-ink-explode-color A hex, rgb or rgba color string
+ *
+ * @usage
+ * ### String values
+ * <hljs lang="html">
+ *   <ANY id="rippleContainer">
+ *       <ANY md-ink-ripple="#FF0000" md-ink-explode="#rippleContainer">
+ *         Ripples in red
+ *       </ANY>
+ *   </ANY>
+ *
+ *   <ANY id="rippleContainer">
+ *       <ANY md-ink-ripple='#0000FF' md-ink-explode-color="#FF0000" md-ink-explode="#rippleContainer">
+ *         Both types of ripple
+ *       </ANY>
+ *   </ANY>
+ *
+ *   <ANY md-ink-explode="false">
+ *     Not rippling
+ *   </ANY>
+ * </hljs>
+ *
+ * ### Interpolated values
+ * <hljs lang="html">
+ *   <ANY md-ink-explode-color="{{ randomColor() }}">
+ *     Ripples with the return value of 'randomColor' function
+ *   </ANY>
+ *
+ *   <ANY md-ink-ripple="{{ canRipple() }}">
+ *     Ripples if 'canRipple' function return value is not 'false' or '0'
+ *   </ANY>
+ * </hljs>
+ *  Note: The container and duration will not observe changes to the Interpolated values via
+ *  `md-ink-explode={{ContainerSelector}}` The initial values will be the final values.
+ */
+function InkExplodeRippleDirective($mdInkRipple) {
+    return{
+        controller: angular.noop,
+        link: function(scope,element,attr){
+            $mdInkRipple.attach(scope, angular.element(element), {
+                center: false,
+                dimBackground: false,
+                fitRipple: false,
+                duration: parseInt(attr.mdInkExplodeDur) || 1000,
+                inkExplode: true
+            });
+        }
+    }
+}

--- a/src/core/services/ripple/explode_ripple.spec.js
+++ b/src/core/services/ripple/explode_ripple.spec.js
@@ -1,0 +1,97 @@
+describe('mdInkExplode directive', function() {
+
+    beforeEach(module('material.core'));
+    describe('with container specified', function(){
+       it('should add the ripple to the correct element', inject(function($compile, $rootScope, $document){
+           var containerSelector = '#id',
+               containerEl = $compile('<div>')($rootScope.$new()),
+               elem = '<div md-ink-explode="'+containerSelector+'"></div>',
+               ripple;
+
+           spyOn($document[0], 'querySelector').and.callFake(function() {
+               return containerEl;
+           });
+
+           expect(containerEl.children().length).toBe(0);
+           elem = $compile(elem)($rootScope.$new());
+           expect($document[0].querySelector).toHaveBeenCalledWith(containerSelector);
+
+           elem.controller('mdInkExplode').createRipple(0, 0);
+           expect(containerEl.children().length).toBe(1);
+           ripple = containerEl.children().children();
+           expect(ripple.length).toBe(1);
+
+           expect(elem.children().length).toBe(0);
+       }));
+        it('should observe changes to the container selector', inject(function($compile, $rootScope, $document){
+           var container1Sel = '#id',
+               container2Sel = '#id2',
+               elem = '<div md-ink-explode="'+container1Sel+'"></div>',
+               container1El = $compile('<div>')($rootScope.$new()),
+               container2El = $compile('<div>')($rootScope.$new()),
+               ripple;
+
+            spyOn($document[0], 'querySelector').and.callFake(function(input) {
+                if (input == container1Sel){
+                    return container1El;
+                }else if(input == container2Sel){
+                    return container2El;
+                }
+            });
+
+            elem = $compile(elem)($rootScope.$new());
+            var rect = elem[0].getBoundingClientRect();
+            var event = {
+                srcElement: elem[0],
+                clientX: rect.left,
+                clientY: rect.top
+            };
+           elem.controller('mdInkExplode').createRippleFromEvent(event);
+           expect($document[0].querySelector).toHaveBeenCalledWith(container1Sel);
+           expect(container1El.children().length).toBe(1);
+           expect(container2El.children().length).toBe(0);
+           ripple = container1El.children().children();
+           expect(ripple.length).toBe(1);
+
+            //Switch Attribute
+           elem.attr('md-ink-explode', container2Sel);
+           //Create another ripple
+            elem.controller('mdInkExplode').createRippleFromEvent(event);
+           expect($document[0].querySelector).toHaveBeenCalledWith(container2Sel);
+            //Should remove the first container
+           expect(container1El.children().length).toBe(0);
+           expect(container2El.children().length).toBe(1);
+           ripple = container2El.children().children();
+           expect(ripple.length).toBe(1);
+       }));
+    });
+    describe('animations', function(){
+        var elem, containerEl, ripple, $window, $timeout;
+        beforeEach(inject(function($compile, $rootScope, $document, _$window_, _$timeout_){
+            $window = _$window_;
+            $timeout = _$timeout_;
+            elem = '<div md-ink-explode="#id"></div>';
+            containerEl = $compile('<div>')($rootScope.$new());
+
+            spyOn($document[0], 'querySelector').and.callFake(function(input) {
+                return containerEl;
+            });
+            elem = $compile(elem)($rootScope.$new());
+
+            elem.controller('mdInkExplode').createRipple(0, 0);
+            ripple = containerEl.children().children();
+        }));
+        it('should start small', function(){
+            var rect = ripple[0].getBoundingClientRect();
+            expect(rect.width).toBe(0);
+            expect(rect.height).toBe(0);
+            expect(ripple.hasClass('md-ripple-explode')).toBeTruthy();
+            expect(ripple.hasClass('md-ripple-placed')).toBeTruthy();
+        });
+        it('should add scaled class', function(){
+            $timeout.flush(1);
+            expect(ripple.hasClass('md-ripple-scaled')).toBeTruthy();
+            expect(ripple.hasClass('md-ripple-active')).toBeTruthy();
+        });
+    })
+});

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -117,11 +117,12 @@ function InkRippleService ($injector) {
  * Controller used by the ripple service in order to apply ripples
  * @ngInject
  */
-function InkRippleCtrl ($scope, $element, rippleOptions, $window, $document, $timeout, $mdUtil) {
+function InkRippleCtrl ($scope, $element, rippleOptions, $window, $document, $timeout, $mdUtil, $mdConstant) {
   this.$window         = $window;
   this.$document       = $document;
   this.$timeout        = $timeout;
   this.$mdUtil         = $mdUtil;
+  this.$mdConstant     = $mdConstant;
   this.$scope          = $scope;
   this.options         = rippleOptions;
   this.explode         = rippleOptions.inkExplode || false;
@@ -278,7 +279,7 @@ InkRippleCtrl.prototype.handleMousedown = function (event) {
  */
 InkRippleCtrl.prototype.handleMouseup = function (event) {
   //If this is an explode ripple and it is not a right click create the ripple
-  if (this.explode && event.which !== 3) {
+  if (this.explode && event.which !== this.$mdConstant.KEY_CODE.RIGHT_CLICK) {
     this.mousedown = false;
     // When jQuery is loaded, we have to get the original event
     createRippleFromEvent(this, event);

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -127,7 +127,7 @@ function InkRippleCtrl ($scope, $element, rippleOptions, $window, $document, $ti
   this.explode         = rippleOptions.inkExplode || false;
   this.$element        = $element;
   this.containerParent = null;
-  this.updateContainer(); //initialize containerParent
+  this.updateContainerParent(); //initialize containerParent
   this.mousedown  = false;
   this.ripples    = [];
   this.timeout    = null; // Stores a reference to the most-recent ripple timeout
@@ -189,7 +189,7 @@ InkRippleCtrl.prototype.color = function (value) {
    */
   function getElementColor () {
     var items = self.options && self.options.colorElement ? self.options.colorElement : [];
-    var elem  = items.length ? items[ 0 ] : self.containerParent[0];
+    var elem  = items.length ? items[ 0 ] : self.containerParent[ 0 ];
 
     return elem ? self.$window.getComputedStyle(elem).color : 'rgb(0,0,0)';
   }
@@ -282,7 +282,7 @@ InkRippleCtrl.prototype.handleMouseup = function (event) {
     this.mousedown = false;
     // When jQuery is loaded, we have to get the original event
     createRippleFromEvent(this, event);
-  }else {
+  } else {
     autoCleanup(this, this.clearRipples);
   }
 };
@@ -293,14 +293,14 @@ InkRippleCtrl.prototype.handleMouseup = function (event) {
  */
 function createRippleFromEvent (self, event) {
   if (event.hasOwnProperty('originalEvent')) event = event.originalEvent;
-  self.updateContainer();
+  self.updateContainerParent();
   self.updateDuration();
   if (self.options.center) {
     self.createRipple(self.container.prop('clientWidth') / 2, self.container.prop('clientWidth') / 2);
   } else {
     // We need to calculate the relative coordinates if the target is a sublayer of the ripple element
-    if (event.srcElement !== self.containerParent[0]) {
-      var layerRect = self.containerParent[0].getBoundingClientRect();
+    if (event.srcElement !== self.containerParent[ 0 ]) {
+      var layerRect = self.containerParent[ 0 ].getBoundingClientRect();
       var layerX    = event.clientX - layerRect.left;
       var layerY    = event.clientY - layerRect.top;
 
@@ -372,7 +372,7 @@ InkRippleCtrl.prototype.createContainer = function () {
  */
 InkRippleCtrl.prototype.getContainer = function () {
   //Check the attribute for modification
-  this.updateContainer();
+  this.updateContainerParent();
   var container;
   if ( !this.containerParent ) return;
   var children = this.containerParent.children();
@@ -388,7 +388,7 @@ InkRippleCtrl.prototype.getContainer = function () {
  * Check the md-ink-explode attribute for modification and update the container element
  * @returns {*}
  */
-InkRippleCtrl.prototype.updateContainer = function () {
+InkRippleCtrl.prototype.updateContainerParent = function() {
   var selector = this.inkExplode();
   if (!selector && !this._lastExplodeSelector) {
     this.containerParent = this.$element;

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -136,7 +136,7 @@ input {
     opacity: 0.20;
   }
 }
-.md-ripple-explode{
+.md-ripple-explode {
   &.md-ripple-placed {
     $sizeDuration: 0.45s * 2;
     transition: margin $sizeDuration $swift-ease-out-timing-function,

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -114,7 +114,7 @@ input {
   transition: all 0.55s $swift-ease-out-timing-function;
 }
 
-.md-ripple {
+.md-ripple, .md-ripple-explode {
   position: absolute;
   transform: translate(-50%, -50%) scale(0);
   transform-origin: 50% 50%;
@@ -134,6 +134,20 @@ input {
   }
   &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
     opacity: 0.20;
+  }
+}
+.md-ripple-explode{
+  &.md-ripple-placed {
+    $sizeDuration: 0.45s * 2;
+    transition: margin $sizeDuration $swift-ease-out-timing-function,
+    border $sizeDuration $swift-ease-out-timing-function,
+    width $sizeDuration $swift-ease-out-timing-function,
+    height $sizeDuration $swift-ease-out-timing-function,
+    opacity 0s $swift-ease-out-timing-function,
+    transform $sizeDuration $swift-ease-out-timing-function;
+  }
+  &.md-ripple-active, &.md-ripple-full, &.md-ripple-visible {
+    opacity: 1;
   }
 }
 

--- a/src/core/util/constant.js
+++ b/src/core/util/constant.js
@@ -14,6 +14,9 @@ function MdConstantFactory($sniffer) {
 
   return {
     KEY_CODE: {
+      LEFT_CLICK: 1,
+      MIDDLE_CLICK: 2,
+      RIGHT_CLICK: 3,
       COMMA: 188,
       SEMICOLON : 186,
       ENTER: 13,


### PR DESCRIPTION
Ink explode directive that I was using in a project and thought it might go well with the current md-ink directive. 

Example with ng-animate-ref for some material transitions.
http://nickbolles.github.io/Javascript-Sandbox/Angular%20App/dist/index.html#/materialtransitions