### PR TITLE
update(docs): renamed `md-text-float` to `md-input-container` in theming doc

### DIFF
--- a/docs/content/Theming/02_declarative_syntax.md
+++ b/docs/content/Theming/02_declarative_syntax.md
@@ -14,7 +14,7 @@ as expected, including:
 - md-slider
 - md-switch
 - md-tabs
-- md-text-float
+- md-input-container
 - md-toolbar
 
 


### PR DESCRIPTION
Related to #1146.