### PR TITLE
update(docs): improve docs for extending an existing theme

### DIFF
--- a/docs/content/Theming/03_configuring_a_theme.md
+++ b/docs/content/Theming/03_configuring_a_theme.md
@@ -110,17 +110,21 @@ angular.module('myApp', ['ngMaterial'])
 });
 </hljs>
 
-Sometimes it is easier to extend an existing color palette to overwrite a few
-colors than define a whole new one. You can use `$mdThemingProvider.extendPalette` 
+### Extending Existing Palettes
+
+Sometimes it is easier to extend an existing color palette to change a few properties
+than to define a whole new palette. You can use `$mdThemingProvider.extendPalette` 
 to quickly extend an existing color palette.
 
 <hljs lang="js">
 angular.module('myApp', ['ngMaterial'])
 .config(function($mdThemingProvider) {
 
-  // Extend the red theme with a few different colors
+  // Extend the red theme with a different color and make the contrast color black instead of white.
+  // For example: raised button text will be black instead of white.
   var neonRedMap = $mdThemingProvider.extendPalette('red', {
-    '500': 'ff0000'
+    '500': '#ff0000',
+    'contrastDefaultColor': 'dark'
   });
 
   // Register the new color palette map with the name `neonRed`
@@ -128,7 +132,7 @@ angular.module('myApp', ['ngMaterial'])
 
   // Use that theme for the primary intentions
   $mdThemingProvider.theme('default')
-    .primaryPalette('neonRed')
+    .primaryPalette('neonRed');
 
 });
 </hljs>


### PR DESCRIPTION
Changing the default text color (black/white) on raised buttons is a common question that keeps coming up.
Hopefully this will help people better understand how to modify that behavior.