### PR TITLE
feat(chips): allow mdChips component to be used with 'data-'-prefixes

### DIFF
--- a/src/components/chips/chips-theme.scss
+++ b/src/components/chips/chips-theme.scss
@@ -1,4 +1,4 @@
-md-chips.md-THEME_NAME-theme {
+md-chips.md-THEME_NAME-theme, data-md-chips.md-THEME_NAME-theme {
 
   .md-chips {
     box-shadow: 0 1px '{{foreground-4}}';
@@ -15,11 +15,11 @@ md-chips.md-THEME_NAME-theme {
     }
   }
 
-  md-chip {
+  md-chip, data-md-chip {
     background: '{{background-300}}';
     color: '{{background-800}}';
 
-    md-icon {
+    md-icon, data-md-icon {
       color: '{{background-700}}';
     }
 
@@ -27,7 +27,7 @@ md-chips.md-THEME_NAME-theme {
       background: '{{primary-color}}';
       color: '{{primary-contrast}}';
 
-      md-icon {
+      md-icon, data-md-icon {
         color: '{{primary-contrast}}';
       }
     }
@@ -37,9 +37,9 @@ md-chips.md-THEME_NAME-theme {
       color: '{{background-800}}';
     }
   }
-  md-chip-remove {
+  md-chip-remove, data-md-chip-remove {
     .md-button {
-      md-icon {
+      md-icon, data-md-icon {
         path {
           fill: '{{background-500}}';
         }

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -14,7 +14,7 @@ $contact-chip-name-width: rem(12) !default;
 
 .md-contact-chips {
   .md-chips {
-    md-chip {
+    md-chip, data-md-chip {
       @include rtl(padding, $contact-chip-padding, rtl-value($contact-chip-padding));
       .md-contact-avatar {
         @include rtl(float, left, right);
@@ -67,7 +67,7 @@ $contact-chip-name-width: rem(12) !default;
   &:not(.md-readonly) {
     cursor: text;
 
-    md-chip:not(.md-readonly) {
+    md-chip:not(.md-readonly), data-md-chip:not(.md-readonly) {
       @include rtl-prop(padding-right, padding-left, $chip-remove-padding-right);
 
       ._md-chip-content {
@@ -76,7 +76,7 @@ $contact-chip-name-width: rem(12) !default;
     }
   }
 
-  md-chip {
+  md-chip, data-md-chip {
     cursor: default;
     border-radius: $chip-height / 2;
     display: block;
@@ -122,7 +122,7 @@ $contact-chip-name-width: rem(12) !default;
       box-shadow: none;
       margin: 0;
       position: relative;
-      md-icon {
+      md-icon, data-md-icon {
         height: $chip-delete-icon-size;
         width: $chip-delete-icon-size;
         position: absolute;
@@ -149,12 +149,12 @@ $contact-chip-name-width: rem(12) !default;
         }
       }
     }
-    md-autocomplete, md-autocomplete-wrap {
+    md-autocomplete, md-autocomplete-wrap, data-md-autocomplete, data-md-autocomplete-wrap {
       background: transparent;
       height: $chip-height;
     }
-    md-autocomplete {
-      md-autocomplete-wrap {
+    md-autocomplete, data-md-autocomplete {
+      md-autocomplete-wrap, data-md-autocomplete-wrap {
         box-shadow: none;
       }
       input {
@@ -170,10 +170,10 @@ $contact-chip-name-width: rem(12) !default;
         outline:none;
       }
     }
-    md-autocomplete, md-autocomplete-wrap {
+    md-autocomplete, md-autocomplete-wrap, data-md-autocomplete, data-md-autocomplete-wrap {
       height: $chip-height;
     }
-    md-autocomplete {
+    md-autocomplete, data-md-autocomplete {
       box-shadow: none;
       input {
         position: relative;
@@ -187,7 +187,7 @@ $contact-chip-name-width: rem(12) !default;
       border-width: 0;
     }
   }
-  md-autocomplete {
+  md-autocomplete, data-md-autocomplete {
     button {
       display: none;
     }
@@ -196,10 +196,10 @@ $contact-chip-name-width: rem(12) !default;
 // IE only
 @media screen and (-ms-high-contrast: active) {
   ._md-chip-input-container,
-  md-chip {
+  md-chip, data-md-chip {
     border: 1px solid #fff;
   }
-  ._md-chip-input-container md-autocomplete {
+  ._md-chip-input-container md-autocomplete, ._md-chip-input-container data-md-autocomplete {
     border: none;
   }
 }

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1,1049 +1,1078 @@
 describe('<md-chips>', function() {
-  var attachedElements = [];
-  var scope, $exceptionHandler, $timeout;
+  
+  var runConfigurations = [{
+    description: "(without data- prefix)",
+    prefix: '',
+    BASIC_CHIP_TEMPLATE: 
+      '<md-chips ng-model="items"></md-chips>',
+    CHIP_TRANSFORM_TEMPLATE: 
+      '<md-chips ng-model="items" md-transform-chip="transformChip($chip)"></md-chips>',
+    CHIP_APPEND_TEMPLATE: 
+      '<md-chips ng-model="items" md-on-append="appendChip($chip)"></md-chips>',
+    CHIP_ADD_TEMPLATE: 
+      '<md-chips ng-model="items" md-on-add="addChip($chip, $index)"></md-chips>',
+    CHIP_REMOVE_TEMPLATE: 
+      '<md-chips ng-model="items" md-on-remove="removeChip($chip, $index)"></md-chips>',
+    CHIP_SELECT_TEMPLATE: 
+      '<md-chips ng-model="items" md-on-select="selectChip($chip)"></md-chips>',
+    CHIP_READONLY_TEMPLATE:
+      '<md-chips ng-model="items" readonly="isReadonly"></md-chips>',
+    CHIP_READONLY_AUTOCOMPLETE_TEMPLATE:
+      '<md-chips ng-model="items" readonly="true">' +
+      '  <md-autocomplete md-items="item in [\'hi\', \'ho\', \'he\']"></md-autocomplete>' +
+      '</md-chips>'
+  }, {
+    description: "(with data- prefix)",
+    prefix: 'data-',
+    BASIC_CHIP_TEMPLATE: 
+      '<data-md-chips data-ng-model="items"></data-md-chips>',
+    CHIP_TRANSFORM_TEMPLATE: 
+      '<data-md-chips data-ng-model="items" data-md-transform-chip="transformChip($chip)"></data-md-chips>',
+    CHIP_APPEND_TEMPLATE: 
+      '<data-md-chips data-ng-model="items" data-md-on-append="appendChip($chip)"></data-md-chips>',
+    CHIP_ADD_TEMPLATE: 
+      '<data-md-chips data-ng-model="items" data-md-on-add="addChip($chip, $index)"></data-md-chips>',
+    CHIP_REMOVE_TEMPLATE: 
+      '<data-md-chips data-ng-model="items" data-md-on-remove="removeChip($chip, $index)"></data-md-chips>',
+    CHIP_SELECT_TEMPLATE: 
+      '<data-md-chips data-ng-model="items" data-md-on-select="selectChip($chip)"></data-md-chips>',
+    CHIP_READONLY_TEMPLATE:
+      '<data-md-chips data-ng-model="items" data-readonly="isReadonly"></data-md-chips>',
+    CHIP_READONLY_AUTOCOMPLETE_TEMPLATE:
+      '<data-md-chips data-ng-model="items" data-readonly="true">' +
+      '  <data-md-autocomplete data-md-items="item in [\'hi\', \'ho\', \'he\']"></data-md-autocomplete>' +
+      '</data-md-chips>'
+  }];
+  
+  runConfigurations.forEach(function(config) {
+    var attachedElements = [];
+    var scope, $exceptionHandler, $timeout;
 
-  var BASIC_CHIP_TEMPLATE =
-    '<md-chips ng-model="items"></md-chips>';
-  var CHIP_TRANSFORM_TEMPLATE =
-    '<md-chips ng-model="items" md-transform-chip="transformChip($chip)"></md-chips>';
-  var CHIP_APPEND_TEMPLATE =
-    '<md-chips ng-model="items" md-on-append="appendChip($chip)"></md-chips>';
-  var CHIP_ADD_TEMPLATE =
-    '<md-chips ng-model="items" md-on-add="addChip($chip, $index)"></md-chips>';
-  var CHIP_REMOVE_TEMPLATE =
-    '<md-chips ng-model="items" md-on-remove="removeChip($chip, $index)"></md-chips>';
-  var CHIP_SELECT_TEMPLATE =
-    '<md-chips ng-model="items" md-on-select="selectChip($chip)"></md-chips>';
-  var CHIP_READONLY_TEMPLATE =
-    '<md-chips ng-model="items" readonly="isReadonly"></md-chips>';
-  var CHIP_READONLY_AUTOCOMPLETE_TEMPLATE =
-    '<md-chips ng-model="items" readonly="true">' +
-    '  <md-autocomplete md-items="item in [\'hi\', \'ho\', \'he\']"></md-autocomplete>' +
-    '</md-chips>';
-
-  afterEach(function() {
-    attachedElements.forEach(function(element) {
-      element.remove();
+    afterEach(function() {
+      attachedElements.forEach(function(element) {
+        element.remove();
+      });
+      attachedElements = [];
     });
-    attachedElements = [];
-  });
 
 
-  describe('with no overrides', function() {
-    beforeEach(module('material.components.chips', 'material.components.autocomplete'));
-    beforeEach(inject(function($rootScope, _$exceptionHandler_, _$timeout_) {
-      scope = $rootScope.$new();
-      scope.items = ['Apple', 'Banana', 'Orange'];
-      $exceptionHandler = _$exceptionHandler_;
-      $timeout = _$timeout_;
-    }));
-
-    describe('basic functionality', function() {
-
-      it('should render a default input element', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        var input = element.find('input');
-        expect(input.length).toBe(1);
-      });
-
-      it('should render a list of chips', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-
-        var chips = getChipElements(element);
-        expect(chips.length).toBe(3);
-        expect(chips[0].innerHTML).toContain('Apple');
-        expect(chips[1].innerHTML).toContain('Banana');
-        expect(chips[2].innerHTML).toContain('Orange');
-      });
-
-      it('should render a user-provided chip template', function() {
-        var template =
-          '<md-chips ng-model="items">' +
-          '  <md-chip-template><div class="mychiptemplate">{$chip}</div></md-chip-template>' +
-          '</md-chips>';
-        var element = buildChips(template);
-        var chip = element.find('md-chip');
-        expect(chip[0].querySelector('div.mychiptemplate')).not.toBeNull();
-      });
-
-      it('should add a chip', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.items.length).toBe(4);
-
-        var chips = getChipElements(element);
-        expect(chips.length).toBe(4);
-        expect(chips[0].innerHTML).toContain('Apple');
-        expect(chips[1].innerHTML).toContain('Banana');
-        expect(chips[2].innerHTML).toContain('Orange');
-
-        expect(chips[3].innerHTML).toContain('Grape');
-      });
-
-      it('should not add a blank chip', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = '';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.items.length).toBe(3);
-      });
-
-      it('should remove a chip', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        element.scope().$apply(function() {
-          // Remove "Banana"
-          ctrl.removeChip(1);
-        });
-
-        var chips = getChipElements(element);
-        expect(chips.length).toBe(2);
-        expect(chips[0].innerHTML).toContain('Apple');
-        expect(chips[1].innerHTML).toContain('Orange');
-      });
-
-      // TODO: Remove in 1.0 release after deprecation
-      it('should warn of deprecation when using md-on-append', inject(function($log) {
-        spyOn($log, 'warn');
-        buildChips(CHIP_APPEND_TEMPLATE);
-        expect($log.warn).toHaveBeenCalled();
+    describe('with no overrides ' + config.description, function() {
+      beforeEach(module('material.components.chips', 'material.components.autocomplete'));
+      beforeEach(inject(function($rootScope, _$exceptionHandler_, _$timeout_) {
+        scope = $rootScope.$new();
+        scope.items = ['Apple', 'Banana', 'Orange'];
+        $exceptionHandler = _$exceptionHandler_;
+        $timeout = _$timeout_;
       }));
 
-      // TODO: Remove in 1.0 release after deprecation
-      it('should retain the deprecated md-on-append functionality until removed', function() {
-        var element = buildChips(CHIP_APPEND_TEMPLATE);
-        var ctrl = element.controller('mdChips');
+      describe('basic functionality', function() {
 
-        var doubleText = function(text) {
-          return "" + text + text;
-        };
-        scope.appendChip = jasmine.createSpy('appendChip').and.callFake(doubleText);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.appendChip).toHaveBeenCalled();
-        expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Grape');
-        expect(scope.items.length).toBe(4);
-        expect(scope.items[3]).toBe('GrapeGrape');
-      });
-
-      it('should call the transform method when adding a chip', function() {
-        var element = buildChips(CHIP_TRANSFORM_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        var doubleText = function(text) {
-          return "" + text + text;
-        };
-        scope.transformChip = jasmine.createSpy('transformChip').and.callFake(doubleText);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.transformChip).toHaveBeenCalled();
-        expect(scope.transformChip.calls.mostRecent().args[0]).toBe('Grape');
-        expect(scope.items.length).toBe(4);
-        expect(scope.items[3]).toBe('GrapeGrape');
-      });
-
-      it('should not add the chip if md-transform-chip returns null', function() {
-        var element = buildChips(CHIP_TRANSFORM_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        var nullChip = function(text) {
-          return null;
-        };
-        scope.transformChip = jasmine.createSpy('transformChip').and.callFake(nullChip);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.transformChip).toHaveBeenCalled();
-        expect(scope.transformChip.calls.mostRecent().args[0]).toBe('Grape');
-        expect(scope.items.length).toBe(3);
-      });
-
-      it('should call the add method when adding a chip', function() {
-        var element = buildChips(CHIP_ADD_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        scope.addChip = jasmine.createSpy('addChip');
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.addChip).toHaveBeenCalled();
-        expect(scope.addChip.calls.mostRecent().args[0]).toBe('Grape'); // Chip
-        expect(scope.addChip.calls.mostRecent().args[1]).toBe(4);       // Index
-      });
-
-
-      it('should call the remove method when removing a chip', function() {
-        var element = buildChips(CHIP_REMOVE_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        scope.removeChip = jasmine.createSpy('removeChip');
-
-        element.scope().$apply(function() {
-          ctrl.items = ['Grape'];
-          ctrl.removeChip(0);
-        });
-
-        expect(scope.removeChip).toHaveBeenCalled();
-        expect(scope.removeChip.calls.mostRecent().args[0]).toBe('Grape'); // Chip
-        expect(scope.removeChip.calls.mostRecent().args[1]).toBe(0);       // Index
-      });
-
-
-      it('should call the select method when selecting a chip', function() {
-        var element = buildChips(CHIP_SELECT_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        scope.selectChip = jasmine.createSpy('selectChip');
-
-        element.scope().$apply(function() {
-          ctrl.items = ['Grape'];
-          ctrl.selectChip(0);
-        });
-
-        expect(scope.selectChip).toHaveBeenCalled();
-        expect(scope.selectChip.calls.mostRecent().args[0]).toBe('Grape');
-      });
-
-      it('should handle appending an object chip', function() {
-        var element = buildChips(CHIP_APPEND_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        var chipObj = function(chip) {
-          return {
-            name: chip,
-            uppername: chip.toUpperCase()
-          };
-        };
-
-        scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Grape';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(scope.appendChip).toHaveBeenCalled();
-        expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Grape');
-        expect(scope.items.length).toBe(4);
-        expect(scope.items[3].name).toBe('Grape');
-        expect(scope.items[3].uppername).toBe('GRAPE');
-      });
-
-      describe('when readonly', function() {
-        var element, ctrl;
-
-        it("properly toggles the controller's readonly property", function() {
-          element = buildChips(CHIP_READONLY_TEMPLATE);
-          ctrl = element.controller('mdChips');
-
-          expect(ctrl.readonly).toBeFalsy();
-
-          scope.$apply('isReadonly = true');
-
-          expect(ctrl.readonly).toBeTruthy();
-        });
-
-        it("properly toggles the wrapper's .md-readonly class", function() {
-          element = buildChips(CHIP_READONLY_TEMPLATE);
-          ctrl = element.controller('mdChips');
-
-          expect(element.find('md-chips-wrap')).not.toHaveClass('md-readonly');
-
-          scope.$apply('isReadonly = true');
-
-          expect(element.find('md-chips-wrap')).toHaveClass('md-readonly');
-        });
-
-        it('is false with empty items should not hide the chips wrapper', function() {
-          scope.isReadonly = false;
-          scope.items = [];
-          element = buildChips(CHIP_READONLY_TEMPLATE);
-
-          expect(element.find('md-chips-wrap').length).toBe(1);
-        });
-
-        it('is true with empty items should not hide the chips wrapper', function() {
-          scope.isReadonly = true;
-          scope.items = [];
-          element = buildChips(CHIP_READONLY_TEMPLATE);
-
-          expect(element.find('md-chips-wrap').length).toBe(1);
-        });
-
-        it('is true should not throw an error when used with an autocomplete', function() {
-          element = buildChips(CHIP_READONLY_AUTOCOMPLETE_TEMPLATE);
-          $timeout.flush();
-
-          expect($exceptionHandler.errors).toEqual([]);
-        });
-      });
-
-      it('should disallow duplicate object chips', function() {
-        var element = buildChips(CHIP_APPEND_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        // Manually set the items
-        ctrl.items = [{name: 'Apple', uppername: 'APPLE'}];
-
-        // Make our custom appendChip function return our existing item
-        var chipObj = function(chip) {
-          return ctrl.items[0];
-        };
-
-        scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Apple';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(ctrl.items.length).toBe(1);
-        expect(scope.appendChip).toHaveBeenCalled();
-        expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
-      });
-
-      it('should disallow identical object chips', function() {
-        var element = buildChips(CHIP_APPEND_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        ctrl.items = [{name: 'Apple', uppername: 'APPLE'}];
-
-        var chipObj = function(chip) {
-          return {
-            name: chip,
-            uppername: chip.toUpperCase()
-          };
-        };
-        scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
-
-        element.scope().$apply(function() {
-          ctrl.chipBuffer = 'Apple';
-          simulateInputEnterKey(ctrl);
-        });
-
-        expect(ctrl.items.length).toBe(1);
-        expect(scope.appendChip).toHaveBeenCalled();
-        expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
-      });
-
-      it('should prevent the default when backspace is pressed', inject(function($mdConstant) {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        var backspaceEvent = {
-          type: 'keydown',
-          keyCode: $mdConstant.KEY_CODE.BACKSPACE,
-          which: $mdConstant.KEY_CODE.BACKSPACE,
-          preventDefault: jasmine.createSpy('preventDefault')
-        };
-
-        element.find('input').triggerHandler(backspaceEvent);
-
-        expect(backspaceEvent.preventDefault).toHaveBeenCalled();
-      }));
-
-      describe('with input text', function() {
-
-        it('should prevent the default when enter is pressed', inject(function($mdConstant) {
-          var element = buildChips(BASIC_CHIP_TEMPLATE);
+        it('should render a default input element', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
           var ctrl = element.controller('mdChips');
 
-          var enterEvent = {
-            type: 'keydown',
-            keyCode: $mdConstant.KEY_CODE.ENTER,
-            which: $mdConstant.KEY_CODE.ENTER,
-            preventDefault: jasmine.createSpy('preventDefault')
-          };
+          var input = element.find('input');
+          expect(input.length).toBe(1);
+        });
 
-          ctrl.chipBuffer = 'Test';
-          element.find('input').triggerHandler(enterEvent);
+        it('should render a list of chips', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
 
-          expect(enterEvent.preventDefault).toHaveBeenCalled();
+          var chips = getChipElements(element);
+          expect(chips.length).toBe(3);
+          expect(chips[0].innerHTML).toContain('Apple');
+          expect(chips[1].innerHTML).toContain('Banana');
+          expect(chips[2].innerHTML).toContain('Orange');
+        });
+
+        it('should render a user-provided chip template', function() {
+          var template =
+            '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">' +
+            '  <' + config.prefix + 'md-chip-template><div class="mychiptemplate">{$chip}</div></' + config.prefix + 'md-chip-template>' +
+            '</' + config.prefix + 'md-chips>';
+          var element = buildChips(template);
+          var chip = element.find('md-chip');
+          expect(chip[0].querySelector('div.mychiptemplate')).not.toBeNull();
+        });
+
+        it('should add a chip', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(scope.items.length).toBe(4);
+
+          var chips = getChipElements(element);
+          expect(chips.length).toBe(4);
+          expect(chips[0].innerHTML).toContain('Apple');
+          expect(chips[1].innerHTML).toContain('Banana');
+          expect(chips[2].innerHTML).toContain('Orange');
+
+          expect(chips[3].innerHTML).toContain('Grape');
+        });
+
+        it('should not add a blank chip', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = '';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(scope.items.length).toBe(3);
+        });
+
+        it('should remove a chip', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          element.scope().$apply(function() {
+            // Remove "Banana"
+            ctrl.removeChip(1);
+          });
+
+          var chips = getChipElements(element);
+          expect(chips.length).toBe(2);
+          expect(chips[0].innerHTML).toContain('Apple');
+          expect(chips[1].innerHTML).toContain('Orange');
+        });
+
+        // TODO: Remove in 1.0 release after deprecation
+        it('should warn of deprecation when using md-on-append', inject(function($log) {
+          spyOn($log, 'warn');
+          buildChips(config.CHIP_APPEND_TEMPLATE);
+          expect($log.warn).toHaveBeenCalled();
         }));
 
-        it('should trim the buffer when a chip will be added', inject(function($mdConstant) {
-          var element = buildChips(BASIC_CHIP_TEMPLATE);
+        // TODO: Remove in 1.0 release after deprecation
+        it('should retain the deprecated md-on-append functionality until removed', function() {
+          var element = buildChips(config.CHIP_APPEND_TEMPLATE);
           var ctrl = element.controller('mdChips');
-          var input = element.find('input');
 
-          // This string contains a lot of spaces, which should be trimmed.
-          input.val('    Test    ');
-          input.triggerHandler('input');
+          var doubleText = function(text) {
+            return "" + text + text;
+          };
+          scope.appendChip = jasmine.createSpy('appendChip').and.callFake(doubleText);
 
-          expect(ctrl.chipBuffer).toBeTruthy();
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
 
-          var enterEvent = {
-            type: 'keydown',
-            keyCode: $mdConstant.KEY_CODE.ENTER,
-            which: $mdConstant.KEY_CODE.ENTER
+          expect(scope.appendChip).toHaveBeenCalled();
+          expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Grape');
+          expect(scope.items.length).toBe(4);
+          expect(scope.items[3]).toBe('GrapeGrape');
+        });
+
+        it('should call the transform method when adding a chip', function() {
+          var element = buildChips(config.CHIP_TRANSFORM_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          var doubleText = function(text) {
+            return "" + text + text;
+          };
+          scope.transformChip = jasmine.createSpy('transformChip').and.callFake(doubleText);
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(scope.transformChip).toHaveBeenCalled();
+          expect(scope.transformChip.calls.mostRecent().args[0]).toBe('Grape');
+          expect(scope.items.length).toBe(4);
+          expect(scope.items[3]).toBe('GrapeGrape');
+        });
+
+        it('should not add the chip if md-transform-chip returns null', function() {
+          var element = buildChips(config.CHIP_TRANSFORM_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          var nullChip = function(text) {
+            return null;
+          };
+          scope.transformChip = jasmine.createSpy('transformChip').and.callFake(nullChip);
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(scope.transformChip).toHaveBeenCalled();
+          expect(scope.transformChip.calls.mostRecent().args[0]).toBe('Grape');
+          expect(scope.items.length).toBe(3);
+        });
+
+        it('should call the add method when adding a chip', function() {
+          var element = buildChips(config.CHIP_ADD_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          scope.addChip = jasmine.createSpy('addChip');
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(scope.addChip).toHaveBeenCalled();
+          expect(scope.addChip.calls.mostRecent().args[0]).toBe('Grape'); // Chip
+          expect(scope.addChip.calls.mostRecent().args[1]).toBe(4);       // Index
+        });
+
+
+        it('should call the remove method when removing a chip', function() {
+          var element = buildChips(config.CHIP_REMOVE_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          scope.removeChip = jasmine.createSpy('removeChip');
+
+          element.scope().$apply(function() {
+            ctrl.items = ['Grape'];
+            ctrl.removeChip(0);
+          });
+
+          expect(scope.removeChip).toHaveBeenCalled();
+          expect(scope.removeChip.calls.mostRecent().args[0]).toBe('Grape'); // Chip
+          expect(scope.removeChip.calls.mostRecent().args[1]).toBe(0);       // Index
+        });
+
+
+        it('should call the select method when selecting a chip', function() {
+          var element = buildChips(config.CHIP_SELECT_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          scope.selectChip = jasmine.createSpy('selectChip');
+
+          element.scope().$apply(function() {
+            ctrl.items = ['Grape'];
+            ctrl.selectChip(0);
+          });
+
+          expect(scope.selectChip).toHaveBeenCalled();
+          expect(scope.selectChip.calls.mostRecent().args[0]).toBe('Grape');
+        });
+
+        it('should handle appending an object chip', function() {
+          var element = buildChips(config.CHIP_APPEND_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          var chipObj = function(chip) {
+            return {
+              name: chip,
+              uppername: chip.toUpperCase()
+            };
           };
 
-          input.triggerHandler(enterEvent);
+          scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
 
-          expect(scope.items).toEqual(['Apple', 'Banana', 'Orange', 'Test']);
-        }));
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Grape';
+            simulateInputEnterKey(ctrl);
+          });
 
-        it('should not trim the input text of the input', inject(function($mdConstant) {
-          var element = buildChips(BASIC_CHIP_TEMPLATE);
+          expect(scope.appendChip).toHaveBeenCalled();
+          expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Grape');
+          expect(scope.items.length).toBe(4);
+          expect(scope.items[3].name).toBe('Grape');
+          expect(scope.items[3].uppername).toBe('GRAPE');
+        });
+
+        describe('when readonly', function() {
+          var element, ctrl;
+
+          it("properly toggles the controller's readonly property", function() {
+            element = buildChips(config.CHIP_READONLY_TEMPLATE);
+            ctrl = element.controller('mdChips');
+
+            expect(ctrl.readonly).toBeFalsy();
+
+            scope.$apply('isReadonly = true');
+
+            expect(ctrl.readonly).toBeTruthy();
+          });
+
+          it("properly toggles the wrapper's .md-readonly class", function() {
+            element = buildChips(config.CHIP_READONLY_TEMPLATE);
+            ctrl = element.controller('mdChips');
+
+            expect(element.find('md-chips-wrap')).not.toHaveClass('md-readonly');
+
+            scope.$apply('isReadonly = true');
+
+            expect(element.find('md-chips-wrap')).toHaveClass('md-readonly');
+          });
+
+          it('is false with empty items should not hide the chips wrapper', function() {
+            scope.isReadonly = false;
+            scope.items = [];
+            element = buildChips(config.CHIP_READONLY_TEMPLATE);
+
+            expect(element.find('md-chips-wrap').length).toBe(1);
+          });
+
+          it('is true with empty items should not hide the chips wrapper', function() {
+            scope.isReadonly = true;
+            scope.items = [];
+            element = buildChips(config.CHIP_READONLY_TEMPLATE);
+
+            expect(element.find('md-chips-wrap').length).toBe(1);
+          });
+
+          it('is true should not throw an error when used with an autocomplete', function() {
+            element = buildChips(config.CHIP_READONLY_AUTOCOMPLETE_TEMPLATE);
+            $timeout.flush();
+
+            expect($exceptionHandler.errors).toEqual([]);
+          });
+        });
+
+        it('should disallow duplicate object chips', function() {
+          var element = buildChips(config.CHIP_APPEND_TEMPLATE);
           var ctrl = element.controller('mdChips');
-          var input = element.find('input');
 
-          input.val('    ');
-          input.triggerHandler('input');
+          // Manually set the items
+          ctrl.items = [{name: 'Apple', uppername: 'APPLE'}];
 
-          expect(ctrl.chipBuffer).toBeTruthy();
+          // Make our custom appendChip function return our existing item
+          var chipObj = function(chip) {
+            return ctrl.items[0];
+          };
 
-          var enterEvent = {
+          scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Apple';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(ctrl.items.length).toBe(1);
+          expect(scope.appendChip).toHaveBeenCalled();
+          expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
+        });
+
+        it('should disallow identical object chips', function() {
+          var element = buildChips(config.CHIP_APPEND_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          ctrl.items = [{name: 'Apple', uppername: 'APPLE'}];
+
+          var chipObj = function(chip) {
+            return {
+              name: chip,
+              uppername: chip.toUpperCase()
+            };
+          };
+          scope.appendChip = jasmine.createSpy('appendChip').and.callFake(chipObj);
+
+          element.scope().$apply(function() {
+            ctrl.chipBuffer = 'Apple';
+            simulateInputEnterKey(ctrl);
+          });
+
+          expect(ctrl.items.length).toBe(1);
+          expect(scope.appendChip).toHaveBeenCalled();
+          expect(scope.appendChip.calls.mostRecent().args[0]).toBe('Apple');
+        });
+
+        it('should prevent the default when backspace is pressed', inject(function($mdConstant) {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          var backspaceEvent = {
             type: 'keydown',
             keyCode: $mdConstant.KEY_CODE.BACKSPACE,
             which: $mdConstant.KEY_CODE.BACKSPACE,
             preventDefault: jasmine.createSpy('preventDefault')
           };
 
-          input.triggerHandler(enterEvent);
+          element.find('input').triggerHandler(backspaceEvent);
 
-          expect(enterEvent.preventDefault).not.toHaveBeenCalled();
-
-          input.val('');
-          input.triggerHandler('input');
-
-          input.triggerHandler(enterEvent);
-
-          expect(enterEvent.preventDefault).toHaveBeenCalledTimes(1);
-        }));
-      });
-
-
-      it('focuses/blurs the component when focusing/blurring the input', inject(function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-
-        // Focus the input and check
-        element.find('input').triggerHandler('focus');
-        expect(ctrl.inputHasFocus).toBe(true);
-        expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(true);
-
-        // Blur the input and check
-        element.find('input').triggerHandler('blur');
-        expect(ctrl.inputHasFocus).toBe(false);
-        expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(false);
-      }));
-
-      describe('placeholder', function() {
-
-        it('should put placeholder text in the input element when chips exist but there is no secondary-placeholder text', inject(function() {
-          var template =
-            '<md-chips ng-model="items" placeholder="placeholder text"></md-chips>';
-          var element = buildChips(template);
-          var ctrl = element.controller('mdChips');
-          var input = element.find('input')[0];
-
-          expect(scope.items.length).toBeGreaterThan(0);
-          expect(input.placeholder).toBe('placeholder text');
+          expect(backspaceEvent.preventDefault).toHaveBeenCalled();
         }));
 
-        it('should put placeholder text in the input element when there are no chips', inject(function() {
-          var ctrl, element, input, template;
+        describe('with input text', function() {
 
-          scope.items = [];
-          template =
-            '<md-chips ng-model="items" placeholder="placeholder text" ' +
-            'secondary-placeholder="secondary-placeholder text"></md-chips>';
-          element = buildChips(template);
-          ctrl = element.controller('mdChips');
-          input = element.find('input')[0];
+          it('should prevent the default when enter is pressed', inject(function($mdConstant) {
+            var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+            var ctrl = element.controller('mdChips');
 
-          expect(scope.items.length).toBe(0);
-          expect(input.placeholder).toBe('placeholder text');
-        }));
+            var enterEvent = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.ENTER,
+              which: $mdConstant.KEY_CODE.ENTER,
+              preventDefault: jasmine.createSpy('preventDefault')
+            };
 
-        it('should put secondary-placeholder text in the input element when there is at least one chip', inject(function() {
-          var template =
-            '<md-chips ng-model="items" placeholder="placeholder text" ' +
-            'secondary-placeholder="secondary-placeholder text"></md-chips>';
-          var element = buildChips(template);
-          var ctrl = element.controller('mdChips');
-          var input = element.find('input')[0];
-
-          expect(scope.items.length).toBeGreaterThan(0);
-          expect(input.placeholder).toBe('secondary-placeholder text');
-        }));
-
-      });
-
-    });
-
-    describe('custom inputs', function() {
-
-      describe('separator-keys', function() {
-        var SEPARATOR_KEYS_CHIP_TEMPLATE =
-          '<md-chips ng-model="items" md-separator-keys="keys"></md-chips>';
-
-        it('should create a new chip when a comma is entered', inject(function($mdConstant) {
-          scope.keys = [$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA];
-          var element = buildChips(SEPARATOR_KEYS_CHIP_TEMPLATE);
-          var ctrl = element.controller('mdChips');
-
-          var commaInput = {
-            type: 'keydown',
-            keyCode: $mdConstant.KEY_CODE.COMMA,
-            which: $mdConstant.KEY_CODE.COMMA,
-            preventDefault: jasmine.createSpy('preventDefault')
-          };
-
-          ctrl.chipBuffer = 'Test';
-          element.find('input').triggerHandler(commaInput);
-
-          expect(commaInput.preventDefault).toHaveBeenCalled();
-        }));
-
-        it('supports custom separator key codes', inject(function($mdConstant) {
-          var semicolon = 186;
-          scope.keys = [$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA, semicolon];
-
-          var element = buildChips(SEPARATOR_KEYS_CHIP_TEMPLATE);
-          var ctrl = element.controller('mdChips');
-
-          var semicolonInput = {
-            type: 'keydown',
-            keyCode: semicolon,
-            which: semicolon,
-            preventDefault: jasmine.createSpy('preventDefault')
-          };
-
-          ctrl.chipBuffer = 'Test';
-          element.find('input').triggerHandler(semicolonInput);
-
-          expect(semicolonInput.preventDefault).toHaveBeenCalled();
-        }));
-      });
-
-      describe('md-max-chips', function() {
-
-        beforeEach(function() {
-          // Clear default items to test the max chips functionality
-          scope.items = [];
-        });
-
-        it('should not add a new chip if the max-chips limit is reached', function () {
-          var element = buildChips('<md-chips ng-model="items" md-max-chips="1"></md-chips>');
-          var ctrl = element.controller('mdChips');
-
-          element.scope().$apply(function() {
             ctrl.chipBuffer = 'Test';
-            simulateInputEnterKey(ctrl);
-          });
+            element.find('input').triggerHandler(enterEvent);
 
-          expect(scope.items.length).toBe(1);
+            expect(enterEvent.preventDefault).toHaveBeenCalled();
+          }));
 
-          element.scope().$apply(function() {
-            ctrl.chipBuffer = 'Test 2';
-            simulateInputEnterKey(ctrl);
-          });
+          it('should trim the buffer when a chip will be added', inject(function($mdConstant) {
+            var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+            var input = element.find('input');
 
-          expect(scope.items.length).not.toBe(2);
+            // This string contains a lot of spaces, which should be trimmed.
+            input.val('    Test    ');
+            input.triggerHandler('input');
+
+            expect(ctrl.chipBuffer).toBeTruthy();
+
+            var enterEvent = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.ENTER,
+              which: $mdConstant.KEY_CODE.ENTER
+            };
+
+            input.triggerHandler(enterEvent);
+
+            expect(scope.items).toEqual(['Apple', 'Banana', 'Orange', 'Test']);
+          }));
+
+          it('should not trim the input text of the input', inject(function($mdConstant) {
+            var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+            var input = element.find('input');
+
+            input.val('    ');
+            input.triggerHandler('input');
+
+            expect(ctrl.chipBuffer).toBeTruthy();
+
+            var enterEvent = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.BACKSPACE,
+              which: $mdConstant.KEY_CODE.BACKSPACE,
+              preventDefault: jasmine.createSpy('preventDefault')
+            };
+
+            input.triggerHandler(enterEvent);
+
+            expect(enterEvent.preventDefault).not.toHaveBeenCalled();
+
+            input.val('');
+            input.triggerHandler('input');
+
+            input.triggerHandler(enterEvent);
+
+            expect(enterEvent.preventDefault).toHaveBeenCalledTimes(1);
+          }));
         });
 
-        it('should update the md-max-chips model validator for forms', function() {
-          var template =
-            '<form name="form">' +
-            '<md-chips name="chips" ng-model="items" md-max-chips="1"></md-chips>' +
-            '</form>';
 
-          var element = buildChips(template);
-          var ctrl = element.find('md-chips').controller('mdChips');
-
-          element.scope().$apply(function() {
-            ctrl.chipBuffer = 'Test';
-            simulateInputEnterKey(ctrl);
-          });
-
-          expect(scope.form.chips.$error['md-max-chips']).toBe(true);
-        });
-
-        it('should not reset the buffer if the maximum is reached', function() {
-          var element = buildChips('<md-chips ng-model="items" md-max-chips="1"></md-chips>');
+        it('focuses/blurs the component when focusing/blurring the input', inject(function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
           var ctrl = element.controller('mdChips');
-
-          element.scope().$apply(function() {
-            ctrl.chipBuffer = 'Test';
-            simulateInputEnterKey(ctrl);
-          });
-
-          expect(scope.items.length).toBe(1);
-
-          element.scope().$apply(function() {
-            ctrl.chipBuffer = 'Test 2';
-            simulateInputEnterKey(ctrl);
-          });
-
-          expect(ctrl.chipBuffer).toBe('Test 2');
-          expect(scope.items.length).not.toBe(2);
-        });
-
-        it('should not append the chip when maximum is reached and using an autocomplete', function() {
-          var template =
-            '<md-chips ng-model="items" md-max-chips="1">' +
-              '<md-autocomplete ' +
-                'md-selected-item="selectedItem" ' +
-                'md-search-text="searchText" ' +
-                'md-items="item in querySearch(searchText)" ' +
-                'md-item-text="item">' +
-             '<span md-highlight-text="searchText">{{itemtype}}</span>' +
-            '</md-autocomplete>' +
-          '</md-chips>';
-
-          setupScopeForAutocomplete();
-          var element = buildChips(template);
-          var ctrl = element.controller('mdChips');
-
-          // Flush the autocompletes init timeout.
-          $timeout.flush();
-
-          var autocompleteCtrl = element.find('md-autocomplete').controller('mdAutocomplete');
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.scope.searchText = 'K';
-          });
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.select(0);
-          });
-
-          $timeout.flush();
-
-          expect(scope.items.length).toBe(1);
-          expect(scope.items[0]).toBe('Kiwi');
-          expect(element.find('input').val()).toBe('');
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.scope.searchText = 'O';
-          });
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.select(0);
-          });
-
-          $timeout.flush();
-
-          expect(scope.items.length).toBe(1);
-          expect(element.find('input').val()).toBe('Orange');
-        });
-
-      });
-
-      describe('focus functionality', function() {
-        var element, ctrl;
-
-        beforeEach(function() {
-          element = buildChips(CHIP_SELECT_TEMPLATE);
-          ctrl = element.controller('mdChips');
-          document.body.appendChild(element[0]);
-        });
-
-        afterEach(function() {
-          element.remove();
-          element = ctrl = null;
-        });
-
-        it('should focus the chip when clicking / touching on the chip', function() {
-          ctrl.focusChip = jasmine.createSpy('focusChipSpy');
-
-          var chips = getChipElements(element);
-          expect(chips.length).toBe(3);
-
-          chips.children().eq(0).triggerHandler('click');
-
-          expect(ctrl.focusChip).toHaveBeenCalledTimes(1);
-        });
-
-        it('should focus the chip through normal content focus', function() {
-          scope.selectChip = jasmine.createSpy('focusChipSpy');
-          var chips = getChipElements(element);
-          expect(chips.length).toBe(3);
-
-          chips.children().eq(0).triggerHandler('focus');
-
-          expect(scope.selectChip).toHaveBeenCalledTimes(1);
-        });
-
-        it('should blur the chip correctly', function() {
-          var chips = getChipElements(element);
-          expect(chips.length).toBe(3);
-
-          var chipContent = chips.children().eq(0);
-          chipContent.triggerHandler('focus');
-
-          expect(ctrl.selectedChip).toBe(0);
-
-          chipContent.eq(0).triggerHandler('blur');
-
-          scope.$digest();
-
-          expect(ctrl.selectedChip).toBe(-1);
-        });
-
-      });
-
-      describe('md-autocomplete', function() {
-        var AUTOCOMPLETE_CHIPS_TEMPLATE = '\
-          <md-chips ng-model="items">\
-            <md-autocomplete\
-              md-selected-item="selectedItem"\
-              md-search-text="searchText"\
-              md-items="item in querySearch(searchText)"\
-              md-item-text="item">\
-            <span md-highlight-text="searchText">{{itemtype}}</span>\
-          </md-autocomplete>\
-        </md-chips>';
-
-        it('should use the selected item as a buffer', inject(function($timeout) {
-          setupScopeForAutocomplete();
-          var element = buildChips(AUTOCOMPLETE_CHIPS_TEMPLATE);
-          var ctrl = element.controller('mdChips');
-          $timeout.flush(); // mdAutcomplete needs a flush for its init.
-          var autocompleteCtrl = element.find('md-autocomplete').controller('mdAutocomplete');
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.scope.searchText = 'K';
-          });
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.select(0);
-          });
-          $timeout.flush();
-
-          expect(scope.items.length).toBe(4);
-          expect(scope.items[3]).toBe('Kiwi');
-          expect(element.find('input').val()).toBe('');
-        }));
-
-        it('simultaneously allows selecting an existing chip AND adding a new one', inject(function($mdConstant) {
-          // Setup our scope and function
-          setupScopeForAutocomplete();
-          scope.transformChip = jasmine.createSpy('transformChip');
-
-          // Modify the base template to add md-transform-chip
-          var modifiedTemplate = AUTOCOMPLETE_CHIPS_TEMPLATE
-            .replace('<md-chips', '<md-chips md-on-append="transformChip($chip)"');
-
-          var element = buildChips(modifiedTemplate);
-
-          var ctrl = element.controller('mdChips');
-          $timeout.flush(); // mdAutcomplete needs a flush for its init.
-          var autocompleteCtrl = element.find('md-autocomplete').controller('mdAutocomplete');
-
-          element.scope().$apply(function() {
-            autocompleteCtrl.scope.searchText = 'K';
-          });
-          autocompleteCtrl.focus();
-          $timeout.flush();
-
-          /*
-           * Send a down arrow/enter to select the right fruit
-           */
-          var downArrowEvent = {
-            type: 'keydown',
-            keyCode: $mdConstant.KEY_CODE.DOWN_ARROW,
-            which: $mdConstant.KEY_CODE.DOWN_ARROW
-          };
-          var enterEvent = {
-            type: 'keydown',
-            keyCode: $mdConstant.KEY_CODE.ENTER,
-            which: $mdConstant.KEY_CODE.ENTER
-          };
-          element.find('input').triggerHandler(downArrowEvent);
-          element.find('input').triggerHandler(enterEvent);
-          $timeout.flush();
-
-          // Check our transformChip calls
-          expect(scope.transformChip).not.toHaveBeenCalledWith('K');
-          expect(scope.transformChip).toHaveBeenCalledWith('Kiwi');
-          expect(scope.transformChip.calls.count()).toBe(1);
-
-          // Check our output
-          expect(scope.items.length).toBe(4);
-          expect(scope.items[3]).toBe('Kiwi');
-          expect(element.find('input').val()).toBe('');
-
-          // Reset our jasmine spy
-          scope.transformChip.calls.reset();
-
-          /*
-           * Use the "new chip" functionality
-           */
-
-          // Set the search text
-          element.scope().$apply(function() {
-            autocompleteCtrl.scope.searchText = 'Acai Berry';
-          });
-
-          // Fire our event and flush any timeouts
-          element.find('input').triggerHandler(enterEvent);
-          $timeout.flush();
-
-          // Check our transformChip calls
-          expect(scope.transformChip).toHaveBeenCalledWith('Acai Berry');
-          expect(scope.transformChip.calls.count()).toBe(1);
-
-          // Check our output
-          expect(scope.items.length).toBe(5);
-          expect(scope.items[4]).toBe('Acai Berry');
-          expect(element.find('input').val()).toBe('');
-        }));
-      });
-
-      describe('user input templates', function() {
-        var NG_MODEL_TEMPLATE = '\
-          <md-chips ng-model="items">\
-            <input type="text" ng-model="inputText">\
-          </md-chips>';
-        var INPUT_TEMPLATE = '\
-          <md-chips ng-model="items">\
-            <input type="text">\
-          </md-chips>';
-
-        it('focuses/blurs the component when focusing/blurring the input', inject(function($timeout) {
-          var element = buildChips(INPUT_TEMPLATE);
-          var ctrl = element.controller('mdChips');
-          $timeout.flush();
 
           // Focus the input and check
           element.find('input').triggerHandler('focus');
-          $timeout.flush();
           expect(ctrl.inputHasFocus).toBe(true);
           expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(true);
 
           // Blur the input and check
           element.find('input').triggerHandler('blur');
-          $timeout.flush();
           expect(ctrl.inputHasFocus).toBe(false);
           expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(false);
         }));
 
-        describe('using ngModel', function() {
-          it('should add the ngModelCtrl.$viewValue when <enter> is pressed',
-            inject(function($timeout) {
-              var element = buildChips(NG_MODEL_TEMPLATE);
-              var ctrl = element.controller('mdChips');
-              $timeout.flush();
+        describe('placeholder', function() {
 
-              var ngModelCtrl = ctrl.userInputNgModelCtrl;
+          it('should put placeholder text in the input element when chips exist but there is no secondary-placeholder text', inject(function() {
+            var template =
+              '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'placeholder="placeholder text"></' + config.prefix + 'md-chips>';
+            var element = buildChips(template);
+            var ctrl = element.controller('mdChips');
+            var input = element.find('input')[0];
 
-              element.scope().$apply(function() {
-                ngModelCtrl.$viewValue = 'Grape';
-                simulateInputEnterKey(ctrl);
-              });
+            expect(scope.items.length).toBeGreaterThan(0);
+            expect(input.placeholder).toBe('placeholder text');
+          }));
 
-              expect(scope.items.length).toBe(4);
-              expect(scope.items[3]).toBe('Grape');
-            }));
+          it('should put placeholder text in the input element when there are no chips', inject(function() {
+            var ctrl, element, input, template;
+
+            scope.items = [];
+            template =
+              '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'placeholder="placeholder text" ' +
+              config.prefix + 'secondary-placeholder="secondary-placeholder text"></' + config.prefix + 'md-chips>';
+            element = buildChips(template);
+            ctrl = element.controller('mdChips');
+            input = element.find('input')[0];
+
+            expect(scope.items.length).toBe(0);
+            expect(input.placeholder).toBe('placeholder text');
+          }));
+
+          it('should put secondary-placeholder text in the input element when there is at least one chip', inject(function() {
+            var template =
+              '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'placeholder="placeholder text" ' +
+              config.prefix + 'secondary-placeholder="secondary-placeholder text"></' + config.prefix + 'md-chips>';
+            var element = buildChips(template);
+            var ctrl = element.controller('mdChips');
+            var input = element.find('input')[0];
+
+            expect(scope.items.length).toBeGreaterThan(0);
+            expect(input.placeholder).toBe('secondary-placeholder text');
+          }));
+
         });
 
-        describe('without ngModel', function() {
-          it('should support an input without an ngModel', inject(function($timeout) {
+      });
+
+      describe('custom inputs', function() {
+
+        describe('separator-keys', function() {
+          var SEPARATOR_KEYS_CHIP_TEMPLATE =
+            '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'md-separator-keys="keys"></' + config.prefix + 'md-chips>';
+
+          it('should create a new chip when a comma is entered', inject(function($mdConstant) {
+            scope.keys = [$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA];
+            var element = buildChips(SEPARATOR_KEYS_CHIP_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+
+            var commaInput = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.COMMA,
+              which: $mdConstant.KEY_CODE.COMMA,
+              preventDefault: jasmine.createSpy('preventDefault')
+            };
+
+            ctrl.chipBuffer = 'Test';
+            element.find('input').triggerHandler(commaInput);
+
+            expect(commaInput.preventDefault).toHaveBeenCalled();
+          }));
+
+          it('supports custom separator key codes', inject(function($mdConstant) {
+            var semicolon = 186;
+            scope.keys = [$mdConstant.KEY_CODE.ENTER, $mdConstant.KEY_CODE.COMMA, semicolon];
+
+            var element = buildChips(SEPARATOR_KEYS_CHIP_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+
+            var semicolonInput = {
+              type: 'keydown',
+              keyCode: semicolon,
+              which: semicolon,
+              preventDefault: jasmine.createSpy('preventDefault')
+            };
+
+            ctrl.chipBuffer = 'Test';
+            element.find('input').triggerHandler(semicolonInput);
+
+            expect(semicolonInput.preventDefault).toHaveBeenCalled();
+          }));
+        });
+
+        describe('md-max-chips', function() {
+
+          beforeEach(function() {
+            // Clear default items to test the max chips functionality
+            scope.items = [];
+          });
+
+          it('should not add a new chip if the max-chips limit is reached', function () {
+            var element = buildChips('<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'md-max-chips="1"></' + config.prefix + 'md-chips>');
+            var ctrl = element.controller('mdChips');
+
+            element.scope().$apply(function() {
+              ctrl.chipBuffer = 'Test';
+              simulateInputEnterKey(ctrl);
+            });
+
+            expect(scope.items.length).toBe(1);
+
+            element.scope().$apply(function() {
+              ctrl.chipBuffer = 'Test 2';
+              simulateInputEnterKey(ctrl);
+            });
+
+            expect(scope.items.length).not.toBe(2);
+          });
+
+          it('should update the md-max-chips model validator for forms', function() {
+            var template =
+              '<form name="form">' +
+              '<' + config.prefix + 'md-chips name="chips" ' + config.prefix + 'ng-model="items" ' + config.prefix + 'md-max-chips="1"></md-chips>' +
+              '</form>';
+
+            var element = buildChips(template);
+            var ctrl = angular.element(element[0].querySelector('md-chips, data-md-chips'))
+                              .controller('mdChips');
+
+            element.scope().$apply(function() {
+              ctrl.chipBuffer = 'Test';
+              simulateInputEnterKey(ctrl);
+            });
+
+            expect(scope.form.chips.$error['md-max-chips']).toBe(true);
+          });
+
+          it('should not reset the buffer if the maximum is reached', function() {
+            var element = buildChips('<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'md-max-chips="1"></' + config.prefix + 'md-chips>');
+            var ctrl = element.controller('mdChips');
+
+            element.scope().$apply(function() {
+              ctrl.chipBuffer = 'Test';
+              simulateInputEnterKey(ctrl);
+            });
+
+            expect(scope.items.length).toBe(1);
+
+            element.scope().$apply(function() {
+              ctrl.chipBuffer = 'Test 2';
+              simulateInputEnterKey(ctrl);
+            });
+
+            expect(ctrl.chipBuffer).toBe('Test 2');
+            expect(scope.items.length).not.toBe(2);
+          });
+
+          it('should not append the chip when maximum is reached and using an autocomplete', function() {
+            var template =
+              '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items" ' + config.prefix + 'md-max-chips="1">' +
+                '<' + config.prefix + 'md-autocomplete ' +
+                  config.prefix + 'md-selected-item="selectedItem" ' +
+                  config.prefix + 'md-search-text="searchText" ' +
+                  config.prefix + 'md-items="item in querySearch(searchText)" ' +
+                  config.prefix + 'md-item-text="item">' +
+               '<span ' + config.prefix + 'md-highlight-text="searchText">{{itemtype}}</span>' +
+              '</' + config.prefix + 'md-autocomplete>' +
+            '</' + config.prefix + 'md-chips>';
+
+            setupScopeForAutocomplete();
+            var element = buildChips(template);
+            var ctrl = element.controller('mdChips');
+
+            // Flush the autocompletes init timeout.
+            $timeout.flush();
+
+            var autocompleteCtrl = element.find(config.prefix + 'md-autocomplete').controller('mdAutocomplete');
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.scope.searchText = 'K';
+            });
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.select(0);
+            });
+
+            $timeout.flush();
+
+            expect(scope.items.length).toBe(1);
+            expect(scope.items[0]).toBe('Kiwi');
+            expect(element.find('input').val()).toBe('');
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.scope.searchText = 'O';
+            });
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.select(0);
+            });
+
+            $timeout.flush();
+
+            expect(scope.items.length).toBe(1);
+            expect(element.find('input').val()).toBe('Orange');
+          });
+
+        });
+
+        describe('focus functionality', function() {
+          var element, ctrl;
+
+          beforeEach(function() {
+            element = buildChips(config.CHIP_SELECT_TEMPLATE);
+            ctrl = element.controller('mdChips');
+            document.body.appendChild(element[0]);
+          });
+
+          afterEach(function() {
+            element.remove();
+            element = ctrl = null;
+          });
+
+          it('should focus the chip when clicking / touching on the chip', function() {
+            ctrl.focusChip = jasmine.createSpy('focusChipSpy');
+
+            var chips = getChipElements(element);
+            expect(chips.length).toBe(3);
+
+            chips.children().eq(0).triggerHandler('click');
+
+            expect(ctrl.focusChip).toHaveBeenCalledTimes(1);
+          });
+
+          it('should focus the chip through normal content focus', function() {
+            scope.selectChip = jasmine.createSpy('focusChipSpy');
+            var chips = getChipElements(element);
+            expect(chips.length).toBe(3);
+
+            chips.children().eq(0).triggerHandler('focus');
+
+            expect(scope.selectChip).toHaveBeenCalledTimes(1);
+          });
+
+          it('should blur the chip correctly', function() {
+            var chips = getChipElements(element);
+            expect(chips.length).toBe(3);
+
+            var chipContent = chips.children().eq(0);
+            chipContent.triggerHandler('focus');
+
+            expect(ctrl.selectedChip).toBe(0);
+
+            chipContent.eq(0).triggerHandler('blur');
+
+            scope.$digest();
+
+            expect(ctrl.selectedChip).toBe(-1);
+          });
+
+        });
+
+        describe('md-autocomplete', function() {
+          var AUTOCOMPLETE_CHIPS_TEMPLATE = '\
+            <' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">\
+              <' + config.prefix + 'md-autocomplete\
+                ' + config.prefix + 'md-selected-item="selectedItem"\
+                ' + config.prefix + 'md-search-text="searchText"\
+                ' + config.prefix + 'md-items="item in querySearch(searchText)"\
+                ' + config.prefix + 'md-item-text="item">\
+              <span ' + config.prefix + 'md-highlight-text="searchText">{{itemtype}}</span>\
+            </' + config.prefix + 'md-autocomplete>\
+          </md-chips>';
+
+          it('should use the selected item as a buffer', inject(function($timeout) {
+            setupScopeForAutocomplete();
+            var element = buildChips(AUTOCOMPLETE_CHIPS_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+            $timeout.flush(); // mdAutcomplete needs a flush for its init.
+            var autocompleteCtrl = element.find(config.prefix + 'md-autocomplete').controller('mdAutocomplete');
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.scope.searchText = 'K';
+            });
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.select(0);
+            });
+            $timeout.flush();
+
+            expect(scope.items.length).toBe(4);
+            expect(scope.items[3]).toBe('Kiwi');
+            expect(element.find('input').val()).toBe('');
+          }));
+
+          it('simultaneously allows selecting an existing chip AND adding a new one', inject(function($mdConstant) {
+            // Setup our scope and function
+            setupScopeForAutocomplete();
+            scope.transformChip = jasmine.createSpy('transformChip');
+
+            // Modify the base template to add md-transform-chip
+            var modifiedTemplate = AUTOCOMPLETE_CHIPS_TEMPLATE
+              .replace('<' + config.prefix + 'md-chips', '<' + config.prefix + 'md-chips ' + config.prefix + 'md-on-append="transformChip($chip)"');
+
+            var element = buildChips(modifiedTemplate);
+
+            var ctrl = element.controller('mdChips');
+            $timeout.flush(); // mdAutcomplete needs a flush for its init.
+            var autocompleteCtrl = element.find(config.prefix + 'md-autocomplete').controller('mdAutocomplete');
+
+            element.scope().$apply(function() {
+              autocompleteCtrl.scope.searchText = 'K';
+            });
+            autocompleteCtrl.focus();
+            $timeout.flush();
+
+            /*
+             * Send a down arrow/enter to select the right fruit
+             */
+            var downArrowEvent = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.DOWN_ARROW,
+              which: $mdConstant.KEY_CODE.DOWN_ARROW
+            };
+            var enterEvent = {
+              type: 'keydown',
+              keyCode: $mdConstant.KEY_CODE.ENTER,
+              which: $mdConstant.KEY_CODE.ENTER
+            };
+            element.find('input').triggerHandler(downArrowEvent);
+            element.find('input').triggerHandler(enterEvent);
+            $timeout.flush();
+
+            // Check our transformChip calls
+            expect(scope.transformChip).not.toHaveBeenCalledWith('K');
+            expect(scope.transformChip).toHaveBeenCalledWith('Kiwi');
+            expect(scope.transformChip.calls.count()).toBe(1);
+
+            // Check our output
+            expect(scope.items.length).toBe(4);
+            expect(scope.items[3]).toBe('Kiwi');
+            expect(element.find('input').val()).toBe('');
+
+            // Reset our jasmine spy
+            scope.transformChip.calls.reset();
+
+            /*
+             * Use the "new chip" functionality
+             */
+
+            // Set the search text
+            element.scope().$apply(function() {
+              autocompleteCtrl.scope.searchText = 'Acai Berry';
+            });
+
+            // Fire our event and flush any timeouts
+            element.find('input').triggerHandler(enterEvent);
+            $timeout.flush();
+
+            // Check our transformChip calls
+            expect(scope.transformChip).toHaveBeenCalledWith('Acai Berry');
+            expect(scope.transformChip.calls.count()).toBe(1);
+
+            // Check our output
+            expect(scope.items.length).toBe(5);
+            expect(scope.items[4]).toBe('Acai Berry');
+            expect(element.find('input').val()).toBe('');
+          }));
+        });
+
+        describe('user input templates', function() {
+          var NG_MODEL_TEMPLATE = '\
+            <' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">\
+              <input type="text" ' + config.prefix + 'ng-model="inputText">\
+            </' + config.prefix + 'md-chips>';
+          var INPUT_TEMPLATE = '\
+            <' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">\
+              <input type="text">\
+            </' + config.prefix + 'md-chips>';
+
+          it('focuses/blurs the component when focusing/blurring the input', inject(function($timeout) {
             var element = buildChips(INPUT_TEMPLATE);
             var ctrl = element.controller('mdChips');
             $timeout.flush();
 
-            element.scope().$apply(function() {
-              ctrl.userInputElement[0].value = 'Kiwi';
-              simulateInputEnterKey(ctrl);
-            });
+            // Focus the input and check
+            element.find('input').triggerHandler('focus');
+            $timeout.flush();
+            expect(ctrl.inputHasFocus).toBe(true);
+            expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(true);
 
-            expect(scope.items.length).toBe(4);
-            expect(scope.items[3]).toBe('Kiwi');
+            // Blur the input and check
+            element.find('input').triggerHandler('blur');
+            $timeout.flush();
+            expect(ctrl.inputHasFocus).toBe(false);
+            expect(element.find('md-chips-wrap').hasClass('md-focused')).toBe(false);
           }));
+
+          describe('using ngModel', function() {
+            it('should add the ngModelCtrl.$viewValue when <enter> is pressed',
+              inject(function($timeout) {
+                var element = buildChips(NG_MODEL_TEMPLATE);
+                var ctrl = element.controller('mdChips');
+                $timeout.flush();
+
+                var ngModelCtrl = ctrl.userInputNgModelCtrl;
+
+                element.scope().$apply(function() {
+                  ngModelCtrl.$viewValue = 'Grape';
+                  simulateInputEnterKey(ctrl);
+                });
+
+                expect(scope.items.length).toBe(4);
+                expect(scope.items[3]).toBe('Grape');
+              }));
+          });
+
+          describe('without ngModel', function() {
+            it('should support an input without an ngModel', inject(function($timeout) {
+              var element = buildChips(INPUT_TEMPLATE);
+              var ctrl = element.controller('mdChips');
+              $timeout.flush();
+
+              element.scope().$apply(function() {
+                ctrl.userInputElement[0].value = 'Kiwi';
+                simulateInputEnterKey(ctrl);
+              });
+
+              expect(scope.items.length).toBe(4);
+              expect(scope.items[3]).toBe('Kiwi');
+            }));
+          });
+        });
+      });
+
+      describe('static chips', function() {
+        var STATIC_CHIPS_TEMPLATE = '\
+          <' + config.prefix + 'md-chips>\
+            <' + config.prefix + 'md-chip>Hockey</' + config.prefix + 'md-chip>\
+            <' + config.prefix + 'md-chip>Lacrosse</' + config.prefix + 'md-chip>\
+            <' + config.prefix + 'md-chip>Baseball</' + config.prefix + 'md-chip>\
+            <' + config.prefix + 'md-chip>{{chipItem}}</' + config.prefix + 'md-chip>\
+          </' + config.prefix + 'md-chips>';
+
+        var STATIC_CHIPS_NGREPEAT_TEMPLATE = '\
+          <div>\
+            <div ' + config.prefix + 'ng-repeat="i in [1,2,3]">\
+              <' + config.prefix + 'md-chips>\
+                <' + config.prefix + 'md-chip>{{i}}</' + config.prefix + 'md-chip>\
+              </' + config.prefix + 'md-chips>\
+            </div>\
+          </div>\
+        ';
+
+        it('should transclude static chips', inject(function($timeout) {
+          scope.chipItem = 'Football';
+          var element = buildChips(STATIC_CHIPS_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+          $timeout.flush();
+
+          var chips = getChipElements(element);
+          expect(chips.length).toBe(4);
+          expect(chips[0].innerHTML).toContain('Hockey');
+          expect(chips[1].innerHTML).toContain('Lacrosse');
+          expect(chips[2].innerHTML).toContain('Baseball');
+          expect(chips[3].innerHTML).toContain('Football');
+        }));
+
+        it('allows ng-repeat outside of md-chips', function() {
+          var element = buildChips(STATIC_CHIPS_NGREPEAT_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+
+          $timeout.flush();
+
+          var chipsArray = getChipsElements(element);
+          var chipArray = getChipElements(element);
+
+          // Check the lengths
+          expect(chipsArray.length).toBe(3);
+          expect(chipArray.length).toBe(3);
+
+          // Check the chip's text
+          expect(chipArray[0].innerHTML).toContain('1');
+          expect(chipArray[1].innerHTML).toContain('2');
+          expect(chipArray[2].innerHTML).toContain('3');
+        });
+      });
+
+      describe('<md-chip-remove>', function() {
+        it('should remove a chip', function() {
+          var element = buildChips(config.BASIC_CHIP_TEMPLATE);
+          var ctrl = element.controller('mdChips');
+          var chips = getChipElements(element);
+
+          expect(chips.length).toBe(3);
+
+          // Remove 'Banana'
+          var db = angular.element(chips[1]).find('button');
+          db[0].click();
+
+          scope.$digest();
+          chips = getChipElements(element);
+          expect(chips.length).toBe(2);
+
+          // Remove 'Orange'
+          db = angular.element(chips[1]).find('button');
+          db[0].click();
+
+          scope.$digest();
+          chips = getChipElements(element);
+          expect(chips.length).toBe(1);
+
         });
       });
     });
 
-    describe('static chips', function() {
-      var STATIC_CHIPS_TEMPLATE = '\
-        <md-chips>\
-          <md-chip>Hockey</md-chip>\
-          <md-chip>Lacrosse</md-chip>\
-          <md-chip>Baseball</md-chip>\
-          <md-chip>{{chipItem}}</md-chip>\
-        </md-chips>';
-
-      var STATIC_CHIPS_NGREPEAT_TEMPLATE = '\
-        <div>\
-          <div ng-repeat="i in [1,2,3]">\
-            <md-chips>\
-              <md-chip>{{i}}</md-chip>\
-            </md-chips>\
-          </div>\
-        </div>\
-      ';
-
-      it('should transclude static chips', inject(function($timeout) {
-        scope.chipItem = 'Football';
-        var element = buildChips(STATIC_CHIPS_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-        $timeout.flush();
-
-        var chips = getChipElements(element);
-        expect(chips.length).toBe(4);
-        expect(chips[0].innerHTML).toContain('Hockey');
-        expect(chips[1].innerHTML).toContain('Lacrosse');
-        expect(chips[2].innerHTML).toContain('Baseball');
-        expect(chips[3].innerHTML).toContain('Football');
+    describe('with $interpolate.start/endSymbol override ' + config.description, function() {
+      beforeEach(module(function($interpolateProvider) {
+        $interpolateProvider.startSymbol('[[').endSymbol(']]');
       }));
 
-      it('allows ng-repeat outside of md-chips', function() {
-        var element = buildChips(STATIC_CHIPS_NGREPEAT_TEMPLATE);
-        var ctrl = element.controller('mdChips');
+      beforeEach(module('material.components.chips', 'material.components.autocomplete'));
 
-        $timeout.flush();
+      beforeEach(inject(function($rootScope) {
+        scope = $rootScope.$new();
+        scope.items = ['Apple', 'Banana', 'Orange'];
+      }));
 
-        var chipsArray = getChipsElements(element);
-        var chipArray = getChipElements(element);
+      it('should render a user-provided chip template with custom start/end symbols', function() {
+        var template =
+          '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">' +
+          '  <' + config.prefix + 'md-chip-template><div class="mychiptemplate">[[$chip]]</div></' + config.prefix + 'md-chip-template>' +
+          '</' + config.prefix + 'md-chips>';
+        var element = buildChips(template);
+        var chips = element[0].querySelectorAll('md-chip .mychiptemplate, data-md-chip .mychiptemplate');
 
-        // Check the lengths
-        expect(chipsArray.length).toBe(3);
-        expect(chipArray.length).toBe(3);
+        expect(angular.element(chips[0]).text().trim()).toEqual('Apple');
+        expect(angular.element(chips[1]).text().trim()).toEqual('Banana');
+        expect(angular.element(chips[2]).text().trim()).toEqual('Orange');
+      });
 
-        // Check the chip's text
-        expect(chipArray[0].innerHTML).toContain('1');
-        expect(chipArray[1].innerHTML).toContain('2');
-        expect(chipArray[2].innerHTML).toContain('3');
+      it('should not interpolate old-style tags in a user-provided chip template', function() {
+        var template =
+          '<' + config.prefix + 'md-chips ' + config.prefix + 'ng-model="items">' +
+          '  <' + config.prefix + 'md-chip-template><div class="mychiptemplate">{{$chip}}</div></' + config.prefix + 'md-chip-template>' +
+          '</' + config.prefix + 'md-chips>';
+        var element = buildChips(template);
+        var chips = element[0].querySelectorAll('md-chip .mychiptemplate, data-md-chip .mychiptemplate');
+
+        expect(angular.element(chips[0]).text().trim()).toEqual('{{$chip}}');
+        expect(angular.element(chips[1]).text().trim()).toEqual('{{$chip}}');
+        expect(angular.element(chips[2]).text().trim()).toEqual('{{$chip}}');
       });
     });
 
-    describe('<md-chip-remove>', function() {
-      it('should remove a chip', function() {
-        var element = buildChips(BASIC_CHIP_TEMPLATE);
-        var ctrl = element.controller('mdChips');
-        var chips = getChipElements(element);
+    // *******************************
+    // Internal helper methods
+    // *******************************
 
-        expect(chips.length).toBe(3);
-
-        // Remove 'Banana'
-        var db = angular.element(chips[1]).find('button');
-        db[0].click();
-
-        scope.$digest();
-        chips = getChipElements(element);
-        expect(chips.length).toBe(2);
-
-        // Remove 'Orange'
-        db = angular.element(chips[1]).find('button');
-        db[0].click();
-
-        scope.$digest();
-        chips = getChipElements(element);
-        expect(chips.length).toBe(1);
-
+    function buildChips(str) {
+      var container;
+      inject(function($compile) {
+        container = $compile(str)(scope);
+        container.scope().$apply();
       });
-    });
-  });
-
-  describe('with $interpolate.start/endSymbol override', function() {
-    beforeEach(module(function($interpolateProvider) {
-      $interpolateProvider.startSymbol('[[').endSymbol(']]');
-    }));
-
-    beforeEach(module('material.components.chips', 'material.components.autocomplete'));
-
-    beforeEach(inject(function($rootScope) {
-      scope = $rootScope.$new();
-      scope.items = ['Apple', 'Banana', 'Orange'];
-    }));
-
-    it('should render a user-provided chip template with custom start/end symbols', function() {
-      var template =
-        '<md-chips ng-model="items">' +
-        '  <md-chip-template><div class="mychiptemplate">[[$chip]]</div></md-chip-template>' +
-        '</md-chips>';
-      var element = buildChips(template);
-      var chips = element[0].querySelectorAll('md-chip .mychiptemplate');
-
-      expect(angular.element(chips[0]).text().trim()).toEqual('Apple');
-      expect(angular.element(chips[1]).text().trim()).toEqual('Banana');
-      expect(angular.element(chips[2]).text().trim()).toEqual('Orange');
-    });
-
-    it('should not interpolate old-style tags in a user-provided chip template', function() {
-      var template =
-        '<md-chips ng-model="items">' +
-        '  <md-chip-template><div class="mychiptemplate">{{$chip}}</div></md-chip-template>' +
-        '</md-chips>';
-      var element = buildChips(template);
-      var chips = element[0].querySelectorAll('md-chip .mychiptemplate');
-
-      expect(angular.element(chips[0]).text().trim()).toEqual('{{$chip}}');
-      expect(angular.element(chips[1]).text().trim()).toEqual('{{$chip}}');
-      expect(angular.element(chips[2]).text().trim()).toEqual('{{$chip}}');
-    });
-  });
-
-  // *******************************
-  // Internal helper methods
-  // *******************************
-
-  function buildChips(str) {
-    var container;
-    inject(function($compile) {
-      container = $compile(str)(scope);
-      container.scope().$apply();
-    });
-    attachedElements.push(container);
-    return container;
-  }
-
-  function setupScopeForAutocomplete() {
-    scope.selectedItem = '';
-    scope.searchText = '';
-    scope.fruits = ['Apple', 'Banana', 'Orange', 'Kiwi', 'Grape'];
-    scope.querySearch = function(searchText) {
-      return scope.fruits.filter(function(item) {
-        return item.toLowerCase().indexOf(searchText.toLowerCase()) === 0;
-      });
+      attachedElements.push(container);
+      return container;
     }
-  }
 
-  function simulateInputEnterKey(ctrl) {
-    var event = {};
-    event.preventDefault = jasmine.createSpy('preventDefault');
-    inject(function($mdConstant) {
-      event.keyCode = $mdConstant.KEY_CODE.ENTER;
-    });
-    ctrl.inputKeydown(event);
-  }
+    function setupScopeForAutocomplete() {
+      scope.selectedItem = '';
+      scope.searchText = '';
+      scope.fruits = ['Apple', 'Banana', 'Orange', 'Kiwi', 'Grape'];
+      scope.querySearch = function(searchText) {
+        return scope.fruits.filter(function(item) {
+          return item.toLowerCase().indexOf(searchText.toLowerCase()) === 0;
+        });
+      }
+    }
 
-  function getChipsElements(root) {
-    return angular.element(root[0].querySelectorAll('md-chips'));
-  }
+    function simulateInputEnterKey(ctrl) {
+      var event = {};
+      event.preventDefault = jasmine.createSpy('preventDefault');
+      inject(function($mdConstant) {
+        event.keyCode = $mdConstant.KEY_CODE.ENTER;
+      });
+      ctrl.inputKeydown(event);
+    }
 
-  function getChipElements(root) {
-    return angular.element(root[0].querySelectorAll('md-chip'));
-  }
+    function getChipsElements(root) {
+      return angular.element(root[0].querySelectorAll('md-chips, data-md-chips'));
+    }
+
+    function getChipElements(root) {
+      return angular.element(root[0].querySelectorAll('md-chip, data-md-chip'));
+    }
+  });
 });

--- a/src/components/chips/demoBasicUsageDataPrefixed/index.html
+++ b/src/components/chips/demoBasicUsageDataPrefixed/index.html
@@ -1,0 +1,62 @@
+<div data-ng-controller="BasicDemoCtrl as ctrl" layout="column" data-ng-cloak>
+
+  <md-content class="md-padding" layout="column">
+    <h2 class="md-title">Use a custom chip template.</h2>
+
+    <form name="fruitForm">
+      <data-md-chips data-ng-model="ctrl.roFruitNames" data-name="fruitName" data-readonly="ctrl.readonly" data-md-max-chips="5">
+        <data-md-chip-template>
+          <strong>{{$chip}}</strong>
+          <em>(fruit)</em>
+        </data-md-chip-template>
+      </data-md-chips>
+
+      <div class="errors" data-ng-messages="fruitForm.fruitName.$error">
+        <div data-ng-message="md-max-chips">The maxmium of chips is reached.</div>
+      </div>
+    </form>
+
+
+    <br/>
+    <h2 class="md-title">Use the default chip template.</h2>
+
+    <data-md-chips data-ng-model="ctrl.fruitNames" data-readonly="ctrl.readonly"></data-md-chips>
+
+
+    <br/>
+    <h2 class="md-title">Make chips editable.</h2>
+
+    <data-md-chips data-ng-model="ctrl.editableFruitNames" data-readonly="ctrl.readonly" data-md-enable-chip-edit="true"></data-md-chips>
+
+    <br/>
+    <h2 class="md-title">Use Placeholders and override hint texts.</h2>
+
+    <data-md-chips
+        data-ng-model="ctrl.tags"
+        data-readonly="ctrl.readonly"
+        data-placeholder="Enter a tag"
+        data-delete-button-label="Remove Tag"
+        data-delete-hint="Press delete to remove tag"
+        data-secondary-placeholder="+Tag"></data-md-chips>
+
+    <br/>
+    <h2 class="md-title">Display an ordered set of objects as chips (with custom template).</h2>
+    <p>Note: the variables <code>$chip</code> and <code>$index</code> are available in custom chip templates.</p>
+
+    <data-md-chips class="custom-chips" data-ng-model="ctrl.vegObjs" data-readonly="ctrl.readonly" data-md-transform-chip="ctrl.newVeg($chip)">
+      <data-md-chip-template>
+        <span>
+          <strong>[{{$index}}] {{$chip.name}}</strong>
+          <em>({{$chip.type}})</em>
+        </span>
+      </data-md-chip-template>
+      <button data-md-chip-remove class="md-primary vegetablechip">
+        <md-icon data-md-svg-icon="md-close"></data-md-icon>
+      </button>
+    </data-md-chips>
+
+    <br/>
+    <md-checkbox data-ng-model="ctrl.readonly">Readonly</data-md-checkbox>
+
+  </md-content>
+</div>

--- a/src/components/chips/demoBasicUsageDataPrefixed/script.js
+++ b/src/components/chips/demoBasicUsageDataPrefixed/script.js
@@ -1,0 +1,40 @@
+(function () {
+  'use strict';
+  angular
+      .module('chipsDemo', ['ngMaterial', 'ngMessages'])
+      .controller('BasicDemoCtrl', DemoCtrl);
+
+  function DemoCtrl ($timeout, $q) {
+    var self = this;
+
+    self.readonly = false;
+
+    // Lists of fruit names and Vegetable objects
+    self.fruitNames = ['Apple', 'Banana', 'Orange'];
+    self.roFruitNames = angular.copy(self.fruitNames);
+    self.editableFruitNames = angular.copy(self.fruitNames);
+
+    self.tags = [];
+    self.vegObjs = [
+      {
+        'name' : 'Broccoli',
+        'type' : 'Brassica'
+      },
+      {
+        'name' : 'Cabbage',
+        'type' : 'Brassica'
+      },
+      {
+        'name' : 'Carrot',
+        'type' : 'Umbelliferous'
+      }
+    ];
+
+    self.newVeg = function(chip) {
+      return {
+        name: chip,
+        type: 'unknown'
+      };
+    };
+  }
+})();

--- a/src/components/chips/demoBasicUsageDataPrefixed/style.scss
+++ b/src/components/chips/demoBasicUsageDataPrefixed/style.scss
@@ -1,0 +1,49 @@
+.errors {
+  font-size: 12px;
+  color: rgb(221,44,0);
+  margin-top: 10px;
+}
+
+.custom-chips {
+  md-chip {
+    position: relative;
+    ._md-chip-remove-container {
+      position: absolute;
+      right: 4px;
+      top: 4px;
+      margin-right: 0;
+      height: 24px;
+      button.vegetablechip {
+        position: relative;
+        height: 24px;
+        width: 24px;
+        line-height: 30px;
+        text-align: center;
+        background: rgba(black, 0.3);
+        border-radius: 50%;
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        margin: 0;
+        transition: background 0.15s linear;
+        display: block;
+        md-icon {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate3d(-50%, -50%, 0) scale(0.7);
+          color: white;
+          fill: white;
+        }
+        &:hover, &:focus {
+          background: rgba(red, 0.8);
+        }
+      }
+    }
+    &:not(.md-readonly) {
+      md-chip-template {
+        padding-right: 5px;
+      }
+    }
+  }
+}

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -247,19 +247,19 @@
       var userTemplate = attr['$mdUserTemplate'];
       attr['$mdUserTemplate'] = null;
 
-      var chipTemplate = getTemplateByQuery('md-chips>md-chip-template');
+      var chipTemplate = getTemplateByQuery('md-chips>md-chip-template, data-md-chips>data-md-chip-template, md-chips>data-md-chip-template, data-md-chips>md-chip-template');
 
       // Set the chip remove, chip contents and chip input templates. The link function will put
       // them on the scope for transclusion later.
-      var chipRemoveTemplate   = getTemplateByQuery('md-chips>*[md-chip-remove]') || templates.remove,
+      var chipRemoveTemplate   = getTemplateByQuery('md-chips>*[md-chip-remove], data-md-chips>*[data-md-chip-remove], data-md-chips>*[md-chip-remove], md-chips>*[data-md-chip-remove]') || templates.remove,
           chipContentsTemplate = chipTemplate || templates.default,
-          chipInputTemplate    = getTemplateByQuery('md-chips>md-autocomplete')
-              || getTemplateByQuery('md-chips>input')
+          chipInputTemplate    = getTemplateByQuery('md-chips>md-autocomplete, data-md-chips>data-md-autocomplete, md-chips>data-md-autocomplete, data-md-chips>md-autocomplete')
+              || getTemplateByQuery('md-chips>input, data-md-chips>input')
               || templates.input,
-          staticChips = userTemplate.find('md-chip');
+          staticChips = angular.element(userTemplate[0].querySelectorAll('md-chip, data-md-chip'));
 
       // Warn of malformed template. See #2545
-      if (userTemplate[0].querySelector('md-chip-template>*[md-chip-remove]')) {
+      if (userTemplate[0].querySelector('md-chip-template>*[md-chip-remove], data-md-chip-template>*[data-md-chip-remove], md-chip-template>*[data-md-chip-remove], data-md-chip-template>*[md-chip-remove]')) {
         $log.warn('invalid placement of md-chip-remove within md-chip-template.');
       }
 
@@ -326,10 +326,12 @@
             scope.$watch('$mdChipsCtrl.readonly', function(readonly) {
               if (!readonly) {
                 $mdUtil.nextTick(function(){
-                  if (chipInputTemplate.indexOf('<md-autocomplete') === 0)
-                    mdChipsCtrl
-                        .configureAutocomplete(element.find('md-autocomplete')
-                            .controller('mdAutocomplete'));
+                  if (chipInputTemplate.indexOf('<md-autocomplete') === 0 || chipInputTemplate.indexOf('<data-md-autocomplete') === 0)
+                      mdChipsCtrl
+                        .configureAutocomplete(
+                          angular.element(element[0].querySelector('md-autocomplete, data-md-autocomplete'))
+                                 .controller('mdAutocomplete')
+                        );
                   mdChipsCtrl.configureUserInput(element.find('input'));
                 });
               }
@@ -347,7 +349,9 @@
         // Compile with the parent's scope and prepend any static chips to the wrapper.
         if (staticChips.length > 0) {
           var compiledStaticChips = $compile(staticChips.clone())(scope.$parent);
-          $timeout(function() { element.find('md-chips-wrap').prepend(compiledStaticChips); });
+          $timeout(function() { 
+            angular.element(element[0].querySelector('md-chips-wrap, data-md-chips-wrap')).prepend(compiledStaticChips);
+          });
         }
       };
     }


### PR DESCRIPTION
Compare to [pull request #7056](https://github.com/angular/material/pull/7056) for a similar issue with md-menu
Changes:
* `<md-chips>`, `<md-chip-template>`, etc. can now also be used as `<data-md-chips>`, `<data-md-chip-template>`
* added a basic usage demo that features those `<data-*>` tags
* made the corresponding tests parametrized so that they are executed both with and without the data-prefix

Background:
'data-'-prefixing is f.e. done by angular-htmlify and allows for the W3C validation of angular templates