### PR TITLE
mdButton: Fix typos in "a" tag docs

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -19,8 +19,7 @@ angular
  * @restrict E
  *
  * @description
- * `a` is a anchnor directive used to inherit theme so stand-alone anchors.
- * This allows standalone `a` tags to support theme colors for md-primary, md-accent, etc.
+ * `a` is an anchor directive used to inherit theme colors for md-primary, md-accent, etc.
  *
  * @usage
  *


### PR DESCRIPTION
Fixes a couple of typos and some confusing language in the description for the new `a` tag under `md-button`. Please let me know if I misunderstood, since the first line was confusingly written at best.