### PR TITLE
fix(menu): Typo in hover deregistration.

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -72,7 +72,7 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
       deregisterScopeListeners.shift()();
     }
     menuItems && menuItems.off('mouseenter', self.handleMenuItemHover);
-    menuItems && menuItems.off('mouseleave', self.handleMenuMouseLeave);
+    menuItems && menuItems.off('mouseleave', self.handleMenuItemMouseLeave);
   };
 
   this.handleMenuItemHover = function(event) {


### PR DESCRIPTION
There was a typo in the hover deregistration code which attempted
to deregister an non-existent function. Fix by adding `Item` to
the handler.

Fixes #7947.

Kudos to @ChrisNightingale for catching the error.