### PR TITLE
fix(input, select, autocomplete, checkbox) correct all margins, paddings and offsets to match spec

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -71,16 +71,19 @@ md-autocomplete {
     &.md-menu-showing {
       z-index: $z-index-backdrop + 1;
     }
+
+    md-input-container.md-input-has-messages md-progress-linear.md-inline {
+      bottom: 16px;
+    }
+
     md-progress-linear {
       position: absolute;
       bottom: -2px;
       left: 0;
       // When `md-inline` is present, we adjust the offset to go over the `ng-message` space
       &.md-inline {
-        bottom: 40px;
-        right: 2px;
-        left: 2px;
-        width: auto;
+        bottom: 8px;
+        width: 100%;
       }
       ._md-mode-indeterminate {
         position: absolute;

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -177,10 +177,6 @@ function MdAutocomplete () {
             ng-class="{ \'md-whiteframe-z1\': !floatingLabel, \'md-menu-showing\': !$mdAutocompleteCtrl.hidden }"\
             role="listbox">\
           ' + getInputElement() + '\
-          <md-progress-linear\
-              class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
-              ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
-              md-mode="indeterminate"></md-progress-linear>\
           <md-virtual-repeat-container\
               md-auto-shrink\
               md-auto-shrink-min="1"\
@@ -254,6 +250,10 @@ function MdAutocomplete () {
                   aria-haspopup="true"\
                   aria-activedescendant=""\
                   aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
+              <md-progress-linear\
+                  class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
+                  ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
+                  md-mode="indeterminate"></md-progress-linear>\
               <div md-autocomplete-parent-scope md-autocomplete-replace>' + leftover + '</div>\
             </md-input-container>';
         } else {
@@ -279,6 +279,10 @@ function MdAutocomplete () {
                 aria-haspopup="true"\
                 aria-activedescendant=""\
                 aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
+            <md-progress-linear\
+                class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
+                ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
+                md-mode="indeterminate"></md-progress-linear>\
             <button\
                 type="button"\
                 tabindex="-1"\

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -31,9 +31,9 @@ md-checkbox {
   @include rtl(margin-left, $checkbox-margin, $checkbox-margin-end);
   @include rtl(margin-right, $checkbox-margin-end, $checkbox-margin);
 
-  &:last-of-type {
-    @include rtl(margin-left, $checkbox-margin, 0);
-    @include rtl(margin-right, 0, $checkbox-margin);
+  &:last-child {
+    @include rtl(margin-left, $checkbox-margin, $checkbox-margin);
+    @include rtl(margin-right, $checkbox-margin, $checkbox-margin);
   }
 
   &.md-focused:not([disabled]) {

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -5,8 +5,10 @@
 //
 // ^^ defined in variables.scss
 //
-$checkbox-margin: 16px !default;
-$checkbox-text-margin: 10px !default;
+$checkbox-margin: 3px !default;
+$checkbox-margin-end: 16px !default;
+
+$checkbox-text-margin: 56px !default;
 $checkbox-top: 12px !default;
 
 .md-inline-form {
@@ -18,20 +20,20 @@ $checkbox-top: 12px !default;
 md-checkbox {
   box-sizing: border-box;
   display: inline-block;
-  margin-bottom: $checkbox-margin;
+  margin: $checkbox-margin;
   white-space: nowrap;
   cursor: pointer;
   outline: none;
   user-select: none;
   position: relative;
   min-width: $checkbox-width;
-  min-height: $checkbox-width;
-  @include rtl(margin-left, 0, $checkbox-margin);
-  @include rtl(margin-right, $checkbox-margin, 0);
+  min-height: $checkbox-width * 2;
+  @include rtl(margin-left, $checkbox-margin, $checkbox-margin-end);
+  @include rtl(margin-right, $checkbox-margin-end, $checkbox-margin);
 
   &:last-of-type {
-    margin-left: 0;
-    margin-right: 0;
+    @include rtl(margin-left, $checkbox-margin, 0);
+    @include rtl(margin-right, 0, $checkbox-margin);
   }
 
   &.md-focused:not([disabled]) {
@@ -62,9 +64,15 @@ md-checkbox {
     vertical-align: middle;
     white-space: normal;
     user-select: text;
+    margin-top: 6px;
+    margin-bottom: 6px;
 
-    @include rtl(margin-left, $checkbox-text-margin + $checkbox-width, 0);
-    @include rtl(margin-right, 0, $checkbox-text-margin + $checkbox-width);
+    @include rtl(margin-left, $checkbox-text-margin - $checkbox-margin, 0);
+    @include rtl(margin-right, 0, $checkbox-text-margin - $checkbox-margin);
+
+    &:empty {
+      display: none;
+    }
 
   }
 }

--- a/src/components/input/demoErrorsAdvanced/index.html
+++ b/src/components/input/demoErrorsAdvanced/index.html
@@ -16,8 +16,8 @@
             <span hide-gt-sm>below</span>
 
             to see the messages switch between some custom hints, and the actual error messages.
-            Note that some of the <code>ng-messages</code> containers use <code>ngIf</code> while
-            others use <code>ng-show</code> or <code>ng-hide</code>.
+            Note that some of the <code>ng-messages</code> containers use <code>ng-show</code> or
+            <code>ng-hide</code>.
           </p>
         </div>
 

--- a/src/components/input/demoErrorsAdvanced/style.css
+++ b/src/components/input/demoErrorsAdvanced/style.css
@@ -1,9 +1,8 @@
 .hint {
     /* Position the hint */
-    position: absolute;
-    left: 2px;
-    right: auto;
-    bottom: 7px;
+    display: inline-block;
+    padding-top: 2px;
+    margin-bottom: -1px;
 
     /* Copy styles from ng-messages */
     font-size: 12px;
@@ -20,12 +19,10 @@
 .hint.ng-hide,
 .hint.ng-enter,
 .hint.ng-leave.ng-leave-active {
-    bottom: 26px;
     opacity: 0;
 }
 
 .hint.ng-leave,
 .hint.ng-enter.ng-enter-active {
-    bottom: 7px;
     opacity: 1;
 }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -435,9 +435,12 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout) {
 
           var newRows = Math.round( Math.round(getHeight() / lineHeight) );
           var rowsToSet = Math.min(newRows, minRows);
-          
+          var newHeight = lineHeight * rowsToSet;
+          if (newHeight)
+            newHeight += paddingSize;
+
           element
-            .css('height', lineHeight * rowsToSet + paddingSize + 'px')
+            .css('height', newHeight + 'px')
             .attr('rows', rowsToSet)
             .toggleClass('_md-textarea-scrollable', newRows >= minRows);
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -140,6 +140,8 @@ function labelDirective() {
       if (!containerCtrl || attr.mdNoFloat || element.hasClass('_md-container-ignore')) return;
 
       containerCtrl.label = element;
+      containerCtrl.element.toggleClass('md-input-has-label', true);
+      
       scope.$on('$destroy', function() {
         containerCtrl.label = null;
       });
@@ -422,17 +424,20 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout) {
           .attr('rows', 1);
 
         if (minRows) {
+          var paddingSize = parseInt(window.getComputedStyle(node)['padding-bottom']) || 0;
           if (!lineHeight) {
             node.style.minHeight = 0;
             lineHeight = element.prop('clientHeight');
+            if (lineHeight)
+              lineHeight -= paddingSize;
             node.style.minHeight = null;
           }
 
           var newRows = Math.round( Math.round(getHeight() / lineHeight) );
           var rowsToSet = Math.min(newRows, minRows);
-
+          
           element
-            .css('height', lineHeight * rowsToSet + 'px')
+            .css('height', lineHeight * rowsToSet + paddingSize + 'px')
             .attr('rows', rowsToSet)
             .toggleClass('_md-textarea-scrollable', newRows >= minRows);
 
@@ -553,7 +558,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
 
       // Force the value into a string since it may be a number,
       // which does not have a length property.
-      charCountEl.text(String(element.val() || value || '').length + '/' + maxlength);
+      charCountEl.text(String(element.val() || value || '').length + ' / ' + maxlength);
       return value;
     }
   }
@@ -591,6 +596,7 @@ function placeholderDirective($log) {
 
       inputContainer.element.addClass('md-icon-float');
       inputContainer.element.prepend(placeholder);
+      inputContainer.element.toggleClass('md-input-has-label', true);
     }
   }
 }
@@ -701,6 +707,8 @@ function ngMessagesDirective() {
     if (attrs.mdAutoHide == 'false' || hasVisibiltyDirective(attrs)) {
       element.toggleClass('md-auto-hide', false);
     }
+
+    inputContainer.element.toggleClass('md-input-has-messages', true);
   }
 
   function hasVisibiltyDirective(attrs) {

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -444,7 +444,7 @@ md-input-container {
       @include rtl(left, auto, 2px);
     }
     
-    &:last-of-type {
+    &:last-child {
       @include rtl(padding-left, 0, $icon-offset);
       @include rtl(padding-right, $icon-offset, 0);
     }

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -1,26 +1,43 @@
-$input-container-padding: 2px !default;
+$input-container-padding-right: 16px !default;
+$input-container-margin: 0 !default;
+$input-container-min-height: 48px !default;
 
+
+$default-padding-left: 1px !default;
+$default-top-margin: 10px !default;
+
+$input-label-font-size: 12px !default;
+$input-label-min-height: 24px !default;
+$input-label-margin-top: $default-top-margin !default;
+$input-label-padding-left: $default-padding-left !default;
 $input-label-default-offset: 24px !default;
-$input-label-default-scale: 1.0 !default;
-$input-label-float-offset: 6px !default;
-$input-label-float-scale: 0.75 !default;
-$input-label-float-width: $input-container-padding + 16px !default;
+$input-label-float-offset: 0 !default;
+$input-label-float-width: 16px !default;
+$input-label-float-scale: 1.0 !default;
 
 $input-placeholder-offset: $input-label-default-offset !default;
 
+$input-margin-top: $default-top-margin !default;
+$input-margin-bottom: 11px !default;
+$input-padding-top: 0px !default;
+$input-padding-left: $default-padding-left !default;
+$input-padding-bottom: 8px !default;
 $input-border-width-default: 1px !default;
 $input-border-width-focused: 2px !default;
-$input-line-height: 26px !default;
-$input-padding-top: 2px !default;
+$input-line-height: normal !default;
+$input-box-sizing: content-box !default;
+
+$textarea-padding-bottom: 4px;
 
 $input-error-font-size: 12px !default;
 $input-error-height: 24px !default;
 $input-error-line-height: $input-error-font-size + 2px !default;
 $error-padding-top: ($input-error-height - $input-error-line-height) / 2 !default;
 
-$icon-offset: 36px !default;
+$icon-offset: 56px !default;
+$icon-height: 24px !default;
 
-$icon-top-offset: ($icon-offset - $input-padding-top - $input-border-width-focused) / 4 !default;
+$icon-top-offset: ($icon-offset - $input-border-width-focused) / 4 !default;
 
 $icon-float-focused-top: -8px !default;
 
@@ -28,8 +45,9 @@ md-input-container {
   @include pie-clearfix();
   display: inline-block;
   position: relative;
-  padding: $input-container-padding;
-  margin: 18px 0;
+  padding-right: $input-container-padding-right;
+  min-height: $input-container-min-height;
+  margin: $input-container-margin;
   vertical-align: middle;
 
   &.md-block {
@@ -40,17 +58,30 @@ md-input-container {
   // height with only 1 message
   .md-errors-spacer {
     @include rtl(float, right, left);
-    min-height: $input-error-height;
+	margin-top: -3px;
+	margin-bottom: 5px;
+	
+    &:empty {
+    	display: none;
+    }
+  }
+  
+  &.md-input-has-messages .md-errors-spacer {
+     display: block;
+     min-height:8px;
+     min-width: 1px;
+     margin-top: 4px;
 
-    // Ensure the element always takes up space, even if empty
-    min-width: 1px;
+    &:empty {
+      display: none;
+    }
   }
 
   > md-icon {
     position: absolute;
-    top: $icon-top-offset;
-    @include rtl(left, 2px, auto);
-    @include rtl(right, auto, 2px);
+    left: 0;
+    top: 50%;
+    margin-top: $icon-height / -2;
   }
 
   textarea,
@@ -72,19 +103,22 @@ md-input-container {
     -moz-appearance: none;
     -webkit-appearance: none;
   }
-  input[type="date"],
-  input[type="datetime-local"],
-  input[type="month"],
-  input[type="time"],
-  input[type="week"] {
-    min-height: $input-line-height;
+  
+  input[type="password"] {
+    letter-spacing: 2px;
   }
+  
   textarea {
     resize: none;
     overflow: hidden;
-
+	padding-left: 0;
+	padding-right: 0;
+	
     &.md-input {
-      min-height: $input-line-height;
+      //min-height: $input-line-height;
+      padding-bottom: 2px;
+      margin-bottom: 9px;
+      box-sizing: content-box;
       -ms-flex-preferred-size: auto; //IE fix
     }
 
@@ -101,7 +135,7 @@ md-input-container {
 
   label:not(._md-container-ignore) {
     position: absolute;
-    bottom: 100%;
+    font-size: 12px;
     @include rtl(left, 0, auto);
     @include rtl(right, auto, 0);
 
@@ -121,11 +155,15 @@ md-input-container {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
-    @include rtl(padding-left, $input-container-padding + 1px, 0);
-    @include rtl(padding-right, 0, $input-container-padding + 1px);
+    margin-top: $input-label-margin-top;
+    @include rtl(padding-left, $input-label-padding-left, 0);
+    @include rtl(padding-right, 0, $input-label-padding-left);
+    line-height: normal;
+    font-size: inherit;
     z-index: 1;
-    transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
-    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
+    transform: translate3d(0, 21px, 0);
+    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
+	            font-size $swift-ease-out-duration $swift-ease-out-timing-function	;
 
     // The max-width is necessary, because in some browsers, using this together with
     // a calc might cause it to overflow the parent. See #7403
@@ -137,12 +175,12 @@ md-input-container {
     position: absolute;
     top: 0;
     opacity: 0;
-    transition-property: opacity, transform;
-    transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
+    transition-property: opacity, transform, font-size;
+    transform: translate3d(0, 21px, 0);
   }
   &.md-input-focused ._md-placeholder {
     opacity: 1;
-    transform: translate3d(0, $input-placeholder-offset, 0);
+    transform: translate3d(0, 0, 0);
   }
   // Placeholder should immediately disappear when the user starts typing
   &.md-input-has-value ._md-placeholder {
@@ -170,17 +208,15 @@ md-input-container {
   .md-input {
     order: 2;
     display: block;
-    margin-top: 0;
-
+    margin-top: $input-margin-top;
+    margin-bottom: $input-margin-bottom;
     background: none;
     padding-top: $input-padding-top;
-    padding-bottom: $input-border-width-focused - $input-border-width-default;
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-bottom: $input-padding-bottom - $input-border-width-default;
     border-width: 0 0 $input-border-width-default 0;
-    line-height: $input-line-height;
-    height: $input-line-height + ($input-padding-top * 2);
-    -ms-flex-preferred-size: $input-line-height; //IE fix
+    line-height: normal;
+    height: auto;
+    -ms-flex-preferred-size: auto; //IE fix
     border-radius: 0;
     border-style: solid; // Firefox fix
 
@@ -207,22 +243,28 @@ md-input-container {
   }
 
   .md-char-counter {
-    @include rtl(text-align, right, left);
-    @include rtl(padding-right, $input-container-padding, 0);
-    @include rtl(padding-left, 0, $input-container-padding);
+  	
+    //@include rtl(text-align, right, left);
+    //@include rtl(padding-right, $input-container-padding, 0);
+    //@include rtl(padding-left, 0, $input-container-padding);
   }
 
   //
   // ngMessage base styles - animations moved to input.js
   //
+  [ng-messages],
   .md-input-messages-animation {
     position: relative;
+    min-height: 14px;
+    padding-top: 2px;
+    margin-bottom: -1px;
     order: 4;
     overflow: hidden;
     @include rtl(clear, left, right);
 
     &.ng-enter {
       // Upon entering the DOM, messages should be hidden
+      [ng-message],
       .md-input-message-animation {
         opacity: 0;
         margin-top: -100px;
@@ -230,12 +272,13 @@ md-input-container {
     }
   }
 
-  .md-input-message-animation, .md-char-counter {
+  [ng-message],
+  .md-char-counter {
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
     overflow: hidden;
 
-    transition: $swift-ease-in;
+    
 
     // Default state for messages is to be visible
     opacity: 1;
@@ -243,7 +286,7 @@ md-input-container {
 
     // Add some top padding which is equal to half the difference between the expected height
     // and the actual height
-    padding-top: $error-padding-top;
+    //padding-top: $error-padding-top;
 
     &:not(.md-char-counter) {
       // Add some padding so that the messages don't touch the character counter
@@ -251,9 +294,15 @@ md-input-container {
       @include rtl(padding-left, 0, rem(0.5));
     }
   }
+  
+  .md-input-message-animation,
+  .md-char-counter {
+  	transition: $swift-ease-in;
+  }
 
   &:not(.md-input-invalid) {
     .md-auto-hide {
+      [ng-message],
       .md-input-message-animation {
         opacity: 0;
         margin-top: -100px;
@@ -263,6 +312,7 @@ md-input-container {
 
   // Note: This is a workaround to fix an ng-enter flicker bug
   .md-auto-hide {
+    [ng-message],
     .md-input-message-animation {
       &:not(.ng-animate) {
         opacity: 0;
@@ -271,6 +321,7 @@ md-input-container {
     }
   }
 
+  [ng-message],
   .md-input-message-animation {
     &.ng-enter {
       opacity: 0;
@@ -282,10 +333,12 @@ md-input-container {
   &.md-input-has-placeholder,
   &.md-input-has-value {
     label:not(.md-no-float) {
-      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
+      transform: translate3d(0, $input-label-float-offset, 0);
       transition: transform $swift-ease-out-timing-function $swift-ease-out-duration,
-                  width $swift-ease-out-timing-function $swift-ease-out-duration;
+                  width $swift-ease-out-timing-function $swift-ease-out-duration,
+                  font-size $swift-ease-out-duration $swift-ease-out-timing-function;
       width: calc((100% - #{$input-label-float-width}) / #{$input-label-float-scale});
+      font-size: 12px;
     }
   }
 
@@ -300,8 +353,13 @@ md-input-container {
   // Use wide border in error state or in focused state
   &.md-input-focused .md-input,
   .md-input.ng-invalid.ng-dirty {
-    padding-bottom: 0; // Increase border width by 1px, decrease padding by 1
+    padding-bottom: $input-padding-bottom - $input-border-width-focused;
     border-width: 0 0 $input-border-width-focused 0;
+  }
+  
+  &.md-input-focused textarea.md-input,
+  textarea.md-input.ng-invalid.ng-dirty {
+    padding-bottom: 2px;
   }
 
   .md-input {
@@ -327,9 +385,9 @@ md-input-container {
     }
 
     > md-icon {
-      top: $icon-top-offset;
-      @include rtl(left, 2px, auto);
-      @include rtl(right, auto, 2px);
+      //top: $icon-top-offset;
+      //@include rtl(left, 2px, auto);
+      //@include rtl(right, auto, 2px);
     }
 
   }
@@ -354,26 +412,41 @@ md-input-container {
       }
     }
   }
+  
+  &:last-of-type {
+    @include rtl(padding-left, 0, 0);
+    @include rtl(padding-right, 0, 0);
+  }
 
   // icon offset should have higher priority as normal label
   &.md-icon-left {
-    @include rtl(padding-left, $icon-offset, 0);
-    @include rtl(padding-right, 0, $icon-offset);
+    @include rtl(padding-left, $icon-offset, $input-container-padding-right);
+    @include rtl(padding-right, $input-container-padding-right, $icon-offset);
     > label {
       @include rtl(left, $icon-offset, auto);
       @include rtl(right, auto, $icon-offset);
     }
+
+    &:last-of-type {
+      @include rtl(padding-left, $icon-offset, 0);
+      @include rtl(padding-right, 0, $icon-offset);
+    }
   }
 
   &.md-icon-right {
-    @include rtl(padding-left, 0, $icon-offset);
-    @include rtl(padding-right, $icon-offset, 0);
+    @include rtl(padding-left, $input-container-padding-right, $icon-offset);
+    @include rtl(padding-right, $icon-offset, $input-container-padding-right);
 
     > md-icon:last-of-type {
       margin: 0;
 
       @include rtl(right, 2px, auto);
       @include rtl(left, auto, 2px);
+    }
+    
+    &:last-of-type {
+      @include rtl(padding-left, 0, $icon-offset);
+      @include rtl(padding-right, $icon-offset, 0);
     }
   }
 
@@ -399,6 +472,59 @@ md-input-container {
       }
     }
   }
+  
+  &.md-input-has-messages {
+    label:not(.md-no-float):not(._md-container-ignore),
+    ._md-placeholder {
+      margin-top: 14px;
+    }
+
+    .md-input{
+      margin-bottom: 4px;
+    }
+    
+
+  }
+
+  &.md-input-has-label {
+    .md-input{
+      margin-top: 34px;
+    }
+
+    &.md-input-focused,
+    .md-input.ng-invalid.ng-dirty {
+      input[type="date"].md-input,
+      input[type="datetime-local"].md-input,
+      input[type="month"].md-input,
+      input[type="time"].md-input,
+      input[type="week"].md-input {
+        padding-bottom: 4px;
+      }
+
+      textarea.md-input {
+        padding-bottom: 9px;
+      }
+    }
+
+    input[type="date"].md-input,
+    input[type="datetime-local"].md-input,
+    input[type="month"].md-input,
+    input[type="time"].md-input,
+    input[type="week"].md-input {
+      margin-top: 31px;
+      padding-bottom: 5px;
+    }
+
+    textarea.md-input {
+      //has label preceding md-input
+      margin-top: 32px;
+      padding-bottom: 9px;
+      box-sizing: border-box;
+      @include rtl(padding-right, 8px, 0);
+      @include rtl(padding-left, 0, 8px);
+    }
+  }
+
 }
 
 @media screen and (-ms-high-contrast: active) {

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -253,21 +253,21 @@ describe('md-input-container directive', function() {
       $timeout.flush();
 
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
-      expect(getCharCounter(el).text()).toBe('0/5');
+      expect(getCharCounter(el).text()).toBe('0 / 5');
 
       pageScope.$apply('foo = "abcde"');
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
-      expect(getCharCounter(el).text()).toBe('5/5');
+      expect(getCharCounter(el).text()).toBe('5 / 5');
 
       pageScope.$apply('foo = "abcdef"');
       el.find('input').triggerHandler('input');
       expect(pageScope.form.foo.$error['md-maxlength']).toBe(true);
-      expect(getCharCounter(el).text()).toBe('6/5');
+      expect(getCharCounter(el).text()).toBe('6 / 5');
 
       pageScope.$apply('foo = "abc"');
       el.find('input').triggerHandler('input');
       expect(pageScope.form.foo.$error['md-maxlength']).toBeFalsy();
-      expect(getCharCounter(el).text()).toBe('3/5');
+      expect(getCharCounter(el).text()).toBe('3 / 5');
     });
 
     it('should render correct character count when value is a number', function() {
@@ -285,7 +285,7 @@ describe('md-input-container directive', function() {
       pageScope.item = {numberValue: 456};
       pageScope.$apply();
 
-      expect(getCharCounter(element).text()).toBe('3/6');
+      expect(getCharCounter(element).text()).toBe('3 / 6');
     });
 
     it('should add and remove maxlength element & error with expression', function() {
@@ -307,7 +307,7 @@ describe('md-input-container directive', function() {
       pageScope.$apply('foo = "abcdef"');
       expect(pageScope.form.foo.$error['md-maxlength']).toBeTruthy();
       expect(getCharCounter(el).length).toBe(1);
-      expect(getCharCounter(el).text()).toBe('6/5');
+      expect(getCharCounter(el).text()).toBe('6 / 5');
 
       pageScope.$apply('max = -1');
       pageScope.$apply('foo = "abcdefg"');

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -10,6 +10,9 @@ md-select.md-THEME_NAME-theme {
     }
     border-bottom-color: '{{foreground-4}}';
   }
+  &.md-no-border ._md-select-value {
+    border-bottom-color: transparent;
+  }
   &.ng-invalid.ng-dirty {
     ._md-select-value {
       color: '{{warn-A700}}' !important;

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -46,6 +46,7 @@ angular.module('material.components.select', [
  * explicit label is present.
  * @param {string=} md-container-class Class list to get applied to the `._md-select-menu-container`
  * element (for custom styling).
+ * @param {boolean=} md-no-border When present bottom border will not be visible
  *
  * @usage
  * With a placeholder (label and aria-label are added dynamically)
@@ -1457,7 +1458,7 @@ function SelectProvider($$interimElementProvider) {
         }
       }
 
-      var left, top, transformOrigin, minWidth;
+      var left, top, transformOrigin, minWidth, fontSize;
       if (shouldOpenAroundTarget) {
         left = targetRect.left;
         top = targetRect.top + targetRect.height;
@@ -1467,14 +1468,16 @@ function SelectProvider($$interimElementProvider) {
           transformOrigin = '50% 100%';
         }
       } else {
-        left = (targetRect.left + centeredRect.left - centeredRect.paddingLeft) + 2;
+        left = (targetRect.left + centeredRect.left - centeredRect.paddingLeft);
         top = Math.floor(targetRect.top + targetRect.height / 2 - centeredRect.height / 2 -
-            centeredRect.top + contentNode.scrollTop) + 2;
+            centeredRect.top + contentNode.scrollTop) + 1;
 
         transformOrigin = (centeredRect.left + targetRect.width / 2) + 'px ' +
           (centeredRect.top + centeredRect.height / 2 - contentNode.scrollTop) + 'px 0px';
 
         minWidth = Math.min(targetRect.width + centeredRect.paddingLeft + centeredRect.paddingRight, maxWidth);
+
+        fontSize = window.getComputedStyle(targetNode)['font-size'];
       }
 
       // Keep left and top within the window
@@ -1488,7 +1491,8 @@ function SelectProvider($$interimElementProvider) {
           styles: {
             left: Math.floor(clamp(bounds.left, left, bounds.right - containerRect.width)),
             top: Math.floor(clamp(bounds.top, top, bounds.bottom - containerRect.height)),
-            'min-width': minWidth
+            'min-width': minWidth,
+            'font-size': fontSize
           }
         },
         dropDown: {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -56,6 +56,11 @@ md-input-container > md-select {
   order: 2;
 }
 
+md-input-container.md-input-has-label > md-select {
+  padding-top: 24px;
+  padding-bottom: 11px;
+}
+
 md-select {
   display: flex;
   margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
@@ -80,14 +85,14 @@ md-select {
     &.ng-invalid.ng-dirty {
       ._md-select-value {
         border-bottom: 2px solid;
-        padding-bottom: 0;
+        padding-bottom: 5px;
       }
     }
     &:focus {
       ._md-select-value {
         border-bottom-width: 2px;
         border-bottom-style: solid;
-        padding-bottom: 0;
+        padding-bottom: 5px;
       }
     }
   }
@@ -97,13 +102,13 @@ md-select {
 ._md-select-value {
   display: flex;
   align-items: center;
-  padding: 2px 2px 1px;
+  padding: 4px 0px 6px 0px;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   background-color: rgba(0,0,0,0);
   position: relative;
   box-sizing: content-box;
-  min-width: 8 * $baseline-grid;
+  min-width: 11 * $baseline-grid;
   min-height: 26px;
   flex-grow: 1;
 
@@ -134,9 +139,11 @@ md-select {
     display: block;
     content: '\25BC';
     position: relative;
-    top: 2px;
+    right: -7px;
+    font-size: 16px;
+    top: 1px;
     speak: none;
-    transform: scaleY(0.6) scaleX(1);
+    transform: scaleY(0.5);
   }
 
   &._md-select-placeholder {
@@ -144,7 +151,6 @@ md-select {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
-    padding-left: 2px;
     z-index: 1;
   }
 }
@@ -205,7 +211,6 @@ md-option {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    font-size: rem(1.6);
   }
   padding: 0 $select-option-padding 0 $select-option-padding;
   height: $select-option-height;

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -168,7 +168,7 @@
   $border-radius: $checkbox-border-radius) {
   ._md-container {
     position: absolute;
-    top: 50%;
+    top: $checkbox-height;
     transform: translateY(-50%);
 
     box-sizing: border-box;

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -119,7 +119,7 @@ $button-fab-padding: rem(1.60) !default;
 
 
 // Shared Checkbox variables
-$checkbox-width: 20px !default;
+$checkbox-width: 18px !default;
 $checkbox-height: $checkbox-width !default;
 $checkbox-border-radius: 2px !default;
 $checkbox-border-width: 2px !default;

--- a/src/core/util/animation/animate.js
+++ b/src/core/util/animation/animate.js
@@ -146,6 +146,8 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
             case 'transformOrigin':
               convertToVendor(key, $mdConstant.CSS.TRANSFORM_ORIGIN, value);
               break;
+            default:
+              css[key] = value;
           }
         }
       });


### PR DESCRIPTION
This is a WIP but I believe completed my changes for md-input-container

I still need to write in the rest, but I wanted to share the changes I've done with input.scss

You can monitor and compare progress of this here:

specFix: http://codepen.io/shortfuse/pen/qZojGW
master: http://codepen.io/shortfuse/pen/ZWxYpN

This is my first time playing with scss so I'll need somebody else to double my work.

You will notice there are some awkward raw numbers being used for padding and margins. The reason why we can't use the exact pixels as represented by the spec is because with webkit, the raw height of the <input> includes leading metrics (space above and below font glyphs). You can't set a line-height less than 100%, so I had to manually set the padding and margins.

The other way to tackle this problem would require JS implementation. In this case, you would be able set the height attribute of <input> equal to the font size. The way I did it, while the numbers are awkward would require no JS. I'm not sure if it'll play nice with IE, but if somebody wants to write a JS component to change the height attribute of the <input>, that could work. My only concern is if, by changing the height, font glyphs could be clipped.

There are no forced height options and most items resize properly to spec, with a margin of error of a pixel or two. In my codepen, all items will align properly to baseline, as long as layout-align is used properly.

I'm using last-of-type, so if you want items to fill width properly, wrap it in a div if it's alone.

The main reason why everything flows properly is because I added ~~use the label+ CSS syntax~~ md-input-has-label attribute which will only apply certain metrics if a label present.

Right now I'm working on adding on the errors component of md-input-container to the scss, but I already have that in my codepen.
