### PR TITLE
fix(subheader): transform span to div to allow custom styling.

### DIFF
--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -49,7 +49,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     template: (
     '<div class="md-subheader _md">' +
     '  <div class="_md-subheader-inner">' +
-    '    <span class="_md-subheader-content"></span>' +
+    '    <div class="_md-subheader-content"></div>' +
     '  </div>' +
     '</div>'
     ),


### PR DESCRIPTION
* Currently span was used as a parent of the transcluded content, which makes customizing really hard.

Fixes #8063.