### PR TITLE
fix(release): replace https github urls with ssh

### DIFF
--- a/release.js
+++ b/release.js
@@ -12,7 +12,7 @@
   var pushCmds       = [ 'rm abort push' ];
   var cleanupCmds    = [];
   var defaultOptions = { encoding: 'utf-8' };
-  var origin         = 'https://github.com/angular/material.git';
+  var origin         = 'git@github.com:angular/material.git';
   var lineWidth      = 80;
   var lastMajorVer   = JSON.parse(exec('curl https://material.angularjs.org/docs.json')).latest;
   var newVersion;
@@ -196,7 +196,7 @@
   function cloneRepo (repo) {
     start(`Cloning ${repo.cyan} from Github...`);
     exec(`rm -rf ${repo}`);
-    exec(`git clone https://github.com/angular/${repo}.git --depth=1`);
+    exec(`git clone git@github.com:angular/${repo}.git --depth=1`);
     done();
     cleanupCmds.push(`rm -rf ${repo}`);
   }


### PR DESCRIPTION
This will prevent the need to type in credentials during release script.

@ThomasBurleson You are free to laugh at me for taking this long to fix this.