### PR TITLE
fix (ie11 fix): change of pointerEvents from initial to inherit

### DIFF
--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -135,7 +135,7 @@
         // If we're open
         if (ctrl.isOpen) {
           // Turn on toolbar pointer events when closed
-          toolbarElement.style.pointerEvents = 'initial';
+          toolbarElement.style.pointerEvents = 'inherit';
 
           backgroundElement.style.width = triggerElement.offsetWidth + 'px';
           backgroundElement.style.height = triggerElement.offsetHeight + 'px';


### PR DESCRIPTION
The inherit attribute did not work well in ie11 on windows7. The buttons of the toolbar could not be opened.  The fix was tested in chrome, FF, IE11, Edge and Safari

Closes #7012