### PR TITLE
fix(tooltip): empty tooltips should not show up.

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -234,6 +234,9 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     }
 
     function showTooltip() {
+      //  Do not show the tooltip if the text is empty.
+      if (!element[0].textContent.trim()) return;
+
       // Insert the element and position at top left, so we can get the position
       // and check if we should display it
       element.css({top: 0, left: 0});

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -141,6 +141,33 @@ describe('<md-tooltip> directive', function() {
         expect($rootScope.testModel.isVisible).toBe(false);
     });
 
+    it('should not show when the text is empty',  function() {
+
+      expect(findTooltip().length).toBe(0);
+
+      buildTooltip(
+        '<md-button>' +
+          'Hello' +
+          '<md-tooltip md-visible="testModel.isVisible">{{ textContent }} </md-tooltip>' +
+        '</md-button>'
+      );
+
+      showTooltip(true);
+
+      expect(findTooltip().length).toBe(0);
+
+      $rootScope.textContent = 'Tooltip';
+      $rootScope.$apply();
+
+      // Trigger a change on the model, otherwise the tooltip component can't detect the
+      // change.
+      showTooltip(false);
+      showTooltip(true);
+
+      expect(findTooltip().length).toBe(1);
+      expect(findTooltip().hasClass('_md-show')).toBe(true);
+    });
+
     it('should set visible on focus and blur', function() {
       buildTooltip(
         '<md-button>' +


### PR DESCRIPTION
Fixes #8021.