### PR TITLE
docs(layout-introduction): Updating allowed values

### DIFF
--- a/docs/app/partials/layout-introduction.tmpl.html
+++ b/docs/app/partials/layout-introduction.tmpl.html
@@ -29,7 +29,7 @@
     </tr>
     <tr>
       <td>flex</td>
-      <td> integer (increments of 5 for 0%->100%)</td>
+      <td> integer (increments of 5 for 0%->100%, 100%/3, 200%/3)</td>
     </tr>
     <tr>
       <td>flex-order</td>
@@ -37,7 +37,7 @@
     </tr>
     <tr>
       <td>flex-offset</td>
-      <td>integer (increments of 5 for 0%->100%, 100%/3, 200%/3)</td>
+      <td>integer (increments of 5 for 0%->95%, 100%/3, 200%/3)</td>
     </tr>
     <tr>
       <td>layout-align</td>


### PR DESCRIPTION
docs(layout-introduction): Update flex allowed values

Update flex allowed values in layout-introduction doc. Flex should include 100/3 and 200/3. Flex-offset should not include 100%. Based on classes created in layout.scss, and testing performed in layout.spec.js