### PR TITLE
demo(menu): Fix layouts of various demos.

### DIFF
--- a/src/components/menu/demoMenuPositionModes/index.html
+++ b/src/components/menu/demoMenuPositionModes/index.html
@@ -3,11 +3,9 @@
     <div layout-align="start center" layout="column" style="min-height:150px;" >
       <h2 class="md-title">Position Mode Demos</h2>
       <p>The <code>md-position-mode</code> attribute can be used to specify the positioning along the <code>x</code> and <code>y</code> axis.</p>
-      <hr/>
-      <h3 class="md-subhead">Target-Based Position Modes</h3>
     </div>
     <div class="menus"  layout-wrap layout="row" layout-fill layout-align="space-between center" style="min-height:200px;">
-      <div layout="column" flex="33" flex-sm="100" layout-align="center center">
+      <div layout="column" flex-xs="100" flex-sm="100" flex="33" layout-align="center center">
         <p>Target Mode Positioning (default)</p>
         <md-menu>
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -23,7 +21,7 @@
           </md-menu-content>
         </md-menu>
       </div>
-      <div layout="column" flex-sm="100" flex="33" layout-align="center center">
+      <div layout="column" flex-xs="100" flex-sm="100" flex="33" layout-align="center center">
         <p>Target mode with <code>md-offset</code></p>
         <md-menu md-offset="0 -5">
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="ctrl.openMenu($mdOpenMenu, $event)">
@@ -36,7 +34,7 @@
           </md-menu-content>
         </md-menu>
       </div>
-      <div layout="column" flex-sm="100" flex="33" layout-align="center center">
+      <div layout="column" flex-xs="100" flex-sm="100" flex="33" layout-align="center center">
         <p><code>md-position-mode="target-right target"</code></p>
         <md-menu md-position-mode="target-right target" >
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">

--- a/src/components/menu/demoMenuPositionModes/script.js
+++ b/src/components/menu/demoMenuPositionModes/script.js
@@ -7,6 +7,8 @@ angular
   })
   .controller('PositionDemoCtrl', function DemoCtrl($mdDialog) {
     var originatorEv;
+    
+    this.menuHref = "http://www.google.com/design/spec/components/menus.html#menus-specs";
 
     this.openMenu = function($mdOpenMenu, ev) {
       originatorEv = ev;

--- a/src/components/menu/demoMenuWidth/index.html
+++ b/src/components/menu/demoMenuWidth/index.html
@@ -1,11 +1,14 @@
 <div class="md-menu-demo" ng-controller="WidthDemoCtrl as ctrl" style="min-height:350px" ng-cloak>
   <div class="menu-demo-container" layout-align="start center" layout="column">
     <div layout-align="start center" layout="column" style="min-height:70px;" >
-    <h2 class="md-title">Different Widths</h2>
-    <p><code>md-menu-content</code> may specify a <code>width</code> attribute which will follow the <a href="http://www.google.com/design/spec/components/menus.html#menus-specs">official spec</a>.</p>
+      <h2 class="md-title">Different Widths</h2>
+      <p>
+        <code>md-menu-content</code> may specify a <code>width</code> attribute which will follow
+        the <a href="ctrl.menuHref" class="md-accent">official spec</a>.
+      </p>
     </div>
     <div class="menus" layout-wrap layout="row" layout-fill layout-align="space-between center" style="min-height:100px;">
-      <div layout="column" flex="33" flex-sm="100" layout-align="center center">
+      <div layout="column" flex="33" flex-sm="100" flex-xs="100" layout-align="center center">
         <p>Wide menu (<code>width=6</code>)</p>
         <md-menu md-offset="0 -7">
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -18,7 +21,7 @@
           </md-menu-content>
         </md-menu>
       </div>
-      <div layout="column" flex-sm="100" flex="33" layout-align="center center">
+      <div layout="column" flex="33" flex-sm="100" flex-xs="100" layout-align="center center">
         <p>Medium menu (<code>width=4</code>)</p>
         <md-menu md-offset="0 -7">
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -31,7 +34,7 @@
           </md-menu-content>
         </md-menu>
       </div>
-      <div layout="column" flex="33" flex-sm="100" layout-align="center center">
+      <div layout="column" flex="33" flex-sm="100" flex-xs="100" layout-align="center center">
         <p>Small menu (<code>width=2</code>)</p>
         <md-menu md-offset="0 -7">
           <md-button aria-label="Open demo menu" class="md-icon-button" ng-click="$mdOpenMenu($event)">
@@ -44,7 +47,6 @@
           </md-menu-content>
         </md-menu>
       </div>
-    </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The layouts did not account for `-xs` screen sizes, so they had the original 3-column layout on very small screens.

Fix by adding the proper `flex-xs` attributes. Also remove an extraneous closing `</div>` tag that was causing issues on some browsers. Also refactored a URL into a script var because it was causing the text to go past 110 characters...and apparently I'm OCD about that 😛 