### PR TITLE
chore(scripts/test-versions): ensure tests are run against the correct files

### DIFF
--- a/scripts/test-versions.sh
+++ b/scripts/test-versions.sh
@@ -74,16 +74,14 @@ for VERSION in "${VERSIONS[@]}"; do
     ZIP_URL="$CDN/$VERSION/angular-$VERSION.zip"
   fi
 
+  ZIP_FILE="angular-$VERSION.zip"
+  ZIP_FILE_PATH="./tmp/$ZIP_FILE"
   BASE_DIR="./tmp/angular-$VERSION"
 
-  if [ ! -d $BASE_DIR ]; then
-    ZIP_FILE="angular-$VERSION.zip"
-    ZIP_FILE_PATH="./tmp/$ZIP_FILE"
-
-    curl $ZIP_URL > $ZIP_FILE_PATH
-    unzip -d $BASE_DIR $ZIP_FILE_PATH
-    mv "$BASE_DIR/angular-$ZIP_FILE_SHA" "$BASE_DIR/files"
-  fi
+  rm -rf $BASE_DIR
+  curl $ZIP_URL > $ZIP_FILE_PATH
+  unzip -d $BASE_DIR $ZIP_FILE_PATH
+  mv "$BASE_DIR/angular-$ZIP_FILE_SHA" "$BASE_DIR/files"
 
   echo "\n\n--- Testing AngularMaterial against AngularJS (${VERSION}) ---\n"
 
@@ -95,7 +93,7 @@ for VERSION in "${VERSIONS[@]}"; do
     MIN_NODE_LIB_FILE="./node_modules/$ANGULAR_FILE/$ANGULAR_FILE.min.js"
 
     rm $NODE_LIB_FILE
-    cp $REPLACEMENT_FILE $NODE_LIB_FILE 
+    cp $REPLACEMENT_FILE $NODE_LIB_FILE
     echo "[copy] copied over $REPLACEMENT_FILE to $NODE_LIB_FILE"
 
     if [ -e $MIN_NODE_LIB_FILE ]; then
@@ -103,7 +101,7 @@ for VERSION in "${VERSIONS[@]}"; do
     fi
 
     if [ -e $MIN_REPLACEMENT_FILE ]; then
-      cp $MIN_REPLACEMENT_FILE $MIN_NODE_LIB_FILE 
+      cp $MIN_REPLACEMENT_FILE $MIN_NODE_LIB_FILE
     fi
     echo "[copy] copied over $MIN_REPLACEMENT_FILE to $MIN_NODE_LIB_FILE"
   done
@@ -128,6 +126,6 @@ done
 if [ $FAILED == true ]; then
   echo "Error: One or more of the karma tests have failed..."
   exit 1
-else 
+else
   echo "All tests have passed successfully..."
 fi


### PR DESCRIPTION
Previously, "version directories" (e.g. `./tmp/angular-1.4.10`) were considered "immutable", i.e. if the directory existed, the files were not downloaded again. While this assumption holds for released versions, it doesn't for the special `snapshot` version (which is the latest code from the master branch and changes constantly).

Since it is not particularly costly, this commit removes the optimization altogether and always downloads the files for each version.