### PR TITLE
fix(list): secondary item container expected a height of 100%

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -294,7 +294,6 @@ md-list-item {
       display: flex;
       align-items: center;
 
-      height: 100%;
       margin: auto;
 
       .md-button, .md-icon-button {


### PR DESCRIPTION
* The height of 100% for the secondary item container was depending on its parent DOM structure. So in some weird cases, the secondary item container was reserving 100% height of the screen.

This property even became unnecessary, because now the secondary items are expecting its size correctly and will fill the remaining space by the auto margin.

Thoroughly tested the List Demo, Divider Demo and a few User-specified list layouts.

Fixes #8094.