### PR TITLE
feat(contactChips): add basic support for md-separator-keys

### DIFF
--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -9,6 +9,7 @@
         md-contact-image="image"
         md-contact-email="email"
         md-require-match="true"
+        md-separator-keys="ctrl.keys"
         md-highlight-flags="i"
         placeholder="To">
     </md-contact-chips>

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -13,7 +13,7 @@
       .module('contactChipsDemo', ['ngMaterial'])
       .controller('ContactChipDemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($q, $timeout, $log) {
+  function DemoCtrl ($q, $timeout, $log, $mdConstant) {
     var self = this;
     var pendingSearch, cancelSearch = angular.noop;
     var lastSearch;
@@ -21,6 +21,7 @@
     self.allContacts = loadContacts();
     self.contacts = [self.allContacts[0]];
     self.asyncContacts = [];
+    self.keys = [$mdConstant.KEY_CODE.COMMA];
 
     self.querySearch = querySearch;
     self.delayedQuerySearch = delayedQuerySearch;

--- a/src/components/chips/js/contactChipsController.js
+++ b/src/components/chips/js/contactChipsController.js
@@ -18,6 +18,18 @@ MdContactChipsCtrl.prototype.queryContact = function(searchText) {
   return this.contactQuery({'$query': searchText});
 };
 
+MdContactChipsCtrl.prototype.inputKeydown = function(event) {
+  if (!this.separatorKeys || this.separatorKeys.indexOf(event.keyCode) < 0) {
+    return;
+  }
+
+  event.stopPropagation();
+  event.preventDefault();
+
+  var autocompleteCtrl = angular.element(event.target).controller('mdAutocomplete');
+  autocompleteCtrl.select(autocompleteCtrl.index);
+};
+
 MdContactChipsCtrl.prototype.itemName = function(item) {
   return item[this.contactName];
 };

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -56,7 +56,8 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
           ng-model="$mdContactChipsCtrl.contacts"\
           ng-change="$mdContactChipsCtrl.ngChange($mdContactChipsCtrl.contacts)"\
           md-require-match="$mdContactChipsCtrl.requireMatch"\
-          md-chip-append-delay="{{$mdContactChipsCtrl.chipAppendDelay}}" \
+          md-chip-append-delay="{{$mdContactChipsCtrl.chipAppendDelay}}"\
+          md-separator-keys="$mdContactChipsCtrl.separatorKeys"\
           md-autocomplete-snap>\
           <md-autocomplete\
               md-menu-class="md-contact-chips-suggestions"\
@@ -67,6 +68,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-no-cache="true"\
               md-min-length="$mdContactChipsCtrl.minLength"\
               md-autoselect\
+              ng-keydown="$mdContactChipsCtrl.inputKeydown($event)"\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\
             <div class="md-contact-suggestion">\
@@ -124,7 +126,8 @@ function MdContactChips($mdTheming, $mdUtil) {
       requireMatch: '=?mdRequireMatch',
       minLength: '=?mdMinLength',
       highlightFlags: '@?mdHighlightFlags',
-      chipAppendDelay: '@?mdChipAppendDelay'
+      chipAppendDelay: '@?mdChipAppendDelay',
+      separatorKeys: '=?mdSeparatorKeys',
     }
   };
 


### PR DESCRIPTION
Add basic support for md-separator-keys. The ENTER and TAB keys trigger
separation by default through md-autocomplete regardless of what
additional key codes are user defined.

Implements #6097, continuation of #6127 with the addition of unit tests requested.
