### PR TITLE
fix(select): don't swallow Ctrl hotkeys in the select

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1236,6 +1236,11 @@ function SelectProvider($$interimElementProvider) {
         }
 
         function onMenuKeyDown(ev) {
+          // Don't swallow hotkeys like Ctrl+r
+          if (ev.ctrlKey) {
+            return;
+          }
+
           var keyCodes = $mdConstant.KEY_CODE;
           ev.preventDefault();
           ev.stopPropagation();

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -414,6 +414,35 @@ describe('<md-select>', function() {
       expect(keydownEvent.stopPropagation).toHaveBeenCalled();
     }));
 
+    it('allows keydown events with Ctrl to propagate from inside the md-select-menu', inject(function($rootScope, $compile) {
+      $rootScope.val = [1];
+      var select = $compile(
+          '<md-input-container>' +
+          '  <label>Label</label>' +
+          '  <md-select multiple ng-model="val" placeholder="Hello World">' +
+          '    <md-option value="1">One</md-option>' +
+          '    <md-option value="2">Two</md-option>' +
+          '    <md-option value="3">Three</md-option>' +
+          '  </md-select>' +
+          '</md-input-container>')($rootScope);
+
+      var mdOption = select.find('md-option');
+      var selectMenu = select.find('md-select-menu');
+      var keydownEvent = {
+        type: 'keydown',
+        ctrlKey: true,
+        target: mdOption[0],
+        preventDefault: jasmine.createSpy(),
+        stopPropagation: jasmine.createSpy()
+      };
+
+      openSelect(select);
+      angular.element(selectMenu).triggerHandler(keydownEvent);
+
+      expect(keydownEvent.preventDefault).not.toHaveBeenCalled();
+      expect(keydownEvent.stopPropagation).not.toHaveBeenCalled();
+    }));
+
     it('supports raw html', inject(function($rootScope, $compile, $sce) {
       $rootScope.val = 0;
       $rootScope.opts = [


### PR DESCRIPTION
Allow keydown events in the md-select menu to propagate so that Ctrl
hotkeys like Ctrl+r work when the select is open.

Fixes #5640