### PR TITLE
IE10-IE11 column-flex bug fix

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -410,3 +410,9 @@
     @include flex-properties-for-name($name);
     @include layout-for-name($name);
 }
+
+/* IE10-IE11 column-flex bug fix (set proper default value) */
+.layout-column > .flex {
+	-ms-flex-basis: auto;
+	flex-basis: auto;
+}


### PR DESCRIPTION
Fix for this bug:
![ie11-flex-bug-0](https://cloud.githubusercontent.com/assets/1409078/14717314/849299e8-07f9-11e6-82a9-126241c81976.png)

as result:
![ie11-flex-bug](https://cloud.githubusercontent.com/assets/1409078/14717323/8f9e4e68-07f9-11e6-91da-e2d9ee8a4a42.png)
