### PR TITLE
fix(datepicker): don't use the locale in the default formatting function

### DIFF
--- a/src/components/datepicker/dateLocale.spec.js
+++ b/src/components/datepicker/dateLocale.spec.js
@@ -47,6 +47,12 @@ describe('$mdDateLocale', function() {
       expect(dateLocale.parseDate(dateStr)).toEqual(jasmine.any(Date));
     });
 
+    it('should default to the US date formatting', function() {
+      var date = new Date(2014, 2, 25);
+      var dateStr = dateLocale.formatDate(date);
+      expect(dateStr).toBe('3/25/2014');
+    });
+
     it('should have default date completion detection', function() {
       // Valid dates.
       expect(dateLocale.isDateComplete('04/05/15')).toBe(true);

--- a/src/components/datepicker/dateLocaleProvider.js
+++ b/src/components/datepicker/dateLocaleProvider.js
@@ -151,7 +151,7 @@
      * @param $locale
      * @returns {DateLocale}
      */
-    DateLocaleProvider.prototype.$get = function($locale) {
+    DateLocaleProvider.prototype.$get = function($locale, $filter) {
       /**
        * Default date-to-string formatting function.
        * @param {!Date} date
@@ -174,7 +174,7 @@
           formatDate = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 1, 0, 0);
         }
 
-        return formatDate.toLocaleDateString();
+        return $filter('date')(formatDate, 'M/d/yyyy');
       }
 
       /**

--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -523,7 +523,7 @@ describe('md-date-picker', function() {
       expect(pageScope.myDate).toEqual(date);
       expect(controller.ngModelCtrl.$modelValue).toEqual(date);
 
-      expect(controller.inputElement.value).toEqual(date.toLocaleDateString());
+      expect(controller.inputElement.value).toEqual('6/1/2015');
       expect(controller.calendarPaneOpenedFrom).toBe(null);
       expect(controller.isCalendarOpen).toBe(false);
     });


### PR DESCRIPTION
By default the datepicker would insert the date into the view after passing it through toLocaleDateString.
This means that if the user's locale date string couldn't be parsed by `new Date` (e.g. their locale is European which formats the dates as DD/MM/YYYY), the datepicker would have inserted an invalid date.
This change switches to using the US date format by default, because it is parse-able by the Date constructor. This shouldn't be unexpected, because the documentation states that users should override the date functions if they're dealing with different kinds of date formats.

Fixes #7456. 
Fixes #7404. 
Fixes #8275.