### PR TITLE
fix(tests): Cleans up the DOM after select, menu, and tooltip tests.

### DIFF
--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -3,20 +3,22 @@ describe('material.components.menu', function() {
   var $mdMenu, $timeout, menuActionPerformed, $mdUtil;
 
   beforeEach(module('material.components.menu'));
-  beforeEach(inject(function(_$mdUtil_, _$mdMenu_, _$timeout_, $document) {
+  beforeEach(inject(function(_$mdUtil_, _$mdMenu_, _$timeout_) {
     $mdUtil = _$mdUtil_;
     $mdMenu = _$mdMenu_;
     $timeout = _$timeout_;
-    var abandonedMenus = $document[0].querySelectorAll('._md-open-menu-container');
-    angular.element(abandonedMenus).remove();
   }));
-  afterEach(function() {
+
+  afterEach(inject(function($document) {
     menuActionPerformed = false;
     attachedElements.forEach(function(element) {
       element.remove();
     });
     attachedElements = [];
-  });
+
+    var abandonedMenus = $document[0].querySelectorAll('._md-open-menu-container');
+    angular.element(abandonedMenus).remove();
+  }));
 
   describe('md-menu directive', function() {
 

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -193,6 +193,9 @@ describe('<md-select>', function() {
 
     // FIXME- does not work with minified, jquery
     //expect($document[0].activeElement).toBe(select[0]);
+
+    // Clean up the DOM after the test.
+    $document[0].body.removeChild(select[0]);
   }));
 
   it('should remove the input-container focus state', inject(function($rootScope, $timeout) {

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -178,6 +178,9 @@ describe('<md-tooltip> directive', function() {
 
       triggerEvent('mouseleave');
       expect($rootScope.testModel.isVisible).toBe(false);
+
+      // Clean up document.body.
+      $document[0].body.removeChild(element[0]);
     }));
 
     it('should not be visible when the window is refocused', inject(function($window, $document) {
@@ -204,6 +207,9 @@ describe('<md-tooltip> directive', function() {
       // Simulate focus event that occurs when tabbing back to the window.
       triggerEvent('focus');
       expect($rootScope.testModel.isVisible).toBe(false);
+
+      // Clean up document.body.
+      $document[0].body.removeChild(element[0]);
     }));
 
   });


### PR DESCRIPTION
@ThomasBurleson Please review. This cleans up the DOM after tests add stuff to it.