### PR TITLE
feat(card): add a class for overriding the image stretching

### DIFF
--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -21,7 +21,8 @@ angular.module('material.components.card', [
  * @description
  * The `<md-card>` directive is a container element used within `<md-content>` containers.
  *
- * An image included as a direct descendant will fill the card's width, while the `<md-card-content>`
+ * An image included as a direct descendant will fill the card's width. If you want to avoid this,
+ * you can add the `md-plain-image` class to the parent element. The `<md-card-content>`
  * container will wrap text content and provide padding. An `<md-card-footer>` element can be
  * optionally included to put content flush against the bottom edge of the card.
  *

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -211,3 +211,10 @@ md-card {
   }
 }
 
+.md-plain-image {
+  > img {
+    width: auto;
+    height: auto;
+  }
+}
+

--- a/src/components/card/card.spec.js
+++ b/src/components/card/card.spec.js
@@ -1,21 +1,27 @@
 describe('mdCard directive', function() {
 
   var $mdThemingMock = function() { $mdThemingMock.called = true; };
+  var $compile;
+  var $rootScope;
 
-  beforeEach(module(function($provide) {
-    $provide.value('$mdTheming', $mdThemingMock);
-  }));
+  beforeEach(function() {
+    module('material.components.card');
+    module(function($provide) {
+      $provide.value('$mdTheming', $mdThemingMock);
+    });
+    inject(function(_$compile_, _$rootScope_) {
+      $compile = _$compile_;
+      $rootScope = _$rootScope_;
+    });
+  });
 
-  beforeEach(module('material.components.card'));
-
-  it('should be themable', inject(function($compile, $rootScope) {
+  it('should be themable', function() {
     $compile('<md-card></md-card>')($rootScope.$new());
     expect($mdThemingMock.called).toBe(true);
-  }));
+  });
 
-  it('should have `._md` class indicator', inject(function($compile, $rootScope) {
+  it('should have `._md` class indicator', function() {
     var element = $compile('<md-card></md-card>')($rootScope.$new());
     expect(element.hasClass('_md')).toBe(true);
-  }));
-  
+  });
 });


### PR DESCRIPTION
* Adds a class that can be used if users don't want their images to be stretched inside `<md-card>`.
* Avoids some repetition in the `md-card` unit tests.

Fixes #7447.

@ThomasBurleson, @topherfangio this is as discussed in the issue. I tried to keep it as simple as possible.