### PR TITLE
feat(input) add md-dense and match css to spec

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -71,16 +71,26 @@ md-autocomplete {
     &.md-menu-showing {
       z-index: $z-index-backdrop + 1;
     }
+
+    md-input-container.md-input-has-messages {
+      md-progress-linear.md-inline {
+        bottom: 18px;
+      }
+
+      &.md-dense md-progress-linear.md-inline {
+        bottom: 20px;
+      }
+
+    }
+
     md-progress-linear {
       position: absolute;
       bottom: -2px;
       left: 0;
       // When `md-inline` is present, we adjust the offset to go over the `ng-message` space
       &.md-inline {
-        bottom: 40px;
-        right: 2px;
-        left: 2px;
-        width: auto;
+        bottom: 8px;
+        width: 100%;
       }
       .md-mode-indeterminate {
         position: absolute;

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -180,10 +180,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
             layout="row"\
             ng-class="{ \'md-whiteframe-z1\': !floatingLabel, \'md-menu-showing\': !$mdAutocompleteCtrl.hidden }">\
           ' + getInputElement() + '\
-          <md-progress-linear\
-              class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
-              ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
-              md-mode="indeterminate"></md-progress-linear>\
           <md-virtual-repeat-container\
               md-auto-shrink\
               md-auto-shrink-min="1"\
@@ -233,7 +229,9 @@ function MdAutocomplete ($$mdSvgRegistry) {
       function getInputElement () {
         if (attr.mdFloatingLabel) {
           return '\
-            <md-input-container flex ng-if="floatingLabel">\
+            <md-input-container\
+                class="' + (element.hasClass('md-dense') ? 'md-dense' : '') + '"\
+                flex ng-if="floatingLabel">\
               <label>{{floatingLabel}}</label>\
               <input type="search"\
                   ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
@@ -259,6 +257,10 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   aria-haspopup="true"\
                   aria-activedescendant=""\
                   aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
+              <md-progress-linear\
+                  class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
+                  ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
+                  md-mode="indeterminate"></md-progress-linear>\
               <div md-autocomplete-parent-scope md-autocomplete-replace>' + leftover + '</div>\
             </md-input-container>';
         } else {
@@ -285,6 +287,10 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 aria-haspopup="true"\
                 aria-activedescendant=""\
                 aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
+            <md-progress-linear\
+                class="' + (attr.mdFloatingLabel ? 'md-inline' : '') + '"\
+                ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
+                md-mode="indeterminate"></md-progress-linear>\
             <button\
                 type="button"\
                 tabindex="-1"\

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -31,11 +31,13 @@ angular
  * @param {expression=} md-indeterminate This determines when the checkbox should be rendered as 'indeterminate'.
  *     If a truthy expression or no value is passed in the checkbox renders in the md-indeterminate state.
  *     If falsy expression is passed in it just looks like a normal unchecked checkbox.
- *     The indeterminate, checked, and unchecked states are mutually exclusive. A box cannot be in any two states at the same time. 
- *     Adding the 'md-indeterminate' attribute overrides any checked/unchecked rendering logic. 
+ *     The indeterminate, checked, and unchecked states are mutually exclusive. A box cannot be in any two states at the same time.
+ *     Adding the 'md-indeterminate' attribute overrides any checked/unchecked rendering logic.
  *     When using the 'md-indeterminate' attribute use 'ng-checked' to define rendering logic instead of using 'ng-model'.
- * @param {expression=} ng-checked If this expression evaluates as truthy, the 'md-checked' css class is added to the checkbox and it 
+ * @param {expression=} ng-checked If this expression evaluates as truthy, the 'md-checked' css class is added to the checkbox and it
  *     will appear checked.
+ * @param md-spacing {string=} Override spacing between icon and text. Default is 36px. Use `wide` for 48px.
+ *     Use `extra-wide` for 56px.
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -1,38 +1,37 @@
-//$checkbox-width: 20px !default;
+//$checkbox-width: 18px !default;
 //$checkbox-height: $checkbox-width !default;
 //$checkbox-border-radius: 2px !default;
 //$checkbox-border-width: 2px !default;
 //
 // ^^ defined in variables.scss
 //
-$checkbox-margin: 16px !default;
-$checkbox-text-margin: 10px !default;
-$checkbox-top: 12px !default;
+$checkbox-margin-end: 16px !default;
+$checkbox-text-margin-top: 8px !default;
+$container-checkbox-margin: 3px !default;
 
-.md-inline-form {
-  md-checkbox {
-    margin: 19px 0 18px;
-  }
-}
+// md-spacing values (horizontal spacing with icons)
+// normal     = 36px (Angular Material default)
+// wide       = 48px (Material Design Spec dense)
+// extra-wide = 56px (Material Design Spec default)
+$checkbox-text-margin: 36px !default;
+$checkbox-text-margin-wide: 48px !default;
+$checkbox-text-margin-extra-wide: 56px !default;
+
+// from input.scss
+$input-label-default-offset: 24px !default;
+
+$md-inline-alignment: $input-label-default-offset;
 
 md-checkbox {
   box-sizing: border-box;
   display: inline-block;
-  margin-bottom: $checkbox-margin;
   white-space: nowrap;
   cursor: pointer;
   outline: none;
   user-select: none;
   position: relative;
   min-width: $checkbox-width;
-  min-height: $checkbox-width;
-  @include rtl(margin-left, 0, $checkbox-margin);
-  @include rtl(margin-right, $checkbox-margin, 0);
-
-  &:last-of-type {
-    margin-left: 0;
-    margin-right: 0;
-  }
+  min-height: $checkbox-width * 2;
 
   &.md-focused:not([disabled]) {
     .md-container:before {
@@ -49,11 +48,16 @@ md-checkbox {
     }
   }
 
-  &.md-align-top-left > div.md-container {
-    top: $checkbox-top;
-  }
-
   @include checkbox-container;
+
+  .md-container {
+    // Use auto for compatibility with md-checkbox padding
+    top: auto;
+    @include rtl(left, initial, auto);
+    @include rtl(right, auto, initial);
+    margin: $container-checkbox-margin;
+    margin-top: $checkbox-height + $container-checkbox-margin;
+  }
 
   .md-label {
     box-sizing: border-box;
@@ -62,9 +66,54 @@ md-checkbox {
     vertical-align: middle;
     white-space: normal;
     user-select: text;
+    margin-top: $checkbox-text-margin-top;
+    margin-bottom: auto;
 
-    @include rtl(margin-left, $checkbox-text-margin + $checkbox-width, 0);
-    @include rtl(margin-right, 0, $checkbox-text-margin + $checkbox-width);
+    @include rtl(margin-left, $checkbox-text-margin, 0);
+    @include rtl(margin-right, 0, $checkbox-text-margin);
 
+    &:empty {
+      // clamp to checkbox-container margins
+      @include rtl(margin-left, $checkbox-height + ($container-checkbox-margin * 2), 0);
+      @include rtl(margin-right, 0, $checkbox-height + ($container-checkbox-margin * 2));
+    }
+
+  }
+
+  [md-spacing="wide"] &,
+  &[md-spacing="wide"] {
+    .md-label {
+      @include rtl(margin-left, $checkbox-text-margin-wide, 0);
+      @include rtl(margin-right, 0, $checkbox-text-margin-wide);
+    }
+  }
+
+  [md-spacing="extra-wide"] &,
+  &[md-spacing="extra-wide"]{
+    .md-label {
+      @include rtl(margin-left, $checkbox-text-margin-extra-wide, 0);
+      @include rtl(margin-right, 0, $checkbox-text-margin-extra-wide);
+    }
+  }
+}
+
+
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
+  & > md-checkbox:not(:last-child), {
+    @include rtl(margin-right, $checkbox-margin-end, 0);
+    @include rtl(margin-left, 0, $checkbox-margin-end);
+  }
+
+  &.md-inline-form,
+  .md-inline-form & {
+    > md-checkbox {
+      margin-top: $md-inline-alignment;
+      margin-bottom: auto;
+    }
   }
 }

--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -8,14 +8,20 @@
   }
 
   .md-datepicker-input-container {
-    border-bottom-color: '{{foreground-4}}';
+    > input {
+      border-bottom-color: '{{foreground-4}}';
+    }
 
     &.md-datepicker-focused {
-      border-bottom-color: '{{primary-color}}'
+      > input {
+        border-bottom-color: '{{primary-color}}'
+      }
     }
 
     &.md-datepicker-invalid {
-      border-bottom-color: '{{warn-A700}}';
+      > input {
+        border-bottom-color: '{{warn-A700}}';
+      }
     }
   }
 

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -6,64 +6,123 @@ $md-datepicker-open-animation-duration: 0.2s !default;
 $md-datepicker-triangle-button-width: 36px !default;
 $md-datepicker-input-mask-height: 40px !default;
 
+$input-padding-bottom: 8px !default;
+$md-datepicker-calendar-offset: 30px !default;
+
+$input-margin-top: 10px !default;
+$input-label-default-offset: 24px !default;
+
+// md-spacing values (horizontal spacing with icons)
+// normal     = 36px (Angular Material default)
+// wide       = 48px (Material Design Spec dense)
+// extra-wide = 56px (Material Design Spec default)
+
+$input-horizontal-offset: 36px !default;
+$input-horizontal-offset-wide: 48px !default;
+$input-horizontal-offset-extra-wide: 56px !default;
+
+
+// The datepickers triangle icon uses the default button margin.
+// We need to use the margin to align the label inside of an input container properly.
+$icon-button-margin: rem(0.600) !default;
+
+$button-margin-and-padding: 14px !default;
+
 
 md-datepicker {
   // Don't let linebreaks happen between the open icon-button and the input.
   white-space: nowrap;
   overflow: hidden;
+  position: relative; // for md-datepicker-button's absolute position
+  md-input-container & {
+    position: initial; // let md-datepicker-button position pass up
+    .md-datepicker-button.md-button {
+      @include rtl-prop(left, right, -$button-margin-and-padding);
+      margin-top: $input-label-default-offset + 6px;
+    }
+    .md-datepicker-triangle-button {
+      top: $input-label-default-offset;
+    }
+    .md-datepicker-input {
+      width: auto;
+    }
+  }
 
   // Leave room for the down-triangle button to "overflow" it's parent without modifying scrollLeft.
   // This prevents the element from shifting right when opening via the triangle button.
   @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2);
   @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2);
+  @include rtl-prop(padding-left, padding-right, $button-margin-and-padding);
+  @include rtl-prop(margin-left, margin-right, -$button-margin-and-padding);
 
   vertical-align: middle;
 }
 
-.md-inline-form {
-  md-datepicker {
-    margin-top: 12px;
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
+  .md-inline-form & > md-datepicker {
+    margin-top: $input-label-default-offset;
+    margin-bottom: auto;
+  }
+
+  & > md-datepicker:not(:last-child), {
+    @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2 + 16px);
   }
 }
 
 // The calendar icon button used to open the calendar pane.
-.md-datepicker-button {
-  display: inline-block;
-  box-sizing: border-box;
+.md-datepicker-button.md-button {
+  top: auto;
+  margin-top: 6px;
+  position: absolute;
+  @include rtl-prop(left, right, 0);
   background: none;
+  z-index: 1;
   vertical-align: middle;
 }
+
 
 // The input into which the user can type the date.
 .md-datepicker-input {
   @include md-flat-input();
   min-width: 120px;
-  max-width: $md-calendar-width - $md-datepicker-button-gap;
+  max-width: $md-calendar-width - $input-horizontal-offset - $md-datepicker-calendar-offset;
+
+  [md-spacing="wide"] &,
+  &[md-spacing="wide"] {
+    max-width: $md-calendar-width - $input-horizontal-offset-wide - $md-datepicker-calendar-offset;
+  }
+
+  [md-spacing="extra-wide"] &,
+  &[md-spacing="extra-wide"] {
+    max-width: $md-calendar-width - $input-horizontal-offset-extra-wide - $md-datepicker-calendar-offset;
+  }
+
 }
 
 // If the datepicker is inside of a md-input-container
 ._md-datepicker-floating-label {
   > label:not(.md-no-float):not(.md-container-ignore) {
-    $width-offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap;
-    $offset: $md-datepicker-triangle-button-width / 2;
-    @include rtl(right, $offset, auto);
-    @include rtl(left, auto, $offset);
-    width: calc(100% - #{$width-offset});
+    @include rtl-prop(left, right, $input-horizontal-offset);
   }
-
+  [md-spacing="wide"] &,
+  &[md-spacing="wide"] {
+    > label:not(.md-no-float):not(.md-container-ignore) {
+      @include rtl-prop(left, right, $input-horizontal-offset-wide);
+    }
+  }
+  [md-spacing="extra-wide"] &,
+  &[md-spacing="extra-wide"] {
+    > label:not(.md-no-float):not(.md-container-ignore) {
+      @include rtl-prop(left, right, $input-horizontal-offset-extra-wide);
+    }
+  }
   > md-datepicker {
-    // Prevents the ripple on the triangle from being clipped.
-    overflow: visible;
-
-    .md-datepicker-input-container {
-      border: none;
-    }
-
-    .md-datepicker-button {
-      // Prevents the button from wrapping around.
-      @include rtl(float, left, right);
-      margin-top: -$md-datepicker-border-bottom-gap / 2;
-    }
+    overflow: visible; // Prevents the ripple on the triangle from being clipped.
   }
 }
 
@@ -73,19 +132,38 @@ md-datepicker {
   // Position relative in order to absolutely position the down-triangle button within.
   position: relative;
 
-  padding-bottom: $md-datepicker-border-bottom-gap;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
+  > input {
+    margin-top: $input-margin-top;
+    padding-top: 0;
+    padding-bottom: $input-padding-bottom - 1;
+    border-bottom-width: 1px;
+    border-bottom-style: solid;
+    margin-bottom: 11px;
+    @include rtl-prop(margin-left, margin-right, $input-horizontal-offset);
+  }
+
+  [md-spacing="wide"] &,
+  &[md-spacing="wide"] {
+    > input {
+      @include rtl-prop(margin-left, margin-right, $input-horizontal-offset-wide);
+    }
+  }
+
+  [md-spacing="extra-wide"] &,
+  &[md-spacing="extra-wide"] {
+    > input {
+      @include rtl-prop(margin-left, margin-right, $input-horizontal-offset-extra-wide);
+    }
+  }
 
   display: inline-block;
   width: auto;
 
-  .md-icon-button + & {
-    @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
-  }
-
   &.md-datepicker-focused {
-    border-bottom-width: 2px;
+    > input {
+      border-bottom-width: 2px;
+      padding-bottom: $input-padding-bottom - 2;
+    }
   }
 }
 
@@ -168,6 +246,7 @@ md-datepicker {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  font-size: 16px;
 
   width: 0;
   height: 0;
@@ -179,11 +258,8 @@ md-datepicker {
 // Button containing the down "disclosure" triangle/arrow.
 .md-datepicker-triangle-button {
   position: absolute;
-  @include rtl-prop(right, left, 0);
-  top: $md-date-arrow-size;
-
-  // TODO(jelbourn): This position isn't great on all platforms.
-  @include rtl(transform, translateY(-25%) translateX(45%), translateY(-25%) translateX(-45%));
+  @include rtl-prop(right, left, -$button-margin-and-padding);
+  top: 0;
 }
 
 // Need crazy specificity to override .md-button.md-icon-button.
@@ -210,31 +286,37 @@ md-datepicker[disabled] {
   overflow: hidden;
 
   .md-datepicker-input-container {
-    // The negative bottom margin prevents the content around the datepicker
-    // from jumping when it gets opened.
-    margin-bottom: -$md-datepicker-border-bottom-gap;
+    @include rtl-prop(margin-left, margin-right, $md-datepicker-calendar-offset);
   }
-
-  .md-icon-button + .md-datepicker-input-container {
-    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
-  }
-
-  .md-datepicker-input,
-  label:not(.md-no-float):not(.md-container-ignore) {
-    margin-bottom: -$md-datepicker-border-bottom-gap;
-  }
-
-  // This needs some extra specificity in order to override
-  // the focused/invalid border colors.
   input.md-datepicker-input {
-    @include rtl-prop(margin-left, margin-right, 24px);
-    height: $md-datepicker-input-mask-height;
+    @include rtl-prop(margin-left, margin-right, $input-horizontal-offset - $md-datepicker-calendar-offset);
     border-bottom-color: transparent;
   }
 
-  .md-datepicker-triangle-button,
-  &.md-input-has-value > label,
-  &.md-input-has-placeholder > label {
+  &._md-datepicker-floating-label {
+   .md-datepicker-input-container {
+      margin-top: 24px;
+    }
+  }
+
+  .md-datepicker-input {
+    margin-top: 10px !important; //override
+  }
+
+  [md-spacing="wide"] &,
+  &[md-spacing="wide"] {
+    input.md-datepicker-input {
+      @include rtl-prop(margin-left, margin-right, $input-horizontal-offset-wide - $md-datepicker-calendar-offset);
+    }
+  }
+  [md-spacing="extra-wide"] &,
+  &[md-spacing="extra-wide"] {
+    input.md-datepicker-input {
+      @include rtl-prop(margin-left, margin-right, $input-horizontal-offset-extra-wide - $md-datepicker-calendar-offset);
+    }
+  }
+
+  .md-datepicker-triangle-button {
     display: none;
   }
 }

--- a/src/components/datepicker/demoBasicUsage/style.css
+++ b/src/components/datepicker/demoBasicUsage/style.css
@@ -1,10 +1,12 @@
 /** Demo styles for mdCalendar. */
 md-content {
+  padding: 8px 16px;
   padding-bottom: 200px;
 }
 
 .validation-messages {
   font-size: 12px;
   color: #dd2c00;
-  margin-left: 15px;
+  margin-left: 36px;
+  margin-top: -8px;
 }

--- a/src/components/input/demoErrorsAdvanced/index.html
+++ b/src/components/input/demoErrorsAdvanced/index.html
@@ -94,7 +94,7 @@
            * must go here in the HTML.
            */
           body[dir=rtl] .hint {
-            right: 2px;
+            right: 0;
             left: auto;
           }
         </style>

--- a/src/components/input/demoErrorsAdvanced/style.css
+++ b/src/components/input/demoErrorsAdvanced/style.css
@@ -1,9 +1,9 @@
 .hint {
     /* Position the hint */
     position: absolute;
-    left: 2px;
+    left: 0;
     right: auto;
-    bottom: 7px;
+    top: 67px;
 
     /* Copy styles from ng-messages */
     font-size: 12px;
@@ -20,12 +20,12 @@
 .hint.ng-hide,
 .hint.ng-enter,
 .hint.ng-leave.ng-leave-active {
-    bottom: 26px;
+    top: 60px;
     opacity: 0;
 }
 
 .hint.ng-leave,
 .hint.ng-enter.ng-enter-active {
-    bottom: 7px;
+    top: 67px;
     opacity: 1;
 }

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -140,6 +140,8 @@ function labelDirective() {
       if (!containerCtrl || attr.mdNoFloat || element.hasClass('md-container-ignore')) return;
 
       containerCtrl.label = element;
+      containerCtrl.element.addClass('md-input-has-label');
+      
       scope.$on('$destroy', function() {
         containerCtrl.label = null;
       });
@@ -179,6 +181,8 @@ function labelDirective() {
  * @param md-detect-hidden {boolean=} When present, textareas will be sized properly when they are
  *   revealed after being hidden. This is off by default for performance reasons because it
  *   guarantees a reflow every digest cycle.
+ * @param md-spacing {string=} Override spacing between icon and text. Default is 36px. Use `wide` for
+ *   48px. Use `extra-wide` for 56px.
  *
  * @usage
  * <hljs lang="html">
@@ -704,7 +708,7 @@ function placeholderDirective($compile) {
       // it later. This is necessary, because if we compile the element beforehand,
       // it won't be able to find the `mdInputContainer` controller.
       inputContainer.element
-        .addClass('md-icon-float')
+        .addClass('md-icon-float md-input-has-label')
         .prepend(newLabel);
 
       $compile(newLabel)(scope);
@@ -808,16 +812,18 @@ function ngMessagesDirective() {
     // If we are not a child of an input container, don't do anything
     if (!inputContainer) return;
 
-    // Add our animation class
-    element.toggleClass('md-input-messages-animation', true);
+    // Ensure inputContainer has class `md-input-has-messages`
+    inputContainer.element.addClass('md-input-has-messages');
 
+    // Add our animation class
     // Add our md-auto-hide class to automatically hide/show messages when container is invalid
-    element.toggleClass('md-auto-hide', true);
+    element.addClass('md-input-messages-animation md-auto-hide');
 
     // If we see some known visibility directives, remove the md-auto-hide class
     if (attrs.mdAutoHide == 'false' || hasVisibiltyDirective(attrs)) {
       element.toggleClass('md-auto-hide', false);
     }
+
   }
 
   function hasVisibiltyDirective(attrs) {

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -1,37 +1,87 @@
-$input-container-padding: 2px !default;
+$input-container-margin-end: 16px !default;
+$input-container-margin: 0 !default;
+$input-container-padding-start: 1px !default;
+$input-container-min-height: 48px !default;
+$input-container-min-height-dense: 40px !default;
 
+
+
+$default-top-margin: 10px !default;
+$default-bottom-margin: 11px !default;
+$default-border-width: 1px !default;
+$default-border-width-focused: 2px !default;
+
+$default-top-margin-dense: $default-top-margin - 2px !default;
+$default-bottom-margin-dense: $default-bottom-margin - 2px !default;
+
+
+$input-label-font-size: 12px !default;
+$input-label-margin-top: $default-top-margin !default;
+
+// Material Design spec says it should be an extra 4px,
+// but that would break horizontal alignment, so use 0px instead
+$input-label-with-messages-margin-top: $default-top-margin + 0px !default;
+
+$input-label-margin-top-dense: $default-top-margin-dense !default;
+$input-label-margin-start: 0 !default;
 $input-label-default-offset: 24px !default;
-$input-label-default-scale: 1.0 !default;
-$input-label-float-offset: 6px !default;
-$input-label-float-scale: 0.75 !default;
-$input-label-float-width: $input-container-padding + 16px !default;
+$input-label-default-offset-dense: $input-label-default-offset - 4px !default;
+$input-label-float-width: 16px !default;
 
-$input-placeholder-offset: $input-label-default-offset !default;
+$input-margin-top: $default-top-margin !default;
+$input-margin-top-dense: $default-top-margin-dense !default;
+$input-margin-bottom: $default-bottom-margin !default;
+$input-margin-bottom-dense: $default-bottom-margin-dense !default;
+$input-font-size: inherit !default;
+$input-font-size-dense: 13px !default;
+$input-padding-top: 0 !default;
+$input-padding-start: 0 !default;
+$input-padding-bottom: 8px !default;
+$input-border-width-default: $default-border-width !default;
+$input-border-width-focused: $default-border-width-focused !default;
 
-$input-border-width-default: 1px !default;
-$input-border-width-focused: 2px !default;
-$input-line-height: 26px !default;
-$input-padding-top: 2px !default;
+$textarea-margin-bottom: 9px !default;
+
 
 $input-error-font-size: 12px !default;
 $input-error-height: 24px !default;
 $input-error-line-height: $input-error-font-size + 2px !default;
 $error-padding-top: ($input-error-height - $input-error-line-height) / 2 !default;
 
-$icon-offset: 36px !default;
+$icon-internal-padding-ratio: (2 / 24) !default; // Material system icon default padding
 
-$icon-top-offset: ($icon-offset - $input-padding-top - $input-border-width-focused) / 4 !default;
+
+$icon-height: 24px !default;
+$icon-offset: ($icon-height * 2) + 8px !default;  //56px
+$icon-internal-padding: $icon-internal-padding-ratio * $icon-height !default;
+
+$icon-height-dense: 20px !default;
+$icon-offset-dense: ($icon-height-dense * 2) + 8px !default;  //48px
+$icon-internal-padding-dense: $icon-internal-padding-ratio * $icon-height-dense !default;
+
+$icon-top-offset: $default-top-margin !default;
 
 $icon-float-focused-top: -8px !default;
 
 $input-resize-handle-height: 10px !default;
 
+// md-spacing values (horizontal spacing with icons)
+// normal     = 36px (Angular Material default)
+// wide       = 48px (Material Design Spec dense)
+// extra-wide = 56px (Material Design Spec default)
+
+$input-with-icon-padding-start: 36px !default;
+$input-with-icon-padding-start-wide: $icon-offset-dense !default;
+$input-with-icon-padding-start-extra-wide: $icon-offset !default;
+
 md-input-container {
   @include pie-clearfix();
   display: inline-block;
   position: relative;
-  padding: $input-container-padding;
-  margin: 18px 0;
+  @include rtl(padding-left, $input-container-padding-start, 0);
+  @include rtl(padding-right, 0, $input-container-padding-start);
+  min-height: $input-container-min-height;
+  margin: $input-container-margin;
   vertical-align: middle;
 
   &.md-block {
@@ -42,16 +92,26 @@ md-input-container {
   // height with only 1 message
   .md-errors-spacer {
     @include rtl(float, right, left);
-    min-height: $input-error-height;
+    margin-top: -3px;
+    margin-bottom: 5px;
 
-    // Ensure the element always takes up space, even if empty
-    min-width: 1px;
+    &:empty {
+      display: none;
+    }
+  }
+
+  &.md-input-has-messages .md-errors-spacer {
+     display: block;
+     min-height:8px;
+     min-width: 1px;
+     margin-top: 4px;
+
   }
 
   .md-resize-handle {
-    position: absolute;
-    bottom: $input-error-height - $input-border-width-default * 2;
-    left: 0;
+    position: relative;
+    @include rtl(float, left, right);
+    margin-top: -1 * ($textarea-margin-bottom + ($input-resize-handle-height / 2));
     height: $input-resize-handle-height;
     background: transparent;
     width: 100%;
@@ -61,8 +121,9 @@ md-input-container {
   > md-icon {
     position: absolute;
     top: $icon-top-offset;
-    @include rtl(left, 2px, auto);
-    @include rtl(right, auto, 2px);
+    margin-top: $icon-internal-padding;
+    @include rtl(left, 0, auto);
+    @include rtl(right, auto, 0);
   }
 
   textarea,
@@ -84,19 +145,20 @@ md-input-container {
     -moz-appearance: none;
     -webkit-appearance: none;
   }
-  input[type="date"],
-  input[type="datetime-local"],
-  input[type="month"],
-  input[type="time"],
-  input[type="week"] {
-    min-height: $input-line-height;
+
+  input[type="password"] {
+    letter-spacing: 2px;
   }
+
   textarea {
     resize: none;
     overflow: hidden;
+    padding-left: 0;
+    padding-right: 0;
 
     &.md-input {
-      min-height: $input-line-height;
+      padding-bottom: 2px;
+      margin-bottom: $textarea-margin-bottom;
       -ms-flex-preferred-size: auto; //IE fix
     }
 
@@ -109,10 +171,10 @@ md-input-container {
 
   label:not(.md-container-ignore) {
     position: absolute;
-    bottom: 100%;
     @include rtl(left, 0, auto);
     @include rtl(right, auto, 0);
-
+    font-size: 12px;
+    width:100%;
     &.md-required:after {
       content: ' *';
       font-size: 13px;
@@ -129,28 +191,27 @@ md-input-container {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
-    @include rtl(padding-left, $input-container-padding + 1px, 0);
-    @include rtl(padding-right, 0, $input-container-padding + 1px);
+    margin-top: $input-label-margin-top;
+    @include rtl(margin-left, $input-label-margin-start, 0);
+    @include rtl(margin-right, 0, $input-label-margin-start);
+    line-height: normal;
+    font-size: inherit;
     z-index: 1;
-    transform: translate3d(0, $input-label-default-offset + 4, 0) scale($input-label-default-scale);
-    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
-
-    // The max-width is necessary, because in some browsers, using this together with
-    // a calc might cause it to overflow the parent. See #7403
-    max-width: 100%;
-
+    transform: translate3d($input-container-padding-start, $input-label-default-offset, 0);
+    transition: transform $swift-ease-out-duration $swift-ease-out-timing-function,
+                font-size $swift-ease-out-duration $swift-ease-out-timing-function;
     @include rtl(transform-origin, left top, right top);
   }
   .md-placeholder {
     position: absolute;
     top: 0;
     opacity: 0;
-    transition-property: opacity, transform;
-    transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
+    transition-property: opacity, transform, font-size;
+    transform: translate3d($input-container-padding-start, $input-label-default-offset, 0);
   }
   &.md-input-focused .md-placeholder {
     opacity: 1;
-    transform: translate3d(0, $input-placeholder-offset, 0);
+    transform: translate3d(0, 0, 0);
   }
   // Placeholder should immediately disappear when the user starts typing
   &.md-input-has-value .md-placeholder {
@@ -178,27 +239,21 @@ md-input-container {
   .md-input {
     order: 2;
     display: block;
-    margin-top: 0;
-
+    margin-top: $input-margin-top;
+    margin-bottom: $input-margin-bottom;
     background: none;
     padding-top: $input-padding-top;
-    padding-bottom: $input-border-width-focused - $input-border-width-default;
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-bottom: $input-padding-bottom - $input-border-width-default;
     border-width: 0 0 $input-border-width-default 0;
-    line-height: $input-line-height;
-    height: $input-line-height + ($input-padding-top * 2);
-    -ms-flex-preferred-size: $input-line-height; //IE fix
+    font-size: $input-font-size;
+    line-height: normal;
+    -ms-flex-preferred-size: auto; //IE fix
     border-radius: 0;
     border-style: solid; // Firefox fix
 
     // Fix number inputs in Firefox to be full-width
     width: 100%;
-    box-sizing: border-box;
 
-    // Hacky fix to force vertical alignment between `input` and `textarea`
-    // Input and textarea do not align by default:
-    // http://jsbin.com/buqomevage/1/edit?html,css,js,output
     @include rtl(float, left, right);
 
     &:focus {
@@ -214,23 +269,22 @@ md-input-container {
     }
   }
 
-  .md-char-counter {
-    @include rtl(text-align, right, left);
-    @include rtl(padding-right, $input-container-padding, 0);
-    @include rtl(padding-left, 0, $input-container-padding);
-  }
-
   //
   // ngMessage base styles - animations moved to input.js
   //
+  [ng-messages],
   .md-input-messages-animation {
     position: relative;
+    min-height: 14px;
+    padding-top: 2px;
+    margin-bottom: -1px;
     order: 4;
     overflow: hidden;
     @include rtl(clear, left, right);
 
     &.ng-enter {
       // Upon entering the DOM, messages should be hidden
+      [ng-message],
       .md-input-message-animation {
         opacity: 0;
         margin-top: -100px;
@@ -238,20 +292,15 @@ md-input-container {
     }
   }
 
-  .md-input-message-animation, .md-char-counter {
+  [ng-message],
+  .md-char-counter {
     font-size: $input-error-font-size;
     line-height: $input-error-line-height;
     overflow: hidden;
 
-    transition: $swift-ease-in;
-
     // Default state for messages is to be visible
     opacity: 1;
     margin-top: 0;
-
-    // Add some top padding which is equal to half the difference between the expected height
-    // and the actual height
-    padding-top: $error-padding-top;
 
     &:not(.md-char-counter) {
       // Add some padding so that the messages don't touch the character counter
@@ -260,8 +309,14 @@ md-input-container {
     }
   }
 
+  .md-input-message-animation,
+  .md-char-counter {
+    transition: $swift-ease-in;
+  }
+
   &:not(.md-input-invalid) {
     .md-auto-hide {
+      [ng-message],
       .md-input-message-animation {
         opacity: 0;
         margin-top: -100px;
@@ -271,6 +326,7 @@ md-input-container {
 
   // Note: This is a workaround to fix an ng-enter flicker bug
   .md-auto-hide {
+    [ng-message],
     .md-input-message-animation {
       &:not(.ng-animate) {
         opacity: 0;
@@ -279,6 +335,7 @@ md-input-container {
     }
   }
 
+  [ng-message],
   .md-input-message-animation {
     &.ng-enter {
       opacity: 0;
@@ -290,9 +347,10 @@ md-input-container {
   &.md-input-has-placeholder,
   &.md-input-has-value {
     label:not(.md-no-float) {
-      transform: translate3d(0, $input-label-float-offset, 0) scale($input-label-float-scale);
+      transform: translate3d(0, 0, 0);
       transition: transform $swift-ease-out-timing-function $swift-ease-out-duration,
-                  width $swift-ease-out-timing-function $swift-ease-out-duration;
+                  font-size $swift-ease-out-duration $swift-ease-out-timing-function;
+      font-size: 12px;
     }
   }
 
@@ -306,10 +364,15 @@ md-input-container {
 
   // Use wide border in error state or in focused state
   &.md-input-focused .md-input,
-  .md-input.ng-invalid.ng-dirty,
-  &.md-input-resized .md-input {
-    padding-bottom: 0; // Increase border width by 1px, decrease padding by 1
+  .md-input.ng-invalid.ng-dirty {
+    padding-bottom: $input-padding-bottom - $input-border-width-focused;
     border-width: 0 0 $input-border-width-focused 0;
+  }
+
+  &.md-input-focused textarea.md-input,
+  textarea.md-input.ng-invalid.ng-dirty,
+  &.md-input-resized .md-input {
+    padding-bottom: 1px;
   }
 
   .md-input {
@@ -334,58 +397,222 @@ md-input-container {
       position: absolute;
     }
 
-    > md-icon {
-      top: $icon-top-offset;
-      @include rtl(left, 2px, auto);
-      @include rtl(right, auto, 2px);
-    }
-
-  }
-
-  &.md-icon-left,
-  &.md-icon-right {
-    > label {
-      &:not(.md-no-float):not(.md-container-ignore),
-      .md-placeholder {
-        width: calc(100% - #{$icon-offset} - #{$input-label-float-width});
-      }
-    }
   }
 
   // icon offset should have higher priority as normal label
   &.md-icon-left {
-    @include rtl(padding-left, $icon-offset, 0);
-    @include rtl(padding-right, 0, $icon-offset);
-    > label {
-      @include rtl(left, $icon-offset, auto);
-      @include rtl(right, auto, $icon-offset);
+    &, & > label {
+      @include rtl(padding-left, $input-with-icon-padding-start, 0);
+      @include rtl(padding-right, 0, $input-with-icon-padding-start);
     }
+
+    &[md-spacing="wide"] {
+      &, & > label {
+        @include rtl(padding-left, $input-with-icon-padding-start-wide, 0);
+        @include rtl(padding-right, 0, $input-with-icon-padding-start-wide);
+      }
+    }
+
+    &[md-spacing="extra-wide"] {
+      &, & > label {
+        @include rtl(padding-left, $input-with-icon-padding-start-extra-wide, 0);
+        @include rtl(padding-right, 0, $input-with-icon-padding-start-extra-wide);
+      }
+    }
+
   }
 
   &.md-icon-right {
-    @include rtl(padding-left, 0, $icon-offset);
-    @include rtl(padding-right, $icon-offset, 0);
+    &, & > label {
+      @include rtl(padding-left, 0, $input-with-icon-padding-start);
+      @include rtl(padding-right, $input-with-icon-padding-start, 0);
+    }
+
+    &[md-spacing="wide"] {
+      &, & > label {
+        @include rtl(padding-left, 0, $input-with-icon-padding-start-wide);
+        @include rtl(padding-right, $input-with-icon-padding-start-wide, 0);
+      }
+    }
+
+    &[md-spacing="extra-wide"] {
+      &, & > label {
+        @include rtl(padding-left, 0, $input-with-icon-padding-start-extra-wide);
+        @include rtl(padding-right, $input-with-icon-padding-start-extra-wide, 0);
+      }
+    }
 
     > md-icon:last-of-type {
       margin: 0;
-
       @include rtl(right, 2px, auto);
       @include rtl(left, auto, 2px);
     }
+
   }
 
   &.md-icon-left.md-icon-right {
-    padding-left: $icon-offset;
-    padding-right: $icon-offset;
+    &, & > label {
+      padding-left: $input-with-icon-padding-start;
+      padding-right: $input-with-icon-padding-start;
+    }
 
-    > label {
-      &:not(.md-no-float):not(.md-container-ignore),
-      .md-placeholder {
-        width: calc(100% - (#{$icon-offset} * 2));
+    &[md-spacing="wide"] {
+      &, & > label {
+        padding-left: $input-with-icon-padding-start-wide;
+        padding-right: $input-with-icon-padding-start-wide;
+      }
+    }
+
+    &[md-spacing="extra-wide"] {
+      &, & > label {
+        padding-left: $input-with-icon-padding-start-extra-wide;
+        padding-right: $input-with-icon-padding-start-extra-wide;
       }
     }
   }
+
+  &.md-input-has-messages {
+    label:not(.md-no-float):not(.md-container-ignore),
+    .md-placeholder {
+      margin-top: $input-label-with-messages-margin-top;
+    }
+
+    .md-input{
+      margin-bottom: 4px;
+    }
+
+  }
+
+  &.md-input-has-label {
+    > md-icon {
+      top: $default-top-margin + $input-label-default-offset;
+    }
+
+    .md-input{
+      margin-top: $default-top-margin + $input-label-default-offset;
+    }
+
+    &.md-input-focused,
+    .md-input.ng-invalid.ng-dirty {
+      input[type="date"].md-input,
+      input[type="datetime-local"].md-input,
+      input[type="month"].md-input,
+      input[type="time"].md-input,
+      input[type="week"].md-input {
+        padding-bottom: 3px;
+      }
+
+    }
+
+    input[type="date"].md-input,
+    input[type="datetime-local"].md-input,
+    input[type="month"].md-input,
+    input[type="time"].md-input,
+    input[type="week"].md-input {
+      margin-top: 32px;
+      padding-bottom: 4px;
+    }
+
+    textarea.md-input {
+      //has label preceding md-input
+      margin-top: 32px;
+      padding-bottom: 4px;
+    }
+  }
+
 }
+
+.md-dense md-input-container,
+md-input-container.md-dense
+{
+  min-height: $input-container-min-height-dense;
+
+  label:not(.md-no-float):not(.md-container-ignore),
+  .md-placeholder {
+    margin-top: $input-label-margin-top-dense;
+    font-size: $input-font-size-dense;
+  }
+
+  .md-input
+  {
+    margin-top: $input-margin-top-dense;
+    margin-bottom: $input-margin-bottom-dense;
+    font-size: $input-font-size-dense;
+  }
+
+  &.md-input-has-messages {
+    .md-input {
+      margin-bottom: $input-margin-bottom-dense - 4px;
+    }
+
+    .md-input-errors-spacer {
+      margin-top: 0;
+    }
+
+    [ng-messages],
+    .md-input-messages-animation {
+      padding-top: 0;
+    }
+  }
+
+  > md-icon {
+    top: $default-top-margin-dense;
+    margin-top: $icon-internal-padding-dense;
+    font-size: 20px;
+    height: 20px;
+    width: 20px;
+    min-height: 20px;
+    min-width: 20px;
+  }
+
+  &.md-input-has-label {
+    min-height: 60px;
+    > md-icon {
+      top: $default-top-margin-dense + $input-label-default-offset-dense;
+    }
+
+    .md-input{
+      margin-top: $default-top-margin-dense + $input-label-default-offset-dense;
+    }
+
+    input[type="date"].md-input,
+    input[type="datetime-local"].md-input,
+    input[type="month"].md-input,
+    input[type="time"].md-input,
+    input[type="week"].md-input {
+      margin-top: 25px;
+    }
+  }
+}
+
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
+  & > md-input-container:not(:last-child), {
+    @include rtl(margin-left, 0, $input-container-margin-end);
+    @include rtl(margin-right, $input-container-margin-end, 0);
+  }
+
+  &.md-inline-form,
+  .md-inline-form & {
+      > md-input-container:not(.md-input-has-label) {
+      margin-top: $input-label-default-offset;
+    }
+  }
+
+  &.md-inline-form,
+  .md-inline-form & {
+    > md-input-container:not(.md-input-has-messages) {
+      margin-bottom: auto;
+    }
+  }
+}
+
+
+
 
 @media screen and (-ms-high-contrast: active) {
   md-input-container.md-default-theme > md-icon {

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -36,7 +36,7 @@ angular.module('material.components.select', [
  *
  * When the select is required and uses a floating label, then the label will automatically contain
  * an asterisk (`*`). This behavior can be disabled by using the `md-no-asterisk` attribute.
- * 
+ *
  * By default, the select will display with an underline to match other form elements. This can be
  * disabled by applying the `md-no-underline` CSS class.
  *
@@ -79,6 +79,7 @@ angular.module('material.components.select', [
  * explicit label is present.
  * @param {string=} md-container-class Class list to get applied to the `.md-select-menu-container`
  * element (for custom styling).
+ * @param {boolean=} md-no-border When present bottom border will not be visible
  *
  * @usage
  * With a placeholder (label and aria-label are added dynamically)
@@ -345,11 +346,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           valueEl.addClass('md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
             containerCtrl.label.addClass('md-placeholder');
+            containerCtrl.label.addClass('md-placeholder md-select-label');
           }
         } else {
           valueEl.removeClass('md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.removeClass('md-placeholder');
+            containerCtrl.label.removeClass('md-placeholder md-select-label');
           }
         }
       };
@@ -1550,9 +1552,9 @@ function SelectProvider($$interimElementProvider) {
           transformOrigin = '50% 100%';
         }
       } else {
-        left = (targetRect.left + centeredRect.left - centeredRect.paddingLeft) + 2;
+        left = (targetRect.left + centeredRect.left - centeredRect.paddingLeft);
         top = Math.floor(targetRect.top + targetRect.height / 2 - centeredRect.height / 2 -
-            centeredRect.top + contentNode.scrollTop) + 2;
+            centeredRect.top + contentNode.scrollTop) + 1;
 
         transformOrigin = (centeredRect.left + targetRect.width / 2) + 'px ' +
           (centeredRect.top + centeredRect.height / 2 - contentNode.scrollTop) + 'px 0px';

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -5,21 +5,38 @@ $select-option-height: 48px !default;
 $select-option-padding: 16px !default;
 $select-container-padding: 16px !default;
 $select-container-transition-duration: 350ms !default;
-
+$select-value-padding-top: 6px;
+$select-value-padding-bottom: 4px;
 $select-max-visible-options: 5 !default;
+
+// from input.scss
+$input-label-default-offset: 24px !default;
+$default-bottom-margin: 11px !default;
+
+$md-inline-alignment: $input-label-default-offset;
 
 // Fixes the animations with the floating label when select is inside an input container
 md-input-container {
   &:not([md-no-float]) {
     .md-select-placeholder span:first-child {
-      transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
-      @include rtl(transform-origin, left top, right top);
+      transform: translate3d(0, 0, 0);
+      transition: transform $swift-ease-out-timing-function $swift-ease-out-duration,
+                  font-size $swift-ease-out-duration $swift-ease-out-timing-function;
+      font-size: inherit;
     }
   }
   &.md-input-focused {
     &:not([md-no-float]) {
       .md-select-placeholder span:first-child {
-        transform: translateY(-22px) translateX(-2px) scale(0.75);
+        transform: translateY(-24px) translate(-1px);
+        transition: transform $swift-ease-out-timing-function $swift-ease-out-duration,
+                    font-size $swift-ease-out-duration $swift-ease-out-timing-function;
+        font-size: 12px;
+      }
+      &:not(.md-input-has-value) {
+        .md-select-label:not(.md-no-float) {
+          opacity: 0;
+        }
       }
     }
   }
@@ -71,11 +88,15 @@ md-input-container {
   }
 }
 
-md-input-container > md-select {
-  margin: 0;
-  order: 2;
+
+md-input-container.md-input-has-label > md-select {
+  padding-top: $input-label-default-offset;
+  margin-bottom: $default-bottom-margin;
 }
 
+md-input-container.md-input-has-messages > md-select {
+  margin-bottom: 4px;
+}
 
 // Show the asterisk on the placeholder if the element is required
 //
@@ -91,18 +112,8 @@ md-input-container:not(.md-input-has-value) {
   }
 }
 
-md-input-container.md-input-invalid {
-  md-select {
-    .md-select-value {
-      border-bottom-style: solid;
-      padding-bottom: 1px;
-    }
-  }
-}
-
 md-select {
   display: flex;
-  margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
 
   &[required], &.ng-required {
     &.ng-invalid {
@@ -120,7 +131,12 @@ md-select {
     // to create a dotted line under the input.
     background-size: 4px 1px;
     background-repeat: repeat-x;
-    margin-bottom: -1px; // Shift downward so dotted line is positioned the same as other bottom borders
+    // Add to padding-bottom to keep dotted line aligned with other bottom borders
+    // Sub from padding-top to keep height consistent
+    // Translate text 1px up to keep in alignment
+    padding-bottom: $select-value-padding-bottom + 1;
+    padding-top: $select-value-padding-top - 1;
+    transform: translate3d(0, 1px, 0);
   }
 
   &:focus {
@@ -133,45 +149,35 @@ md-select {
     &:hover {
       cursor: pointer
     }
-    &.ng-invalid.ng-touched {
+    &.ng-invalid.ng-touched:not(:focus) {
       .md-select-value {
-        border-bottom-style: solid;
-        padding-bottom: 1px;
+        border-bottom: 1px solid;
       }
     }
     &:focus {
       .md-select-value {
         border-bottom-width: 2px;
         border-bottom-style: solid;
-        padding-bottom: 0;
-      }
-      &.ng-invalid.ng-touched {
-        .md-select-value {
-          padding-bottom: 0;
-        }
+        padding-bottom: $select-value-padding-bottom - 1;
       }
     }
-  }
-}
-
-// Fix value by 1px to align with standard text inputs (and spec)
-md-input-container.md-input-has-value .md-select-value {
-  > span:not(.md-select-icon) {
-    transform: translate3d(0, 1px, 0);
   }
 }
 
 .md-select-value {
   display: flex;
   align-items: center;
-  padding: 2px 2px 1px;
+  padding-top: $select-value-padding-top;
+  padding-bottom: $select-value-padding-bottom;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   background-color: rgba(0,0,0,0);
   position: relative;
   box-sizing: content-box;
-  min-width: 8 * $baseline-grid;
+  min-width: 11 * $baseline-grid;
   min-height: 26px;
+  margin-bottom: auto;
+  -ms-flex-item-align: start; // workaround for margin-bottom: auto
   flex-grow: 1;
 
 
@@ -192,7 +198,6 @@ md-input-container.md-input-has-value .md-select-value {
     align-items: flex-end;
     text-align: end;
     width: 3 * $baseline-grid;
-    margin: 0 .5 * $baseline-grid;
     transform: translate3d(0, -2px, 0);
     font-size: 1.2rem;
   }
@@ -202,9 +207,11 @@ md-input-container.md-input-has-value .md-select-value {
     content: '\25BC';
     position: relative;
     top: 2px;
+    @include rtl(right, -4px, auto);
+    @include rtl(left, auto, -4px);
     speak: none;
     font-size: 16px;
-    transform: scaleY(0.6) scaleX(1);
+    transform: scaleY(0.5);
   }
 
   &.md-select-placeholder {
@@ -212,7 +219,6 @@ md-input-container.md-input-has-value .md-select-value {
     order: 1;
     pointer-events: none;
     -webkit-font-smoothing: antialiased;
-    padding-left: 2px;
     z-index: 1;
   }
 }
@@ -313,5 +319,49 @@ md-select-menu[multiple] {
       @include rtl(margin-left, $select-option-padding * (2 / 3), auto);
       @include rtl(margin-right, auto, $select-option-padding * (2 / 3));
     }
+  }
+}
+
+.md-dense md-input-container,
+md-input-container.md-dense {
+  .md-select-value {
+    padding-top: 0px;
+    padding-bottom: 4px;
+    font-size: 13px;
+  }
+
+  md-select:not([disabled]).ng-invalid.ng-dirty,
+  md-select:not([disabled]):focus {
+    .md-select-value {
+      padding-bottom: 3px;
+    }
+  }
+
+}
+
+md-input-container.md-input-invalid {
+  md-select:not(:focus) {
+    .md-select-value {
+      border-bottom: 1px solid;
+      padding-bottom: $select-value-padding-bottom;
+    }
+  }
+}
+
+.layout-row,
+.layout-xs-row, .layout-gt-xs-row,
+.layout-sm-row, .layout-gt-sm-row,
+.layout-md-row, .layout-gt-md-row,
+.layout-lg-row, .layout-gt-lg-row,
+.layout-xl-row {
+  & > md-select:not(:last-child), {
+    @include rtl(margin-left, 0, $select-container-padding);
+    @include rtl(margin-right, $select-container-padding, 0);
+  }
+
+  &.md-inline-form > md-select,
+  .md-inline-form & > md-select {
+    margin-top: $md-inline-alignment;
+    margin-bottom: auto;
   }
 }

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -46,7 +46,7 @@
 // Mixin for a "flat" input that can be used for components that contain an input
 // (datepicker, autocomplete).
 @mixin md-flat-input() {
-  font-size: 14px;
+  font-size: 16px;
 
   box-sizing: border-box;
   border: none;

--- a/src/core/style/variables.scss
+++ b/src/core/style/variables.scss
@@ -129,7 +129,7 @@ $button-fab-padding: rem(1.60) !default;
 
 
 // Shared Checkbox variables
-$checkbox-width: 20px !default;
+$checkbox-width: 18px !default;
 $checkbox-height: $checkbox-width !default;
 $checkbox-border-radius: 2px !default;
 $checkbox-border-width: 2px !default;


### PR DESCRIPTION
I've rewritten many of the scss and js files to conform to Material Design spec. There are many changes, but it wasn't possible to separate much of these into smaller pull requests because of the way they depend on each other. I have changes for md-toolbar that can be used later on another PR.

Here are codepens I've made to show the issues with the current implementations and the new changes. Be sure to set your browser with to less than 960px for toolbar height to match the examples.

Layout Tests
Master: http://codepen.io/shortfuse/full/ZWxYpN/
SpecFix: http://codepen.io/shortfuse/full/qZojGW/

Horizontal Tests
Master: http://codepen.io/shortfuse/full/JKGdQv/
SpecFix: http://codepen.io/shortfuse/full/gMPYjE/

In summary, over JS, input-containers will have the classes `md-input-has-label` and `md-input-has-messages` so certain CSS rules can apply dependent on if there is a label and/or messages.

* Add md-dense to `md-input`, `md-autocomplete`, and `md-select`
* Password spacing set to 2px
* Variable top and bottom margins
* Intelligently hide md-error-spacer when blank and messages present
* Fix md-select to align properly and match spec
* Fix checkbox to 18px instead of 20px
* Add `md-no-border` option for md-select
* Ensure `md-select-menu` `font-size` matches `md-select` `font-size`
* Fix `md-autocomplete` spacing
* Fix text-less `md-checkbox` width
* Align `md-icon` to top of input box (support all font-sizes)
* Support **any** font size for `md-input`
* Added missing spaces to counter text (ie: `26 / 30` instead of `26/30`)

Material Design Sources:

https://www.google.com/design/spec/components/text-fields.html
https://www.google.com/design/spec/patterns/errors.html