### PR TITLE
feat(switch-refactor): add classes md-full-width and md-invert

### DIFF
--- a/src/components/switch/demoBasicUsage/index.html
+++ b/src/components/switch/demoBasicUsage/index.html
@@ -1,4 +1,4 @@
-<div class="inset" ng-controller="SwitchDemoCtrl" ng-cloak>
+<div class="inset" ng-controller="SwitchDemoCtrl" ng-cloak layout="column">
   <md-switch ng-model="data.cb1" aria-label="Switch 1">
     Switch 1: {{ data.cb1 }}
   </md-switch>

--- a/src/components/switch/demoClasses/index.html
+++ b/src/components/switch/demoClasses/index.html
@@ -1,0 +1,51 @@
+<div ng-controller="AppCtrl" class="md-padding" ng-cloak>
+  <div>
+    <fieldset class="standard">
+      <legend>Using &lt;ng-model&gt;</legend>
+      <div layout="column" layout-wrap>
+        <md-switch
+            ng-model="data.cb1"
+            aria-label="Switch 1"
+            ng-true-value="'yup'"
+            ng-false-value="'nope'"
+            class="md-align-top">
+          <span> Switch 1  (md-align-top) </span> <br/>
+            <span class="ipsum">
+              Duis placerat lectus et justo mollis, nec sodales orci congue. Vestibulum semper non urna ac suscipit.
+              Vestibulum tempor, ligula id laoreet hendrerit, massa augue iaculis magna,
+              sit amet dapibus tortor ligula non nibh.
+            </span>
+          <br/>
+          <span>{{ data.cb1 }}</span>
+        </md-switch>
+        <md-switch aria-label="Switch full width" ng-model="data.cb2" class="md-full-width">
+          <span>Switch 2 (md-full-width):</span>
+        </md-switch>
+        <md-switch
+            ng-model="data.cb3"
+            aria-label="Switch 3"
+            ng-true-value="'yup'"
+            ng-false-value="'nope'"
+            class="md-invert md-align-top">
+          <span>Switch 3 (md-invert md-align-top)</span> <br/>
+            <span class="ipsum">
+              Duis placerat lectus et justo mollis, nec sodales orci congue. Vestibulum semper non urna ac suscipit.
+              Vestibulum tempor, ligula id laoreet hendrerit, massa augue iaculis magna,
+              sit amet dapibus tortor ligula non nibh.
+            </span>
+          <br/>
+          <span>{{ data.cb3 }}</span>
+        </md-switch>
+        <md-switch aria-label="Switch right and full width" ng-model="data.cb" class="md-full-width md-invert">
+          <span>Switch 4 (md-full-width & md-invert)</span>
+        </md-switch>
+        <p>Switch with floating text
+          <md-switch aria-label="Switch" ng-model="data.cb5" class="floating-text">
+            <span>(Click me)</span>
+          </md-switch>
+          to demonstrate the correct alignment.
+        </p>
+      </div>
+    </fieldset>
+  </div>
+</div>

--- a/src/components/switch/demoClasses/script.js
+++ b/src/components/switch/demoClasses/script.js
@@ -1,0 +1,16 @@
+
+angular.module('switchDemo2', ['ngMaterial'])
+
+.controller('AppCtrl', function($scope) {
+
+  $scope.data = {};
+  $scope.data.cb1 = true;
+  $scope.data.cb2 = false;
+  $scope.data.cb3 = false;
+  $scope.data.cb4 = false;
+  $scope.data.cb5 = false;
+  $scope.data.cb6 = true;
+  $scope.data.cb7 = false;
+  $scope.data.cb8 = false;
+  $scope.data.cb9 = true;
+});

--- a/src/components/switch/demoClasses/style.css
+++ b/src/components/switch/demoClasses/style.css
@@ -1,0 +1,24 @@
+
+
+fieldset.standard {
+  border-style: solid;
+  border-width: 1px;
+}
+legend {
+  color: #3F51B5;
+}
+legend code {
+  color: #3F51B5;
+  font-weight: normal;
+}
+
+.ipsum {
+  color: saddlebrown;
+}
+md-switch span{
+  direction: ltr;
+  unicode-bidi: embed;
+}
+ p > md-switch{
+   margin:0;
+ }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -3,6 +3,7 @@ $switch-height: $baseline-grid * 3 !default;
 $switch-bar-height: 14px !default;
 $switch-thumb-size: 20px !default;
 $switch-margin: 16px !default;
+$switch-text-margin: 8px !default;
 
 .md-inline-form {
   md-switch {
@@ -17,13 +18,21 @@ md-switch {
   cursor: pointer;
   outline: none;
   user-select: none;
-  height: 30px;
-  line-height: 28px;
+  height: auto;
+  line-height: inherit;
   align-items: center;
-  display: flex;
+  display: inline-flex;
+  justify-content: flex-start;
 
-  @include rtl(margin-left, inherit, $switch-margin);
-  @include rtl(margin-right, $switch-margin, inherit);
+  &::before {
+    content: '&nbsp;';
+    height: auto;
+    visibility: hidden;
+    width: 0;
+    max-width: 0;
+    flex: 0 0 0;
+    order:0;
+  }
 
   &:last-of-type {
     @include rtl(margin-left, inherit, 0);
@@ -44,8 +53,8 @@ md-switch {
     height: $switch-height;
     position: relative;
     user-select: none;
-    @include rtl-prop(margin-right, margin-left, 8px);
-    float: left;
+    min-width: $switch-width;
+    order:1;
   }
 
   // If the user moves his mouse off the switch, stil display grabbing cursor
@@ -69,12 +78,6 @@ md-switch {
         background-color: rgba(0, 0, 0, 0.12);
       }
     }
-  }
-
-  ._md-label {
-    border-color: transparent;
-    border-width: 0;
-    float: left;
   }
 
   ._md-bar {
@@ -149,6 +152,44 @@ md-switch {
     }
   }
 
+  &.md-align-top > div._md-container {
+    align-self: flex-start;
+  }
+
+  ._md-label {
+    box-sizing: border-box;
+    position: relative;
+    white-space: normal;
+    user-select: text;
+    text-align: justify;
+    @include rtl(margin-left, $switch-text-margin, 0);
+    @include rtl(margin-right, 0 ,$switch-text-margin);
+    order:2;
+    &:empty {
+      display: none;
+    }
+  }
+
+  &.md-full-width {
+    display: flex;
+    > ._md-label {
+      flex:1 1 auto;
+    }
+  }
+
+  &.md-full-width:not(.md-invert) {
+    > ._md-label {
+      @include rtl(direction, rtl, ltr);
+    }
+  }
+
+  &.md-invert {
+    > ._md-label {
+      @include rtl(margin-right, $switch-text-margin, 0);
+      @include rtl(margin-left, 0 ,$switch-text-margin);
+      order: -1;
+    }
+  }
 }
 
 @media screen and (-ms-high-contrast: active) {


### PR DESCRIPTION
- refactor css styling for better support alignment with text (also with empty label), tested on IE11, Edge, Chrome, Safari, Firefox
- add class md-full-width to change inline-flex to flex
- add class md-invert to change the places of _md-container and _md-label