### PR TITLE
fix(panel): Remove useless button in dialog demos.

### DIFF
--- a/src/components/panel/demoBasicUsage/panel.tmpl.html
+++ b/src/components/panel/demoBasicUsage/panel.tmpl.html
@@ -16,9 +16,6 @@
   </div>
 
   <div layout="row" class="demo-dialog-button">
-    <md-button flex class="md-primary">
-      Nothing
-    </md-button>
     <md-button md-autofocus flex class="md-primary" ng-click="ctrl.closeDialog()">
       Close
     </md-button>

--- a/src/components/panel/demoPanelAnimations/panel.tmpl.html
+++ b/src/components/panel/demoPanelAnimations/panel.tmpl.html
@@ -16,9 +16,6 @@
   </div>
 
   <div layout="row" class="demo-dialog-button">
-    <md-button flex class="md-primary">
-      Nothing
-    </md-button>
     <md-button md-autofocus flex class="md-primary" ng-click="ctrl.closeDialog()">
       Close
     </md-button>


### PR DESCRIPTION
@KarenParker @gmoothart @DerekLouie Please review.

There is no action associated with the button, so the panel seems broken when it's clicked.