### PR TITLE
fix(tabs): prevent input label disappearing on tab change

### DIFF
--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -206,6 +206,9 @@ md-tab-content {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;
       visibility: hidden;
+      label{
+        visibility: inherit;
+      }
     }
   }
   &.md-right:not(.md-active) {
@@ -216,6 +219,9 @@ md-tab-content {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;
       visibility: hidden;
+      label{
+        visibility: inherit;
+      }
     }
   }
   > div.ng-leave {


### PR DESCRIPTION
md-input-container labels within an md-tab disappear immediately when you change tabs.

You can see the issue by switching tabs here: http://codepen.io/anon/pen/ONooQy

This is happening because the tab is setting this on the label:
```
md-tab-content.md-left:not(.md-active) * {
      transition: visibility 0s linear;
      transition-delay: 0.5s;
      visibility: hidden; 
}
```
The problem is the label already has a transition set with a higher specificity so visibility:hidden goes into effect immediately instead of a 0.5s delay.

This change ensures the label's visibility matches the visibility of its parent when the tab isn't active, which allows it to disappear at the correct time.

