### PR TITLE
fix(menuBar): menuBar should query for uncompiled md-button directives.

### DIFF
--- a/src/components/menuBar/js/menuBarDirective.js
+++ b/src/components/menuBar/js/menuBarDirective.js
@@ -107,7 +107,10 @@ function MenuBarDirective($mdUtil, $mdTheming) {
         if (menuEl.nodeName == 'MD-MENU') {
           if (!menuEl.hasAttribute('md-position-mode')) {
             menuEl.setAttribute('md-position-mode', 'left bottom');
-            menuEl.querySelector('button,a').setAttribute('role', 'menuitem');
+
+            // Since we're in the compile function and actual `md-buttons` are not compiled yet,
+            // we need to query for possible `md-buttons` as well.
+            menuEl.querySelector('button, a, md-button').setAttribute('role', 'menuitem');
           }
           var contentEls = $mdUtil.nodesToArray(menuEl.querySelectorAll('md-menu-content'));
           angular.forEach(contentEls, function(contentEl) {

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -26,11 +26,27 @@ describe('material.components.menuBar', function() {
       });
 
       describe('ARIA', function() {
+        
         it('sets role="menubar" on the menubar', function() {
           var menuBar = setup();
           var ariaRole = menuBar[0].getAttribute('role');
           expect(ariaRole).toBe('menubar');
         });
+        
+        it('should set the role on the menu trigger correctly', inject(function($compile, $rootScope) {
+          var el = $compile(
+            '<md-menu-bar>' +
+              '<md-menu ng-repeat="i in [1, 2, 3]">' +
+                '<md-button id="triggerButton" ng-click="lastClicked = $index"></md-button>' +
+                '<md-menu-content></md-menu-content>' +
+              '</md-menu>' +
+            '</md-menu-bar>'
+          )($rootScope);
+
+          $rootScope.$digest();
+
+          expect(el[0].querySelector('#triggerButton').getAttribute('role')).toBe('menuitem');
+        }));
       });
 
       describe('nested menus', function() {


### PR DESCRIPTION
* Currently we're querying for buttons in the compile function, and we expecting the md-buttons to be already compiled.<br/>
But that's not correct, because those will be replaced with a button, after their compile has finished.

Querying for the md-button directive as well solves this.

Fixes #6802.