### PR TITLE
Avoid "index" property duplication/gapping when adding/removing middle tabs

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -369,6 +369,11 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (destroyed) return;
     var selectedIndex = ctrl.selectedIndex,
         tab           = ctrl.tabs.splice(tabData.getIndex(), 1)[ 0 ];
+    angular.forEach(ctrl.tabs, function(remainingTab) {
+      if(remainingTab.index > tab.index) {
+        remainingTab.index -= 1;
+      }
+    });
     refreshIndex();
     // when removing a tab, if the selected index did not change, we have to manually trigger the
     //   tab select/deselect events
@@ -404,6 +409,11 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         },
         tab       = angular.extend(proto, tabData);
     if (angular.isDefined(index)) {
+      angular.forEach(ctrl.tabs, function(existingTab) {
+        if(existingTab.index >= index) {
+          existingTab.index += 1;
+        }
+      });
       ctrl.tabs.splice(index, 0, tab);
     } else {
       ctrl.tabs.push(tab);


### PR DESCRIPTION
Right now when a tab is added in the middle of a tabset (e.g. through its ng-if changed to true) the "index" property of existing tabs won't be updated resulting in the new tab having the same index as the tab that was at that position before. So we end up with duplicate index properties for multiple tabs.
Same for the case when a tab is removed from the middle the indexes are not updated and as a result there will be a gap.