### PR TITLE
perf(tooltip): clean up improvements

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -98,16 +98,10 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     }
 
     function configureWatchers () {
-      scope.$on('$destroy', function() {
-        scope.visible = false;
-        element.remove();
-        angular.element($window).off('resize', debouncedOnResize);
-      });
-
       if (element[0] && 'MutationObserver' in $window) {
         var attributeObserver = new MutationObserver(function(mutations) {
           mutations
-            .forEach(function (mutation) {              
+            .forEach(function (mutation) {
               if (mutation.attributeName === 'md-visible') {
                 if (!scope.visibleWatcher)
                   scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
@@ -118,16 +112,37 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
             });
         });
 
-        attributeObserver.observe(element[0], { attributes: true});
+        attributeObserver.observe(element[0], { attributes: true });
 
-        if (attr.hasOwnProperty('mdVisible')) // build watcher only if mdVisible is being used
+        // build watcher only if mdVisible is being used
+        if (attr.hasOwnProperty('mdVisible')) {
           scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
-
-      }
-      else { // MutationObserver not supported
+        }
+      } else { // MutationObserver not supported
         scope.visibleWatcher = scope.$watch('visible', onVisibleChanged );
         scope.$watch('direction', updatePosition );
       }
+
+      var onElementDestroy = function() {
+        scope.$destroy();
+      };
+
+      // Clean up if the element or parent was removed via jqLite's .remove.
+      // A couple of notes:
+      // - In these cases the scope might not have been destroyed, which is why we
+      // destroy it manually. An example of this can be having `md-visible="false"` and
+      // adding tooltips while they're invisible. If `md-visible` becomes true, at some
+      // point, you'd usually get a lot of inputs.
+      // - We use `.one`, not `.on`, because this only needs to fire once. If we were
+      // using `.on`, it would get thrown into an infinite loop.
+      // - This kicks off the scope's `$destroy` event which finishes the cleanup.
+      element.one('$destroy', onElementDestroy);
+      parent.one('$destroy', onElementDestroy);
+      scope.$on('$destroy', function() {
+        setVisible(false);
+        element.remove();
+        attributeObserver && attributeObserver.disconnect();
+      });
     }
 
     function addAriaLabel () {
@@ -143,8 +158,6 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
 
     function bindEvents () {
       var mouseActive = false;
-
-      var ngWindow = angular.element($window);
 
       // add an mutationObserver when there is support for it
       // and the need for it in the form of viable host(parent[0])
@@ -172,13 +185,24 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       function windowScrollHandler() {
         setVisible(false);
       }
-      
-      ngWindow.on('blur', windowBlurHandler);
-      ngWindow.on('resize', debouncedOnResize);
+
+      angular.element($window)
+        .on('blur', windowBlurHandler)
+        .on('resize', debouncedOnResize);
+
       document.addEventListener('scroll', windowScrollHandler, true);
       scope.$on('$destroy', function() {
-        ngWindow.off('blur', windowBlurHandler);
-        ngWindow.off('resize', debouncedOnResize);
+        angular.element($window)
+          .off('blur', windowBlurHandler)
+          .off('resize', debouncedOnResize);
+
+        parent
+          .off('focus mouseenter touchstart', enterHandler)
+          .off('blur mouseleave touchend touchcancel', leaveHandler)
+          .off('mousedown', mousedownHandler);
+
+        // Trigger the handler in case any the tooltip was still visible.
+        leaveHandler();
         document.removeEventListener('scroll', windowScrollHandler, true);
         attributeObserver && attributeObserver.disconnect();
       });
@@ -201,18 +225,19 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         }
         mouseActive = false;
       };
+      var mousedownHandler = function() {
+        mouseActive = true;
+      };
 
       // to avoid `synthetic clicks` we listen to mousedown instead of `click`
-      parent.on('mousedown', function() { mouseActive = true; });
+      parent.on('mousedown', mousedownHandler);
       parent.on('focus mouseenter touchstart', enterHandler );
-
-
     }
 
     function setVisible (value) {
       // break if passed value is already in queue or there is no queue and passed value is current in the scope
       if (setVisible.queued && setVisible.visible === !!value || scope.visible === !!value) return;
-      
+
       setVisible.value = !!value;
       if (!setVisible.queued) {
         if (value) {
@@ -224,8 +249,8 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
               onVisibleChanged(scope.visible);
           }, scope.delay);
         } else {
-          $mdUtil.nextTick(function() { 
-            scope.visible = false; 
+          $mdUtil.nextTick(function() {
+            scope.visible = false;
             if (!scope.visibleWatcher)
               onVisibleChanged(false);
           });

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -12,7 +12,8 @@ describe('<md-tooltip> directive', function() {
   }));
   afterEach(function() {
     // Make sure to remove/cleanup after each test
-    element && element.scope().$destroy();
+    var scope = element && element.scope();
+    scope && scope.$destroy();
     element = undefined;
   });
 
@@ -212,6 +213,83 @@ describe('<md-tooltip> directive', function() {
       $document[0].body.removeChild(element[0]);
     }));
 
+  });
+
+  describe('cleanup', function() {
+    it('should clean up the scope if the parent was removed from the DOM', function() {
+      buildTooltip(
+        '<md-button>' +
+         '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
+      var tooltip = findTooltip();
+
+      expect(tooltip.length).toBe(1);
+      expect(tooltip.scope()).toBeTruthy();
+
+      element.remove();
+      expect(tooltip.scope()).toBeUndefined();
+      expect(findTooltip().length).toBe(0);
+    });
+
+    it('should clean up if the parent scope was destroyed', function() {
+      buildTooltip(
+        '<md-button>' +
+         '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
+      var tooltip = findTooltip();
+
+      expect(tooltip.length).toBe(1);
+      expect(tooltip.scope()).toBeTruthy();
+
+      element.scope().$destroy();
+      expect(tooltip.scope()).toBeUndefined();
+      expect(findTooltip().length).toBe(0);
+    });
+
+    it('should remove the tooltip when its own scope is destroyed', function() {
+      buildTooltip(
+        '<md-button>' +
+         '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
+      var tooltip = findTooltip();
+
+      expect(tooltip.length).toBe(1);
+      tooltip.scope().$destroy();
+      expect(findTooltip().length).toBe(0);
+    });
+
+    it('should not re-appear if it was outside the DOM when the parent was removed', function() {
+      buildTooltip(
+        '<md-button>' +
+         '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
+
+      showTooltip(false);
+      expect(findTooltip().length).toBe(0);
+
+      element.remove();
+      showTooltip(true);
+      expect(findTooltip().length).toBe(0);
+    });
+
+    it('should unbind the parent listeners when it gets destroyed', function() {
+      buildTooltip(
+        '<md-button>' +
+           '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
+
+      triggerEvent('focus');
+      expect($rootScope.testModel.isVisible).toBe(true);
+
+      element.remove();
+      triggerEvent('blur mouseleave touchend touchcancel');
+      expect($rootScope.testModel.isVisible).toBe(true);
+    });
   });
 
   // ******************************************************


### PR DESCRIPTION
* Fixes the toolip not being removed if the element to which it is attached gets removed from the DOM.
* Fixes the tooltip element sometimes not being removed when it's scope gets destroyed.
* Fixes some event handlers that weren't being removed when the tooltip is destroyed.

Fixes #8198.