### PR TITLE
feat(toast): add center option for horizontal position

### DIFF
--- a/src/components/toast/demoBasicUsage/index.html
+++ b/src/components/toast/demoBasicUsage/index.html
@@ -19,10 +19,17 @@
 
       <div>
         <p><b>Toast Position: "{{getToastPosition()}}"</b></p>
-        <md-checkbox ng-repeat="(name, isSelected) in toastPosition"
-          ng-model="toastPosition[name]">
-          {{name}}
-        </md-checkbox>
+        <div layout="row" layout-padding>
+          <md-radio-group class="md-primary" layout="row" ng-model="verticalPosition">
+            <md-radio-button value="top">top</md-radio-button>
+            <md-radio-button value="bottom">bottom</md-radio-button>
+          </md-radio-group>
+          <md-radio-group layout="row" ng-model="horizontalPosition">
+            <md-radio-button value="left">left</md-radio-button>
+            <md-radio-button value="center">center</md-radio-button>
+            <md-radio-button value="right">right</md-radio-button>
+          </md-radio-group>
+        </div>
       </div>
     </div>
     <div layout="row">

--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -2,33 +2,12 @@
 angular.module('toastDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope, $mdToast) {
-  var last = {
-      bottom: false,
-      top: true,
-      left: false,
-      right: true
-    };
-
-  $scope.toastPosition = angular.extend({},last);
+  $scope.verticalPosition = 'top';
+  $scope.horizontalPosition = 'right';
 
   $scope.getToastPosition = function() {
-    sanitizePosition();
-
-    return Object.keys($scope.toastPosition)
-      .filter(function(pos) { return $scope.toastPosition[pos]; })
-      .join(' ');
+    return $scope.verticalPosition + ' ' + $scope.horizontalPosition;
   };
-
-  function sanitizePosition() {
-    var current = $scope.toastPosition;
-
-    if ( current.bottom && last.top ) current.top = false;
-    if ( current.top && last.bottom ) current.bottom = false;
-    if ( current.right && last.left ) current.left = false;
-    if ( current.left && last.right ) current.right = false;
-
-    last = angular.extend({},current);
-  }
 
   $scope.showSimpleToast = function() {
     var pinTo = $scope.getToastPosition();

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -203,7 +203,7 @@ function MdToastDirective($mdToast) {
   *     active before automatically closing.  Set to 0 or false to have the toast stay open until
   *     closed manually. Default: 3000.
   *   - `position` - `{string=}`: Where to place the toast. Available: any combination
-  *     of 'bottom', 'left', 'top', 'right'. Default: 'bottom left'.
+  *     of 'bottom' or 'top' for vertical and 'left', 'center' or 'right' for horizontal. Default: 'bottom left'.
   *   - `controller` - `{string=}`: The controller to associate with this toast.
   *     The controller will be injected the local `$mdToast.hide( )`, which is a function
   *     used to hide the toast.

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -169,6 +169,10 @@ md-toast {
     &._md-right {
       right: 0;
     }
+    &._md-center {
+      left: 50%;
+      transform: translate3d(-50%, 0, 0);
+    }
     &._md-top {
       top: 0;
     }


### PR DESCRIPTION
Added the option to position Toasts in horizontal center. This is needed for `mdToast` to comply with [Material Specs](https://www.google.com/design/spec/components/snackbars-toasts.html#snackbars-toasts-specs). Discussion in #1773 

I updated the demo and docs so this is ready to merge upon approval.