### PR TITLE
fix(dialog): remove whitespace from "custom" dialog demo

### DIFF
--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -36,7 +36,7 @@
       <md-button ng-click="answer('not useful')">
        Not Useful
       </md-button>
-      <md-button ng-click="answer('useful')" style="margin-right:20px;">
+      <md-button ng-click="answer('useful')">
         Useful
       </md-button>
     </md-dialog-actions>


### PR DESCRIPTION
  Remove extra unnecessary padding from right button that was probably left over by accident.

  This was added in b401751 for #3135.  It should probably have been removed in 3aab9e4e.

![before master](https://cloud.githubusercontent.com/assets/325176/14908500/eb4bda4a-0e2b-11e6-9ae4-7f2c67050060.png)

  Material Design specifies 8dp (6px) between the right edge of the right-most button and the right
  edge of the containing dialog.

  See https://www.google.com/design/spec/components/dialogs.html#dialogs-behavior

![spec](https://cloud.githubusercontent.com/assets/325176/14908504/fb8c5722-0e2b-11e6-9277-78a48352386a.png)

### Fixed

![after fixed](https://cloud.githubusercontent.com/assets/325176/14908510/179a3fec-0e2c-11e6-969f-64b997a33d5b.png)
