### PR TITLE
fix(toast, list): use a pseudo element to be able to use min-height.

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -37,20 +37,6 @@ $list-item-dense-header-font-size: round($subhead-font-size-base * 0.8) !default
 $list-item-dense-font-size: round($body-font-size-base * 0.85) !default;
 $list-item-dense-line-height: 1.05 !default;
 
-// This is a mixin, which fixes IE11's vertical alignment issue, when using `min-height`.
-// This mixin isn't that much generic to be used in other cases.
-// It can be only used for the list-item's button container.
-// See https://connect.microsoft.com/IE/feedback/details/816293/
-@mixin ie11-min-height-flexbug($min-height) {
-  div.md-button:first-child {
-    &::before {
-      content: '';
-      min-height: $min-height;
-      visibility: hidden;
-    }
-  }
-}
-
 md-list {
   display: block;
   padding: $list-padding-top $list-padding-right $list-padding-bottom $list-padding-left;
@@ -114,7 +100,9 @@ md-list {
         &, & > ._md-no-style {
           min-height: $list-item-dense-two-line-height;
 
-          @include ie11-min-height-flexbug($list-item-dense-two-line-height);
+          div.md-button:first-child {
+            @include ie11-min-height-flexbug($list-item-dense-two-line-height);
+          }
 
           > .md-avatar, .md-avatar-icon {
             margin-top: $baseline-grid * 1.5;
@@ -126,7 +114,9 @@ md-list {
         &, & > ._md-no-style {
           min-height: $list-item-dense-three-line-height;
 
-          @include ie11-min-height-flexbug($list-item-dense-three-line-height);
+          div.md-button:first-child {
+            @include ie11-min-height-flexbug($list-item-dense-three-line-height);
+          }
 
           > md-icon:first-child,
           > .md-avatar {
@@ -385,14 +375,18 @@ md-list-item {
       height: auto;
       min-height: $list-item-two-line-height;
 
-      @include ie11-min-height-flexbug($list-item-two-line-height);
+      div.md-button:first-child {
+        @include ie11-min-height-flexbug($list-item-two-line-height);
+      }
 
       > .md-avatar, .md-avatar-icon {
         margin-top: $baseline-grid * 1.5;
       }
+
       > md-icon:first-child {
         align-self: flex-start;
       }
+
       .md-list-item-text {
         flex: 1 1 auto;
       }
@@ -404,7 +398,9 @@ md-list-item {
       height: auto;
       min-height: $list-item-three-line-height;
 
-      @include ie11-min-height-flexbug($list-item-three-line-height);
+      div.md-button:first-child {
+        @include ie11-min-height-flexbug($list-item-three-line-height);
+      }
 
       > md-icon:first-child,
       > .md-avatar {

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -28,10 +28,14 @@ md-toast {
     display: flex;
     align-items: center;
 
-    height: 0;
     max-height: 7 * $toast-height;
     max-width: 100%;
+
     min-height: 48px;
+    // Since we're vertically centering our text by using flexbox and having a min-height, we need to apply
+    // a fix for an IE11 flexbug, otherwise the text won't be centered vertically.
+    @include ie11-min-height-flexbug(48px);
+
     padding: 0 $md-toast-content-padding;
 
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -104,6 +104,16 @@
   @return $map-str + '}';
 }
 
+// This is a mixin, which fixes IE11's vertical alignment issue, when using `min-height`.
+// See https://connect.microsoft.com/IE/feedback/details/816293/
+@mixin ie11-min-height-flexbug($min-height) {
+  &::before {
+    content: '';
+    min-height: $min-height;
+    visibility: hidden;
+    display: inline-block;
+  }
+}
 
 // mixin definition ; sets LTR and RTL within the same style call
 // @see https://css-tricks.com/almanac/properties/d/direction/


### PR DESCRIPTION
* Currently all browsers, except IE11 are supporting flexbox's align-items property when having a `min-height`.
This bug is solved in the Edge Browser, but the fix will never land in IE11.

The vertical alignment bug for the list component was already solved by a previous commit, but the fix was only working for IE11 on Windows 8+.
IE11 on Windows 7- was not giving the pseudo element a `inline-block` position. (#7629)

See the `inline-block` suggestion in the official issue report
- https://connect.microsoft.com/IE/feedback/details/816293/ie11-flexbox-with-min-height-not-vertically-aligning-with-align-items-center

Also this commit, removes the fixed height on the toast and uses the IE11 as well. (#8092)
So it's now possible, that the toast grows and the vertical alignment is also working.

Thoroughly tested with IE11 on Win 7, 8, 10 and of course all other browsers (Chrome, FF, Safari)

Fixes #7629. Fixes #8092.