### PR TITLE
fix(sidenav): rightNav button and input text is blurry on IE11

### DIFF
--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -87,9 +87,9 @@ md-sidenav {
 .md-sidenav-right {
   left: 100%;
   top: 0;
-  transform: translate3d(-100%, 0, 0);
+  transform: translate(-100%, 0);
   &._md-closed {
-    transform: translate3d(0%, 0, 0);
+    transform: translate(0%, 0);
   }
 }
 


### PR DESCRIPTION
 Use `translate` instead of `translate3d` for better IE11 support
 Same was previously done for `md-dialog` here: https://github.com/angular/material/commit/689a34da23f68d76ab682544f46441005ec20fd9

Fixes #6007.

Before:
![rightnavblurryie11](https://cloud.githubusercontent.com/assets/3506071/14944861/ca1b296c-0fce-11e6-881f-4a8c0195c960.PNG)

After:
![rightnavfixedie11](https://cloud.githubusercontent.com/assets/3506071/14944862/d65b3488-0fce-11e6-9d19-4a2a585d93f4.PNG)
