### PR TITLE
Fixing inconsistencies with md-highlight.

### DIFF
--- a/src/components/autocomplete/js/highlightController.js
+++ b/src/components/autocomplete/js/highlightController.js
@@ -33,9 +33,9 @@ function MdHighlightCtrl ($scope, $element, $attrs) {
 
   function getRegExp (text, flags) {
     var str = '';
-    if (flags.indexOf('^') >= 1) str += '^';
-    str += text;
-    if (flags.indexOf('$') >= 1) str += '$';
-    return new RegExp(sanitize(str), flags.replace(/[\$\^]/g, ''));
+    if (flags.indexOf('^') >= 0) str += '^';
+    str += sanitize(text);
+    if (flags.indexOf('$') >= 0) str += '$';
+    return new RegExp(str, flags.replace(/[\$\^]/g, ''));
   }
 }


### PR DESCRIPTION
I've found inconsistencies with md-hightlight regarding flags.  Both ^ and $ were not being read if they were in the first position.  Additionally, the flags were being sanitized once placed into the final string which makes them useless and buggy.

Per the previous code:

```
<div md-highlight-text="'words'" md-highlight-flags="i^g">Words and Words</div>
<div md-highlight-text="'words'" md-highlight-flags="^ig">Words and Words</div>
```

becomes:

```
<div md-highlight-text="'words'" md-highlight-flags="i^g">Words and Words</div>
<div md-highlight-text="'words'" md-highlight-flags="^ig"><span class="highlight">Words</span> and <span class="highlight">Words</span></div>
```

I've updated the code to sanitize only the incoming text.  Additionally, ^ and $ flags are allowed in the first position of `md-hightlight-flags`.