### PR TITLE
feat(list): add support for ng-dblclick.

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -97,7 +97,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
       tEl[0].setAttribute('role', 'listitem');
 
-      if (tAttrs.ngClick || tAttrs.ngHref || tAttrs.href || tAttrs.uiSref || tAttrs.ngAttrUiSref) {
+      if (tAttrs.ngClick || tAttrs.ngDblclick ||  tAttrs.ngHref || tAttrs.href || tAttrs.uiSref || tAttrs.ngAttrUiSref) {
         wrapIn('button');
       } else {
         for (var i = 0, type; type = proxiedTypes[i]; ++i) {
@@ -198,7 +198,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       }
 
       function copyAttributes(item, wrapper) {
-        var copiedAttrs = ['ng-if', 'ng-click', 'aria-label', 'ng-disabled',
+        var copiedAttrs = ['ng-if', 'ng-click', 'ng-dblclick', 'aria-label', 'ng-disabled',
           'ui-sref', 'href', 'ng-href', 'target', 'ng-attr-ui-sref', 'ui-sref-opts'];
 
         angular.forEach(copiedAttrs, function(attr) {

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -154,6 +154,32 @@ describe('mdListItem directive', function() {
     expect(innerContent.firstElementChild.nodeName).toBe('P');
   });
 
+  it('creates buttons when used with ng-dblclick', function() {
+    var listItem = setup(
+      '<md-list-item ng-dblclick="sayHello()" ng-disabled="true">' +
+        '<p>Hello world</p>' +
+      '</md-list-item>');
+
+    // List items, which are clickable always contain a button wrap at the top level.
+    var buttonWrap = listItem.children().eq(0);
+    expect(listItem).toHaveClass('_md-button-wrap');
+
+    // The button wrap should contain the button executor, the inner content, flex filler and the
+    // secondary item container as children.
+    expect(buttonWrap.children().length).toBe(4);
+
+    var buttonExecutor = buttonWrap.children()[0];
+
+    // The list item should forward the click and disabled attributes.
+    expect(buttonExecutor.hasAttribute('ng-dblclick')).toBe(true);
+    expect(buttonExecutor.hasAttribute('ng-disabled')).toBe(true);
+
+    var innerContent = buttonWrap.children()[1];
+
+    expect(innerContent.nodeName).toBe('DIV');
+    expect(innerContent.firstElementChild.nodeName).toBe('P');
+  });
+
   it('creates buttons when used with ui-sref', function() {
     var listItem = setup(
       '<md-list-item ui-sref="somestate">' +


### PR DESCRIPTION
* Currently the list component is not taking care of `ng-dblclick`, the list contents will be not wrapped inside of a button and there will be no hover, ripple effect.

FIxes #8303.