### PR TITLE
Improve md-prevent-menu-close to wrap child Elements

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -289,7 +289,7 @@ function MenuProvider($$interimElementProvider) {
           do {
             if (target == opts.menuContentEl[0]) return;
             if ((hasAnyAttribute(target, ['ng-click', 'ng-href', 'ui-sref']) ||
-                target.nodeName == 'BUTTON' || target.nodeName == 'MD-BUTTON') && !hasAnyAttribute(target, ['md-prevent-menu-close'])) {
+                target.nodeName == 'BUTTON' || target.nodeName == 'MD-BUTTON') && !hasOrParentHasAnyAttribute(target, ['md-prevent-menu-close'])) {
               var closestMenu = $mdUtil.getClosest(target, 'MD-MENU');
               if (!target.hasAttribute('disabled') && (!closestMenu || closestMenu == opts.parent[0])) {
                 close();
@@ -313,6 +313,18 @@ function MenuProvider($$interimElementProvider) {
                   return true;
                 }
               }
+            }
+            return false;
+          }
+          
+          function hasOrParentHasAnyAttribute(target, attrs){
+            if (!target) return false;
+            var parent = target.parentElement;
+            while(parent && parent.nodeName != 'MD-MENU'){
+              if(hasAnyAttribute(parent,attrs)){
+                 return true;
+              }
+              parent = parent.parentElement;
             }
             return false;
           }

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -317,11 +317,11 @@ function MenuProvider($$interimElementProvider) {
             return false;
           }
           
-          function hasOrParentHasAnyAttribute(target, attrs){
+          function hasOrParentHasAnyAttribute(target, attrs) {
             if (!target) return false;
             var parent = target.parentElement;
-            while(parent && parent.nodeName != 'MD-MENU'){
-              if(hasAnyAttribute(parent,attrs)){
+            while (parent && parent.nodeName != 'MD-MENU') {
+              if (hasAnyAttribute(parent,attrs)) {
                  return true;
               }
               parent = parent.parentElement;


### PR DESCRIPTION
Allow the use of "md-prevent-menu-close" on parent element inside a md-menu to prevent close behavior on click.

Uses cases:
-Allow to use md-prevent-menu-close on a directive who has a md-button inside the template.