### PR TITLE
fix(ng-maxLength): rerender mdMaxLength when ngModel is updated in the controller

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -527,9 +527,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
       
       //render count when model changes as well
       //rerenders when the model changes in the controller and not an event
-      scope.$watch(attr.ngModel, function(value) {
-         renderCharCount();
-      });
+      scope.$watch(attr.ngModel, renderCharCount);
       
       scope.$watch(attr.mdMaxlength, function(value) {
         maxlength = value;

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -524,7 +524,13 @@ function mdMaxlengthDirective($animate, $mdUtil) {
       element.on('input keydown keyup', function() {
         renderCharCount(); //make sure it's called with no args
       });
-
+      
+      //render count when model changes as well
+      //rerenders when the model changes in the controller and not an event
+      scope.$watch(attr.ngModel, function(value) {
+         renderCharCount();
+      });
+      
       scope.$watch(attr.mdMaxlength, function(value) {
         maxlength = value;
         if (angular.isNumber(value) && value > 0) {


### PR DESCRIPTION
This issue comes up when sharing one form for several models. For example a list. If you were to click on one item that displays the form and it has a value for the scope variable being counted, it works fine. But if you change to a different list item that does not have a value, mdMaxLength keeps the count from the previous model, but the input is empty. 