### PR TITLE
fix(switch-drag): drag to left doesn't update switch view

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -169,7 +169,8 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
       }
 
       function listener(ev) {
-        if (element[0].hasAttribute('disabled')) {
+        if (element[0].hasAttribute('disabled') || scope.mouseActive == true) {
+          scope.mouseActive = false;
           return;
         }
 

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -47,7 +47,7 @@ angular.module('material.components.switch', [
  *
  * </hljs>
  */
-function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdGesture) {
+function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdGesture, $timeout) {
   var checkboxDirective = mdCheckboxDirective[0];
 
   return {
@@ -139,11 +139,15 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
 
         // We changed if there is no distance (this is a click a click),
         // or if the drag distance is >50% of the total.
-        var isChanged = ngModel.$viewValue ? drag.translate > 0.5 : drag.translate < 0.5;
+        var isChanged = ngModel.$viewValue ? drag.translate < 0.5 : drag.translate > 0.5;
         if (isChanged) {
           applyModelValue(!ngModel.$viewValue);
         }
         drag = null;
+
+        //ignore followed click event in checkbox directive! --> ($setViewValue)
+        scope.mouseActive = true;
+        $timeout(function () { scope.mouseActive = false; }, 100);
       }
 
       function applyModelValue(newValue) {


### PR DESCRIPTION
md-switch drag to left generates a second click event in checkbox directive and the view was reset. This fix resolves this.