### PR TITLE
mdSelect:fix name attribute issue for mdSelect

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -183,7 +183,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     if (attr.name) {
       var autofillClone = angular.element('<select class="_md-visually-hidden">');
       autofillClone.attr({
-        'name': '.' + attr.name,
+        'name': attr.name,
         'ng-model': attr.ngModel,
         'aria-hidden': 'true',
         'tabindex': '-1'
@@ -255,7 +255,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       $mdTheming(element);
 
       if (attr.name && formCtrl) {
-        var selectEl = element.parent()[0].querySelector('select[name=".' + attr.name + '"]');
+        var selectEl = element.parent()[0].querySelector('select[name="' + attr.name + '"]');
         $mdUtil.nextTick(function() {
           var controller = angular.element(selectEl).controller('ngModel');
           if (controller) {


### PR DESCRIPTION
* if `mdSelect` has `name` attribute, it will create a hidden select component, but this is a `.` before the attribute name