### PR TITLE
fix($mdUtil) nextTick now keeps reference to correct scope.

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -179,7 +179,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Removes any events or leftover elements created by this controller
    */
   function cleanup () {
-    if(!ctrl.hidden) {
+    if (!ctrl.hidden) {
       $mdUtil.enableScrolling();
     }
 

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -587,7 +587,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       var queue = nextTick.queue || [];
 
       //-- add callback to the queue
-      queue.push(callback);
+      queue.push({scope: scope, callback: callback});
 
       //-- set default value for digest
       if (digest == null) digest = true;
@@ -606,16 +606,18 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
        * Trigger digest if necessary
        */
       function processQueue() {
-        var skip = scope && scope.$$destroyed;
-        var queue = !skip ? nextTick.queue : [];
-        var digest = !skip ? nextTick.digest : null;
+        var queue = nextTick.queue;
+        var digest = nextTick.digest;
 
         nextTick.queue = [];
         nextTick.timeout = null;
         nextTick.digest = false;
 
-        queue.forEach(function(callback) {
-          callback();
+        queue.forEach(function(queueItem) {
+          var skip = queueItem.scope && queueItem.scope.$$destroyed;
+          if (!skip) {
+            queueItem.callback();
+          }
         });
 
         if (digest) $rootScope.$digest();

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -247,15 +247,76 @@ describe('util', function() {
         //-- but callback is still called more
         expect(callback.calls.count()).toBe(10);
       }));
+
       it('should return a timeout', inject(function($mdUtil) {
         var timeout = $mdUtil.nextTick(angular.noop);
         expect(timeout.$$timeoutId).toBeOfType('number');
       }));
+
       it('should return the same timeout for multiple calls', inject(function($mdUtil) {
         var a = $mdUtil.nextTick(angular.noop),
           b = $mdUtil.nextTick(angular.noop);
         expect(a).toBe(b);
       }));
+
+      it('should use scope argument and `scope.$$destroyed` to skip the callback', inject(function($mdUtil) {
+        var callback = jasmine.createSpy('callback');
+        var scope = $rootScope.$new(true);
+
+        $mdUtil.nextTick(callback, false, scope);
+        scope.$destroy();
+
+        flush(function(){
+          expect(callback).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should only skip callbacks of scopes which were destroyed', inject(function($mdUtil) {
+        var callback1 = jasmine.createSpy('callback1');
+        var callback2 = jasmine.createSpy('callback2');
+        var scope1 = $rootScope.$new(true);
+        var scope2 = $rootScope.$new(true);
+
+        $mdUtil.nextTick(callback1, false, scope1);
+        $mdUtil.nextTick(callback2, false, scope2);
+        scope1.$destroy();
+
+        flush(function() {
+          expect(callback1).not.toHaveBeenCalled();
+          expect(callback2).toHaveBeenCalled();
+        });
+      }));
+
+      it('should skip callback for destroyed scopes even if first scope registered is undefined', inject(function($mdUtil) {
+        var callback1 = jasmine.createSpy('callback1');
+        var callback2 = jasmine.createSpy('callback2');
+        var scope = $rootScope.$new(true);
+
+        $mdUtil.nextTick(callback1, false);  // no scope
+        $mdUtil.nextTick(callback2, false, scope);
+        scope.$destroy();
+
+        flush(function() {
+          expect(callback1).toHaveBeenCalled();
+          expect(callback2).not.toHaveBeenCalled();
+        });
+      }));
+
+      it('should use scope argument and `!scope.$$destroyed` to invoke the callback', inject(function($mdUtil) {
+        var callback = jasmine.createSpy('callback');
+        var scope = $rootScope.$new(true);
+
+        $mdUtil.nextTick(callback, false, scope);
+        flush(function(){
+          expect(callback).toHaveBeenCalled();
+        });
+      }));
+
+      function flush(expectation) {
+        $rootScope.$digest();
+        $timeout.flush();
+        expectation && expectation();
+      }
     });
 
     describe('hasComputedStyle', function () {
@@ -432,30 +493,6 @@ describe('util', function() {
         }));
       });
     });
-
-    it('should use scope argument and `scope.$$destroyed` to skip the callback', inject(function($mdUtil) {
-      var callBackUsed, callback = function(){ callBackUsed = true; };
-      var scope = $rootScope.$new(true);
-
-      $mdUtil.nextTick(callback,false,scope);
-      scope.$destroy();
-
-      flush(function(){ expect( callBackUsed ).toBeUndefined(); });
-    }));
-
-    it('should use scope argument and `!scope.$$destroyed` to invoke the callback', inject(function($mdUtil) {
-       var callBackUsed, callback = function(){ callBackUsed = true; };
-       var scope = $rootScope.$new(true);
-
-       $mdUtil.nextTick(callback,false,scope);
-       flush(function(){ expect( callBackUsed ).toBe(true); });
-     }));
-
-    function flush(expectation) {
-      $rootScope.$digest();
-      $timeout.flush();
-      expectation && expectation();
-    }
   });
 
   describe('processTemplate', function() {


### PR DESCRIPTION
Previously, `nextTick` would decide whether to run the functions based
on the first `scope` argument passed during a given digest cycle.  This
could fail in multiple scenarios ...

1) The first `nextTick` call didn't supply a scope, but subsequent calls did.
2) Multiple components (with different scopes) registered callbacks during the same digest cycle.

This could lead to callbacks being executed when they shouldn't be (if
the first scope registered wasn't $$destroyed, this _this_ scope was),
or callbacks not being executed when they should be (the first scope was
$$destroyed, but this scope wasn't).

I believe that this fixes #8358