### PR TITLE
fix(datepicker): align input border colors with inputs.

### DIFF
--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -8,10 +8,10 @@
   }
 
   .md-datepicker-input-container {
-    border-bottom-color: '{{background-300}}';
+    border-bottom-color: '{{foreground-4}}';
 
     &.md-datepicker-focused {
-      border-bottom-color: '{{primary-500}}'
+      border-bottom-color: '{{primary-color}}'
     }
 
     &.md-datepicker-invalid {


### PR DESCRIPTION
* Currently the datepicker had some different theme colors for the border.
  Those colors should be the same as in the input component.

Fixes #8148.