### PR TITLE
fix(select): properly hide the progressbar

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -170,7 +170,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         .find('md-content')
         .prepend(angular.element(
           '<div>' +
-          ' <md-progress-circular md-mode="indeterminate" ng-if="!$$loadingAsyncDone" md-diameter="25px"></md-progress-circular>' +
+          ' <md-progress-circular md-mode="indeterminate" ng-if="$$loadingAsyncDone === false" md-diameter="25px"></md-progress-circular>' +
           '</div>'
         ));
 
@@ -550,7 +550,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
     var selectCtrl = ctrls[0];
 
     element.addClass('_md');     // private md component indicator for styling
-    
+
     $mdTheming(element);
     element.on('click', clickListener);
     element.on('keypress', keyListener);


### PR DESCRIPTION
The loader in `md-select` is being shown/hidden via the `$$loadingAsyncDone` property. Initially it is `undefined`, which causes the loader to continue rendering in the background, until the user opens and closes the select.

Fixes #8379.