### PR TITLE
fix(tooltip): cancel show timeouts when leaving before delay.

### DIFF
--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -141,6 +141,29 @@ describe('<md-tooltip> directive', function() {
         expect($rootScope.testModel.isVisible).toBe(false);
     });
 
+    it('should cancel when mouseleave was before the delay', function() {
+      buildTooltip(
+        '<md-button>' +
+          'Hello' +
+          '<md-tooltip md-delay="99" md-autohide md-visible="testModel.isVisible">' +
+            'Tooltip' +
+          '</md-tooltip>' +
+        '</md-button>'
+      );
+
+
+      triggerEvent('mouseenter', true);
+      expect($rootScope.testModel.isVisible).toBeFalsy();
+
+      triggerEvent('mouseleave', true);
+      expect($rootScope.testModel.isVisible).toBeFalsy();
+
+      // Total 99 == tooltipDelay
+      $timeout.flush(99);
+
+      expect($rootScope.testModel.isVisible).toBe(false);
+    });
+
     it('should set visible on focus and blur', function() {
       buildTooltip(
         '<md-button>' +


### PR DESCRIPTION
* When a user hovers over a tooltip, which has a delay, and we're leaving the tooltips parent before the delay is finished, then we're detaching all leave handlers, which is not valid.<br/>
  We should cancel the show timeout, when the leave occurs before the delay.

Fixes #8363.