### PR TITLE
feat(autocomplete): add ability to style md-virtual-repeat-container

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -124,11 +124,11 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
-    it('should allow you to set an id to the md-virtual-repeat-container element', inject(function() {
-      var scope = createScope(null, {menuContainerId: 'custom-menu-container-id'});
+    it('should allow you to set a class to the md-virtual-repeat-container element', inject(function() {
+      var scope = createScope(null, {menuContainerClass: 'custom-menu-container-class'});
       var template = '\
           <md-autocomplete\
-              md-menu-container-id="{{menuContainerId}}"\
+              md-menu-container-class="{{menuContainerClass}}"\
               md-input-id="input-id"\
               md-selected-item="selectedItem"\
               md-search-text="searchText"\
@@ -140,7 +140,7 @@ describe('<md-autocomplete>', function() {
       var element = compile(template, scope);
       var repeatContainer = element.find('md-virtual-repeat-container');
 
-      expect(repeatContainer.attr('id')).toBe(scope.menuContainerId);
+      expect(repeatContainer.attr('class')).toContain(scope.menuContainerClass);
 
       element.remove();
 

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -124,6 +124,28 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should allow you to set an id to the md-virtual-repeat-container element', inject(function() {
+      var scope = createScope(null, {menuContainerId: 'custom-menu-container-id'});
+      var template = '\
+          <md-autocomplete\
+              md-menu-container-id="{{menuContainerId}}"\
+              md-input-id="input-id"\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var repeatContainer = element.find('md-virtual-repeat-container');
+
+      expect(repeatContainer.attr('id')).toBe(scope.menuContainerId);
+
+      element.remove();
+
+    }));
+
     it('should allow allow using ng-readonly', inject(function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template = '\

--- a/src/components/autocomplete/demoCustomTemplate/index.html
+++ b/src/components/autocomplete/demoCustomTemplate/index.html
@@ -13,7 +13,8 @@
           md-item-text="item.name"
           md-min-length="0"
           placeholder="Pick an Angular repository"
-          md-menu-class="autocomplete-custom-template">
+          md-menu-class="autocomplete-custom-template"
+          md-menu-container-id="autocomplete-custom-template-id">
         <md-item-template>
           <span class="item-title">
             <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>

--- a/src/components/autocomplete/demoCustomTemplate/index.html
+++ b/src/components/autocomplete/demoCustomTemplate/index.html
@@ -14,7 +14,7 @@
           md-min-length="0"
           placeholder="Pick an Angular repository"
           md-menu-class="autocomplete-custom-template"
-          md-menu-container-id="autocomplete-custom-template-id">
+          md-menu-container-class="autocomplete-custom-template-class">
         <md-item-template>
           <span class="item-title">
             <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -55,6 +55,8 @@ angular
  * @param {boolean=} md-no-asterisk When present, asterisk will not be appended to the floating label
  * @param {boolean=} md-autoselect If true, the first item will be selected by default
  * @param {string=} md-menu-class This will be applied to the dropdown menu for styling
+ * @param {string=} md-menu-container-id This will be applied to the parent container of the dropdown
+ *     menu for styling
  * @param {string=} md-floating-label This will add a floating label to autocomplete and wrap it in
  *     `md-input-container`
  * @param {string=} md-input-name The name attribute given to the input element to be used with
@@ -149,6 +151,7 @@ function MdAutocomplete () {
       floatingLabel:    '@?mdFloatingLabel',
       autoselect:       '=?mdAutoselect',
       menuClass:        '@?mdMenuClass',
+      menuContainerId:  '@?mdMenuContainerId',
       inputId:          '@?mdInputId'
     },
     link: function(scope, element, attrs, controller) {
@@ -181,6 +184,7 @@ function MdAutocomplete () {
               ng-if="$mdAutocompleteCtrl.loadingIsVisible()"\
               md-mode="indeterminate"></md-progress-linear>\
           <md-virtual-repeat-container\
+              id="{{menuContainerId}}"\
               md-auto-shrink\
               md-auto-shrink-min="1"\
               ng-mouseenter="$mdAutocompleteCtrl.listEnter()"\

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -55,8 +55,8 @@ angular
  * @param {boolean=} md-no-asterisk When present, asterisk will not be appended to the floating label
  * @param {boolean=} md-autoselect If true, the first item will be selected by default
  * @param {string=} md-menu-class This will be applied to the dropdown menu for styling
- * @param {string=} md-menu-container-id This will be applied to the parent container of the dropdown
- *     menu for styling
+ * @param {string=} md-menu-container-class This will add a class to `md-virtual-repeat-container`,
+ *     the parent container of the dropdown list
  * @param {string=} md-floating-label This will add a floating label to autocomplete and wrap it in
  *     `md-input-container`
  * @param {string=} md-input-name The name attribute given to the input element to be used with

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -132,27 +132,27 @@ function MdAutocomplete () {
     controller:   'MdAutocompleteCtrl',
     controllerAs: '$mdAutocompleteCtrl',
     scope:        {
-      inputName:        '@mdInputName',
-      inputMinlength:   '@mdInputMinlength',
-      inputMaxlength:   '@mdInputMaxlength',
-      searchText:       '=?mdSearchText',
-      selectedItem:     '=?mdSelectedItem',
-      itemsExpr:        '@mdItems',
-      itemText:         '&mdItemText',
-      placeholder:      '@placeholder',
-      noCache:          '=?mdNoCache',
-      selectOnMatch:    '=?mdSelectOnMatch',
-      matchInsensitive: '=?mdMatchCaseInsensitive',
-      itemChange:       '&?mdSelectedItemChange',
-      textChange:       '&?mdSearchTextChange',
-      minLength:        '=?mdMinLength',
-      delay:            '=?mdDelay',
-      autofocus:        '=?mdAutofocus',
-      floatingLabel:    '@?mdFloatingLabel',
-      autoselect:       '=?mdAutoselect',
-      menuClass:        '@?mdMenuClass',
-      menuContainerId:  '@?mdMenuContainerId',
-      inputId:          '@?mdInputId'
+      inputName:          '@mdInputName',
+      inputMinlength:     '@mdInputMinlength',
+      inputMaxlength:     '@mdInputMaxlength',
+      searchText:         '=?mdSearchText',
+      selectedItem:       '=?mdSelectedItem',
+      itemsExpr:          '@mdItems',
+      itemText:           '&mdItemText',
+      placeholder:        '@placeholder',
+      noCache:            '=?mdNoCache',
+      selectOnMatch:      '=?mdSelectOnMatch',
+      matchInsensitive:   '=?mdMatchCaseInsensitive',
+      itemChange:         '&?mdSelectedItemChange',
+      textChange:         '&?mdSearchTextChange',
+      minLength:          '=?mdMinLength',
+      delay:              '=?mdDelay',
+      autofocus:          '=?mdAutofocus',
+      floatingLabel:      '@?mdFloatingLabel',
+      autoselect:         '=?mdAutoselect',
+      menuClass:          '@?mdMenuClass',
+      menuContainerClass: '@?mdMenuContainerClass',
+      inputId:            '@?mdInputId'
     },
     link: function(scope, element, attrs, controller) {
       // Retrieve the state of using a md-not-found template by using our attribute, which will
@@ -191,7 +191,8 @@ function MdAutocomplete () {
               ng-mouseleave="$mdAutocompleteCtrl.listLeave()"\
               ng-mouseup="$mdAutocompleteCtrl.mouseUp()"\
               ng-hide="$mdAutocompleteCtrl.hidden"\
-              class="md-autocomplete-suggestions-container md-whiteframe-z1"\
+              class="md-autocomplete-suggestions-container md-whiteframe-z1' +
+                (attr.mdMenuContainerClass != null ? ' ' + attr.mdMenuContainerClass : '') + '"\
               ng-class="{ \'md-not-found\': $mdAutocompleteCtrl.notFoundVisible() }"\
               role="presentation">\
             <ul class="md-autocomplete-suggestions"\


### PR DESCRIPTION
…er generated by `md-autocomplete`. 

This allows control over css styling for specific instances of `<md-virtual-repeat-container>` created by `md-autocomplete`.

Fixes [#8393](https://github.com/angular/material/issues/8393)
