### PR TITLE
docs(*): update links to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ The Changelog may contain releases for `patch` or `minor`. If you do not see a f
 
 Developers interested in contributing should read the following guidelines:
 
-- [Issue Guidelines](CONTRIBUTING.md#submit)
-- [Contributing Guidelines](CONTRIBUTING.md)
+- [Issue Guidelines](.github/CONTRIBUTING.md#submit)
+- [Contributing Guidelines](.github/CONTRIBUTING.md)
 - [Coding Guidelines](docs/guides/CODING.md)
 - [ChangeLog](CHANGELOG.md)
 

--- a/docs/guides/MERGE_REQUESTS.md
+++ b/docs/guides/MERGE_REQUESTS.md
@@ -152,7 +152,7 @@ For example:
 > ```
 
 For more examples of how to format commit messages, see
-[the guidelines in CONTRIBUTING.md](../../CONTRIBUTING.md#-git-commit-guidelines).
+[the guidelines in CONTRIBUTING.md](../../.github/CONTRIBUTING.md#-git-commit-guidelines).
 
 ```sh
 git push origin master

--- a/docs/guides/PULL_REQUESTS.md
+++ b/docs/guides/PULL_REQUESTS.md
@@ -4,7 +4,7 @@ Before you submit your pull request consider the following guidelines:
 * Search [GitHub](https://github.com/angular/material/pulls) for an open or closed Pull Request
   that relates to your submission. You don't want to duplicate effort.
 
-* Please sign our [Contributor License Agreement (CLA)](../../CONTRIBUTING.md#cla) before sending pull
+* Please sign our [Contributor License Agreement (CLA)](../../.github/CONTRIBUTING.md#cla) before sending pull
   requests. We cannot accept code without this.
 
 * Make your changes in a new git branch:
@@ -23,7 +23,7 @@ Before you submit your pull request consider the following guidelines:
   and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our
-  [commit message conventions](../../CONTRIBUTING.md#commit-message-format). Adherence to the [commit message conventions](../../CONTRIBUTING.md#commit-message-format) is required
+  [commit message conventions](../../.github/CONTRIBUTING.md#commit-message-format). Adherence to the [commit message conventions](../../.github/CONTRIBUTING.md#commit-message-format) is required
   because release notes are automatically generated from these messages.
 
      ```shell


### PR DESCRIPTION
CONTRIBUTING.md was moved from the root of the repository to `.gibthub/` in f5af7a12.  This broke some links from other `.md` documentation files to `CONTRIBUTING.md`.

This pull request fixes those links.

This extends #8372 with fixes to some additional broken links.

## Steps to reproduce

Given I am on [github.com/angular/material](https://github.com/angular/material)
When I click "Contributing Guidelines"
Then I should see "Contributing to Angular Material"
  - *FAILS* GitHub's default 404 not found error page
