### PR TITLE
feat(autocomplete): Adding md-container-class

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -68,6 +68,7 @@ angular
  *     the item if the search text is an exact match
  * @param {boolean=} md-match-case-insensitive When set and using `md-select-on-match`, autocomplete
  *     will select on case-insensitive match
+  * @param {string=} md-container-class This will be applied to md-virtual-repeat-container for styling
  *
  * @usage
  * ### Basic Example
@@ -149,7 +150,8 @@ function MdAutocomplete () {
       floatingLabel:    '@?mdFloatingLabel',
       autoselect:       '=?mdAutoselect',
       menuClass:        '@?mdMenuClass',
-      inputId:          '@?mdInputId'
+      inputId:          '@?mdInputId',
+      containerClass:   '@?mdContainerClass'
     },
     link: function(scope, element, attrs, controller) {
       // Retrieve the state of using a md-not-found template by using our attribute, which will
@@ -188,7 +190,8 @@ function MdAutocomplete () {
               ng-mouseup="$mdAutocompleteCtrl.mouseUp()"\
               ng-hide="$mdAutocompleteCtrl.hidden"\
               class="md-autocomplete-suggestions-container md-whiteframe-z1"\
-              ng-class="{ \'md-not-found\': $mdAutocompleteCtrl.notFoundVisible() }"\
+              ng-class="{ \'md-not-found\': $mdAutocompleteCtrl.notFoundVisible(), \
+                          \'{{::containerClass}}\' : containerClass }"\
               role="presentation">\
             <ul class="md-autocomplete-suggestions"\
                 ng-class="::menuClass"\


### PR DESCRIPTION
This attribute enables to set a class to the autocomplete dropdown wrapper, so the caller can have full control over css. Currently you can set a class for the menu ul inside the md-virtual-repeat-container, but this doesn't allow to style the entire container.