### PR TITLE
fix(card): fix style for .md-subhead class when not only child

### DIFF
--- a/src/components/card/card-theme.scss
+++ b/src/components/card/card-theme.scss
@@ -26,10 +26,8 @@ md-card.md-THEME_NAME-theme {
 
   md-card-title {
     md-card-title-text {
-      &:not(:only-child) {
-        .md-subhead {
-          color: '{{foreground-2}}';
-        }
+      .md-subhead:not(:only-child) {
+        color: '{{foreground-2}}';
       }
     }
   }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -88,10 +88,8 @@ md-card {
         font-size: 14px;
       }
 
-      &:only-child {
-        .md-subhead {
-          padding-top: 3 * $card-padding / 4;
-        }
+      .md-subhead:only-child {
+        padding-top: 3 * $card-padding / 4;
       }
     }
 


### PR DESCRIPTION
Apply style when no md-card-title-media

fixes #8431.