### PR TITLE
feat(compiler): add support for sequential resolve.

### DIFF
--- a/src/core/services/compiler/compiler.spec.js
+++ b/src/core/services/compiler/compiler.spec.js
@@ -103,6 +103,27 @@ describe('$mdCompiler service', function() {
         compile(options);
         expect(options).toEqual(clone);
       });
+
+      it('should invoke the promises with the resolved locals', inject(function($q, $timeout) {
+        var deferedFirst = $q.defer();
+        var firstPromiseValue = null;
+        
+        compile({
+          resolve: {
+            firstPromise: function() {
+              return deferedFirst.promise;
+            },
+            secondProperty: function(firstPromise) {
+              firstPromiseValue = firstPromise;
+            }
+          }
+        });
+
+        deferedFirst.resolve('First Promise Value');
+        $timeout.flush();
+        
+        expect(firstPromiseValue).toBe('First Promise Value');
+      }));
     });
 
     describe('after link()', function() {


### PR DESCRIPTION
* Currently all promises are executed in order, but they don't take advantage of each promises resolve.
  All promises are getting executed in order, and at the end we wait for all promises to resolve.
![image](https://cloud.githubusercontent.com/assets/4987015/15220208/f2d1247e-1866-11e6-828e-3817284dab1a.png)


This commit changes the invoking behavior.
* All promises getting executed in order, but we only execute the next promise, when the current promise was resolved.
  This allows us to inject the resolved value into the next resolve property / key.

![image](https://cloud.githubusercontent.com/assets/4987015/15220223/ff4217e0-1866-11e6-995e-690832dfc8eb.png)

FYI: We didn't discuss about that enhancement with the team yet. I just put that PR together because I'd like to do something fun :)

Closes #8417.