### PR TITLE
refactor($mdIcon): remove unused dependency from `MdIconService`

### DIFF
--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -359,7 +359,7 @@
 
    $get : ['$templateRequest', '$q', '$log', '$templateCache', '$mdUtil', function($templateRequest, $q, $log, $templateCache, $mdUtil) {
      this.preloadIcons($templateCache);
-     return MdIconService(config, $templateRequest, $q, $log, $templateCache, $mdUtil);
+     return MdIconService(config, $templateRequest, $q, $log, $mdUtil);
    }]
  };
 
@@ -413,8 +413,8 @@
   * SVG DOM elements.
   */
 
-  /* @ngInject */
- function MdIconService(config, $templateRequest, $q, $log, $templateCache, $mdUtil) {
+ /* @ngInject */
+ function MdIconService(config, $templateRequest, $q, $log, $mdUtil) {
    var iconCache = {};
    var urlRegex = /[-\w@:%\+.~#?&//=]{2,}\.[a-z]{2,4}\b(\/[-\w@:%\+.~#?&//=]*)?/i;
    var dataUrlRegex = /^data:image\/svg\+xml[\s*;\w\-\=]*?(base64)?,(.*)$/i;


### PR DESCRIPTION
`MdIconService` no more needs the `$templateCache` as of 0397e29.