### PR TITLE
fix(build): fix a warning when running local server

### DIFF
--- a/src/core/util/media.js
+++ b/src/core/util/media.js
@@ -84,9 +84,9 @@ angular.module('material.core')
  *   $scope.anotherCustom = $mdMedia('max-width: 300px');
  * });
  * </hljs>
- * @ngInject
  */
 
+/* @ngInject */
 function mdMediaFactory($mdConstant, $rootScope, $window) {
   var queries = {};
   var mqls = {};


### PR DESCRIPTION
A warning was being logged when running the docs site locally. It was because the @ngInject in the doc string isn't considered a valid tag.