### PR TITLE
fix($mdIcon): prevent "Possibly unhandled rejection" errors

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -4,22 +4,20 @@ describe('MdIcon directive', function() {
   var $compile;
   var $mdIconProvider;
 
-  beforeEach(module('material.core'));
-  beforeEach(module('material.components.icon'));
-  beforeEach(module('material.components.icon',function(_$mdIconProvider_){
-     $mdIconProvider = _$mdIconProvider_;
-   }));
-   afterEach( function() {
-     $mdIconProvider.defaultFontSet('material-icons');
-     $mdIconProvider.fontSet('fa', 'fa');
-   });
+  beforeEach(module('material.components.icon', function(_$mdIconProvider_) {
+    $mdIconProvider = _$mdIconProvider_;
+  }));
+  afterEach(function() {
+    $mdIconProvider.defaultFontSet('material-icons');
+    $mdIconProvider.fontSet('fa', 'fa');
+  });
 
 
   describe('for font-icons:', function () {
 
-    beforeEach( inject(function($rootScope, _$compile_){
-        $scope = $rootScope;
-        $compile = _$compile_;
+    beforeEach(inject(function($rootScope, _$compile_) {
+      $scope = $rootScope;
+      $compile = _$compile_;
     }));
 
 
@@ -339,19 +337,18 @@ describe('MdIcon service', function() {
   var $scope;
   var $mdIconProvider;
 
-  beforeEach(module('material.core'));
-  beforeEach(module('material.components.icon',function(_$mdIconProvider_){
+  beforeEach(module('material.components.icon', function(_$mdIconProvider_) {
     $mdIconProvider = _$mdIconProvider_;
     $mdIconProvider
-      .icon('android'     , 'android.svg')
-      .icon('c2'          , 'c2.svg')
-      .icon('notfound'    ,'notfoundicon.svg')
-      .iconSet('social'   , 'social.svg' )
-      .iconSet('notfound' , 'notfoundgroup.svg' )
+      .icon('android'    , 'android.svg')
+      .icon('c2'         , 'c2.svg')
+      .icon('notfound'   , 'notfoundicon.svg')
+      .iconSet('social'  , 'social.svg' )
+      .iconSet('notfound', 'notfoundgroup.svg' )
       .defaultIconSet('core.svg');
   }));
 
-  beforeEach(inject(function($templateCache, _$httpBackend_, _$mdIcon_, $rootScope){
+  beforeEach(inject(function($templateCache, _$httpBackend_, _$mdIcon_, $rootScope) {
     $mdIcon = _$mdIcon_;
     $httpBackend = _$httpBackend_;
     $scope = $rootScope;
@@ -362,10 +359,9 @@ describe('MdIcon service', function() {
 
     $httpBackend.whenGET('notfoundgroup.svg').respond(404, 'Cannot GET notfoundgroup.svg');
     $httpBackend.whenGET('notfoundicon.svg').respond(404, 'Cannot GET notfoundicon.svg');
-
   }));
 
-  describe('should configure fontSets',function() {
+  describe('should configure fontSets', function() {
 
     it('with Material Icons by default', function () {
       expect($mdIcon.fontSet()).toBe('material-icons');

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -510,29 +510,39 @@ describe('MdIcon service', function() {
     });
 
     describe('icon group is not found', function() {
-      it('should log Error', function() {
-        var msg;
-        try {
-          $mdIcon('notfound:someIcon')
-            .catch(function(error) {
-              msg = error.data;
-            });
+      it('should log Error and reject', inject(function($log) {
+        var errorMessage = 'Cannot GET notfoundgroup.svg';
+        var caughtRejection = false;
 
-          $httpBackend.flush();
-        } finally {
-          expect(msg).toEqual('Cannot GET notfoundgroup.svg');
-        }
-      });
+        $mdIcon('notfound:someIcon')
+          .catch(function(error) {
+            expect(error.data).toBe(errorMessage);
+            caughtRejection = true;
+          });
+
+        $httpBackend.flush();
+
+        expect(caughtRejection).toBe(true);
+        expect($log.warn.logs[0]).toEqual([errorMessage]);
+      }));
     });
 
     describe('icon is not found', function() {
-      it('should not throw Error', function() {
-        expect(function(){
-          $mdIcon('notfound');
+      it('should log Error and reject', inject(function($log) {
+        var errorMessage = 'Cannot GET notfoundicon.svg';
+        var caughtRejection = false;
 
-          $httpBackend.flush();
-        }).not.toThrow();
-      });
+        $mdIcon('notfound')
+          .catch(function(error) {
+            expect(error.data).toBe(errorMessage);
+            caughtRejection = true;
+          });
+
+        $httpBackend.flush();
+
+        expect(caughtRejection).toBe(true);
+        expect($log.warn.logs[0]).toEqual([errorMessage]);
+      }));
     });
   });
 

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -562,8 +562,6 @@
    function announceNotFound(err) {
      var msg = angular.isString(err) ? err : (err.message || err.data || err.statusText);
      $log.warn(msg);
-
-     return $q.reject(msg);
    }
 
    /**


### PR DESCRIPTION
The `announceNotFound()` function was creating and returning a rejected promise that was neither
handled nor exposed to the user, causing "Possibly unhandled rejection" errors.

This should fix the failing tests against Angular snapshot on CI.

<sub>
This PR also includes a `refactor` commit (removing some unnecessary module loading and making whitespace a little more consistent :stuck_out_tongue:) and a `test` commit that more thoroughly covers the actual behavior when icons/groups are not found (i.e. logging + rejecting).
</sub>