### PR TITLE
fix(swipe): safe apply the callback

### DIFF
--- a/src/components/swipe/swipe.js
+++ b/src/components/swipe/swipe.js
@@ -86,7 +86,7 @@ function getDirective(name) {
       function postLink(scope, element, attr) {
         var fn = $parse(attr[directiveName]);
         element.on(eventName, function(ev) {
-          scope.$apply(function() { fn(scope, { $event: ev }); });
+          scope.$applyAsync(function() { fn(scope, { $event: ev }); });
         });
       }
     }


### PR DESCRIPTION
Fixes the swipe directive occasionally throwing "$digest in progress" errors.
Shout out to @DevVersion for the tip to replace the `nextTick` with an `$applyAsync`.

Fixes #8318.