### PR TITLE
fix(checkbox): md-checkbox documentation update & indeterminate color fix.

### DIFF
--- a/src/components/checkbox/checkbox-theme.scss
+++ b/src/components/checkbox/checkbox-theme.scss
@@ -80,6 +80,10 @@ md-checkbox.md-THEME_NAME-theme {
       border-color: '{{background-200}}';
     }
 
+    ._md-icon:after {
+      border-color: '{{foreground-3}}';
+    }
+
     ._md-label {
       color: '{{foreground-3}}';
     }

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -31,8 +31,11 @@ angular
  * @param {expression=} md-indeterminate This determines when the checkbox should be rendered as 'indeterminate'.
  *     If a truthy expression or no value is passed in the checkbox renders in the md-indeterminate state.
  *     If falsy expression is passed in it just looks like a normal unchecked checkbox.
- *     The indeterminate, checked, and unchecked states are mutually exclusive. A box cannot be in any two states at the same time.
- *     When a checkbox is indeterminate that overrides any checked/unchecked rendering logic.
+ *     The indeterminate, checked, and unchecked states are mutually exclusive. A box cannot be in any two states at the same time. 
+ *     Adding the 'md-indeterminate' attribute overrides any checked/unchecked rendering logic. 
+ *     When using the 'md-indeterminate' attribute use 'ng-checked' to define rendering logic instead of using 'ng-model'.
+ * @param {expression=} ng-checked If this expression evaluates as truthy, the 'md-checked' css class is added to the checkbox and it 
+ *     will appear checked.
  *
  * @usage
  * <hljs lang="html">


### PR DESCRIPTION
The md-checkbox documentation was missing a doc for the "ng-checked" attribute (which is somewhat needed when using the md-indeterminate attribute).

Also, there seems to have been a color mixup w/ the indeterminate-disabled checkbox icon.

@ErinCoughlan @ThomasBurleson 

Special thanks to @dtarasiuk for spotting this!

Broken:

![checkboxindetbug](https://cloud.githubusercontent.com/assets/709204/15413061/c459ba04-1de1-11e6-83e8-bbc143cd25d4.png)

Fixed:

![checkboxindetbugfixed](https://cloud.githubusercontent.com/assets/709204/15413067/cd60b8a0-1de1-11e6-8457-47b13cd5a7d9.png)