### PR TITLE
fix(whiteframe): prevent contents from being printed black

### DIFF
--- a/src/components/whiteframe/whiteframe.scss
+++ b/src/components/whiteframe/whiteframe.scss
@@ -76,3 +76,9 @@
     border: 1px solid #fff;
   }
 }
+
+@media print {
+  md-whiteframe {
+    background-color: #fff;
+  }
+}


### PR DESCRIPTION
Chrome has an issue where elements with box shadows get printed all black (see https://bugs.chromium.org/p/chromium/issues/detail?id=174583). This is a workaround to make the text readable.

Fixes #8512.