### PR TITLE
fix(tooltip): properly default to "bottom", if no position is specified

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -49,7 +49,13 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       autohide: '=?mdAutohide',
       direction: '@?mdDirection'    // only expect raw or interpolated string value; not expression
     },
-    link: postLink
+    compile: function(tElement, tAttr) {
+      if (!tAttr.mdDirection) {
+        tAttr.$set('mdDirection', 'bottom');
+      }
+
+      return postLink;
+    }
   };
 
   function postLink(scope, element, attr) {

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -34,6 +34,16 @@ describe('<md-tooltip> directive', function() {
     expect(error).toBe(undefined);
   });
 
+  it('should set the position to "bottom", if it is undefined', function() {
+    buildTooltip(
+      '<md-button>' +
+       '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+      '</md-button>'
+    );
+
+    expect(findTooltip().attr('md-direction')).toBe('bottom');
+  });
+
   it('should preserve parent text', function(){
       buildTooltip(
         '<md-button>' +


### PR DESCRIPTION
Properly defaults to "bottom" if the user didn't supply a direction.

Fixes #8389.