### PR TITLE
feat(datepicker): add the ability to open the calendar when the input is focused

### DIFF
--- a/src/components/datepicker/datePicker.spec.js
+++ b/src/components/datepicker/datePicker.spec.js
@@ -131,6 +131,12 @@ describe('md-date-picker', function() {
     }).toThrowError('md-datepicker should not be placed inside md-input-container.');
   });
 
+  it('should be able open the calendar when the input is focused', function() {
+    createDatepickerInstance('<md-datepicker ng-model="myDate" md-open-on-focus></md-datepicker>');
+    controller.ngInputElement.triggerHandler('focus');
+    expect(document.querySelector('md-calendar')).toBeTruthy();
+  });
+
   describe('ngMessages suport', function() {
     it('should set the `required` $error flag', function() {
       pageScope.isRequired = true;

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -18,7 +18,10 @@
     <md-datepicker ng-model="myDate" md-placeholder="Enter date"
         md-min-date="minDate" md-max-date="maxDate"
         md-date-filter="onlyWeekendsPredicate"></md-datepicker>
-    
+
+    <h4>Opening the calendar when the input is focused</h4>
+    <md-datepicker ng-model="myDate" md-placeholder="Enter date" md-open-on-focus></md-datepicker>
+
     <h4>With ngMessages</h4>
     <form name="myForm">
       <md-datepicker name="dateField" ng-model="myDate" md-placeholder="Enter date"
@@ -33,6 +36,6 @@
         <div ng-message="filtered">Only weekends are allowed!</div>
       </div>
     </form>
-    
+
   </md-content>
 </div>


### PR DESCRIPTION
Adds the "md-open-on-focus" attribute, which when specified, opens the datepicker's calendar when the input is focused.

Fixes #4650.