### PR TITLE
fix(theming): remove console warn for same primary and accent palettes

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -670,12 +670,6 @@ function generateTheme(theme, name, nonce) {
       }
     });
 
-
-    if (theme.colors.primary.name == theme.colors.accent.name) {
-      console.warn('$mdThemingProvider: Using the same palette for primary and' +
-                   ' accent. This violates the material design spec.');
-    }
-
     GENERATED[theme.name] = true;
   }
 


### PR DESCRIPTION
- This is not disallowed in the Material spec, so the warning should be removed

@ErinCoughlan 

fixes #8260