### PR TITLE
docs($mdMedia): Remove erroneous installation buttons.

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -93,7 +93,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
     $routeProvider.when('/' + service.url, {
       templateUrl: service.outputPath,
       resolve: {
-        component: angular.noop,
+        component: function() { return { isService: true } },
         doc: function() { return service; }
       },
       controller: 'ComponentDocCtrl'

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -80,7 +80,7 @@
           <div class="md-toolbar-item docs-tools" layout="row">
             <md-button class="md-icon-button"
                        aria-label="Install with Bower"
-                       ng-if="!currentComponent.docs.length"
+                       ng-if="!currentComponent.docs.length && !currentComponent.isService"
                        target="_blank"
                        ng-href="https://github.com/angular/bower-material">
               <md-tooltip md-autohide>Install with Bower</md-tooltip>
@@ -88,7 +88,7 @@
             </md-button>
             <md-button class="md-icon-button"
                        aria-label="Install with NPM"
-                       ng-if="!currentComponent.docs.length"
+                       ng-if="!currentComponent.docs.length && !currentComponent.isService"
                        target="_blank"
                        ng-href="https://www.npmjs.com/package/angular-material">
               <md-tooltip md-autohide>Install with NPM</md-tooltip>
@@ -96,7 +96,7 @@
             </md-button>
             <md-button class="md-icon-button"
                        aria-label="View Source on Github"
-                       ng-if="!currentComponent.docs.length"
+                       ng-if="!currentComponent.docs.length && !currentComponent.isService"
                        target="_blank"
                        ng-href="{{BUILDCONFIG.repository}}/{{menu.version.current.github}}">
               <md-tooltip md-autohide>View Source on Github</md-tooltip>


### PR DESCRIPTION
On the docs page for `$mdMedia`, we were showing all of the buttons that allow you to install Angular Material. This was confusing and incorrect.

Fix build to remove these buttons for services in addition to components.

Fixes #6805.