### PR TITLE
docs: Fix attribute directives in dropdown.

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -771,10 +771,22 @@ function($rootScope, $scope, component, demos, $templateRequest) {
 })
 
 .filter('directiveBrackets', function() {
-  return function(str) {
-    if (str.indexOf('-') > -1) {
-      return '<' + str + '>';
+  return function(str, restrict) {
+    if (restrict) {
+      // If it is restricted to only attributes
+      if (!restrict.element && restrict.attribute) {
+        return '[' + str + ']';
+      }
+      
+      // If it is restricted to elements and isn't a service
+      if (restrict.element && str.indexOf('-') > -1) {
+        return '<' + str + '>';
+      }
+      
+      // TODO: Handle class/comment restrictions if we ever have any to document
     }
+    
+    // Just return the original string if we don't know what to do with it
     return str;
   };
 });

--- a/docs/config/processors/componentsData.js
+++ b/docs/config/processors/componentsData.js
@@ -33,10 +33,11 @@ function buildDocData(doc, extraData, descriptor) {
   var filePath = doc.fileInfo.filePath;
   var indexOfBasePath = filePath.indexOf(basePathFromProjectRoot);
   var path = filePath.substr(indexOfBasePath + basePathFromProjectRoot.length, filePath.length);
-
+  
   return _.assign({
     name: doc.name,
     type: doc.docType,
+    restrict: doc.restrict,
     outputPath: doc.outputPath,
     url: doc.path,
     label: doc.label || doc.name,

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -115,7 +115,7 @@
                     ng-value="doc.url"
                     ng-click="redirectToUrl(doc.url)"
                     aria-label="{{ doc | humanizeDoc }}">
-                  {{doc | humanizeDoc | directiveBrackets}}
+                  {{doc | humanizeDoc | directiveBrackets:doc.restrict}}
                 </md-option>
               </md-optgroup>
               <md-optgroup label="Services" ng-if="(currentComponent.docs | filter: { type: 'service' }).length">

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "colors": "^1.1.0",
     "conventional-changelog": "git://github.com/robertmesserle/conventional-changelog.git",
     "dgeni": "^0.4.1",
-    "dgeni-packages": "^0.10.3",
+    "dgeni-packages": "^0.13.0",
     "esprima": "^1.2.2",
     "github-contributors-list": "^1.2.1",
     "glob": "~4.0.2",

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -1,5 +1,4 @@
 /**
- * @private
  * @ngdoc module
  * @name material.components.switch
  */

--- a/src/components/whiteframe/whiteframe.js
+++ b/src/components/whiteframe/whiteframe.js
@@ -10,7 +10,6 @@ angular
  * @ngdoc directive
  * @module material.components.whiteframe
  * @name mdWhiteframe
- * @restrict A
  *
  * @description
  * The md-whiteframe directive allows you to apply an elevation shadow to an element.
@@ -34,7 +33,6 @@ function MdWhiteframeDirective($log) {
   var DEFAULT_DP = 4;
 
   return {
-    restrict: 'A',
     link: postLink
   };
 


### PR DESCRIPTION
Currently the attribute directives in the API Reference dropdown available on all of the demo pages appear as element directives because they are all wrapped with `<>` instead of `[]`. Add the necessary code to change this and update dgeni to latest version with necessary additions.

Also changes `<md-whiteframe>` to be an element or an attribute directive as the examples show.

Fixes #7620.