### PR TITLE
fix(theming): only insert default theme if its usable.

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -526,7 +526,7 @@ function parseRules(theme, colorType, rules) {
 var rulesByType = {};
 
 // Generate our themes at run time given the state of THEMES and PALETTES
-function generateAllThemes($injector, $mdTheming ) {
+function generateAllThemes($injector, $mdTheming) {
   var head = document.head;
   var firstChild = head ? head.firstElementChild : null;
   var themeCss = !disableTheming && $injector.has('$MD_THEME_CSS') ? $injector.get('$MD_THEME_CSS') : '';
@@ -581,7 +581,7 @@ function generateAllThemes($injector, $mdTheming ) {
   if (generateOnDemand) return;
 
   angular.forEach($mdTheming.THEMES, function(theme) {
-    if (!GENERATED[theme.name]) {
+    if (!GENERATED[theme.name] && !($mdTheming.defaultTheme() !== 'default' && theme.name === 'default')) {
       generateTheme(theme, theme.name, nonce);
     }
   });


### PR DESCRIPTION
* Currently we always generate the default theme, even when the defaultTheme has changed.
  This is not necessary and impacts the performance significant.

We should only inject the default theme, when it's usable.

@EladBezalel and I went through the logic again, and this one should be fine.

Fixes #7425.