### PR TITLE
fix(interimElement): prevent unhandled rejection error in $exceptionH…

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -373,7 +373,10 @@ function InterimElementProvider() {
             return reason;
           });
 
-        return interim.deferred.promise;
+        // Since Angular 1.6.7, promises will be logged to $exceptionHandler when the promise
+        // is not handling the rejection. We create a pseudo catch handler, which will prevent the
+        // promise from being logged to the $exceptionHandler.
+        return interim.deferred.promise.catch(angular.noop);
       }
 
       /*


### PR DESCRIPTION
Since Angular 1.6.7, promises will be logged to $exceptionHandler when the promise
is not handling the rejection. We create a pseudo catch handler, which will prevent the
promise from being logged to the $exceptionHandler.

See https://github.com/angular/angular.js/commit/c9dffde1cb167660120753181cb6d01dc1d1b3d0

cc. @petebacondarwin 