### PR TITLE
fix(datepicker): disabled dates blending in with background on a dark theme

### DIFF
--- a/src/components/datepicker/calendar-theme.scss
+++ b/src/components/datepicker/calendar-theme.scss
@@ -44,6 +44,10 @@
 
   .md-calendar-date-disabled,
   .md-calendar-month-label-disabled {
-    color: '{{foreground-3}}';
+    // Note that this uses half the opacity of the default text color,
+    // because the calendar is white, even on the dark theme, otherwise
+    // the default disabled color `foreground-3` blends in with the
+    // background.
+    color: '{{background-A200-0.435}}';
   }
 }


### PR DESCRIPTION
The disabled dates were blending in with the calendar when used together with a dark theme.

Fixes #8550.