### PR TITLE
minor doc fix: changed erroneous `flex="22"` to `flex="20"`

### DIFF
--- a/docs/app/partials/layout-introduction.tmpl.html
+++ b/docs/app/partials/layout-introduction.tmpl.html
@@ -218,7 +218,7 @@
       <div flex="33" flex-md="{{ vm.box1Width }}" class="one"></div>
       <div flex="33" layout="{{ vm.direction }}" layout-md="row" class="two">
 
-        <div flex="22" flex-md="10" hide-lg class="two_one"></div>
+        <div flex="20" flex-md="10" hide-lg class="two_one"></div>
         <div flex="30px" show hide-md="{{ vm.hideBox }}" flex-md="25" class="two_two"></div>
         <div flex="20" flex-md="65" class="two_three"></div>
 


### PR DESCRIPTION
Example code had `flex="22"` while MD spec and angular material docs say multiples of 5. Changed to `flex="20"`