### PR TITLE
feat(util): add the ability to pass in a predicate function

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -472,19 +472,29 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * getClosest replicates jQuery.closest() to walk up the DOM tree until it finds a matching nodeName
      *
      * @param el Element to start walking the DOM from
-     * @param tagName Tag name to find closest to el, such as 'form'
+     * @param check Either a string or a function. If a string is passed, it will be evaluated against
+     * each of the parent nodes' tag name. If a function is passed, the loop will call it with each of
+     * the parents and will use the return value to determine whether the node is a match.
      * @param onlyParent Only start checking from the parent element, not `el`.
      */
-    getClosest: function getClosest(el, tagName, onlyParent) {
+    getClosest: function getClosest(el, validateWith, onlyParent) {
+      if ( angular.isString(validateWith) ) {
+        var tagName = validateWith.toUpperCase();
+        validateWith = function(el) {
+          return el.nodeName === tagName;
+        };
+      }
+
       if (el instanceof angular.element) el = el[0];
-      tagName = tagName.toUpperCase();
       if (onlyParent) el = el.parentNode;
       if (!el) return null;
+
       do {
-        if (el.nodeName === tagName) {
+        if (validateWith(el)) {
           return el;
         }
       } while (el = el.parentNode);
+
       return null;
     },
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -522,4 +522,62 @@ describe('util', function() {
       }));
     });
   });
+
+  describe('getClosest', function() {
+    var $mdUtil;
+
+    beforeEach(inject(function(_$mdUtil_) {
+      $mdUtil = _$mdUtil_;
+    }));
+
+    it('should be able to get the closest parent of a particular node type', function() {
+      var grandparent = angular.element('<h1>');
+      var parent = angular.element('<h2>');
+      var element = angular.element('<h3>');
+
+      parent.append(element);
+      grandparent.append(parent);
+
+      var result = $mdUtil.getClosest(element, 'h1');
+
+      expect(result).toBeTruthy();
+      expect(result.nodeName.toLowerCase()).toBe('h1');
+
+      grandparent.remove();
+    });
+
+    it('should be able to start from the parent of the specified node', function() {
+      var grandparent = angular.element('<div>');
+      var parent = angular.element('<span>');
+      var element = angular.element('<div>');
+
+      parent.append(element);
+      grandparent.append(parent);
+
+      var result = $mdUtil.getClosest(element, 'div', true);
+
+      expect(result).toBeTruthy();
+      expect(result).not.toBe(element[0]);
+
+      grandparent.remove();
+    });
+
+    it('should be able to take in a predicate function', function() {
+      var grandparent = angular.element('<div random-attr>');
+      var parent = angular.element('<div>');
+      var element = angular.element('<span>');
+
+      parent.append(element);
+      grandparent.append(parent);
+
+      var result = $mdUtil.getClosest(element, function(el) {
+        return el.hasAttribute('random-attr');
+      });
+
+      expect(result).toBeTruthy();
+      expect(result).toBe(grandparent[0]);
+
+      grandparent.remove();
+    });
+  });
 });


### PR DESCRIPTION
Note that this is a nice-to-have that I found myself needing while working on the datepicker. I eventually worked around it, but it could be good for the future.

* It could be useful to be able to match node in `getClosest` by more than their tag name. This change adds the ability to pass in a function instead.
* Adds a few unit tests for `getClosest`, since it didn't have any.