### PR TITLE
fix(datepicker): icon alignment

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -27,6 +27,7 @@ md-datepicker {
   display: inline-block;
   box-sizing: border-box;
   background: none;
+  vertical-align: middle;
 }
 
 // The input into which the user can type the date.


### PR DESCRIPTION
Some of the recent changes was throwing the datepicker's alignment off. This gets it back to normal.