### PR TITLE
fix(select): don't mutate the form data

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -188,8 +188,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     if (attr.name) {
       var autofillClone = angular.element('<select class="_md-visually-hidden">');
       autofillClone.attr({
-        'name': '.' + attr.name,
-        'ng-model': attr.ngModel,
+        'name': attr.name,
         'aria-hidden': 'true',
         'tabindex': '-1'
       });
@@ -200,6 +199,15 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         else if (el.hasAttribute('value')) newEl.attr('value', el.getAttribute('value'));
         autofillClone.append(newEl);
       });
+
+      // Adds an extra option that will hold the selected value for the
+      // cases where the select is a part of a non-angular form. This can be done with a ng-model,
+      // however if the `md-option` is being `ng-repeat`-ed, Angular seems to insert a similar
+      // `option` node, but with a value of `? string: <value> ?` which would then get submitted.
+      // This also goes around having to prepend a dot to the name attribute.
+      autofillClone.append(
+        '<option ng-value="' + attr.ngModel + '" selected></option>'
+      );
 
       element.parent().append(autofillClone);
     }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -570,6 +570,29 @@ describe('<md-select>', function() {
         expect($rootScope.testForm.$pristine).toBe(true);
       }));
 
+
+      it('should forward the model value to the hidden select', inject(function($rootScope, $timeout, $compile) {
+        $rootScope.opts = [1, 2, 3, 4];
+        var select = $compile('<form>' +
+          '<md-select ng-model="model" name="testing-select">' +
+            '<md-option ng-repeat="opt in opts">{{ opt }}</md-option>' +
+          '</md-select></form>')($rootScope).find('select'); // not md-select
+
+        $rootScope.$digest();
+        $timeout.flush();
+
+        expect(select.val()).toBeFalsy();
+        $rootScope.$apply('model = 3');
+        expect(select.val()).toBe('3');
+      }));
+
+      it('should forward the name attribute to the hidden select', inject(function($rootScope, $timeout, $compile) {
+        var select = $compile('<form>' +
+          '<md-select ng-model="model" name="testing-select">' +
+          '</md-select></form>')($rootScope).find('select');
+
+        expect(select.attr('name')).toBe('testing-select');
+      }));
     });
 
     describe('view->model', function() {
@@ -833,7 +856,7 @@ describe('<md-select>', function() {
           '    <md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
           '  </md-select>' +
           '</form>';
-        
+
         $rootScope.opts = [1, 2, 3, 4];
 
         $compile(template)($rootScope);
@@ -842,13 +865,13 @@ describe('<md-select>', function() {
         $rootScope.model = 0;
         $rootScope.$digest();
         expect($rootScope.testForm.$valid).toBe(false);
-        
+
         // Option 1 is available; should be true
         $rootScope.model = 1;
         $rootScope.$digest();
         expect($rootScope.testForm.$valid).toBe(true);
       }));
-      
+
       it('should keep the form pristine when model is predefined', inject(function($rootScope, $timeout, $compile) {
         $rootScope.model = [1, 2];
         $rootScope.opts = [1, 2, 3, 4];


### PR DESCRIPTION
* Fixes the md-select prepending a dot to the name of the hidden select that mirrors its' value.
* Fixes the hidden select getting a modified value in the form of `? <typeof value>:<value> ?`.

Closes #8581.