### PR TITLE
fix(card): image stretching on IE

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -65,7 +65,7 @@ md-card {
     display: flex;
     flex: 0 0 auto;
     width: 100%;
-    height: 100% !important;
+    height: auto;
   }
 
   md-card-title {

--- a/src/components/colors/demoBasicUsage/regularCard.tmpl.html
+++ b/src/components/colors/demoBasicUsage/regularCard.tmpl.html
@@ -1,7 +1,7 @@
 <md-card>
   <md-card-title>
     <md-card-title-media>
-      <div class="md-media-sm card-media" layout layout-align="center center" >
+      <div class="md-media-sm card-media" layout>
         <md-icon md-svg-icon="person" style="color:grey"></md-icon>
       </div>
     </md-card-title-media>

--- a/src/components/colors/demoBasicUsage/userCard.tmpl.html
+++ b/src/components/colors/demoBasicUsage/userCard.tmpl.html
@@ -1,8 +1,7 @@
 <md-card md-colors="::{backgroundColor: '{{theme}}-primary-700'}">
   <md-card-title>
     <md-card-title-media>
-      <div class="md-media-sm card-media" layout layout-align="center center"
-           md-colors="::{background: '{{theme}}-accent'}">
+      <div class="md-media-sm card-media" layout md-colors="::{background: '{{theme}}-accent'}">
         <md-icon md-svg-icon="person"></md-icon>
       </div>
     </md-card-title-media>


### PR DESCRIPTION
* Fixes the card images stretching too much in IE11.
* Fixes icons not being aligned in the colors demo.

Fixes #8629.