### PR TITLE
fix(select): Fix pristine/dirty error, scope conflict, and many styles.

### DIFF
--- a/src/components/input/demoErrors/index.html
+++ b/src/components/input/demoErrors/index.html
@@ -12,13 +12,23 @@
         </div>
       </md-input-container>
 
-      <md-input-container class="md-block">
-        <label>Client Name</label>
-        <input required name="clientName" ng-model="project.clientName">
-        <div ng-messages="projectForm.clientName.$error">
-          <div ng-message="required">This is required.</div>
-        </div>
-      </md-input-container>
+      <div layout="row">
+        <md-input-container flex="50">
+          <label>Client Name</label>
+          <input required name="clientName" ng-model="project.clientName">
+          <div ng-messages="projectForm.clientName.$error">
+            <div ng-message="required">This is required.</div>
+          </div>
+        </md-input-container>
+
+        <md-input-container flex="50">
+          <label>Project Type</label>
+          <md-select name="type" ng-model="project.type" required>
+            <md-option value="app">Application</md-option>
+            <md-option value="web">Website</md-option>
+          </md-select>
+        </md-input-container>
+      </div>
 
       <md-input-container class="md-block">
         <label>Client Email</label>
@@ -58,6 +68,10 @@
           </div>
         </div>
       </md-input-container>
+
+      <div>
+        <md-button type="submit">Submit</md-button>
+      </div>
 
       <p style="font-size:.8em; width: 100%; text-align: center;">
         Make sure to include <a href="https://docs.angularjs.org/api/ngMessages" target="_blank">ngMessages</a> module when using ng-message markup.

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -14,8 +14,10 @@ md-input-container.md-THEME_NAME-theme {
     color: '{{foreground-3}}';
   }
 
-  label.md-required:after {
-    color: '{{warn-A700}}'
+  &.md-input-invalid {
+    label.md-required:after {
+      color: '{{warn-A700}}'
+    }
   }
 
   &:not(.md-input-focused):not(.md-input-invalid) label.md-required:after {

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -337,14 +337,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-      return ngModelCtrl.$invalid && (ngModelCtrl.$touched || isParentFormSubmitted());
-    };
-
-    var isParentFormSubmitted = function () {
-      var parent = $mdUtil.getClosest(element, 'form');
-      var form = parent ? angular.element(parent).controller('form') : null;
-
-      return form ? form.$submitted : false;
+      return ngModelCtrl.$invalid && (ngModelCtrl.$touched || $mdUtil.isParentFormSubmitted(element));
     };
 
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);

--- a/src/components/select/demoBasicUsage/index.html
+++ b/src/components/select/demoBasicUsage/index.html
@@ -1,26 +1,83 @@
-<div ng-controller="AppCtrl as ctrl" class="md-padding" ng-cloak>
-  <div>
-    <h1 class="md-title">Enter an address</h1>
-    <div layout="row">
+<div ng-controller="AppCtrl as ctrl" class="md-padding" ng-cloak layout="column">
 
-      <md-input-container>
-        <label>Street Name</label>
-        <input>
-      </md-input-container>
+  <p>
+    The <code>&lt;md-select&gt;</code> component can be used within a
+    <code>&lt;md-input-container&gt;</code> or as a stand alone component by using the
+    <code>md-no-underline</code> class.
+  </p>
 
-      <md-input-container>
-        <label>City</label>
-        <input>
-      </md-input-container>
+  <md-card>
+    <md-card-title>
+      <md-card-title-text>
+        <span class="md-headline">Account Preferences</span>
+        <span class="md-subhead">Tell us a little about you.</span>
+      </md-card-title-text>
+    </md-card-title>
 
-      <md-input-container>
-        <label>State</label>
-        <md-select ng-model="ctrl.userState">
-          <md-option ng-repeat="state in ctrl.states" value="{{state.abbrev}}" ng-disabled="$index === 1">
-            {{state.abbrev}}
-          </md-option>
+    <md-card-content>
+      <div layout="row">
+        <md-input-container>
+          <label>Street Name</label>
+          <input>
+        </md-input-container>
+
+        <md-input-container>
+          <label>City</label>
+          <input>
+        </md-input-container>
+
+        <md-input-container>
+          <label>State</label>
+          <md-select ng-model="ctrl.userState">
+            <md-option ng-repeat="state in ctrl.states" value="{{state.abbrev}}" ng-disabled="$index === 1">
+              {{state.abbrev}}
+            </md-option>
+          </md-select>
+        </md-input-container>
+      </div>
+    </md-card-content>
+  </md-card>
+
+  <md-card>
+    <md-card-title>
+      <md-card-title-text>
+        <span class="md-headline">Battle Preferences</span>
+        <span class="md-subhead">Choose wisely if you want to win.</span>
+      </md-card-title-text>
+    </md-card-title>
+
+    <md-card-content>
+      <div layout="row" layout-align="space-between center">
+        <span>What is your favorite weapon?</span>
+        <md-select ng-model="weapon" placeholder="Weapon" class="md-no-underline">
+          <md-option value="axe">Axe</md-option>
+          <md-option value="sword">Sword</md-option>
+          <md-option value="wand">Wand</md-option>
+          <md-option value="pen">Pen?</md-option>
         </md-select>
-      </md-input-container>
-    </div>
-  </div>
+      </div>
+
+      <div layout="row" layout-align="space-between center">
+        <span>What armor do you wear?</span>
+        <md-select ng-model="armor" placeholder="Armor" class="md-no-underline" required>
+          <md-option value="cloth">Cloth</md-option>
+          <md-option value="leather">Leather</md-option>
+          <md-option value="chain">Chainmail</md-option>
+          <md-option value="plate">Plate</md-option>
+        </md-select>
+      </div>
+
+      <div layout="row" layout-align="space-between center">
+        <span>How do you refresh your magic?</span>
+        <md-select ng-model="drink" placeholder="Drink" class="md-no-underline">
+          <md-option value="water">Water</md-option>
+          <md-option value="juice">Juice</md-option>
+          <md-option value="milk">Milk</md-option>
+          <md-option value="wine">Wine</md-option>
+          <md-option value="mead">Mead</md-option>
+        </md-select>
+      </div>
+    </md-card-content>
+  </md-card>
+
 </div>

--- a/src/components/select/demoValidations/index.html
+++ b/src/components/select/demoValidations/index.html
@@ -1,19 +1,39 @@
-<div ng-controller="AppCtrl" layout="column" layout-align="center center" style="min-height: 300px;" ng-cloak>
+<div ng-controller="AppCtrl" ng-cloak layout="column" layout-align="center center" layout-padding>
   <form name="myForm">
-    <p>Note that invalid styling only applies if invalid and dirty</p>
-    <md-input-container class="md-block">
-      <label>Favorite Number</label>
-      <md-select name="myModel" ng-model="myModel" required>
-        <md-option value="1">One</md-option>
-        <md-option value="2">Two</md-option>
-      </md-select>
-      <div class="errors" ng-messages="myForm.myModel.$error" ng-if="myForm.$dirty">
-        <div ng-message="required">Required</div>
-      </div>
-    </md-input-container>
-    <div layout="row">
-      <md-button ng-click="clearValue()" ng-disabled="!myModel" style="margin-right: 20px;">Clear</md-button>
-      <md-button ng-click="save()" ng-disabled="myForm.$invalid" class="md-primary" layout layout-align="center end">Save</md-button>
+    <p>
+      Note that, similar to regular inputs, the invalid styling only applies if the select is both
+      invalid <em>and</em> touched, or the form has been submitted.
+    </p>
+
+    <div layout="row" layout-align="start" flex>
+      <md-input-container flex="50">
+        <label>Quest</label>
+        <input type="text" name="quest" ng-model="quest" required />
+      </md-input-container>
+
+      <md-input-container flex="50">
+        <label>Favorite Number</label>
+        <md-select name="favoriteColor" ng-model="favoriteColor" required>
+          <md-option value="red">Red</md-option>
+          <md-option value="blue">Blue</md-option>
+          <md-option value="green">Green</md-option>
+        </md-select>
+        <div class="errors" ng-messages="myForm.favoriteColor.$error">
+          <div ng-message="required">Required</div>
+        </div>
+      </md-input-container>
+    </div>
+
+    <div layout="row" layout-align="start">
+      <md-checkbox ng-model="myForm.$invalid" disabled>Form Invalid</md-checkbox>
+      <md-checkbox ng-model="myForm.$dirty" disabled>Form Dirty</md-checkbox>
+      <md-checkbox ng-model="myForm.$submitted" disabled>Form Submitted</md-checkbox>
+      <md-checkbox ng-model="myForm.favoriteColor.$touched" disabled>Select Touched</md-checkbox>
+    </div>
+
+    <div layout="row" layout-align="end" flex>
+      <md-button ng-click="clearValue()" ng-disabled="!(quest || favoriteColor)">Clear</md-button>
+      <md-button ng-click="save()" class="md-primary">Save</md-button>
     </div>
   </form>
 </div>

--- a/src/components/select/demoValidations/script.js
+++ b/src/components/select/demoValidations/script.js
@@ -1,9 +1,15 @@
 angular.module('selectDemoValidation', ['ngMaterial', 'ngMessages'])
 .controller('AppCtrl', function($scope) {
   $scope.clearValue = function() {
-    $scope.myModel = undefined;
+    $scope.quest = undefined;
+    $scope.favoriteColor = undefined;
   };
   $scope.save = function() {
-    alert('Form was valid!');
+    if ($scope.myForm.$valid) {
+      alert('Form was valid.');
+    } else {
+      $scope.myForm.$setSubmitted(true);
+      alert('Form was invalid!');
+    }
   };
 });

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -1,3 +1,29 @@
+md-input-container {
+  &.md-input-focused {
+    &:not(.md-input-has-value) {
+      md-select.md-THEME_NAME-theme {
+        ._md-select-value {
+          color: '{{primary-color}}';
+          &._md-select-placeholder {
+            color: '{{primary-color}}';
+          }
+        }
+      }
+    }
+  }
+
+  &.md-input-invalid {
+    md-select.md-THEME_NAME-theme ._md-select-value {
+      color: '{{warn-A700}}' !important;
+      border-bottom-color: '{{warn-A700}}' !important;
+    }
+
+    md-select.md-THEME_NAME-theme.md-no-underline ._md-select-value {
+      border-bottom-color: transparent !important;
+    }
+  }
+}
+
 md-select.md-THEME_NAME-theme {
   &[disabled] ._md-select-value {
     border-bottom-color: transparent;
@@ -10,10 +36,16 @@ md-select.md-THEME_NAME-theme {
     }
     border-bottom-color: '{{foreground-4}}';
   }
-  &.ng-invalid.ng-dirty {
+  &.md-no-underline ._md-select-value {
+    border-bottom-color: transparent !important;
+  }
+  &.ng-invalid.ng-touched {
     ._md-select-value {
       color: '{{warn-A700}}' !important;
       border-bottom-color: '{{warn-A700}}' !important;
+    }
+    &.md-no-underline ._md-select-value {
+      border-bottom-color: transparent !important;
     }
   }
   &:not([disabled]):focus {
@@ -23,6 +55,9 @@ md-select.md-THEME_NAME-theme {
       &._md-select-placeholder {
         color: '{{ foreground-1 }}';
       }
+    }
+    &.md-no-underline ._md-select-value {
+      border-bottom-color: transparent !important;
     }
     &.md-accent ._md-select-value {
       border-bottom-color: '{{accent-color}}';

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -35,8 +35,10 @@ angular.module('material.components.select', [
  * @description Displays a select box, bound to an ng-model.
  *
  * When the select is required and uses a floating label, then the label will automatically contain
- * an asterisk (`*`).<br/>
- * This behavior can be disabled by using the `md-no-asterisk` attribute.
+ * an asterisk (`*`). This behavior can be disabled by using the `md-no-asterisk` attribute.
+ * 
+ * By default, the select will display with an underline to match other form elements. This can be
+ * disabled by applying the `md-no-underline` CSS class.
  *
  * @param {expression} ng-model The model!
  * @param {boolean=} multiple Whether it's multiple.
@@ -244,8 +246,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       if (containerCtrl) {
         var isErrorGetter = containerCtrl.isErrorGetter || function() {
-            return ngModelCtrl.$invalid && ngModelCtrl.$touched;
-          };
+          return ngModelCtrl.$invalid && (ngModelCtrl.$touched || $mdUtil.isParentFormSubmitted(element));
+        };
 
         if (containerCtrl.input) {
           // We ignore inputs that are in the md-select-header (one
@@ -339,11 +341,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       if (!isReadonly) {
         element
           .on('focus', function(ev) {
-            // only set focus on if we don't currently have a selected value. This avoids the "bounce"
-            // on the label transition because the focus will immediately switch to the open menu.
-            if (containerCtrl && containerCtrl.element.hasClass('md-input-has-value')) {
-              containerCtrl.setFocused(true);
-            }
+            // Always focus the container (if we have one) so floating labels and other styles are
+            // applied properly
+            containerCtrl && containerCtrl.setFocused(true);
           });
 
         // Attach before ngModel's blur listener to stop propagation of blur event
@@ -351,12 +351,12 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
         element.on('blur', function(event) {
           if (untouched) {
             untouched = false;
-            if (selectScope.isOpen) {
+            if (selectScope._mdSelectIsOpen) {
               event.stopImmediatePropagation();
             }
           }
 
-          if (selectScope.isOpen) return;
+          if (selectScope._mdSelectIsOpen) return;
           containerCtrl && containerCtrl.setFocused(false);
           inputCheckValue();
         });
@@ -529,7 +529,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       }
 
       function openSelect() {
-        selectScope.isOpen = true;
+        selectScope._mdSelectIsOpen = true;
         element.attr('aria-expanded', 'true');
 
         $mdSelect.show({
@@ -543,7 +543,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           hasBackdrop: true,
           loadingAsync: attr.mdOnOpen ? scope.$eval(attr.mdOnOpen) || true : false
         }).finally(function() {
-          selectScope.isOpen = false;
+          selectScope._mdSelectIsOpen = false;
           element.focus();
           element.attr('aria-expanded', 'false');
           ngModelCtrl.$setTouched();

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -8,6 +8,23 @@ $select-container-transition-duration: 350ms !default;
 
 $select-max-visible-options: 5 !default;
 
+// Fixes the animations with the floating label when select is inside an input container
+md-input-container {
+  &:not([md-no-float]) {
+    ._md-select-placeholder span:first-child {
+      transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
+      @include rtl(transform-origin, left top, right top);
+    }
+  }
+  &.md-input-focused {
+    &:not([md-no-float]) {
+      ._md-select-placeholder span:first-child {
+        transform: translateY(-22px) translateX(-2px) scale(0.75);
+      }
+    }
+  }
+}
+
 ._md-select-menu-container {
   position: fixed;
   left: 0;
@@ -15,6 +32,9 @@ $select-max-visible-options: 5 !default;
   z-index: $z-index-select;
   opacity: 0;
   display: none;
+
+  // Fix 1px alignment issue to line up with text inputs (and spec)
+  transform: translateY(-1px);
 
   // Don't let the user select a new choice while it's animating
   &:not(._md-clickable) {
@@ -56,9 +76,44 @@ md-input-container > md-select {
   order: 2;
 }
 
+
+// Show the asterisk on the placeholder if the element is required
+//
+// NOTE: When the input has a value and uses a floating label, the floating label will show the
+// asterisk denoting that it is required
+md-input-container:not(.md-input-has-value) {
+  md-select[required], md-select.ng-required {
+    ._md-select-value span:first-child:after {
+      content: ' *';
+      font-size: 13px;
+      vertical-align: top;
+    }
+  }
+}
+
+md-input-container.md-input-invalid {
+  md-select {
+    ._md-select-value {
+      border-bottom-style: solid;
+      padding-bottom: 1px;
+    }
+  }
+}
+
 md-select {
   display: flex;
   margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
+
+  &[required], &.ng-required {
+    &.ng-invalid {
+      ._md-select-value span:first-child:after {
+        content: ' *';
+        font-size: 13px;
+        vertical-align: top;
+      }
+    }
+  }
+
   &[disabled] ._md-select-value {
     background-position: 0 bottom;
     // This background-size is coordinated with a linear-gradient set in select-theme.scss
@@ -67,6 +122,7 @@ md-select {
     background-repeat: repeat-x;
     margin-bottom: -1px; // Shift downward so dotted line is positioned the same as other bottom borders
   }
+
   &:focus {
     outline: none;
   }
@@ -77,10 +133,10 @@ md-select {
     &:hover {
       cursor: pointer
     }
-    &.ng-invalid.ng-dirty {
+    &.ng-invalid.ng-touched {
       ._md-select-value {
-        border-bottom: 2px solid;
-        padding-bottom: 0;
+        border-bottom-style: solid;
+        padding-bottom: 1px;
       }
     }
     &:focus {
@@ -89,10 +145,21 @@ md-select {
         border-bottom-style: solid;
         padding-bottom: 0;
       }
+      &.ng-invalid.ng-touched {
+        ._md-select-value {
+          padding-bottom: 0;
+        }
+      }
     }
   }
 }
 
+// Fix value by 1px to align with standard text inputs (and spec)
+md-input-container.md-input-has-value ._md-select-value {
+  > span:not(._md-select-icon) {
+    transform: translate3d(0, 1px, 0);
+  }
+}
 
 ._md-select-value {
   display: flex;
@@ -111,7 +178,6 @@ md-select {
   > span:not(._md-select-icon) {
     max-width: 100%;
     flex: 1 1 auto;
-    transform: translate3d(0, 2px, 0);
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
@@ -127,7 +193,8 @@ md-select {
     text-align: end;
     width: 3 * $baseline-grid;
     margin: 0 .5 * $baseline-grid;
-    transform: translate3d(0, 1px, 0);
+    transform: translate3d(0, -2px, 0);
+    font-size: 1.2rem;
   }
 
   ._md-select-icon:after {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -181,6 +181,17 @@ describe('<md-select>', function() {
     expect($rootScope.myForm.select.$touched).toBe(true);
   }));
 
+  it('applies the md-input-focused class to the container when focused with the keyboard', function() {
+    var element = setupSelect('ng-model="val"');
+    var select = element.find('md-select');
+
+    select.triggerHandler('focus');
+    expect(element.hasClass('md-input-focused')).toBe(true);
+
+    select.triggerHandler('blur');
+    expect(element.hasClass('md-input-focused')).toBe(false);
+  });
+
   it('restores focus to select when the menu is closed', inject(function($document) {
     var select = setupSelect('ng-model="val"').find('md-select');
     openSelect(select);

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -715,7 +715,21 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       return value === '' || !!value && (negatedCheck === false || value !== 'false' && value !== '0');
     },
 
-    hasComputedStyle: hasComputedStyle
+    hasComputedStyle: hasComputedStyle,
+
+    /**
+     * Returns true if the parent form of the element has been submitted.
+     * 
+     * @param element An Angular or HTML5 element.
+     * 
+     * @returns {boolean}
+     */
+    isParentFormSubmitted: function(element) {
+      var parent = $mdUtil.getClosest(element, 'form');
+      var form = parent ? angular.element(parent).controller('form') : null;
+
+      return form ? form.$submitted : false;
+    }
   };
 
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -503,6 +503,43 @@ describe('util', function() {
       })
     );
   });
+  
+  describe('isParentFormSubmitted', function() {
+    var formTemplate =
+      '<form>' +
+      '  <input type="text" name="test" ng-model="test" />' +
+      '  <input type="submit" />' +
+      '<form>';
+
+    it('returns false if you pass no element', inject(function($mdUtil) {
+      expect($mdUtil.isParentFormSubmitted()).toBe(false);
+    }));
+    
+    it('returns false if there is no form', inject(function($mdUtil) {
+      var element = angular.element('<input />');
+      
+      expect($mdUtil.isParentFormSubmitted(element)).toBe(false);
+    }));
+    
+    it('returns false if the parent form is NOT submitted', inject(function($compile, $rootScope, $mdUtil) { 
+      var scope = $rootScope.$new();
+      var form = $compile(formTemplate)(scope);
+      
+      expect($mdUtil.isParentFormSubmitted(form.find('input'))).toBe(false);
+    }));
+    
+    it('returns true if the parent form is submitted', inject(function($compile, $rootScope, $mdUtil) {
+      var scope = $rootScope.$new();
+      var form = $compile(formTemplate)(scope);
+
+      var formController = form.controller('form');
+      
+      formController.$setSubmitted();
+
+      expect(formController.$submitted).toBe(true);
+      expect($mdUtil.isParentFormSubmitted(form.find('input'))).toBe(true);
+    }));
+  });
 
   describe('with $interpolate.start/endSymbol override', function() {
 


### PR DESCRIPTION
Fix styles and code to follow pristine/dirty styling of other input elements and provide CSS class for stand-alone usage.

 - Select now behaves like a normal input, appearing as invalid
   if the user focuses/blurs the element, or submits the form,
   without selecting an option.
 - Fix issues with floating labels not working on focus.
 - Add new `md-no-underline` CSS class to allow for stand-alone
   usage (non-form).
 - Update demos to show new stand-alone usage with required
   example.
 - Standardize asterisk visibility when required when standalone
   or inside of a `<md-input-container>`

Additionally, the select component currently sets the `isOpen` variable on the `$scope`. This can cause conflicts if the user has their own `isOpen` variable on the scope.

Fix by privatizing our own variable to `_mdSelectIsOpen` to reduce chances of a conflict.

Fixes #8529. Fixes #7988. Fixes #8527.