### PR TITLE
fix(menu): Fix icon/text alignment in Firefox.

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -81,7 +81,25 @@ md-menu-item {
     padding-right: 2*$baseline-grid;
   }
 
+  /*
+   * We cannot use flex on <button> elements due to a bug in Firefox, so we also can't use it on
+   * <a> elements. Add some top padding to fix alignment since buttons automatically align their
+   * text vertically.
+   */
+  > a.md-button {
+    padding-top: 5px;
+  }
+
   > .md-button {
+    // Firefox-specific reset styling to fix alignment issues (see #8464)
+    &::-moz-focus-inner {
+      padding: 0;
+      border: 0
+    }
+
+    @include rtl(text-align, left, right);
+
+    display: inline-block;
     border-radius: 0;
     margin: auto 0;
     font-size: (2*$baseline-grid) - 1;
@@ -90,10 +108,6 @@ md-menu-item {
     height: 100%;
     padding-left: 2*$baseline-grid;
     padding-right: 2*$baseline-grid;
-    @include rtl(text-align, left, right);
-    display: flex;
-    align-items: baseline;
-    align-content: flex-start;
     width:100%;
     md-icon {
       @include rtl(margin, auto 2*$baseline-grid auto 0,  auto 0 auto 2*$baseline-grid);


### PR DESCRIPTION
By default, Firefox provides focus border styling which was modifying the layout of the button elements within a menu item. The original fix was to use `display: flex` to fix this, however, Firefox currently
disregards the `display` property on the buttons and was thus causing the text to be on a separate line from the text.

Fix by using `display: inline-block` for both `<a>` and `<button>` elements and adding some special padding for the `<a>` tags to fix the top alignment. Also apply special Firefox-specific styling to remove the focus border/styling.

Fixes #8464.