### PR TITLE
fix(select): Disallow keyboard selection of disabled options.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -517,7 +517,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
           if (e.keyCode <= 90 && e.keyCode >= 31) {
             e.preventDefault();
             var node = selectMenuCtrl.optNodeForKeyboardSearch(e);
-            if (!node) return;
+            if (!node || node.hasAttribute('disabled')) return;
             var optionCtrl = angular.element(node).controller('mdOption');
             if (!selectMenuCtrl.isMultiple) {
               selectMenuCtrl.deselect(Object.keys(selectMenuCtrl.selected)[0]);

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1098,6 +1098,16 @@ describe('<md-select>', function() {
         pressKey(el, 50);
         expect($rootScope.someModel).toBe(2);
       }));
+
+      it('disallows selection of disabled options', inject(function($rootScope) {
+        var optsTemplate =
+          '<md-option value="1">1</md-option>' +
+          '<md-option value="2" ng-disabled="true">2</md-option>';
+        var el = setupSelect('ng-model="someModel"', optsTemplate).find('md-select');
+
+        pressKey(el, 50);
+        expect($rootScope.someModel).toBe(undefined);
+      }));
     });
 
     describe('md-select-menu', function() {


### PR DESCRIPTION
Although disabled options are not selectable via the mouse or arrow keys, we currently allow users to select an option by typing the first few letters. This logic did not account for disabled options.

Add a quick check to see if the requested option is disabled.

Fixes #8626.