### PR TITLE
fix(datepicker): apply theming to the calendar pane

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -235,6 +235,7 @@
     this.calendarPane.id = 'md-date-pane' + $mdUtil.nextUid();
 
     $mdTheming($element);
+    $mdTheming(angular.element(this.calendarPane));
 
     /** Pre-bound click handler is saved so that the event listener can be removed. */
     this.bodyClickHandler = angular.bind(this, this.handleBodyClick);


### PR DESCRIPTION
The calendar pane wasn't registered with the theming service, causing it to be transparent in certain situations.

Fixes #8690.