### PR TITLE
fix(tooltip): fix regression on touch devices with a mouse

### DIFF
--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -1,16 +1,14 @@
 describe('<md-tooltip> directive', function() {
-  var $compile, $rootScope, $material, $timeout, leaveEvent, enterEvent;
+  var $compile, $rootScope, $material, $timeout;
   var element;
 
   beforeEach(module('material.components.tooltip'));
   beforeEach(module('material.components.button'));
-  beforeEach(inject(function(_$compile_, _$rootScope_, _$material_, _$timeout_, $mdConstant){
+  beforeEach(inject(function(_$compile_, _$rootScope_, _$material_, _$timeout_){
     $compile   = _$compile_;
     $rootScope = _$rootScope_;
     $material  = _$material_;
     $timeout   = _$timeout_;
-    leaveEvent = $mdConstant.IS_TOUCH ? 'touchend' : 'mouseleave';
-    enterEvent = $mdConstant.IS_TOUCH ? 'touchstart' : 'mouseenter';
   }));
   afterEach(function() {
     // Make sure to remove/cleanup after each test
@@ -114,7 +112,7 @@ describe('<md-tooltip> directive', function() {
       '</outer>'
     );
 
-    triggerEvent(enterEvent, true);
+    triggerEvent('mouseenter', true);
     expect($rootScope.testModel.isVisible).toBeUndefined();
 
   }));
@@ -167,7 +165,7 @@ describe('<md-tooltip> directive', function() {
       expect(findTooltip().length).toBe(0);
     });
 
-    it('should set visible on enter and leave events', function() {
+    it('should set visible on mouseenter and mouseleave', function() {
         buildTooltip(
           '<md-button>' +
              'Hello' +
@@ -177,14 +175,31 @@ describe('<md-tooltip> directive', function() {
           '</md-button>'
         );
 
-        triggerEvent(enterEvent);
+        triggerEvent('mouseenter');
         expect($rootScope.testModel.isVisible).toBe(true);
 
-        triggerEvent(leaveEvent);
+        triggerEvent('mouseleave');
         expect($rootScope.testModel.isVisible).toBe(false);
     });
 
-    it('should cancel when the leave event was before the delay', function() {
+    it('should should toggle visibility on touch start', function() {
+        buildTooltip(
+          '<md-button>' +
+             'Hello' +
+             '<md-tooltip md-visible="testModel.isVisible">' +
+              'Tooltip' +
+            '</md-tooltip>' +
+          '</md-button>'
+        );
+
+        triggerEvent('touchstart');
+        expect($rootScope.testModel.isVisible).toBe(true);
+
+        triggerEvent('touchstart');
+        expect($rootScope.testModel.isVisible).toBe(false);
+    });
+
+    it('should cancel when mouseleave was before the delay', function() {
       buildTooltip(
         '<md-button>' +
           'Hello' +
@@ -195,10 +210,10 @@ describe('<md-tooltip> directive', function() {
       );
 
 
-      triggerEvent(enterEvent, true);
+      triggerEvent('mouseenter', true);
       expect($rootScope.testModel.isVisible).toBeFalsy();
 
-      triggerEvent(leaveEvent, true);
+      triggerEvent('mouseleave', true);
       expect($rootScope.testModel.isVisible).toBeFalsy();
 
       // Total 99 == tooltipDelay
@@ -251,7 +266,7 @@ describe('<md-tooltip> directive', function() {
       expect($rootScope.testModel.isVisible).toBe(false);
     });
 
-    it('should not be visible when a leave event fires right after a mousedown', inject(function($document) {
+    it('should not be visible on mousedown and then mouseleave', inject(function($document) {
       buildTooltip(
         '<md-button>' +
          'Hello' +
@@ -269,7 +284,7 @@ describe('<md-tooltip> directive', function() {
       expect($document[0].activeElement).toBe(element[0]);
       expect($rootScope.testModel.isVisible).toBe(true);
 
-      triggerEvent(leaveEvent);
+      triggerEvent('mouseleave');
       expect($rootScope.testModel.isVisible).toBe(false);
 
       // Clean up document.body.
@@ -292,7 +307,7 @@ describe('<md-tooltip> directive', function() {
       triggerEvent('focus,mousedown');
       expect(document.activeElement).toBe(element[0]);
 
-      triggerEvent(leaveEvent);
+      triggerEvent('mouseleave');
 
       // Simulate tabbing away.
       angular.element($window).triggerHandler('blur');

--- a/src/core/util/constant.js
+++ b/src/core/util/constant.js
@@ -34,7 +34,6 @@ function MdConstantFactory($sniffer, $window, $document) {
   }
 
   return {
-    IS_TOUCH: ('ontouchstart' in $window) || $window.DocumentTouch && $document[0] instanceof DocumentTouch,
     KEY_CODE: {
       COMMA: 188,
       SEMICOLON : 186,


### PR DESCRIPTION
Reverts most of the changes from #8700 and switches to a simpler approach that uses a repeated `touchstart` to hide the tooltip, instead of `touchend`, which fires too early.
Also re-enables mouse events for all kinds of devices, in order to cover cases where the devices has both a touchscreen and a mouse.

Fixes #8710.