### PR TITLE
fix(select): remove some unnecessary logic

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -268,16 +268,6 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
       findSelectContainer();
       $mdTheming(element);
 
-      if (attr.name && formCtrl) {
-        var selectEl = element.parent()[0].querySelector('select[name=".' + attr.name + '"]');
-        $mdUtil.nextTick(function() {
-          var controller = angular.element(selectEl).controller('ngModel');
-          if (controller) {
-            formCtrl.$removeControl(controller);
-          }
-        });
-      }
-
       if (formCtrl && angular.isDefined(attr.multiple)) {
         $mdUtil.nextTick(function() {
           var hasModelValue = ngModelCtrl.$modelValue || ngModelCtrl.$viewValue;


### PR DESCRIPTION
Since PR #8651 the shadow `select` element isn't using ngModel anymore, which makes this logic redundant. It also spares us an extra digest being caused by nextTick.