### PR TITLE
fix(datePicker): remove unresolved variable

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -6,6 +6,10 @@ $md-datepicker-open-animation-duration: 0.2s !default;
 $md-datepicker-triangle-button-width: 36px !default;
 $md-datepicker-input-mask-height: 40px !default;
 
+// The datepickers triangle icon uses the default button margin.
+// We need to use the margin to align the label inside of an input container properly.
+$icon-button-margin: rem(0.600) !default;
+
 md-datepicker {
   // Don't let linebreaks happen between the open icon-button and the input.
   white-space: nowrap;


### PR DESCRIPTION
* Currently the datePicker scss contains a variable which is not defined.
  This causes issues with the module compilation for closure and default.

The CI can't currently build a new snapshot to `bower-material`, because the variable is undefined.
I guess the variable has been removed, because the icon doesn't have any margin (yet)

![image](https://cloud.githubusercontent.com/assets/4987015/15986167/83c73052-3001-11e6-85a5-d9d30e2f142b.png)
