### PR TITLE
fix(md-input) prevent label from focus when tabbing

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -685,7 +685,7 @@ function placeholderDirective($compile) {
     // md-select handles placeholders on it's own
     if (element[0].nodeName != 'MD-SELECT') {
       // Move the placeholder expression to the label
-      var newLabel = angular.element('<label ng-click="delegateClick()">' + attr.placeholder + '</label>');
+      var newLabel = angular.element('<label ng-click="delegateClick()" tabindex="-1">' + attr.placeholder + '</label>');
 
       // Note that we unset it via `attr`, in order to get Angular
       // to remove any observers that it might have set up. Otherwise


### PR DESCRIPTION
Ensures keyboard won't focus on label when tabbed.