### PR TITLE
fix(input): add support for ng-value

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -342,6 +342,12 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
 
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);
 
+    // When the developer uses the ngValue directive for the input, we have to observe the attribute, because
+    // Angular's ngValue directive is just setting the `value` attribute.
+    if (attr.ngValue) {
+      attr.$observe('value', inputCheckValue);
+    }
+
     ngModelCtrl.$parsers.push(ngModelPipelineCheckValue);
     ngModelCtrl.$formatters.push(ngModelPipelineCheckValue);
 

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -185,6 +185,18 @@ describe('md-input-container directive', function() {
     expect(el).not.toHaveClass('md-input-has-value');
   });
 
+  it('should set has-value class on container with ng-value', function() {
+    var el = setup('ng-value="value"');
+
+    pageScope.$apply('value = "My Value"');
+
+    expect(el).toHaveClass('md-input-has-value');
+
+    pageScope.$apply('value = ""');
+    
+    expect(el).not.toHaveClass('md-input-has-value');
+  });
+
   it('should set has-value class on container for ng-model input', function() {
     pageScope.value = 'test';
     var el = setup('ng-model="value"');


### PR DESCRIPTION
* When a developer uses `ng-value` on the input directive, the directive will just set the attribute on value change, without triggering any `input` event.
  This means, that we have to watch the value attribute, when the `ngValue` attribute is specified.

See https://github.com/angular/angular.js/blob/master/src/ng/directive/input.js#L1803

Fixes #8670