### PR TITLE
feat(datepicker): is-open attribute, ability to hide icons, demo layout

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -47,9 +47,10 @@ md-datepicker {
 // If the datepicker is inside of a md-input-container
 ._md-datepicker-floating-label {
   > label:not(.md-no-float):not(._md-container-ignore) {
-    $offset: $md-datepicker-triangle-button-width + $md-datepicker-button-gap + $icon-button-margin + $baseline-grid;
-    @include rtl-prop(left, right, $offset);
-    width: calc(100% - #{$offset + $md-datepicker-triangle-button-width});
+    $offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap + $icon-button-margin + $baseline-grid;
+    @include rtl(right, $icon-button-margin, auto);
+    @include rtl(left, auto, $icon-button-margin);
+    width: calc(100% - #{$offset});
   }
 
   > md-datepicker {
@@ -80,7 +81,10 @@ md-datepicker {
 
   display: inline-block;
   width: auto;
-  @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
+
+  .md-icon-button + & {
+    @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
+  }
 
   &.md-datepicker-focused {
     border-bottom-width: 2px;
@@ -209,11 +213,13 @@ md-datepicker[disabled] {
   overflow: hidden;
 
   .md-datepicker-input-container {
-    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
-
     // The negative bottom margin prevents the content around the datepicker
     // from jumping when it gets opened.
     margin-bottom: -$md-datepicker-border-bottom-gap;
+  }
+
+  .md-icon-button + .md-datepicker-input-container {
+    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
   }
 
   .md-datepicker-input,

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -1,59 +1,80 @@
-<div ng-controller="AppCtrl" style='padding: 40px;' ng-cloak>
-  <md-content>
+<div ng-controller="AppCtrl" ng-cloak>
+  <md-content layout-padding>
 
-    <h4>Standard date-picker</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date"></md-datepicker>
-
-    <h4>Disabled date-picker</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date" disabled></md-datepicker>
-
-    <h4>Date-picker with min date and max date</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date"
-        md-min-date="minDate" md-max-date="maxDate"></md-datepicker>
-
-    <h4>Only weekends are selectable</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date"
-        md-date-filter="onlyWeekendsPredicate"></md-datepicker>
-
-    <h4>Only weekends within given range are selectable</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date"
-        md-min-date="minDate" md-max-date="maxDate"
-        md-date-filter="onlyWeekendsPredicate"></md-datepicker>
-
-    <h4>Opening the calendar when the input is focused</h4>
-    <md-datepicker ng-model="myDate" md-placeholder="Enter date"
-      md-open-on-focus></md-datepicker>
-
-    <h4>With ngMessages</h4>
-    <form name="myForm">
-      <md-datepicker name="dateField" ng-model="myDate" md-placeholder="Enter date"
-          required md-min-date="minDate" md-max-date="maxDate"
-          md-date-filter="onlyWeekendsPredicate"></md-datepicker>
-
-      <div class="validation-messages" ng-messages="myForm.dateField.$error">
-        <div ng-message="valid">The entered value is not a date!</div>
-        <div ng-message="required">This date is required!</div>
-        <div ng-message="mindate">Date is too early!</div>
-        <div ng-message="maxdate">Date is too late!</div>
-        <div ng-message="filtered">Only weekends are allowed!</div>
+    <div layout-gt-xs="row">
+      <div flex-gt-xs>
+        <h4>Standard date-picker</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date"></md-datepicker>
       </div>
-    </form>
 
-    <h4>Inside a md-input-container</h4>
-    <form name="myOtherForm">
-      <md-input-container>
-        <label>Enter date</label>
+      <div flex-gt-xs>
+        <h4>Disabled date-picker</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date" disabled></md-datepicker>
+      </div>
+    </div>
 
-        <md-datepicker ng-model="myDate" name="dateField" md-min-date="minDate"
-          md-max-date="maxDate"></md-datepicker>
+    <div layout-gt-xs="row">
+      <div flex-gt-xs>
+        <h4>Date-picker with min date and max date</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date"
+            md-min-date="minDate" md-max-date="maxDate"></md-datepicker>
+      </div>
 
-        <div class="validation-messages" ng-messages="myOtherForm.dateField.$error">
+      <div flex-gt-xs>
+        <h4>Only weekends are selectable</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date"
+            md-date-filter="onlyWeekendsPredicate"></md-datepicker>
+      </div>
+    </div>
+
+    <div layout-gt-xs="row">
+      <div flex-gt-xs>
+        <h4>Only weekends within given range are selectable</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date"
+            md-min-date="minDate" md-max-date="maxDate"
+            md-date-filter="onlyWeekendsPredicate"></md-datepicker>
+      </div>
+
+      <div flex-gt-xs>
+        <h4>Opening the calendar when the input is focused</h4>
+        <md-datepicker ng-model="myDate" md-placeholder="Enter date"
+          md-open-on-focus></md-datepicker>
+      </div>
+    </div>
+
+    <div layout-gt-xs="row">
+      <form name="myForm" flex-gt-xs>
+        <h4>With ngMessages</h4>
+        <md-datepicker name="dateField" ng-model="myDate" md-placeholder="Enter date"
+            required md-min-date="minDate" md-max-date="maxDate"
+            md-date-filter="onlyWeekendsPredicate"></md-datepicker>
+
+        <div class="validation-messages" ng-messages="myForm.dateField.$error">
           <div ng-message="valid">The entered value is not a date!</div>
           <div ng-message="required">This date is required!</div>
           <div ng-message="mindate">Date is too early!</div>
           <div ng-message="maxdate">Date is too late!</div>
+          <div ng-message="filtered">Only weekends are allowed!</div>
         </div>
-      </md-input-container>
-    </form>
+      </form>
+
+      <form name="myOtherForm" flex-gt-xs>
+        <h4>Inside a md-input-container</h4>
+
+        <md-input-container>
+          <label>Enter date</label>
+          <md-datepicker ng-model="myDate" name="dateField" md-min-date="minDate"
+            md-max-date="maxDate"></md-datepicker>
+
+          <div class="validation-messages" ng-messages="myOtherForm.dateField.$error">
+            <div ng-message="valid">The entered value is not a date!</div>
+            <div ng-message="required">This date is required!</div>
+            <div ng-message="mindate">Date is too early!</div>
+            <div ng-message="maxdate">Date is too late!</div>
+          </div>
+        </md-input-container>
+      </form>
+    </div>
+
   </md-content>
 </div>

--- a/src/components/datepicker/demoBasicUsage/script.js
+++ b/src/components/datepicker/demoBasicUsage/script.js
@@ -11,9 +11,9 @@ angular.module('datepickerBasicUsage',
       $scope.myDate.getFullYear(),
       $scope.myDate.getMonth() + 2,
       $scope.myDate.getDate());
-  
+
   $scope.onlyWeekendsPredicate = function(date) {
     var day = date.getDay();
     return day === 0 || day === 6;
-  }
+  };
 });

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -1,5 +1,5 @@
 
-describe('md-date-picker', function() {
+describe('md-datepicker', function() {
   // When constructing a Date, the month is zero-based. This can be confusing, since people are
   // used to seeing them one-based. So we create these aliases to make reading the tests easier.
   var JAN = 0, FEB = 1, MAR = 2, APR = 3, MAY = 4, JUN = 5, JUL = 6, AUG = 7, SEP = 8, OCT = 9,
@@ -368,6 +368,29 @@ describe('md-date-picker', function() {
 
     });
 
+    it('should open and close the floating calendar pane element via an expression on the scope', function() {
+      pageScope.isOpen = false;
+      createDatepickerInstance('<md-datepicker ng-model="myDate" md-is-open="isOpen"></md-datepicker>');
+
+      expect(controller.calendarPane.offsetHeight).toBe(0);
+      expect(controller.isCalendarOpen).toBe(false);
+
+      pageScope.$apply(function() {
+        pageScope.isOpen = true;
+      });
+
+      // Open the calendar externally
+      expect(controller.calendarPane.offsetHeight).toBeGreaterThan(0);
+      expect(controller.isCalendarOpen).toBe(true);
+
+      // Close the calendar via the datepicker
+      controller.$scope.$apply(function() {
+        controller.closeCalendarPane();
+      });
+      expect(pageScope.isOpen).toBe(false);
+      expect(controller.isCalendarOpen).toBe(false);
+    });
+
     it('should adjust the position of the floating pane if it would go off-screen', function() {
       // Absolutely position the picker near the edge of the screen.
       var bodyRect = document.body.getBoundingClientRect();
@@ -540,5 +563,26 @@ describe('md-date-picker', function() {
     createDatepickerInstance('<md-datepicker ng-model="myDate" md-open-on-focus></md-datepicker>');
     controller.ngInputElement.triggerHandler('focus');
     expect(document.querySelector('md-calendar')).toBeTruthy();
+  });
+
+  describe('hiding the icons', function() {
+    var calendarSelector = '.md-datepicker-button .md-datepicker-calendar-icon';
+    var triangleSelector = '.md-datepicker-triangle-button';
+
+    it('should be able to hide the calendar icon', function() {
+      createDatepickerInstance('<md-datepicker ng-model="myDate" md-hide-icons="calendar"></md-datepicker>');
+      expect(element.querySelector(calendarSelector)).toBeNull();
+    });
+
+    it('should be able to hide the triangle icon', function() {
+      createDatepickerInstance('<md-datepicker ng-model="myDate" md-hide-icons="triangle"></md-datepicker>');
+      expect(element.querySelector(triangleSelector)).toBeNull();
+    });
+
+    it('should be able to hide all icons', function() {
+      createDatepickerInstance('<md-datepicker ng-model="myDate" md-hide-icons="all"></md-datepicker>');
+      expect(element.querySelector(calendarSelector)).toBeNull();
+      expect(element.querySelector(triangleSelector)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
* Adds is-open attribute that allows for the datepicker calendar to be triggered from the outside.
* Adds the ability to disable the datepicker icons.
* Changes the datepicker demo to a 2-column layout, making it more compact.

Fixes #8481.