### PR TITLE
fix(tooltip): properly handle tapping away

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -232,11 +232,19 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
         // Prevent the tooltip from showing when the window is receiving focus.
         if (e.type === 'focus' && elementFocusedOnWindowBlur) {
           elementFocusedOnWindowBlur = false;
-        } else if (e.type === 'touchstart' && scope.visible) {
-          leaveHandler();
         } else if (!scope.visible) {
           parent.on(LEAVE_EVENTS, leaveHandler);
           setVisible(true);
+
+          // If the user is on a touch device, we should bind the tap away after
+          // the `touched` in order to prevent the tooltip being removed immediately.
+          if (e.type === 'touchstart') {
+            parent.one('touchend', function() {
+              $mdUtil.nextTick(function() {
+                $document.one('touchend', leaveHandler);
+              }, false);
+            });
+          }
         }
       };
       var leaveHandler = function () {

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -182,7 +182,7 @@ describe('<md-tooltip> directive', function() {
         expect($rootScope.testModel.isVisible).toBe(false);
     });
 
-    it('should should toggle visibility on touch start', function() {
+    it('should should toggle visibility on the next touch', inject(function($document) {
         buildTooltip(
           '<md-button>' +
              'Hello' +
@@ -194,10 +194,12 @@ describe('<md-tooltip> directive', function() {
 
         triggerEvent('touchstart');
         expect($rootScope.testModel.isVisible).toBe(true);
+        triggerEvent('touchend');
 
-        triggerEvent('touchstart');
+        $document.triggerHandler('touchend');
+        $timeout.flush();
         expect($rootScope.testModel.isVisible).toBe(false);
-    });
+    }));
 
     it('should cancel when mouseleave was before the delay', function() {
       buildTooltip(


### PR DESCRIPTION
This is a follow-up to #8700 and #8730. It helps with the fact that we can't rely on the focus/blur events in touch devices, in order to hide the tooltip.