### PR TITLE
fix(colors): validate theme is a string

### DIFF
--- a/src/components/colors/colors.js
+++ b/src/components/colors/colors.js
@@ -283,6 +283,10 @@
           var lastColors = {};
 
           var parseColors = function (theme) {
+            if (typeof theme !== 'string') {
+              theme = '';
+            }
+
             if (!attrs.mdColors) {
               attrs.mdColors = '{}';
             }


### PR DESCRIPTION
- scope.$watch was calling parseColors with a scope and not a theme string, which caused the theme parsing when mdThemeController is present to be incorrect

fixes #8720