### PR TITLE
feat(md-theme) improve support for contrast/text colors

### DIFF
--- a/docs/guides/THEMES_IMPL_NOTES.md
+++ b/docs/guides/THEMES_IMPL_NOTES.md
@@ -12,7 +12,7 @@ the `$mdTheming` service and tacked into the document head.
 * Instead of using hard-coded color or a SCSS variable, the colors are defined with a mini-DSL
 (described deblow).
 * The build process takes all of those `-theme.scss` files and globs them up into one enourmous
-string.  
+string.
 * The build process wraps that string with code to set it an angular module constant:
     ``` angular.module('material.core').constant('$MD_THEME_CSS', 'HUGE_THEME_STRING'); ```
 * That code gets dumped at the end of `angular-material.js`
@@ -24,15 +24,20 @@ mini-DSL, applies the colors for the theme, and appends the resulting CSS into t
 
 
 ### The mini-DSL
-* Each color is written in the form `'{{palette-hue-opacity}}'`, where opacity is optional. 
+* Each color is written in the form `'{{palette-hue-contrast-opacity}}'`, where `hue`, `contrast`,
+and opacity are optional.
 * For example, `'{{primary-500}}'`
-* Palettes are `primary`, `accent`, `warn`, `background`, `foreground`
-* The hues for each type except `foreground` use the Material Design hues.
-* The `forground` palette is a number from one to four:
-  * `foreground-1`: text
-  * `foreground-2`: secondary text, icons
-  * `foreground-3`: disabled text, hint text
-  * `foreground-4`: dividers  
-* There is also a special hue called `contrast` that will give a contrast color (for text). 
-For example, `accent-contrast` will be a contrast color for the accent color, for use as a text 
-color on an accent-colored background.
+* Palettes are `primary`, `accent`, `warn`, `background`
+* The hues for each type use the Material Design hues. When not specified, each palette defaults
+`hue` to `500` with the exception of `background`
+* The `opacity` value can be a decimal between 0 and 1 or one the following values:
+  * `icon`: icon
+  * `secondary`: secondary text,
+  * `disabled`: disabled text or icons
+  * `hint`: hint text,
+  * `divider`: dividers
+* Default values for `opacity` differ based on light and dark theme
+* `contrast` that will give a contrast color (for text) and can be mixed with `opacity`.
+For example, `accent-contrast` will be a contrast color for the accent color, for use as a text
+color on an accent-colored background. Adding an `opacity` value as in `accent-contrast-icon` will
+apply the Material Design icon opacity.

--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -1,29 +1,34 @@
 md-autocomplete.md-THEME_NAME-theme {
-  background: '{{background-A100}}';
+  background-color: '{{background-default}}';
+  color: '{{background-default-contrast}}';
+  input {
+    color: '{{background-default-contrast}}';
+  }
   &[disabled]:not([md-floating-label]) {
-    background: '{{background-100}}';
+    background-color: '{{background-hue-3}}';
+    color: '{{background-default-contrast-disabled}}';;
   }
   button {
     md-icon {
       path {
-        fill: '{{background-600}}';
+        fill: '{{background-contrast-icon}}';
       }
     }
     &:after {
-      background: '{{background-600-0.3}}';
+      background-color: '{{background-600-0.3}}';
     }
   }
 }
 .md-autocomplete-suggestions-container.md-THEME_NAME-theme {
-  background: '{{background-A100}}';
+  background-color: '{{background-default}}';
   li {
-    color: '{{background-900}}';
+    color: '{{background-default-contrast}}';
     .highlight {
-      color: '{{background-600}}';
+      color: '{{background-default-contrast-hint}}';
     }
     &:hover,
     &.selected {
-      background: '{{background-200}}';
+      background-color: '{{background-hue-3}}';
     }
   }
 }

--- a/src/components/bottomSheet/bottom-sheet-theme.scss
+++ b/src/components/bottomSheet/bottom-sheet-theme.scss
@@ -1,19 +1,19 @@
 
 md-bottom-sheet.md-THEME_NAME-theme {
-  background-color: '{{background-50}}';
-  border-top-color: '{{background-300}}';
+  background-color: '{{background-default}}';
+  border-top-color: '{{background-default-contrast-divider}}';
 
   &.md-list {
     md-list-item {
-      color: '{{foreground-1}}';
+      color: '{{background-default-contrast}}';
     }
   }
 
   .md-subheader {
-    background-color: '{{background-50}}';
+    background-color: '{{background-default}}';
   }
 
   .md-subheader {
-    color: '{{foreground-1}}';
+    color: '{{background-default-contrast-secondary}}';
   }
 }

--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -1,4 +1,5 @@
 .md-button.md-THEME_NAME-theme {
+  color: '{{background-default-contrast}}';
 
   &:not([disabled]) {
     &:hover {
@@ -16,7 +17,7 @@
     background-color: '{{accent-color}}';
     color: '{{accent-contrast}}';
     md-icon {
-      color: '{{accent-contrast}}';
+      color: '{{accent-contrast-icon}}';
     }
     &:not([disabled]) {
       &:hover {
@@ -24,6 +25,22 @@
       }
       &.md-focused {
         background-color: '{{accent-A700}}';
+      }
+    }
+  }
+  
+  &.md-raised {
+    color: '{{background-default-contrast}}';
+    background-color: '{{background-default}}';
+    &:not([disabled]) {
+      md-icon {
+        color: '{{background-default-contrast-icon}}';
+      }
+      &:hover {
+        background-color: '{{background-default}}';
+      }
+      &.md-focused {
+        background-color: '{{background-200}}';
       }
     }
   }
@@ -36,7 +53,7 @@
       background-color: '{{primary-color}}';
       &:not([disabled]) {
         md-icon {
-          color: '{{primary-contrast}}';
+          color: '{{primary-contrast-icon}}';
         }
         &:hover {
           background-color: '{{primary-600}}';
@@ -52,48 +69,16 @@
       }
     }
   }
-  &.md-fab {
-    background-color: '{{accent-color}}';
-    color: '{{accent-contrast}}';
-    &:not([disabled]) {
-      .md-icon {
-        color: '{{accent-contrast}}';
-      }
-      &:hover {
-        background-color: '{{accent-A700}}';
-      }
-      &.md-focused {
-        background-color: '{{accent-A700}}';
-      }
-    }
-  }
-
-  &.md-raised {
-    color: '{{background-900}}';
-    background-color: '{{background-50}}';
-    &:not([disabled]) {
-      md-icon {
-        color: '{{background-900}}';
-      }
-      &:hover {
-        background-color: '{{background-50}}';
-      }
-      &.md-focused {
-        background-color: '{{background-200}}';
-      }
-    }
-  }
 
   &.md-warn {
     color: '{{warn-color}}';
-
     &.md-raised,
     &.md-fab {
       color: '{{warn-contrast}}';
       background-color: '{{warn-color}}';
       &:not([disabled]) {
         md-icon {
-          color: '{{warn-contrast}}';
+          color: '{{warn-contrast-icon}}';
         }
         &:hover {
           background-color: '{{warn-600}}';
@@ -118,7 +103,7 @@
       background-color: '{{accent-color}}';
       &:not([disabled]) {
         md-icon {
-          color: '{{accent-contrast}}';
+          color: '{{accent-contrast-icon}}';
         }
         &:hover {
           background-color: '{{accent-A700}}';
@@ -140,22 +125,25 @@
   &.md-fab[disabled],
   &.md-accent[disabled],
   &.md-warn[disabled] {
-    color: '{{foreground-3}}';
     cursor: default;
+    color: '{{background-default-contrast-0.26}}';
+
+    &.md-dark-theme {
+      color: '{{background-default-contrast-0.30}}';
+    }
 
     md-icon {
-      color: '{{foreground-3}}';
+      color: '{{background-default-contrast-disabled}}';
     }
   }
   &.md-raised[disabled],
   &.md-fab[disabled] {
-    background-color: '{{foreground-4}}';
+    background-color: '{{background-default-contrast-0.12}}';
   }
   &[disabled] {
     background-color: transparent;
   }
 }
-
 
 ._md {
   a.md-THEME_NAME-theme:not(.md-button) {

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -28,7 +28,6 @@ button.md-button::-moz-focus-inner {
 .md-button {
   border-radius: $button-border-radius;
   box-sizing: border-box;
-  color: currentColor;
 
   user-select: none;
   position: relative; //for child absolute-positioned <canvas>

--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -1,5 +1,4 @@
 section {
-  background: #f7f7f7;
   border-radius: 3px;
   text-align: center;
   margin: 1em;

--- a/src/components/card/card-theme.scss
+++ b/src/components/card/card-theme.scss
@@ -1,36 +1,47 @@
-$card-border-radius: 2px !default;
-
-md-card.md-THEME_NAME-theme {
-  color: '{{foreground-1}}';
-  background-color: '{{background-hue-1}}';
-  border-radius: $card-border-radius;
-
-  .md-card-image {
-    border-radius: $card-border-radius $card-border-radius 0 0;
-  }
-
+@mixin md-card-styled-elements($colorType: 'background', $hueType: 'color') {
+  background-color: '{{' + $colorType + '-' + $hueType + '}}';
+  color: '{{' + $colorType + '-' + $hueType + '-contrast}}';
   md-card-header {
     md-card-avatar {
       md-icon {
-        color: '{{background-color}}';
+        color: '{{' + $colorType + '-color}}';
         background-color: '{{foreground-3}}';
       }
     }
-
     md-card-header-text {
       .md-subhead {
-        color: '{{foreground-2}}'
+        color: '{{' + $colorType + '-' + $hueType + '-contrast-secondary}}';
       }
     }
   }
-
   md-card-title {
     md-card-title-text {
       &:not(:only-child) {
         .md-subhead {
-          color: '{{foreground-2}}';
+          color: '{{' + $colorType + '-' + $hueType + '-contrast-secondary}}';
         }
       }
     }
+  }
+}
+
+$card-border-radius: 2px !default;
+
+md-card.md-THEME_NAME-theme {
+  border-radius: $card-border-radius;
+  .md-card-image {
+    border-radius: $card-border-radius $card-border-radius 0 0;
+  }
+
+  @include md-card-styled-elements('background', 'hue-1');
+
+  &.md-primary {
+    @include md-card-styled-elements('primary');
+  }
+  &.md-accent {
+    @include md-card-styled-elements('accent');
+  }
+  &.md-warn {
+    @include md-card-styled-elements('warn');
   }
 }

--- a/src/components/card/card.js
+++ b/src/components/card/card.js
@@ -125,6 +125,7 @@ function mdCardDirective($mdTheming) {
     restrict: 'E',
     link: function ($scope, $element, attr) {
       $element.addClass('_md');     // private md component indicator for styling
+      $element.addClass('_md-theme-fill');
       $mdTheming($element);
     }
   };

--- a/src/components/card/demoBasicUsage/index.html
+++ b/src/components/card/demoBasicUsage/index.html
@@ -1,7 +1,7 @@
 <div ng-controller="AppCtrl" ng-cloak >
   <md-content class="md-padding" layout-xs="column" layout="row">
     <div flex-xs flex-gt-xs="50" layout="column">
-      <md-card md-theme="{{ showDarkTheme ? 'dark-grey' : 'default' }}" md-theme-watch>
+      <md-card md-theme="{{ showDarkTheme ? 'dark-grey' : 'default' }}" md-theme-watch ng-class="{'md-primary': showColorTypes}">
         <md-card-title>
           <md-card-title-text>
             <span class="md-headline">Card with image</span>
@@ -16,7 +16,7 @@
           <md-button>Action 2</md-button>
         </md-card-actions>
       </md-card>
-      <md-card md-theme="{{ showDarkTheme ? 'dark-orange' : 'default' }}" md-theme-watch>
+      <md-card md-theme="{{ showDarkTheme ? 'dark-orange' : 'default' }}" md-theme-watch ng-class="{'md-accent': showColorTypes}">
         <md-card-title>
           <md-card-title-text>
             <span class="md-headline">Card with image</span>
@@ -41,7 +41,7 @@
       </md-card>
     </div>
     <div flex-xs flex-gt-xs="50" layout="column">
-      <md-card md-theme="{{ showDarkTheme ? 'dark-purple' : 'default' }}" md-theme-watch>
+      <md-card md-theme="{{ showDarkTheme ? 'dark-purple' : 'default' }}" md-theme-watch ng-class="{'md-warn': showColorTypes}">
         <md-card-title>
           <md-card-title-text>
             <span class="md-headline">Card with image</span>
@@ -56,7 +56,7 @@
           <md-button>Action 2</md-button>
         </md-card-actions>
       </md-card>
-      <md-card md-theme="{{ showDarkTheme ? 'dark-blue' : 'default' }}" md-theme-watch>
+      <md-card md-theme="{{ showDarkTheme ? 'dark-blue' : 'default' }}" md-theme-watch ng-class="{'md-primary': showColorTypes, 'md-hue-1': showColorTypes}">
         <md-card-title>
           <md-card-title-text>
             <span class="md-headline">Card with image</span>
@@ -72,6 +72,7 @@
         </md-card-actions>
       </md-card>
       <div layout layout-padding layout-align="center end" style="height:200px">
+        <md-checkbox ng-model="showColorTypes">Use Colored Cards</md-checkbox>
         <md-checkbox ng-model="showDarkTheme">Use 'Dark' Themed Cards</md-checkbox>
       </div>
     </div>

--- a/src/components/content/content-theme.scss
+++ b/src/components/content/content-theme.scss
@@ -1,6 +1,5 @@
 md-content.md-THEME_NAME-theme {
-  color: '{{foreground-1}}';
+  color: '{{background-default-contrast}}';
   background-color: '{{background-default}}';
+  @include md-theme-fill-support;
 }
-
-

--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -58,6 +58,7 @@ function mdContentDirective($mdTheming) {
     controller: ['$scope', '$element', ContentController],
     link: function(scope, element) {
       element.addClass('_md');     // private md component indicator for styling
+      element.addClass('_md-theme-fill');
       element.addClass('md-no-flicker'); // add a class that helps prevent flickering on iOS devices
 
       $mdTheming(element);

--- a/src/components/icon/icon-theme.scss
+++ b/src/components/icon/icon-theme.scss
@@ -1,5 +1,10 @@
 md-icon.md-THEME_NAME-theme {
-  color: '{{foreground-2}}';
+  color: '{{background-default-contrast-icon}}';
+  fill: currentColor;
+  &.md-inactive,
+  &[disabled] {
+    color: '{{background-default-contrast-disabled}}';
+  }
 
   &.md-primary {
     color: '{{primary-color}}';

--- a/src/components/icon/icon.scss
+++ b/src/components/icon/icon.scss
@@ -3,7 +3,6 @@ md-icon {
   background-repeat: no-repeat no-repeat;
   display: inline-block;
   vertical-align: middle;
-  fill: currentColor;
   height: $icon-size;
   width: $icon-size;
 

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -1,17 +1,17 @@
 md-input-container.md-THEME_NAME-theme {
   .md-input {
-    @include input-placeholder-color('\'{{foreground-3}}\'');
-    color: '{{foreground-1}}';
-    border-color: '{{foreground-4}}';
+    @include input-placeholder-color('\'{{background-default-contrast-hint}}\'');
+    color: '{{background-default-contrast}}';
+    border-color: '{{background-default-contrast-divider}}';
   }
 
   > md-icon {
-    color: '{{foreground-1}}';
+    color: '{{background-default-contrast-icon}}';
   }
 
   label,
   ._md-placeholder {
-    color: '{{foreground-3}}';
+    color: '{{background-default-contrast-hint}}';
   }
 
   &.md-input-invalid {
@@ -21,22 +21,34 @@ md-input-container.md-THEME_NAME-theme {
   }
 
   &:not(.md-input-focused):not(.md-input-invalid) label.md-required:after {
-    color: '{{foreground-2}}';
+    color: '{{background-default-contrast-secondary}}';
   }
 
   .md-input-messages-animation, .md-input-message-animation {
     color: '{{warn-A700}}';
     .md-char-counter {
-      color: '{{foreground-1}}';
+      color: '{{background-default-contrast}}';
     }
   }
 
   &:not(.md-input-invalid) {
     &.md-input-has-value {
       label {
-        color: '{{foreground-2}}';
+        color: '{{background-default-secondary}}';
       }
     }
+  }
+  .md-input {
+    &[disabled],
+    [disabled] & {
+      border-bottom-color: transparent;
+      color: '{{background-default-contrast-disabled}}';
+      background-image: linear-gradient(to right, '{{background-default-contrast-disabled}}' 0%, '{{background-default-contrast-disabled}}' 33%, transparent 0%);
+      background-image: -ms-linear-gradient(left, transparent 0%, '{{background-default-contrast-disabled}}' 100%);
+    }
+  }
+
+  &:not(.md-input-invalid) {
     &.md-input-focused,
     &.md-input-resized {
       .md-input {
@@ -78,15 +90,6 @@ md-input-container.md-THEME_NAME-theme {
     }
     .md-input-message-animation, .md-char-counter {
       color: '{{warn-A700}}';
-    }
-  }
-  .md-input {
-    &[disabled],
-    [disabled] & {
-      border-bottom-color: transparent;
-      color: '{{foreground-3}}';
-      background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
-      background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
     }
   }
 }

--- a/src/components/menu/menu-theme.scss
+++ b/src/components/menu/menu-theme.scss
@@ -1,24 +1,23 @@
 md-menu-content.md-THEME_NAME-theme {
-  background-color: '{{background-A100}}';
+  background-color: '{{background-hue-1}}';
 
   md-menu-item {
-    color: '{{background-A200-0.87}}';
+    color: '{{background-hue-1-contrast}}';
 
     md-icon {
-      color: '{{background-A200-0.54}}';
+      color: '{{background-hue-1-contrast-icon}}';
     }
 
     .md-button[disabled] {
-      color: '{{background-A200-0.25}}';
+      color: '{{background-hue-1-contrast-disabled}}';
 
       md-icon {
-        color: '{{background-A200-0.25}}';
+        color: '{{background-hue-1-contrast-disabled}}';
       }
     }
-
   }
 
   md-menu-divider {
-    background-color: '{{background-A200-0.11}}';
+    background-color: '{{background-hue-1-contrast-divider}}';
   }
 }

--- a/src/components/menuBar/menu-bar-theme.scss
+++ b/src/components/menuBar/menu-bar-theme.scss
@@ -1,45 +1,46 @@
-md-menu-bar.md-THEME_NAME-theme {
-  & > button.md-button {
-    color: '{{foreground-2}}';
-    border-radius: 2px;
-  }
-
-  md-menu._md-open > button, md-menu > button:focus {
-    outline: none;
-    background: '{{background-200}}';
-  }
-
-  &._md-open:not(._md-keyboard-mode) md-menu:hover > button {
-    background-color: '{{ background-500-0.2}}';
-  }
-
-  &:not(._md-keyboard-mode):not(._md-open) {
-    md-menu button:hover,
-    md-menu button:focus {
-      background: transparent;
-    }
-  }
-}
-
-md-menu-content.md-THEME_NAME-theme {
-  .md-menu > .md-button:after {
-    color: '{{background-A200-0.54}}';
-  }
-
-  .md-menu._md-open > .md-button {
-    background-color: '{{ background-500-0.2}}';
-  }
-}
-
 md-toolbar.md-THEME_NAME-theme.md-menu-toolbar {
-  background-color: '{{background-A100}}';
-  color: '{{background-A200}}';
+  background-color: '{{background-hue-1}}';
+  color: '{{background-hue-1-contrast}}';
   md-toolbar-filler {
     background-color: '{{primary-color}}';
-    color: '{{background-A100-0.87}}';
+    color: '{{primary-color-contrast}}';
     md-icon {
-      color: '{{background-A100-0.87}}';
+      color: '{{primary-color-contrast}}';
     }
   }
 
+  md-menu-bar {
+    & > button.md-button {
+      color: '{{background-contrast-secondary}}';
+      border-radius: 2px;
+    }
+
+    md-menu._md-open > button, md-menu > button:focus {
+      outline: none;
+      outline-color: transparent;
+      background: '{{background-hue-2}}';
+      color: '{{background-hue-2-contrast}}';
+    }
+
+    &._md-open:not(._md-keyboard-mode) md-menu:hover > button {
+      background-color: '{{background-500-0.2}}';
+    }
+
+    &:not(._md-keyboard-mode):not(._md-open) {
+      md-menu button:hover,
+      md-menu button:focus {
+        background: transparent;
+      }
+    }
+  }
+
+  md-menu-content {
+    .md-menu > .md-button:after {
+      color: '{{background-hue-3-0.54}}';
+    }
+
+    .md-menu._md-open > .md-button {
+      background-color: '{{ background-500-0.2}}';
+    }
+  }
 }

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -27,14 +27,14 @@ md-input-container {
 md-select.md-THEME_NAME-theme {
   &[disabled] ._md-select-value {
     border-bottom-color: transparent;
-    background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
-    background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
+    background-image: linear-gradient(to right, '{{background-contrast-hint}}' 0%, '{{background-contrast-hint}}' 33%, transparent 0%);
+    background-image: -ms-linear-gradient(left, transparent 0%, '{{background-contrast-hint}}' 100%);
   }
   ._md-select-value {
     &._md-select-placeholder {
-      color: '{{foreground-3}}';
+      color: '{{background-contrast-hint}}';
     }
-    border-bottom-color: '{{foreground-4}}';
+    border-bottom-color: '{{background-contrast-divider}}';
   }
   &.md-no-underline ._md-select-value {
     border-bottom-color: transparent !important;
@@ -51,9 +51,9 @@ md-select.md-THEME_NAME-theme {
   &:not([disabled]):focus {
     ._md-select-value {
       border-bottom-color: '{{primary-color}}';
-      color: '{{ foreground-1 }}';
+      color: '{{background-contrast}}';
       &._md-select-placeholder {
-        color: '{{ foreground-1 }}';
+        color: '{{background-contrast}}';
       }
     }
     &.md-no-underline ._md-select-value {
@@ -68,9 +68,9 @@ md-select.md-THEME_NAME-theme {
   }
   &[disabled] {
     ._md-select-value {
-      color: '{{foreground-3}}';
+      color: '{{background-contrast-disabled}}';
       &._md-select-placeholder {
-        color: '{{foreground-3}}';
+        color: '{{background-contrast-disabled}}';
       }
     }
   }
@@ -78,25 +78,25 @@ md-select.md-THEME_NAME-theme {
 
 md-select-menu.md-THEME_NAME-theme {
   md-content {
-    background: '{{background-A100}}';
+    background-color: '{{background-hue-1}}';
 
     md-optgroup {
-      color: '{{background-600-0.87}}';
+      color: '{{background-hue-1-contrast-secondary}}';
     }
 
     md-option {
-      color: '{{background-900-0.87}}';
+      color: '{{background-hue-1-contrast}}';
 
       &[disabled] {
         ._md-text {
-          color: '{{background-400-0.87}}';
+          color: '{{background-hue-1-contrast-disabled}}';
         }
       }
 
       &:not([disabled]) {
         &:focus,
         &:hover {
-          background: '{{background-200}}'
+          background: '{{background-hue-3}}'
         }
       }
 
@@ -120,6 +120,6 @@ md-select-menu.md-THEME_NAME-theme {
   @include checkbox-primary('[selected]');
 
   md-option ._md-text {
-    color: '{{background-900-0.87}}';
+    color: '{{background-hue-1-contrast}}';
   }
 }

--- a/src/components/switch/demoBasicUsage/index.html
+++ b/src/components/switch/demoBasicUsage/index.html
@@ -1,25 +1,52 @@
-<div class="inset" ng-controller="SwitchDemoCtrl" ng-cloak>
-  <md-switch ng-model="data.cb1" aria-label="Switch 1">
-    Switch 1: {{ data.cb1 }}
-  </md-switch>
-
-  <md-switch ng-model="data.cb2" aria-label="Switch 2" ng-true-value="'yup'" ng-false-value="'nope'" class="md-warn">
-    Switch 2 (md-warn): {{ data.cb2 }}
-  </md-switch>
-
-  <md-switch ng-disabled="true" aria-label="Disabled switch" ng-model="disabledModel">
-    Switch (Disabled)
-  </md-switch>
-
-  <md-switch ng-disabled="true" aria-label="Disabled active switch" ng-model="data.cb4">
-    Switch (Disabled, Active)
-  </md-switch>
-
-  <md-switch class="md-primary" md-no-ink aria-label="Switch No Ink" ng-model="data.cb5">
-    Switch (md-primary): No Ink
-  </md-switch>
-
-  <md-switch ng-model="data.cb6" aria-label="Switch 6" ng-change="onChange(data.cb6)">
-    Switch 6 message: {{ message }}
-  </md-switch>
+<div class="inset" ng-controller="SwitchDemoCtrl" ng-cloak layout='row'>
+  <md-content>
+    <md-switch ng-model="data.cb1" aria-label="Switch 1">
+      Switch 1: {{ data.cb1 }}
+    </md-switch>
+  
+    <md-switch ng-model="data.cb2" aria-label="Switch 2" ng-true-value="'yup'" ng-false-value="'nope'" class="md-warn">
+      Switch 2 (md-warn): {{ data.cb2 }}
+    </md-switch>
+  
+    <md-switch ng-disabled="true" aria-label="Disabled switch" ng-model="disabledModel">
+      Switch (Disabled)
+    </md-switch>
+  
+    <md-switch ng-disabled="true" aria-label="Disabled active switch" ng-model="data.cb4">
+      Switch (Disabled, Active)
+    </md-switch>
+  
+    <md-switch class="md-primary" md-no-ink aria-label="Switch No Ink" ng-model="data.cb5">
+      Switch (md-primary): No Ink
+    </md-switch>
+  
+    <md-switch ng-model="data.cb6" aria-label="Switch 6" ng-change="onChange(data.cb6)">
+      Switch 6 message: {{ message }}
+    </md-switch>
+  </md-content>
+  <md-content md-theme="docs-switch-dark">
+    <md-switch ng-model="data.cb1" aria-label="Switch 1">
+      Switch 1: {{ data.cb1 }}
+    </md-switch>
+  
+    <md-switch ng-model="data.cb2" aria-label="Switch 2" ng-true-value="'yup'" ng-false-value="'nope'" class="md-warn">
+      Switch 2 (md-warn): {{ data.cb2 }}
+    </md-switch>
+  
+    <md-switch ng-disabled="true" aria-label="Disabled switch" ng-model="disabledModel">
+      Switch (Disabled)
+    </md-switch>
+  
+    <md-switch ng-disabled="true" aria-label="Disabled active switch" ng-model="data.cb4">
+      Switch (Disabled, Active)
+    </md-switch>
+  
+    <md-switch class="md-primary" md-no-ink aria-label="Switch No Ink" ng-model="data.cb5">
+      Switch (md-primary): No Ink
+    </md-switch>
+  
+    <md-switch ng-model="data.cb6" aria-label="Switch 6" ng-change="onChange(data.cb6)">
+      Switch 6 message: {{ message }}
+    </md-switch>
+  </md-content>
 </div>

--- a/src/components/switch/demoBasicUsage/script.js
+++ b/src/components/switch/demoBasicUsage/script.js
@@ -11,4 +11,10 @@ angular.module('switchDemo1', ['ngMaterial'])
   $scope.onChange = function(cbState) {
   	$scope.message = cbState;
   };
+})
+.config(function($mdThemingProvider) {
+    $mdThemingProvider.theme('docs-switch-dark')
+      .primaryPalette('blue')
+      .accentPalette('teal')
+      .dark();
 });

--- a/src/components/switch/demoBasicUsage/style.css
+++ b/src/components/switch/demoBasicUsage/style.css
@@ -2,3 +2,6 @@
     padding-left: 25px;
     padding-top:25px;
 }
+md-content {
+  margin: 16px
+}

--- a/src/components/switch/switch-theme.scss
+++ b/src/components/switch/switch-theme.scss
@@ -1,57 +1,43 @@
+@mixin md-switch-checked ($group, $shade) {
+  .md-ink-ripple {
+      color: '{{' + $group + '-'+ $shade +'}}';
+  }
+  ._md-thumb {
+    background-color: '{{' + $group + '-' + $shade + '}}';
+  }
+  ._md-bar {
+    background-color: '{{' + $group + '-' + $shade + '-0.5}}';
+  }
+  &.md-focused ._md-thumb:before {
+    background-color: '{{' + $group + '-' + $shade + '-0.26}}';
+  }
+}
+
 md-switch.md-THEME_NAME-theme {
   .md-ink-ripple {
-    color: '{{background-500}}';
+    color: '{{background-contrast-1.0}}';
   }
   ._md-thumb {
     background-color: '{{background-50}}';
   }
   ._md-bar {
-    background-color: '{{background-500}}';
+    background-color: '{{background-contrast-0.38}}';
+  }
+  &.md-focused ._md-thumb:before {
+    background-color: '{{background-contrast-0.26}}';
   }
 
   &.md-checked {
-    .md-ink-ripple {
-      color: '{{accent-color}}';
-    }
-    ._md-thumb {
-      background-color: '{{accent-color}}';
-    }
-    ._md-bar {
-      background-color: '{{accent-color-0.5}}';
-    }
-    &.md-focused ._md-thumb:before {
-      background-color: '{{accent-color-0.26}}';
-    }
+    @include md-switch-checked('accent', '500');
 
     &.md-primary {
-      .md-ink-ripple {
-        color: '{{primary-color}}';
-      }
-      ._md-thumb {
-        background-color: '{{primary-color}}';
-      }
-      ._md-bar {
-        background-color: '{{primary-color-0.5}}';
-      }
-      &.md-focused ._md-thumb:before {
-        background-color: '{{primary-color-0.26}}';
-      }
+      @include md-switch-checked('primary', '500');
     }
 
     &.md-warn {
-      .md-ink-ripple {
-        color: '{{warn-color}}';
-      }
-      ._md-thumb {
-        background-color: '{{warn-color}}';
-      }
-      ._md-bar {
-        background-color: '{{warn-color-0.5}}';
-      }
-      &.md-focused ._md-thumb:before {
-        background-color: '{{warn-color-0.26}}';
-      }
+      @include md-switch-checked('warn', '500');
     }
+
   }
 
   &[disabled] {
@@ -59,7 +45,38 @@ md-switch.md-THEME_NAME-theme {
       background-color: '{{background-400}}';
     }
     ._md-bar {
-      background-color: '{{foreground-4}}';
+      background-color: '{{background-contrast-0.12}}';
+    }
+  }
+
+  &.md-theme-dark {
+    ._md-thumb {
+      background-color: '{{background-400}}';
+    }
+    ._md-bar {
+      background-color: '{{background-contrast-0.30}}';
+    }
+
+    &.md-checked {
+      @include md-switch-checked('accent', '200');
+
+      &.md-primary {
+        @include md-switch-checked('primary', '200');
+      }
+
+      &.md-warn {
+        @include md-switch-checked('warn', '200');
+      }
+
+    }
+
+    &[disabled] {
+      ._md-thumb {
+        background-color: '{{background-800}}';
+      }
+      ._md-bar {
+        background-color: '{{background-contrast-0.10}}';
+      }
     }
   }
 }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -63,12 +63,6 @@ md-switch {
       right: -8px;
       bottom: -8px;
     }
-
-    &:not(.md-checked) {
-      ._md-thumb:before {
-        background-color: rgba(0, 0, 0, 0.12);
-      }
-    }
   }
 
   ._md-label {

--- a/src/components/tabs/tabs-theme.scss
+++ b/src/components/tabs/tabs-theme.scss
@@ -66,7 +66,7 @@
 md-tabs.md-THEME_NAME-theme {
   md-tabs-wrapper {
     background-color: transparent;
-    border-color: '{{foreground-4}}';
+    border-color: '{{background-contrast-divider}}';
   }
   .md-paginator md-icon {
     color: '{{primary-color}}';
@@ -78,10 +78,10 @@ md-tabs.md-THEME_NAME-theme {
   }
 
   .md-tab {
-    color: '{{foreground-2}}';
+    color: '{{background-contrast-secondary}}';
     &[disabled] {
       &, md-icon {
-        color: '{{foreground-3}}';
+        color: '{{background-contrast-disabled}}';
       }
     }
     &.md-active, &.md-focused {

--- a/src/components/toolbar/demoBasicUsage/index.html
+++ b/src/components/toolbar/demoBasicUsage/index.html
@@ -34,7 +34,7 @@
           <span>Toolbar with Standard Buttons</span>
         </h2>
         <span flex></span>
-        <md-button class="md-raised" aria-label="Learn More">
+        <md-button class="md-raised md-primary" aria-label="Learn More">
           Learn More
         </md-button>
         <md-button class="md-fab md-mini" aria-label="Favorite">

--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -1,38 +1,5 @@
 md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
-  background-color: '{{primary-color}}';
-  color: '{{primary-contrast}}';
-
-  md-icon {
-    color: '{{primary-contrast}}';
-    fill: '{{primary-contrast}}';
-  }
-
-  .md-button[disabled] md-icon {
-    color: '{{primary-contrast-0.26}}';
-    fill: '{{primary-contrast-0.26}}';
-  }
-
-  &.md-accent {
-    background-color: '{{accent-color}}';
-    color: '{{accent-contrast}}';
-
-    .md-ink-ripple {
-      color: '{{accent-contrast}}';
-    }
-
-    md-icon {
-      color: '{{accent-contrast}}';
-      fill: '{{accent-contrast}}';
-    }
-
-    .md-button[disabled] md-icon {
-      color: '{{accent-contrast-0.26}}';
-      fill: '{{accent-contrast-0.26}}';
-    }
-  }
-
-  &.md-warn {
-    background-color: '{{warn-color}}';
-    color: '{{warn-contrast}}';
-  }
+  background-color: '{{background-color}}';
+  color: '{{background-contrast}}';
+  @include md-theme-fill-support
 }

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -70,6 +70,8 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
     link: function(scope, element, attr) {
 
       element.addClass('_md');     // private md component indicator for styling
+      element.addClass('_md-theme-fill');
+      element.addClass('md-primary'); //default
       $mdTheming(element);
 
       $mdUtil.nextTick(function () {

--- a/src/components/tooltip/tooltip-theme.scss
+++ b/src/components/tooltip/tooltip-theme.scss
@@ -1,6 +1,6 @@
 md-tooltip.md-THEME_NAME-theme {
-  color: '{{background-A100}}';
+  color: '{{background-800-contrast}}';
   ._md-content {
-    background-color: '{{foreground-2}}';
+    background-color: '{{background-800}}';
   }
 }

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -163,7 +163,7 @@ describe('$mdThemingProvider', function() {
       expect(themingProvider._PALETTES.extended['100']).toEqual(testPalette['100']);
       expect(themingProvider._PALETTES.extended['50']).toEqual('newValue');
     });
-  }); 
+  });
 
   describe('css template parsing', function() {
     beforeEach(setup);
@@ -249,6 +249,22 @@ describe('$mdThemingProvider', function() {
           .toEqual('color: rgba(0,0,0,0.12);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-shadow}}"; }')[0].content)
           .toEqual('color: ;');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.54);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.54);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-disabled}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.38);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-hint}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.38);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-divider}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.12);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-0.05}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.05);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
       });
       it('for a dark theme', function() {
         testTheme.dark();
@@ -262,6 +278,24 @@ describe('$mdThemingProvider', function() {
           .toEqual('color: rgba(255,255,255,0.12);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-shadow}}"; }')[0].content)
           .toEqual('color: 1px 1px 0px rgba(0,0,0,0.4), -1px -1px 0px rgba(0,0,0,0.4);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,1);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-disabled}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.5);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-hint}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.5);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-divider}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.12);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-0.05}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.05);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-900-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,255,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
       });
     });
     it('parses contrast colors', function() {
@@ -353,7 +387,7 @@ describe('$mdThemeProvider with custom styles', function() {
     });
     
     // Verify that $MD_THEME_CSS is still set to '/**/' in the test environment.
-    // Check angular-material-mocks.js for $MD_THEME_CSS latest value if this test starts to fail. 
+    // Check angular-material-mocks.js for $MD_THEME_CSS latest value if this test starts to fail.
     inject(function($MD_THEME_CSS) { expect($MD_THEME_CSS).toBe('/**/'); });
     
     // Find the string '/**//*test*/' in the head tag.
@@ -380,7 +414,7 @@ describe('$mdThemeProvider with on-demand generation', function() {
 
     // Use a single simple style rule for which we can check presence / absense.
     $provide.constant('$MD_THEME_CSS',
-        "sparkle.md-THEME_NAME-theme { color: '{{primary-color}}' }");
+        "sparkle.md-THEME_NAME-theme { color: '{{primary-color}}'; }");
 
     $mdThemingProvider.theme('sweden')
         .primaryPalette('light-blue')
@@ -407,13 +441,14 @@ describe('$mdThemeProvider with on-demand generation', function() {
 
     var styles = getThemeStyleElements();
     // One style tag for each default hue (default, hue-1, hue-2, hue-3).
-    expect(styles.length).toBe(4);
+    // One style tag for each md-theme-fill type ('', primary, accent, warn)
+    expect(styles.length).toBe(8);
     expect(document.head.innerHTML).toMatch(/md-sweden-theme/);
     expect(document.head.innerHTML).not.toMatch(/md-belarus-theme/);
 
     $mdTheming.generateTheme('belarus');
     styles = getThemeStyleElements();
-    expect(styles.length).toBe(8);
+    expect(styles.length).toBe(16);
     expect(document.head.innerHTML).toMatch(/md-sweden-theme/);
     expect(document.head.innerHTML).toMatch(/md-belarus-theme/);
   });
@@ -632,5 +667,73 @@ describe('md-themable directive', function() {
   it('should apply a class for a nested default theme', inject(function($rootScope, $compile) {
     var el = $compile('<div md-theme="default" md-themable></div>')($rootScope);
     expect(el.hasClass('md-default-theme')).toBe(true);
+  }));
+});
+
+describe('components inside a component with md-theme-fill', function() {
+  var element, themingProvider, _window;
+  function getThemeStyleElements() {
+    return document.head.querySelectorAll('style[md-theme-style]');
+  }
+
+  function cleanThemeStyleElements() {
+    angular.forEach(getThemeStyleElements(), function(style) {
+      document.head.removeChild(style);
+    });
+  }
+
+  beforeEach(module('material.core', function($provide, $mdThemingProvider) {
+    // Theming requires that there is at least one element present in the document head.
+    cleanThemeStyleElements();
+
+    // Use a single simple style rule for which we can check presence / absense.
+    $provide.constant('$MD_THEME_CSS', "childdiv.md-THEME_NAME-theme { background-color: '{{background-default}}'; }");
+
+    $mdThemingProvider.theme('testFill')
+        .primaryPalette('red')
+        .accentPalette('green');
+
+    themingProvider = $mdThemingProvider;
+  }));
+
+  beforeEach(inject(function($window){
+    _window = $window;
+  }));
+
+  afterEach(inject(function($document){
+    element && $document[0].body.removeChild(element[0]);
+  }));
+
+  function getBackgroundColor(element) {
+    return themingProvider._rgba(themingProvider._colorToRgbaArray(
+      _window.getComputedStyle(element).backgroundColor
+    ));
+  }
+  function getPaletteColor(palette, hue) {
+    return themingProvider._rgba(themingProvider._PALETTES[palette][hue].value);
+  }
+  function getThemePalettes(theme) {
+    return themingProvider._THEMES[theme || 'default'].colors;
+  }
+  it('should apply filled color to children background-color', inject(function($rootScope, $compile, $document, $mdTheming) {
+    $mdTheming.generateTheme('testFill');
+    var primaryPalette = getThemePalettes('testFill').primary;
+    var accentPalette = getThemePalettes('testFill').accent;
+    var backgroundPalette = getThemePalettes('testFill').background;
+    element = $compile('<parentdiv md-theme="testFill"><childdiv>test</childdiv></parentdiv>')($rootScope);
+    var childEl = angular.element(element.children()[0]);
+    $document[0].body.appendChild(element[0]);
+    $mdTheming(element);
+    $mdTheming(childEl);
+
+    element.addClass('_md-theme-fill');
+    $rootScope.$apply();
+    expect(getBackgroundColor(childEl[0])).toEqual(getPaletteColor(backgroundPalette.name, backgroundPalette.hues['default']));
+    element.addClass('md-primary');
+    $rootScope.$apply();
+    expect(getBackgroundColor(childEl[0])).toEqual(getPaletteColor(primaryPalette.name, primaryPalette.hues['default']));
+    element.removeClass('md-primary');
+    element.addClass('md-accent');
+    expect(getBackgroundColor(childEl[0])).toEqual(getPaletteColor(accentPalette.name, accentPalette.hues['default']));
   }));
 });

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -284,3 +284,18 @@
     }
   }
 }
+
+@mixin md-theme-fill-support($hueColor: 'color') {
+  &.md-primary {
+    background-color: '{{primary-' + $hueColor + '}}';
+    color: '{{primary-' + $hueColor + '-contrast}}';
+  }
+  &.md-accent {
+    background-color: '{{accent-' + $hueColor + '}}';
+    color: '{{accent-' + $hueColor + '-contrast}}';
+  }
+  &.md-warn {
+    background-color: '{{warn-' + $hueColor + '}}';
+    color: '{{warn-' + $hueColor + '-contrast}}';
+  }
+}


### PR DESCRIPTION
This deprecates `foreground-*` and instead uses `background-default-contrast-*`. In short:

    newMapping = {
      "foreground-1": "background-default-contrast",
      "foreground-2": "background-default-contrast-secondary",
      "foreground-3": "background-default-contrast-hint",
      "foreground-4": "background-default-contrast-divider"
    }

I also added `contrast-disabled` and `contrast-icon` which are the same as `contrast-hint`.

Now you can create css for items with `primary-contrast-secondary` or others. This should help close issue #7987 

For example, you can now do this:

    md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) md-input-container {
      .md-input {
        @include input-placeholder-color('\'{{primary-contrast-hint}}\'');
        color: '{{primary-contrast}}';
        border-color: '{{primary-contrast-divider}}';
      }
    }