### PR TITLE
fix(datepicker): hidden calendar pane overflowing in IE

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -99,10 +99,9 @@ md-datepicker {
   // overflowing it's parent, however IE and Edge seem to disregard it.
   // The `left: -100%` pulls the element back in order to ensure that
   // it doesn't cause an overflow.
-  left: -100%;
   position: absolute;
   top: 0;
-  left: 0;
+  left: -100%;
   z-index: $z-index-calendar-pane;
   border-width: 1px;
   border-style: solid;


### PR DESCRIPTION
There's a workaround for the datepicker that fixes an overflow in IE and Edge, however it was being overwritten a few lines down.
I couldn't find a good reason for it to be overwritten so I removed it.