### PR TITLE
fix(progress-linear): stop the CSS animations when the element is disabled

### DIFF
--- a/src/components/progressLinear/demoBasicUsage/style.css
+++ b/src/components/progressLinear/demoBasicUsage/style.css
@@ -51,7 +51,6 @@ p.small > code {
 .container {
   display: block;
   position: relative;
-  height: 100%;
   width: 100%;
   border: 2px solid rgb(170,209,249);
   transition: opacity  0.1s linear;

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -115,15 +115,16 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
 
       attr.$observe('disabled', function(value) {
         if (value === true || value === false) {
-          isDisabled = value;
+          isDisabled = !!value;
         } else {
           isDisabled = angular.isDefined(value);
         }
 
-        element.toggleClass(DISABLED_CLASS, !!isDisabled);
+        element.toggleClass(DISABLED_CLASS, isDisabled);
+        container.toggleClass(lastMode, !isDisabled);
       });
 
-      attr.$observe('mdMode',function(mode){
+      attr.$observe('mdMode', function(mode) {
         if (lastMode) container.removeClass( lastMode );
 
         switch( mode ) {
@@ -151,7 +152,7 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
 
         //$log.debug( $mdUtil.supplant(info, [mode]) );
 
-        element.attr("md-mode",mode);
+        element.attr("md-mode", mode);
         attr.mdMode = mode;
       }
     }

--- a/src/components/progressLinear/progress-linear.spec.js
+++ b/src/components/progressLinear/progress-linear.spec.js
@@ -1,150 +1,129 @@
 describe('mdProgressLinear', function() {
 
-  beforeEach(module('material.components.progressLinear'));
+  var element, $rootScope, $compile, $mdConstant;
 
-  it('should auto-set the md-mode to "indeterminate" if not specified', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear></md-progress-linear>' +
-      '</div>')($rootScope);
+  function makeElement(attrs) {
+    element = $compile(
+      '<div>' +
+        '<md-progress-linear ' + (attrs || '') + '></md-progress-linear>' +
+      '</div>'
+    )($rootScope);
 
-    $rootScope.$apply(function() {
-      $rootScope.progress = 50;
-      $rootScope.mode = "";
+    $rootScope.$digest();
+    return element;
+  }
+
+  beforeEach(function() {
+    module('material.components.progressLinear');
+
+    inject(function(_$compile_, _$rootScope_, _$mdConstant_) {
+      $rootScope = _$rootScope_;
+      $compile = _$compile_;
+      $mdConstant = _$mdConstant_;
     });
+  });
 
+  afterEach(function() {
+    element && element.remove();
+  });
+
+  it('should auto-set the md-mode to "indeterminate" if not specified', function() {
+    var element = makeElement();
     var progress = element.find('md-progress-linear');
+
     expect(progress.attr('md-mode')).toEqual('indeterminate');
-  }));
+  });
 
-  it('should auto-set the md-mode to "indeterminate" if specified a not valid mode', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear md-mode="test"></md-progress-linear>' +
-      '</div>')($rootScope);
-
-    $rootScope.$apply(function() {
-      $rootScope.progress = 50;
-      $rootScope.mode = "";
-    });
-
+  it('should auto-set the md-mode to "indeterminate" if specified a not valid mode', function() {
+    var element = makeElement('md-mode="test"');
     var progress = element.find('md-progress-linear');
+
     expect(progress.attr('md-mode')).toEqual('indeterminate');
-  }));
+  });
 
-  it('should trim the md-mode value', inject(function($compile, $rootScope, $mdConstant) {
-    element = $compile('<div>' +
-          '<md-progress-linear md-mode=" indeterminate"></md-progress-linear>' +
-          '</div>')($rootScope);
-
-    $rootScope.$apply(function() {
-    });
-
+  it('should trim the md-mode value', function() {
+    var element = makeElement('md-mode=" indeterminate"');
     var progress = element.find('md-progress-linear');
+
     expect(progress.attr('md-mode')).toEqual('indeterminate');
-  }));
+  });
 
-  it('should auto-set the md-mode to "determinate" if not specified but has value', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}"></md-progress-linear>' +
-      '</div>')($rootScope);
-
-    $rootScope.$apply(function() {
-      $rootScope.progress = 50;
-      $rootScope.mode = "";
-    });
-
+  it('should auto-set the md-mode to "determinate" if not specified but has value', function() {
+    var element = makeElement('value="{{progress}}"');
     var progress = element.find('md-progress-linear');
+
+    $rootScope.$apply('progress = 50');
+
     expect(progress.attr('md-mode')).toEqual('determinate');
-  }));
+  });
 
-  it('should set not transform if mode is undefined', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}" md-mode="{{mode}}">' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
+  it('should set not transform if mode is undefined', function() {
+    var element = makeElement('value="{{progress}}" md-mode="{{mode}}"');
+    var bar2 = element[0].querySelector('._md-bar2');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
-      $rootScope.mode = "";
+      $rootScope.mode = '';
     });
-
-    var progress = element.find('md-progress-linear'),
-      bar2 = angular.element(progress[0].querySelectorAll('._md-bar2'))[0];
 
     expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toEqual('');
-  }));
+  });
 
-  it('should set transform based on value', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}" md-mode="determinate">' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
+  it('should set transform based on value', function() {
+    var element = makeElement('value="{{progress}}" md-mode="determinate"');
+    var bar2 = element[0].querySelector('._md-bar2');
 
-    $rootScope.$apply(function() {
-      $rootScope.progress = 50;
-    });
-
-    var progress = element.find('md-progress-linear'),
-      bar2 = angular.element(progress[0].querySelectorAll('._md-bar2'))[0];
-
+    $rootScope.$apply('progress = 50');
     expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toEqual('translateX(-25%) scale(0.5, 1)');
-  }));
+  });
 
-  it('should update aria-valuenow', inject(function($compile, $rootScope) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}">' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
-
-    $rootScope.$apply(function() {
-      $rootScope.progress = 50;
-    });
-
+  it('should update aria-valuenow', function() {
+    var element = makeElement('value="{{progress}}"');
     var progress = element.find('md-progress-linear');
 
+    $rootScope.$apply('progress = 50');
     expect(progress.eq(0).attr('aria-valuenow')).toEqual('50');
-  }));
+  });
 
-  it('should set transform based on buffer value', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="{{progress}}" md-buffer-value="{{progress2}}" md-mode="buffer">' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
+  it('should set transform based on buffer value', function() {
+    var element = makeElement('value="{{progress}}" md-buffer-value="{{progress2}}" md-mode="buffer"');
+    var bar1 = element[0].querySelector('._md-bar1');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
       $rootScope.progress2 = 75;
     });
 
-    var progress = element.find('md-progress-linear'),
-        bar1 = angular.element(progress[0].querySelectorAll('._md-bar1'))[0];
-
     expect(bar1.style[$mdConstant.CSS.TRANSFORM]).toEqual('translateX(-12.5%) scale(0.75, 1)');
-  }));
+  });
 
-  it('should not set transform in query mode', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<div>' +
-      '<md-progress-linear md-mode="query" value="{{progress}}">' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
+  it('should not set transform in query mode', function() {
+    var element = makeElement('md-mode="query" value="{{progress}}"');
+    var bar2 = element[0].querySelector('._md-bar2');
 
-    $rootScope.$apply(function() {
-      $rootScope.progress = 80;
+    $rootScope.$apply('progress = 80');
+    expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toBeFalsy();
+  });
+
+  describe('disabled mode', function() {
+    it('should hide the element', function() {
+      var element = makeElement('disabled');
+      var progress = element.find('md-progress-linear').eq(0);
+      expect(progress.hasClass('_md-progress-linear-disabled')).toBe(true);
     });
 
-    var progress = element.find('md-progress-linear'),
-      bar2 = angular.element(progress[0].querySelectorAll('._md-bar2'))[0];
+    it('should toggle the mode on the container', function() {
+      var element = makeElement('md-mode="query" ng-disabled="isDisabled"');
+      var container = angular.element(element[0].querySelector('._md-container'));
+      var modeClass = '_md-mode-query';
 
-    expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toBeFalsy();
-  }));
+      expect(container.hasClass(modeClass)).toBe(true);
 
-  it('should hide the element if it is disabled', inject(function($compile, $rootScope) {
-    var element = $compile('<div>' +
-      '<md-progress-linear value="25" disabled>' +
-      '</md-progress-linear>' +
-      '</div>')($rootScope);
+      $rootScope.$apply('isDisabled = true');
+      expect(container.hasClass(modeClass)).toBe(false);
 
-    var progress = element.find('md-progress-linear').eq(0);
-
-    expect(progress.hasClass('_md-progress-linear-disabled')).toBe(true);
-  }));
+      $rootScope.$apply('isDisabled = false');
+      expect(container.hasClass(modeClass)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
* Stops the progressbar's CSS animations if it's disabled. Until now they kept running in the background.
* Cleans up the progressLinear testing setup.
* Fixes a container in the demo being too tall.

Fixes #8764.