### PR TITLE
fix(card): Image selector should only select immediate children or im…

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -60,7 +60,7 @@ md-card {
   }
 
   > img,
-  > :not(md-card-content) img {
+  > md-card-header img {
     box-sizing: border-box;
     display: flex;
     flex: 0 0 auto;


### PR DESCRIPTION
…ages within `md-card-header`

Closes #8785

This allows you to have completely custom card layouts without having the `img` selectors interfere. It should also make it safer to update these selectors as it will no longer break custom layout(only ones uses specific material layouts).

Examples of custom layouts. 

- A table within a card with some fields being images
- A profile type card with your picture in it(think google+ style)
- Any other non standard layout

Note I'm aware you might say use a div with `.md-whiteframe-z1` like the docs. But that means you can't use any other parts that you get for free from cards. You'd also probably end up with something like `<my-custom-card>` as a wrapper which is confusing when it is simple to make `md-card` support more custom layouts.