### PR TITLE
fix(textarea): properly preserve the padding after measuring the lineheight

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -447,8 +447,9 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
 
         if (!lineHeight) {
           // offsetHeight includes padding which can throw off our value
+          var originalPadding = element[0].style.padding || '';
           lineHeight = element.css('padding', 0).prop('offsetHeight');
-          element.css('padding', null);
+          element[0].style.padding = originalPadding;
         }
 
         if (minRows && lineHeight) {

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -193,7 +193,7 @@ describe('md-input-container directive', function() {
     expect(el).toHaveClass('md-input-has-value');
 
     pageScope.$apply('value = ""');
-    
+
     expect(el).not.toHaveClass('md-input-has-value');
   });
 
@@ -750,6 +750,18 @@ describe('md-input-container directive', function() {
     it('should not add the handle if md-no-resize is present', function() {
       createAndAppendElement('md-no-resize');
       expect(element.querySelector('.md-resize-handle')).toBeFalsy();
+    });
+
+    it('should reset the padding after measuring the line height', function() {
+      createAndAppendElement();
+      ngTextarea.triggerHandler('input');
+      expect(textarea.style.padding).toBeFalsy();
+    });
+
+    it('should preserve the original inline padding', function() {
+      createAndAppendElement('style="padding: 10px;"');
+      ngTextarea.triggerHandler('input');
+      expect(textarea.style.padding).toBe('10px');
     });
   });
 


### PR DESCRIPTION
* Fixes the textarea not resetting the padding if the page has jQuery.
* Fixes the textarea not preserving padding from an inline style.

Fixes #8782.