### PR TITLE
fix(chips): detect cursor position for selecting previous chip.

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -114,10 +114,19 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
   }
 
   if (event.keyCode === this.$mdConstant.KEY_CODE.BACKSPACE) {
-    if (chipBuffer) return;
+    // Only select and focus the previous chip, if the current caret position of the
+    // input element is at the beginning.
+    if (getCursorPosition(event.target) !== 0) {
+      return;
+    }
+
     event.preventDefault();
     event.stopPropagation();
-    if (this.items.length) this.selectAndFocusChipSafe(this.items.length - 1);
+
+    if (this.items.length) {
+      this.selectAndFocusChipSafe(this.items.length - 1);
+    }
+
     return;
   }
 
@@ -138,6 +147,19 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
     this.resetChipBuffer();
   }
 };
+
+/**
+ * Returns the cursor position of the specified input element.
+ * If no selection is present it returns -1.
+ * @param element HTMLInputElement
+ * @returns {Number} Cursor Position of the input.
+ */
+function getCursorPosition(element) {
+  if (element.selectionStart === element.selectionEnd) {
+    return element.selectionStart;
+  }
+  return -1;
+}
 
 
 /**

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -175,7 +175,6 @@
             ng-model="$mdChipsCtrl.chipBuffer"\
             ng-focus="$mdChipsCtrl.onInputFocus()"\
             ng-blur="$mdChipsCtrl.onInputBlur()"\
-            ng-trim="false"\
             ng-keydown="$mdChipsCtrl.inputKeydown($event)">';
 
   var CHIP_DEFAULT_TEMPLATE = '\


### PR DESCRIPTION
* Currently we check the truthyness of the chipBuffer, to confirm that the user is at the beginning of the chip input.
  Once he is at the beginning, we select and focus the previous chip, so the user can keep deleting the chips.

* Checking for truthyness is not working, because Angular is trimming all ngModel values for the autocomplete and default chip input.
  This caused issues, where users can't delete their spaces in the input anymore.

Checking the cursor position is more appropriated here, and works without affecting the autocomplete.
This allows the autocomplete to work independently without any changes with the `md-chips` component.

Tested with Chrome, Firefox and IE.

(Would be cool to test with #8752)

Fixes #8750