### PR TITLE
fix(mdAria): apply aria-label to buttons correctly

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -142,7 +142,7 @@ function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
     $mdButtonInkRipple.attach(scope, element);
 
     // Use async expect to support possible bindings in the button label
-    $mdAria.expectWithText(element, 'aria-label');
+    $mdAria.expectWithoutText(element, 'aria-label');
 
     // For anchor elements, we have to set tabindex manually when the
     // element is disabled

--- a/src/components/button/button.spec.js
+++ b/src/components/button/button.spec.js
@@ -31,15 +31,15 @@ describe('md-button', function() {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('should expect an aria-label if element has text content', inject(function($compile, $rootScope, $log) {
+    it('should not expect an aria-label if element has text content', inject(function($compile, $rootScope, $log) {
       spyOn($log, 'warn');
 
       var button = $compile('<md-button>Hello</md-button>')($rootScope);
-      expect(button.attr('aria-label')).toBe("Hello");
+      expect(button.attr('aria-label')).toBeUndefined();
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('should set an aria-label if the text content using bindings', inject(function($$rAF, $compile, $rootScope, $log, $timeout) {
+    it('should not set an aria-label if the text content uses bindings', inject(function($$rAF, $compile, $rootScope, $log, $timeout) {
       spyOn($log, 'warn');
 
       var scope = angular.extend($rootScope.$new(),{greetings : "Welcome"});
@@ -48,7 +48,7 @@ describe('md-button', function() {
       $rootScope.$apply();
       $$rAF.flush();    // needed for $mdAria.expectAsync()
 
-      expect(button.attr('aria-label')).toBe("Welcome");
+      expect(button.attr('aria-label')).toBeUndefined();
       expect($log.warn).not.toHaveBeenCalled();
     }));
 

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -52,7 +52,7 @@ describe('<md-tooltip> directive', function() {
         '</md-button>'
       );
 
-      expect(element.attr('aria-label')).toBe("Hello");
+      expect(element.text()).toBe("Hello");
   });
 
   it('should label parent', function(){

--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -65,7 +65,8 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
   return {
     expect: expect,
     expectAsync: expectAsync,
-    expectWithText: expectWithText
+    expectWithText: expectWithText,
+    expectWithoutText: expectWithoutText
   };
 
   /**
@@ -112,6 +113,15 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
         return getText(element);
       });
     } else {
+      expect(element, attrName, content);
+    }
+  }
+
+  function expectWithoutText(element, attrName) {
+    var content = getText(element);
+    var hasBinding = content.indexOf($interpolate.startSymbol()) > -1;
+
+    if ( !hasBinding && !content) {
       expect(element, attrName, content);
     }
   }

--- a/src/core/services/aria/aria.spec.js
+++ b/src/core/services/aria/aria.spec.js
@@ -39,6 +39,24 @@ describe('$mdAria service', function() {
       expect($log.warn).toHaveBeenCalled();
     }));
 
+    it('should not warn if element has text', inject(function($compile, $rootScope, $log, $mdAria) {
+      spyOn($log, 'warn');
+      var button = $compile('<button>Text</button>')($rootScope);
+
+      $mdAria.expectWithoutText(button, 'aria-label');
+
+      expect($log.warn).not.toHaveBeenCalled();
+    }));
+
+    it('should warn if control is missing text', inject(function($compile, $rootScope, $log, $mdAria) {
+      spyOn($log, 'warn');
+      var radioButton = $compile('<md-radio-button>Text</md-radio-button>')($rootScope);
+
+      $mdAria.expectWithText(radioButton, 'aria-label');
+
+      expect($log.warn).not.toHaveBeenCalled();
+    }));
+
     it('should not warn if child element has attribute', inject(function($compile, $rootScope, $log, $mdAria) {
       spyOn($log, 'warn');
       var button = $compile('<button><md-icon aria-label="text"></md-icon></button>')($rootScope);


### PR DESCRIPTION
I added a method to check for text content before copying or expecting an `aria-label`. It's essentially the inverse of the `expectWithText` method needed for custom radio buttons and checkboxes, which require an `aria-label` to expose an accessible name, even when there's text content. Buttons don't have that same requirement so they shouldn't have text content copied to the `aria-label` attribute. They only need it when there's no text content at all.

Closes #8789