### PR TITLE
fix(toast): apply theming correctly to custom toasts

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -354,8 +354,9 @@ function MdToastProvider($$interimElementProvider) {
             }
           }
 
-
-          return templateRoot.outerHTML;
+          // We have to return the innerHTMl, because we do not want to have the `md-template` element to be
+          // the root element of our interimElement.
+          return templateRoot.innerHTML;
         }
 
         return template || '';


### PR DESCRIPTION
* Custom configurations for `md-toast` didn't receive any theming, because the interimElement service was applying the theming on the the `md-template` element, which was accidentally used as our template root element.

Fixes #8777.