### PR TITLE
fix(autocomplete): list reappearing after tabbing away

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -292,7 +292,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * When the user's mouse leaves the menu, blur events may hide the menu again.
    */
   function onListLeave () {
-    if (!hasFocus) elements.input.focus();
+    if (!hasFocus && !ctrl.hidden) elements.input.focus();
     noBlur = false;
     ctrl.hidden = shouldHide();
   }


### PR DESCRIPTION
The autocomplete list has a `mouseleave` handler that refocuses the input. This caused the dropdown to re-appear if the user tabs away while the mouse is over the list.

Fixes #8748.