### PR TITLE
fix(autocomplete): initialize scope variable with empty string

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -565,6 +565,40 @@ describe('<md-autocomplete>', function() {
       expect($mdUtil.enableScrolling).toHaveBeenCalled();
     }));
 
+    it('should initialize the search text with an empty string', inject(function($mdUtil, $timeout, $material) {
+      var scope = createScope();
+
+      // Delete our searchText variable from the generated scope, because we
+      // want to confirm, that the autocomplete uses an empty string by default.
+      delete scope.searchText;
+
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <md-item-template>{{item.display}}</md-item-template>' +
+        '  <md-not-found>Sorry, not found...</md-not-found>' +
+        '</md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+
+      $material.flushOutstandingAnimations();
+
+      // Run our initial flush
+      $timeout.flush();
+      waitForVirtualRepeat(element);
+
+      // Set our search text to a value that we know doesn't exist
+      expect(scope.searchText).toBe('');
+
+      // Make sure we wrap up anything and remove the element
+      $timeout.flush();
+      element.remove();
+    }));
+
     it('ensures the parent scope digests along with the current scope', inject(function($timeout, $material) {
       var scope = createScope(null, {bang: 'boom'});
       var template =

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -63,7 +63,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Initialize the controller, setup watchers, gather elements
    */
   function init () {
-    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: null, selectedItem: null });
+    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: '', selectedItem: null });
     $mdTheming($element);
     configureWatchers();
     $mdUtil.nextTick(function () {


### PR DESCRIPTION
* Currently the autocomplete searchText will be initialized with the value of null, but this is not valid, because once
  the autocomplete will be focused the searchText will be set to to an empty string.

 In general the searchText should be initialized with an empty string, if the scope variable is not defined.

Fixes #8767