### PR TITLE
fix(dialog): dialog open animation

### DIFF
--- a/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
+++ b/src/components/dialog/demoBasicUsage/dialog1.tmpl.html
@@ -1,4 +1,4 @@
-<md-dialog aria-label="Mango (Fruit)"  ng-cloak>
+<md-dialog aria-label="Mango (Fruit)">
   <form>
     <md-toolbar>
       <div class="md-toolbar-tools">


### PR DESCRIPTION
The `ng-cloak` directive on the root `md-dialog` element in the dialog1.tmpl.html file was keeping the opening animation from occurring. Removed and it now works fine.

Fixes #8560.