### PR TITLE
fix(datepicker): use the short days from the locale

### DIFF
--- a/src/components/datepicker/js/dateLocale.spec.js
+++ b/src/components/datepicker/js/dateLocale.spec.js
@@ -6,6 +6,7 @@ describe('$mdDateLocale', function() {
   var $localeFake = {
     DATETIME_FORMATS: {
       DAY: ['Sundog', 'Mondog', 'Tuesdog', 'Wednesdog', 'Thursdog', 'Fridog', 'Saturdog'],
+      SHORTDAY: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
       MONTH: ['JanZ', 'FebZ', 'MarZ', 'AprZ', 'MayZ', 'JunZ', 'JulZ', 'AugZ', 'SeptZ',
           'OctZ', 'NovZ', 'DecZ'],
       SHORTMONTH: ['JZ', 'FZ', 'MZ', 'AZ', 'MZ', 'JZ', 'JZ', 'AZ', 'SZ', 'OZ', 'NZ', 'DZ']

--- a/src/components/datepicker/js/dateLocaleProvider.js
+++ b/src/components/datepicker/js/dateLocaleProvider.js
@@ -248,8 +248,8 @@
 
       // The default "short" day strings are the first character of each day,
       // e.g., "Monday" => "M".
-      var defaultShortDays = $locale.DATETIME_FORMATS.DAY.map(function(day) {
-        return day[0];
+      var defaultShortDays = $locale.DATETIME_FORMATS.SHORTDAY.map(function(day) {
+        return day.substring(0, 1);
       });
 
       // The default dates are simply the numbers 1 through 31.


### PR DESCRIPTION
The datepicker was taking the first letter of the DAY in the $locale, instead of using the SHORTDAY.

Fixes #8816.