### PR TITLE
fix(site): Fix navigation toggle to properly open on page refresh.

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -502,22 +502,44 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
             return controller.isOpen($scope.section);
           },
           function (open) {
-            var $ul = $element.find('ul');
+            // We must run this in a next tick so that the getTargetHeight function is correct
+            $mdUtil.nextTick(function() {
+              var $ul = $element.find('ul');
+              var $li = $ul[0].querySelector('a.active');
+              var docsMenuContent = document.querySelector('.docs-menu').parentNode;
+              var targetHeight = open ? getTargetHeight() : 0;
 
-            var targetHeight = open ? getTargetHeight() : 0;
-            $timeout(function () {
-              $ul.css({height: targetHeight + 'px'});
-            }, 0, false);
+              $timeout(function () {
+                // Set the height of the list
+                $ul.css({height: targetHeight + 'px'});
 
-            function getTargetHeight() {
-              var targetHeight;
-              $ul.addClass('no-transition');
-              $ul.css('height', '');
-              targetHeight = $ul.prop('clientHeight');
-              $ul.css('height', 0);
-              $ul.removeClass('no-transition');
-              return targetHeight;
-            }
+                // If we are open and the user has not scrolled the content div; scroll the active
+                // list item into view.
+                if (open && $li && $ul[0].scrollTop === 0) {
+                  $timeout(function() {
+                    var activeHeight = $li.scrollHeight;
+                    var activeOffset = $li.offsetTop;
+                    var parentOffset = $li.offsetParent.offsetTop;
+
+                    // Reduce it a bit (2 list items' height worth) so it doesn't touch the nav
+                    var negativeOffset = activeHeight * 2;
+                    var newScrollTop = activeOffset + parentOffset - negativeOffset;
+
+                    $mdUtil.animateScrollTo(docsMenuContent, newScrollTop);
+                  }, 350, false);
+                }
+              }, 0, false);
+
+              function getTargetHeight() {
+                var targetHeight;
+                $ul.addClass('no-transition');
+                $ul.css('height', '');
+                targetHeight = $ul.prop('clientHeight');
+                $ul.css('height', 0);
+                $ul.removeClass('no-transition');
+                return targetHeight;
+              }
+            }, false);
           }
         );
       });

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -19,7 +19,7 @@ angular
 /**
  * @ngInject
  */
-function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $interpolate, $log, $rootElement, $window) {
+function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $interpolate, $log, $rootElement, $window, $$rAF) {
   // Setup some core variables for the processTemplate method
   var startSymbol = $interpolate.startSymbol(),
     endSymbol = $interpolate.endSymbol(),
@@ -750,6 +750,51 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       var form = parent ? angular.element(parent).controller('form') : null;
 
       return form ? form.$submitted : false;
+    },
+
+    /**
+     * Animate the requested element's scrollTop to the requested scrollPosition with basic easing.
+     *
+     * @param element The element to scroll.
+     * @param scrollEnd The new/final scroll position.
+     */
+    animateScrollTo: function(element, scrollEnd) {
+      var scrollStart = element.scrollTop;
+      var scrollChange = scrollEnd - scrollStart;
+      var scrollingDown = scrollStart < scrollEnd;
+      var startTime = $mdUtil.now();
+
+      $$rAF(scrollChunk);
+
+      function scrollChunk() {
+        var newPosition = calculateNewPosition();
+        
+        element.scrollTop = newPosition;
+        
+        if (scrollingDown ? newPosition < scrollEnd : newPosition > scrollEnd) {
+          $$rAF(scrollChunk);
+        }
+      }
+      
+      function calculateNewPosition() {
+        var duration = 1000;
+        var currentTime = $mdUtil.now() - startTime;
+        
+        return ease(currentTime, scrollStart, scrollChange, duration);
+      }
+
+      function ease(currentTime, start, change, duration) {
+        // If the duration has passed (which can occur if our app loses focus due to $$rAF), jump
+        // straight to the proper position
+        if (currentTime > duration) {
+          return start + change;
+        }
+        
+        var ts = (currentTime /= duration) * currentTime;
+        var tc = ts * currentTime;
+
+        return start + change * (-2 * tc + 3 * ts);
+      }
     }
   };
 


### PR DESCRIPTION
Currently, the navigation groups on the left would have their icon appear to be toggled open, but the actual content would be invisible because the element's height was not being properly set.

Fix by setting the height in a `$mdUtil.nextTick()` so that it fires at the appropriate time (and can measure the height).

Additionally, add some code to scroll the selected item into view so that users know which page they are visiting.

Fixes #8841.