### PR TITLE
fix(docs): codepen should link to correct license

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -122,8 +122,8 @@
         return content + '\n\n'+
           commentStart + '\n'+
           'Copyright 2016 Google Inc. All Rights Reserved. \n'+
-          'Use of this source code is governed by an MIT-style license that can be in found'+
-          'in the LICENSE file at http://material.angularjs.org/license.\n'+
+          'Use of this source code is governed by an MIT-style license that can be found'+
+          'in the LICENSE file at http://material.angularjs.org/HEAD/license.\n'+
           commentEnd;
       }
 


### PR DESCRIPTION
* Currently when checking out a codepen, the license will be appended to all source files.
  The license of the docs will be linked inside of that comment. But that link is not correct.

* Fix incorrect wording for the license footer for codpens