### PR TITLE
fix(panel): destroy the scope when the panelRef is destroyed

### DIFF
--- a/src/components/panel/demoBasicUsage/script.js
+++ b/src/components/panel/demoBasicUsage/script.js
@@ -92,8 +92,11 @@ function PanelDialogCtrl(mdPanelRef) {
 
 
 PanelDialogCtrl.prototype.closeDialog = function() {
-  this._mdPanelRef && this._mdPanelRef.close().then(function() {
+  var panelRef = this._mdPanelRef;
+
+  panelRef && panelRef.close().then(function() {
     angular.element(document.querySelector('.demo-dialog-open-button')).focus();
+    panelRef.destroy();
   });
 };
 

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -245,7 +245,9 @@ angular
  * @ngdoc method
  * @name MdPanelRef#close
  * @description
- * Hides and detaches the panel.
+ * Hides and detaches the panel. Note that this will **not** destroy the panel. If you
+ * don't intend on using the panel again, call the {@link MdPanelRef#destroy destroy} method
+ * afterwards.
  *
  * @returns {!angular.$q.Promise} A promise that is resolved when the panel is
  * closed.
@@ -963,6 +965,7 @@ MdPanelRef.prototype.detach = function() {
  * Destroys the panel. The Panel cannot be opened again after this.
  */
 MdPanelRef.prototype.destroy = function() {
+  this._config.scope.$destroy();
   this._config.locals = null;
 };
 
@@ -1197,12 +1200,12 @@ MdPanelRef.prototype._updatePosition = function(opt_init) {
 
   if (positionConfig) {
     positionConfig._setPanelPosition(this._panelEl);
-    
+
     // Hide the panel now that position is known.
     if (opt_init) {
       this._panelContainer.addClass(MD_PANEL_HIDDEN);
     }
-    
+
     this._panelEl.css('top', positionConfig.getTop());
     this._panelEl.css('bottom', positionConfig.getBottom());
     this._panelEl.css('left', positionConfig.getLeft());

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -141,6 +141,16 @@ describe('$mdPanel', function() {
     expect(panelRef._config.locals).toEqual(null);
   });
 
+  it('destroy should destroy the panel scope', function () {
+    openPanel(DEFAULT_CONFIG);
+
+    expect(panelRef._config.scope.$$destroyed).toBe(false);
+
+    panelRef.destroy();
+
+    expect(panelRef._config.scope.$$destroyed).toBe(true);
+  });
+
   describe('promises logic:', function() {
     var config;
 


### PR DESCRIPTION
The panel wasn't destroying its' scope within the `destroy` method, causing potential memory leaks.

Fixes #8845.

CC @ErinCoughlan 