### PR TITLE
fix(bottomSheet): md-bottom-sheet open animation

### DIFF
--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
@@ -1,8 +1,8 @@
-<md-bottom-sheet class="md-grid" layout="column" ng-cloak>
-  <div layout="row" layout-align="center center">
+<md-bottom-sheet class="md-grid" layout="column">
+  <div layout="row" layout-align="center center" ng-cloak>
     <h4>Since <code>clickOutsideToClose = false</code>, drag down or press ESC to close</h4>
   </div>
-  <div>
+  <div ng-cloak>
     <md-list flex layout="row" layout-align="center center">
       <md-list-item ng-repeat="item in items">
         <div>

--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-list-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-list-template.html
@@ -1,6 +1,6 @@
-<md-bottom-sheet class="md-list md-has-header" ng-cloak>
-  <md-subheader>Comment Actions</md-subheader>
-  <md-list>
+<md-bottom-sheet class="md-list md-has-header">
+  <md-subheader ng-cloak>Comment Actions</md-subheader>
+  <md-list ng-cloak>
     <md-list-item ng-repeat="item in items">
 
       <md-button


### PR DESCRIPTION
* The md-bottom-sheet component did not have an opening animation on the docs demo.
* Relocated some ng-cloak directive calls from the md-bottom-sheet root element to its child elements.

Fixes #8854.