### PR TITLE
update(dialog, bottom-sheet): show warning if ng-cloak is applied on template

### DIFF
--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -139,7 +139,8 @@ function MdBottomSheetProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function bottomSheetDefaults($animate, $mdConstant, $mdUtil, $mdTheming, $mdBottomSheet, $rootElement, $mdGesture) {
+  function bottomSheetDefaults($animate, $mdConstant, $mdUtil, $mdTheming, $mdBottomSheet, $rootElement,
+                               $mdGesture, $log) {
     var backdrop;
 
     return {
@@ -159,6 +160,12 @@ function MdBottomSheetProvider($$interimElementProvider) {
 
       // prevent tab focus or click focus on the bottom-sheet container
       element.attr('tabindex',"-1");
+
+      // Once the md-bottom-sheet has `ng-cloak` applied on his template the opening animation will not work properly.
+      // This is a very common problem, so we have to notify the developer about this.
+      if (element.hasClass('ng-cloak')) {
+        $log.warn('$mdBottomSheet: `ng-cloak` on a md-bottom-sheet will possibly affect the opening animation.', element[0]);
+      }
 
       if (!options.disableBackdrop) {
         // Add a backdrop that will close on click

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -63,6 +63,25 @@ describe('$mdBottomSheet service', function () {
         expect(parent.find('md-bottom-sheet').length).toBe(1);
       }));
 
+    it('should warn if the template contains a `ng-cloak`', inject(function($mdBottomSheet, $material, $log) {
+      var parent = angular.element('<div>');
+
+      // Enable spy on $log.warn
+      spyOn($log, 'warn');
+
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet ng-cloak>',
+        parent: parent,
+        clickOutsideToClose: false
+      });
+
+      $material.flushOutstandingAnimations();
+
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
     it('should not append any backdrop when `disableBackdrop === true`',
       inject(function($mdBottomSheet, $rootElement, $material) {
         var parent = angular.element('<div>');

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -694,8 +694,16 @@ function MdDialogProvider($$interimElementProvider) {
         element = angular.element(contentEl);
       }
 
+      var dialogElement = element.find('md-dialog');
+
+      // Once a dialog has `ng-cloak` applied on his template the dialog animation will not work properly.
+      // This is a very common problem, so we have to notify the developer about this.
+      if (dialogElement.hasClass('ng-cloak')) {
+        $log.warn('$mdDialog: `ng-cloak` on a dialog will possibly affect the opening animation.', dialogElement[0]);
+      }
+
       captureParentAndFromToElements(options);
-      configureAria(element.find('md-dialog'), options);
+      configureAria(dialogElement, options);
       showBackdrop(scope, element, options);
 
       return dialogPopIn(element, options)

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -187,6 +187,32 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('md-dialog-content'));
     }));
 
+    it('should warn if the template contains a ng-cloak', inject(function($mdDialog, $rootScope, $document, $log) {
+      var parent = angular.element('<div>');
+
+      // Enable spy on $log.warn
+      spyOn($log, 'warn');
+
+      $mdDialog.show(
+        $mdDialog.alert({
+          template:
+            '<md-dialog ng-cloak>' +
+              '<md-dialog-content>' +
+                '<p>Muppets are the best</p>' +
+              '</md-dialog-content>' +
+            '</md-dialog>',
+          parent: parent
+        })
+      );
+
+      runAnimation(parent.find('md-dialog'));
+
+      console.log($log.warn.logs);
+
+      // The $mdDialog should throw a warning about the `ng-cloak`.
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
     it('should use the prefixed id from `md-dialog` for `md-dialog-content`', inject(function ($mdDialog, $rootScope, $document) {
       jasmine.mockElementFocus(this);
 


### PR DESCRIPTION

* Once a user specifies `ng-cloak` on the template of a `md-dialog` or `md-bottom-sheet`, the opening animation will not work properly.
  The user / developer should be warned about that, because it's quite a common issue.

References #8855. References #8854. References #8805. References #8560.