### PR TITLE
docs(sidenav): add demo for custom sidenav

### DIFF
--- a/src/components/sidenav/demoBasicUsage/index.html
+++ b/src/components/sidenav/demoBasicUsage/index.html
@@ -7,7 +7,6 @@
         class="md-sidenav-left"
         md-component-id="left"
         md-is-locked-open="$mdMedia('gt-md')"
-        md-disable-backdrop
         md-whiteframe="4">
 
       <md-toolbar class="md-theme-indigo">
@@ -27,7 +26,7 @@
 
     <md-content flex layout-padding>
 
-      <div layout="column" layout-fill layout-align="top center">
+      <div layout="column" layout-align="top center">
         <p>
         The left sidenav will 'lock open' on a medium (>=960px wide) device.
         </p>

--- a/src/components/sidenav/demoCustomSidenav/index.html
+++ b/src/components/sidenav/demoCustomSidenav/index.html
@@ -1,0 +1,43 @@
+<div ng-controller="AppCtrl" layout="column" style="height: 500px;" ng-cloak>
+
+  <section layout="row" flex>
+
+    <md-sidenav class="md-sidenav-left" md-component-id="left"
+                md-disable-backdrop="" md-whiteframe="4">
+
+      <md-toolbar class="md-theme-indigo">
+        <h1 class="md-toolbar-tools">Disabled Backdrop</h1>
+      </md-toolbar>
+
+      <md-content layout-margin="">
+        <p>
+          This sidenav is not showing any backdrop, where users can click on it, to close the sidenav.
+        </p>
+        <md-button ng-click="toggleLeft()" class="md-accent">
+          Close this Sidenav
+        </md-button>
+      </md-content>
+
+    </md-sidenav>
+
+    <md-content flex layout-padding>
+
+      <div layout="column" layout-align="top center">
+        <p>
+          Developers can also disable the backdrop of the sidenav.<br/>
+          This will disable the functionality to click outside to close the sidenav.
+        </p>
+
+        <div>
+          <md-button ng-click="toggleLeft()" class="md-raised">
+            Toggle Sidenav
+          </md-button>
+        </div>
+
+      </div>
+
+    </md-content>
+
+  </section>
+
+</div>

--- a/src/components/sidenav/demoCustomSidenav/script.js
+++ b/src/components/sidenav/demoCustomSidenav/script.js
@@ -1,0 +1,12 @@
+angular
+  .module('sidenavDemo2', ['ngMaterial'])
+  .controller('AppCtrl', function ($scope, $timeout, $mdSidenav) {
+    $scope.toggleLeft = buildToggler('left');
+    $scope.toggleRight = buildToggler('right');
+
+    function buildToggler(componentId) {
+      return function() {
+        $mdSidenav(componentId).toggle();
+      }
+    }
+  });


### PR DESCRIPTION
* Fixes the ugly scrollbars from the demo (through layout-fill).
  Horizontal Scrollbar now also appeared on Chrome 51.

* Added a second demo for a sidenav, with custom settings (`md-disable-backdrop`)
  Having the disabled backdrop in the first demo, looks weird and seems like a bug.