### PR TITLE
refactor: Revert CSS privatization.

### DIFF
--- a/docs/app/partials/menu-link.tmpl.html
+++ b/docs/app/partials/menu-link.tmpl.html
@@ -3,7 +3,7 @@
     ng-href="{{section.url}}"
     ng-click="focusSection()">
   {{section | humanizeDoc}}
-  <span class="_md-visually-hidden"
+  <span class="md-visually-hidden"
     ng-if="isSelected()">
     current page
   </span>

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -65,7 +65,7 @@
             <span ng-if="menu.currentPage.name !== menu.currentSection.name">
               <span hide-sm hide-md>{{menu.currentSection.name}}</span>
               <span class="docs-menu-separator-icon" hide-sm hide-md style="transform: translate3d(0, 1px, 0)">
-                <span class="_md-visually-hidden">-</span>
+                <span class="md-visually-hidden">-</span>
                 <md-icon
                     aria-hidden="true"
                     md-svg-src="img/icons/ic_chevron_right_24px.svg"

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -82,7 +82,7 @@ md-autocomplete {
         left: 2px;
         width: auto;
       }
-      ._md-mode-indeterminate {
+      .md-mode-indeterminate {
         position: absolute;
         top: 0;
         left: 0;

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -207,7 +207,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
           </md-virtual-repeat-container>\
         </md-autocomplete-wrap>\
         <aria-status\
-            class="_md-visually-hidden"\
+            class="md-visually-hidden"\
             role="status"\
             aria-live="assertive">\
           <p ng-repeat="message in $mdAutocompleteCtrl.messages track by $index" ng-if="message">{{message}}</p>\
@@ -291,7 +291,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-if="$mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled"\
                 ng-click="$mdAutocompleteCtrl.clear($event)">\
               <md-icon md-svg-src="' + $$mdSvgRegistry.mdClose + '"></md-icon>\
-              <span class="_md-visually-hidden">Clear</span>\
+              <span class="md-visually-hidden">Clear</span>\
             </button>\
                 ';
         }

--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -12,26 +12,26 @@ md-backdrop {
 
   z-index: $z-index-backdrop;
 
-  &._md-menu-backdrop {
+  &.md-menu-backdrop {
     position: fixed !important;
     z-index: $z-index-menu - 1;
   }
-  &._md-select-backdrop {
+  &.md-select-backdrop {
     z-index: $z-index-dialog + 1;
     transition-duration: 0;
   }
-  &._md-dialog-backdrop {
+  &.md-dialog-backdrop {
     z-index: $z-index-dialog - 1;
   }
-  &._md-bottom-sheet-backdrop {
+  &.md-bottom-sheet-backdrop {
     z-index: $z-index-bottom-sheet - 1;
   }
-  &._md-sidenav-backdrop {
+  &.md-sidenav-backdrop {
     z-index: $z-index-sidenav - 1;
   }
 
 
-  &._md-click-catcher {
+  &.md-click-catcher {
     position: absolute;
   }
 

--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -170,7 +170,7 @@ function MdBottomSheetProvider($$interimElementProvider) {
 
       if (!options.disableBackdrop) {
         // Add a backdrop that will close on click
-        backdrop = $mdUtil.createBackdrop(scope, "_md-bottom-sheet-backdrop md-opaque");
+        backdrop = $mdUtil.createBackdrop(scope, "md-bottom-sheet-backdrop md-opaque");
 
         // Prevent mouse focus on backdrop; ONLY programatic focus allowed.
         // This allows clicks on backdrop to propogate to the $rootElement and

--- a/src/components/bottomSheet/demoBasicUsage/style.css
+++ b/src/components/bottomSheet/demoBasicUsage/style.css
@@ -22,7 +22,7 @@
   }
 
 
-md-list-item, md-list-item ._md-list-item-inner {
+md-list-item, md-list-item .md-list-item-inner {
   min-height: 48px;
 
 }
@@ -33,7 +33,7 @@ h2 {
 }
 
 
-.md-subheader ._md-subheader-inner {
+.md-subheader .md-subheader-inner {
   padding: 0;
 }
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -180,7 +180,7 @@ button.md-button.md-fab {
   }
 }
 
-._md-toast-open-top {
+.md-toast-open-top {
   .md-button.md-fab-top-left,
   .md-button.md-fab-top-right {
     transition: $swift-ease-out;
@@ -194,7 +194,7 @@ button.md-button.md-fab {
   }
 }
 
-._md-toast-open-bottom {
+.md-toast-open-bottom {
   .md-button.md-fab-bottom-left,
   .md-button.md-fab-bottom-right {
     transition: $swift-ease-out;

--- a/src/components/checkbox/checkbox-theme.scss
+++ b/src/components/checkbox/checkbox-theme.scss
@@ -7,7 +7,7 @@ md-checkbox.md-THEME_NAME-theme {
     color: '{{background-600}}';
   }
 
-  &.md-checked.md-focused ._md-container:before {
+  &.md-checked.md-focused .md-container:before {
     background-color: '{{accent-color-0.26}}';
   }
 
@@ -19,15 +19,15 @@ md-checkbox.md-THEME_NAME-theme {
     color: '{{accent-color-0.87}}';
   }
 
-  ._md-icon {
+  .md-icon {
     border-color: '{{foreground-2}}';
   }
 
-  &.md-checked ._md-icon {
+  &.md-checked .md-icon {
     background-color: '{{accent-color-0.87}}';
   }
 
-  &.md-checked ._md-icon:after {
+  &.md-checked .md-icon:after {
     border-color: '{{accent-contrast-0.87}}';
   }
 
@@ -49,42 +49,42 @@ md-checkbox.md-THEME_NAME-theme {
         color: '{{warn-color-0.87}}';
       }
 
-      ._md-icon {
+      .md-icon {
         border-color: '{{foreground-2}}';
       }
 
-      &.md-checked ._md-icon {
+      &.md-checked .md-icon {
         background-color: '{{warn-color-0.87}}';
       }
 
-      &.md-checked.md-focused:not([disabled]) ._md-container:before {
+      &.md-checked.md-focused:not([disabled]) .md-container:before {
         background-color: '{{warn-color-0.26}}';
       }
 
-      &.md-checked ._md-icon:after {
+      &.md-checked .md-icon:after {
         border-color: '{{background-200}}';
       }
     }
   }
 
   &[disabled] {
-    ._md-icon {
+    .md-icon {
       border-color: '{{foreground-3}}';
     }
 
-    &.md-checked ._md-icon {
+    &.md-checked .md-icon {
       background-color: '{{foreground-3}}';
     }
 
-    &.md-checked ._md-icon:after {
+    &.md-checked .md-icon:after {
       border-color: '{{background-200}}';
     }
 
-    ._md-icon:after {
+    .md-icon:after {
       border-color: '{{foreground-3}}';
     }
 
-    ._md-label {
+    .md-label {
       color: '{{foreground-3}}';
     }
   }

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -64,10 +64,10 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
     require: '?ngModel',
     priority: 210, // Run before ngAria
     template:
-      '<div class="_md-container" md-ink-ripple md-ink-ripple-checkbox>' +
-        '<div class="_md-icon"></div>' +
+      '<div class="md-container" md-ink-ripple md-ink-ripple-checkbox>' +
+        '<div class="md-icon"></div>' +
       '</div>' +
-      '<div ng-transclude class="_md-label"></div>',
+      '<div ng-transclude class="md-label"></div>',
     compile: compile
   };
 

--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -35,7 +35,7 @@ md-checkbox {
   }
 
   &.md-focused:not([disabled]) {
-    ._md-container:before {
+    .md-container:before {
       left: -8px;
       top: -8px;
       right: -8px;
@@ -43,19 +43,19 @@ md-checkbox {
     }
 
     &:not(.md-checked) {
-      ._md-container:before {
+      .md-container:before {
         background-color: rgba(0, 0, 0, 0.12);
       }
     }
   }
 
-  &.md-align-top-left > div._md-container {
+  &.md-align-top-left > div.md-container {
     top: $checkbox-top;
   }
 
   @include checkbox-container;
 
-  ._md-label {
+  .md-label {
     box-sizing: border-box;
     position: relative;
     display: inline-block;

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -143,7 +143,7 @@ describe('mdCheckbox', function() {
     document.body.appendChild(checkbox[0]);
 
     var container = checkbox.children().eq(0);
-    expect(container[0]).toHaveClass('_md-container');
+    expect(container[0]).toHaveClass('md-container');
 
     // We simulate IE11's focus bug, which always focuses an unfocusable div
     // https://connect.microsoft.com/IE/feedback/details/1028411/

--- a/src/components/chips/chips-theme.scss
+++ b/src/components/chips/chips-theme.scss
@@ -7,7 +7,7 @@ md-chips.md-THEME_NAME-theme {
       box-shadow: 0 2px '{{primary-color}}';
     }
 
-    ._md-chip-input-container {
+    .md-chip-input-container {
       input {
         @include input-placeholder-color('\'{{foreground-3}}\'');
         color: '{{foreground-1}}';

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -60,7 +60,7 @@ $contact-chip-name-width: rem(12) !default;
   @include rtl(padding, $chip-wrap-padding, rtl-value($chip-wrap-padding));
   vertical-align: middle;
 
-  &.md-readonly ._md-chip-input-container {
+  &.md-readonly .md-chip-input-container {
     min-height: $chip-height;
   }
 
@@ -73,7 +73,7 @@ $contact-chip-name-width: rem(12) !default;
     md-chip {
       @include rtl-prop(padding-right, padding-left, $chip-remove-padding-right);
 
-      ._md-chip-content {
+      .md-chip-content {
         @include rtl-prop(padding-right, padding-left, rem(0.4));
       }
     }
@@ -93,7 +93,7 @@ $contact-chip-name-width: rem(12) !default;
     max-width: 100%;
     position: relative;
 
-    ._md-chip-content {
+    .md-chip-content {
       display: block;
       @include rtl(float, left, right);
       white-space: nowrap;
@@ -110,12 +110,12 @@ $contact-chip-name-width: rem(12) !default;
       -khtml-user-select: none; /* webkit (konqueror) browsers */
       -ms-user-select: none; /* IE10+ */
     }
-    ._md-chip-remove-container {
+    .md-chip-remove-container {
       position: absolute;
       @include rtl-prop(right, left, 0);
       line-height: $chip-remove-line-height;
     }
-    ._md-chip-remove {
+    .md-chip-remove {
       text-align: center;
       width: $chip-height;
       height: $chip-height;
@@ -136,7 +136,7 @@ $contact-chip-name-width: rem(12) !default;
       }
     }
   }
-  ._md-chip-input-container {
+  .md-chip-input-container {
     display: block;
     line-height: $chip-height;
     @include rtl(margin, $chip-margin, rtl-value($chip-margin));
@@ -199,11 +199,11 @@ $contact-chip-name-width: rem(12) !default;
 }
 // IE only
 @media screen and (-ms-high-contrast: active) {
-  ._md-chip-input-container,
+  .md-chip-input-container,
   md-chip {
     border: 1px solid #fff;
   }
-  ._md-chip-input-container md-autocomplete {
+  .md-chip-input-container md-autocomplete {
     border: none;
   }
 }

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -217,7 +217,7 @@ describe('<md-chips>', function() {
 
           expect(containers.length).toBe(0);
 
-          var removeContainer = wrap[0].querySelector('._md-chip-remove-container');
+          var removeContainer = wrap[0].querySelector('.md-chip-remove-container');
           expect(removeContainer).not.toBeTruthy();
         });
 
@@ -270,10 +270,10 @@ describe('<md-chips>', function() {
           // and a user-provided value.
           expect(controller.removable).toBe(undefined);
 
-          var containers = wrap[0].querySelectorAll("._md-chip-input-container");
+          var containers = wrap[0].querySelectorAll(".md-chip-input-container");
           expect(containers.length).not.toBe(0);
 
-          var removeContainer = wrap[0].querySelector('._md-chip-remove-container');
+          var removeContainer = wrap[0].querySelector('.md-chip-remove-container');
           expect(removeContainer).toBeTruthy();
         });
 
@@ -289,7 +289,7 @@ describe('<md-chips>', function() {
           expect(wrap.hasClass("md-removable")).toBe(false);
           expect(controller.removable).toBe(false);
 
-          var containers = wrap[0].querySelectorAll("._md-chip-remove-container");
+          var containers = wrap[0].querySelectorAll(".md-chip-remove-container");
           expect(containers.length).toBe(0);
 
           scope.$apply('removable = true');
@@ -297,7 +297,7 @@ describe('<md-chips>', function() {
           expect(wrap.hasClass("md-removable")).toBe(true);
           expect(controller.removable).toBe(true);
 
-          containers = wrap[0].querySelector("._md-chip-remove-container");
+          containers = wrap[0].querySelector(".md-chip-remove-container");
           expect(containers).toBeTruthy();
         });
 
@@ -367,12 +367,12 @@ describe('<md-chips>', function() {
 
           expect(ctrl.removable).toBeUndefined();
 
-          var removeContainer = wrap[0].querySelector('._md-chip-remove-container');
+          var removeContainer = wrap[0].querySelector('.md-chip-remove-container');
           expect(removeContainer).toBeFalsy();
 
           scope.$apply('isRemovable = true');
 
-          removeContainer = wrap[0].querySelector('._md-chip-remove-container');
+          removeContainer = wrap[0].querySelector('.md-chip-remove-container');
           expect(removeContainer).toBeTruthy();
         });
 

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -65,7 +65,7 @@ describe('<md-contact-chips>', function() {
 
         var element = buildChips(CONTACT_CHIPS_TEMPLATE);
         var ctrl = element.controller('mdContactChips');
-        var chip = angular.element(element[0].querySelector('._md-chip-content'));
+        var chip = angular.element(element[0].querySelector('.md-chip-content'));
 
         expect(chip.find('img').length).toBe(1);
     });
@@ -77,7 +77,7 @@ describe('<md-contact-chips>', function() {
 
         var element = buildChips(CONTACT_CHIPS_TEMPLATE);
         var ctrl = element.controller('mdContactChips');
-        var chip = angular.element(element[0].querySelector('._md-chip-content'));
+        var chip = angular.element(element[0].querySelector('.md-chip-content'));
 
         expect(chip.find('img').length).toBe(0);
     });

--- a/src/components/chips/demoBasicUsage/style.scss
+++ b/src/components/chips/demoBasicUsage/style.scss
@@ -7,7 +7,7 @@
 .custom-chips {
   md-chip {
     position: relative;
-    ._md-chip-remove-container {
+    .md-chip-remove-container {
       position: absolute;
       right: 4px;
       top: 4px;

--- a/src/components/chips/js/chipController.js
+++ b/src/components/chips/js/chipController.js
@@ -75,7 +75,7 @@ MdChipCtrl.prototype.init = function(controller) {
  * @return {Object}
  */
 MdChipCtrl.prototype.getChipContent = function() {
-  var chipContents = this.$element[0].getElementsByClassName('_md-chip-content');
+  var chipContents = this.$element[0].getElementsByClassName('md-chip-content');
   return angular.element(chipContents[0]);
 };
 

--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -22,7 +22,7 @@ angular
 // This hint text is hidden within a chip but used by screen readers to
 // inform the user how they can interact with a chip.
 var DELETE_HINT_TEMPLATE = '\
-    <span ng-if="!$mdChipsCtrl.readonly" class="_md-visually-hidden">\
+    <span ng-if="!$mdChipsCtrl.readonly" class="md-visually-hidden">\
       {{$mdChipsCtrl.deleteHint}}\
     </span>';
 
@@ -57,7 +57,7 @@ function MdChip($mdTheming, $mdUtil) {
 
         angular
           .element(element[0]
-          .querySelector('._md-chip-content'))
+          .querySelector('.md-chip-content'))
           .on('blur', function () {
             chipsController.resetSelectedChip();
             chipsController.$scope.$applyAsync();

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -472,7 +472,7 @@ MdChipsCtrl.prototype.selectAndFocusChip = function(index) {
  * Call `focus()` on the chip at `index`
  */
 MdChipsCtrl.prototype.focusChip = function(index) {
-  this.$element[0].querySelector('md-chip[index="' + index + '"] ._md-chip-content').focus();
+  this.$element[0].querySelector('md-chip[index="' + index + '"] .md-chip-content').focus();
 };
 
 /**

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -155,19 +155,18 @@
         <md-chip ng-repeat="$chip in $mdChipsCtrl.items"\
             index="{{$index}}"\
             ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly}">\
-          <div class="_md-chip-content"\
+          <div class="md-chip-content"\
               tabindex="-1"\
               aria-hidden="true"\
               ng-click="!$mdChipsCtrl.readonly && $mdChipsCtrl.focusChip($index)"\
               ng-focus="!$mdChipsCtrl.readonly && $mdChipsCtrl.selectChip($index)"\
               md-chip-transclude="$mdChipsCtrl.chipContentsTemplate"></div>\
           <div ng-if="$mdChipsCtrl.isRemovable()"\
-               class="_md-chip-remove-container"\
+               class="md-chip-remove-container"\
                md-chip-transclude="$mdChipsCtrl.chipRemoveTemplate"></div>\
         </md-chip>\
-        <div class="_md-chip-input-container">\
-          <div ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl"\
-               md-chip-transclude="$mdChipsCtrl.chipInputTemplate"></div>\
+        <div class="md-chip-input-container" ng-if="!$mdChipsCtrl.readonly && $mdChipsCtrl.ngModelCtrl">\
+          <div md-chip-transclude="$mdChipsCtrl.chipInputTemplate"></div>\
         </div>\
       </md-chips-wrap>';
 
@@ -187,14 +186,14 @@
 
   var CHIP_REMOVE_TEMPLATE = '\
       <button\
-          class="_md-chip-remove"\
+          class="md-chip-remove"\
           ng-if="$mdChipsCtrl.isRemovable()"\
           ng-click="$mdChipsCtrl.removeChipAndFocusInput($$replacedScope.$index)"\
           type="button"\
           aria-hidden="true"\
           tabindex="-1">\
         <md-icon md-svg-src="{{ $mdChipsCtrl.mdCloseIcon }}"></md-icon>\
-        <span class="_md-visually-hidden">\
+        <span class="md-visually-hidden">\
           {{$mdChipsCtrl.deleteButtonLabel}}\
         </span>\
       </button>';

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -43,7 +43,7 @@ md-datepicker {
 
 // If the datepicker is inside of a md-input-container
 ._md-datepicker-floating-label {
-  > label:not(.md-no-float):not(._md-container-ignore) {
+  > label:not(.md-no-float):not(.md-container-ignore) {
     $width-offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap;
     $offset: $md-datepicker-triangle-button-width / 2;
     @include rtl(right, $offset, auto);
@@ -220,7 +220,7 @@ md-datepicker[disabled] {
   }
 
   .md-datepicker-input,
-  label:not(.md-no-float):not(._md-container-ignore) {
+  label:not(.md-no-float):not(.md-container-ignore) {
     margin-bottom: -$md-datepicker-border-bottom-gap;
   }
 

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -557,9 +557,9 @@ function MdDialogProvider($$interimElementProvider) {
         '<md-dialog md-theme="{{ dialog.theme }}" aria-label="{{ dialog.ariaLabel }}" ng-class="dialog.css">',
         '  <md-dialog-content class="md-dialog-content" role="document" tabIndex="-1">',
         '    <h2 class="md-title">{{ dialog.title }}</h2>',
-        '    <div ng-if="::dialog.mdHtmlContent" class="_md-dialog-content-body" ',
+        '    <div ng-if="::dialog.mdHtmlContent" class="md-dialog-content-body" ',
         '        ng-bind-html="::dialog.mdHtmlContent"></div>',
-        '    <div ng-if="::!dialog.mdHtmlContent" class="_md-dialog-content-body">',
+        '    <div ng-if="::!dialog.mdHtmlContent" class="md-dialog-content-body">',
         '      <p>{{::dialog.mdTextContent}}</p>',
         '    </div>',
         '    <md-input-container md-no-float ng-if="::dialog.$type == \'prompt\'" class="md-prompt-input-container">',
@@ -995,7 +995,7 @@ function MdDialogProvider($$interimElementProvider) {
       }
 
       if (options.hasBackdrop) {
-        options.backdrop = $mdUtil.createBackdrop(scope, "_md-dialog-backdrop md-opaque");
+        options.backdrop = $mdUtil.createBackdrop(scope, "md-dialog-backdrop md-opaque");
         $animate.enter(options.backdrop, options.parent);
       }
 
@@ -1057,7 +1057,7 @@ function MdDialogProvider($$interimElementProvider) {
       // Set up elements before and after the dialog content to capture focus and
       // redirect back into the dialog.
       topFocusTrap = document.createElement('div');
-      topFocusTrap.classList.add('_md-dialog-focus-trap');
+      topFocusTrap.classList.add('md-dialog-focus-trap');
       topFocusTrap.tabIndex = 0;
 
       bottomFocusTrap = topFocusTrap.cloneNode(false);
@@ -1154,7 +1154,7 @@ function MdDialogProvider($$interimElementProvider) {
       var dialogEl = container.find('md-dialog');
       var animator = $mdUtil.dom.animator;
       var buildTranslateToOrigin = animator.calculateZoomToOrigin;
-      var translateOptions = {transitionInClass: '_md-transition-in', transitionOutClass: '_md-transition-out'};
+      var translateOptions = {transitionInClass: 'md-transition-in', transitionOutClass: 'md-transition-out'};
       var from = animator.toTransformCss(buildTranslateToOrigin(dialogEl, options.openFrom || options.origin));
       var to = animator.toTransformCss("");  // defaults to center display (or parent or $rootElement)
 
@@ -1171,7 +1171,7 @@ function MdDialogProvider($$interimElementProvider) {
 
             if (options.closeTo) {
               // Using the opposite classes to create a close animation to the closeTo element
-              translateOptions = {transitionInClass: '_md-transition-out', transitionOutClass: '_md-transition-in'};
+              translateOptions = {transitionInClass: 'md-transition-out', transitionOutClass: 'md-transition-in'};
               from = to;
               to = animator.toTransformCss(buildTranslateToOrigin(dialogEl, options.closeTo));
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -19,12 +19,12 @@ $dialog-padding: $baseline-grid * 3 !default;
 
 md-dialog {
 
-  &._md-transition-in {
+  &.md-transition-in {
     opacity: 1;
     transition: $swift-ease-out;
     transform: translate(0,0) scale(1.0);
   }
-  &._md-transition-out {
+  &.md-transition-out {
     opacity: 0;
     transition: $swift-ease-out;
     transform: translate(0,100%) scale(0.2);
@@ -70,7 +70,7 @@ md-dialog {
       margin: 0;
     }
 
-    ._md-dialog-content-body {
+    .md-dialog-content-body {
       width:100%;
     }
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -60,7 +60,7 @@ describe('$mdDialog', function() {
           var mdDialog = mdContainer.find('md-dialog');
           var mdContent = mdDialog.find('md-dialog-content');
           var title = mdContent.find('h2');
-          var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
+          var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
           var buttons = parent.find('md-button');
           var css = mdDialog.attr('class').split(' ');
 
@@ -101,7 +101,7 @@ describe('$mdDialog', function() {
       var mdDialog = mdContainer.find('md-dialog');
       var mdContent = mdDialog.find('md-dialog-content');
       var title = mdContent.find('h2');
-      var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
+      var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
       var buttons = parent.find('md-button');
       var theme = mdDialog.attr('md-theme');
       var css = mdDialog.attr('class').split(' ');
@@ -365,7 +365,7 @@ describe('$mdDialog', function() {
       var container = angular.element(parent[0].querySelector('.md-dialog-container'));
       var dialog = parent.find('md-dialog');
       var title = parent.find('h2');
-      var contentBody = parent[0].querySelector('._md-dialog-content-body');
+      var contentBody = parent[0].querySelector('.md-dialog-content-body');
       var buttons = parent.find('md-button');
 
       expect(dialog.attr('role')).toBe('dialog');
@@ -418,7 +418,7 @@ describe('$mdDialog', function() {
 
       runAnimation();
 
-      var contentBody = parent[0].querySelector('._md-dialog-content-body');
+      var contentBody = parent[0].querySelector('.md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('<div class="mine">Choose</div>');
     }));
@@ -439,7 +439,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-      var contentBody = container[0].querySelector('._md-dialog-content-body');
+      var contentBody = container[0].querySelector('.md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('Choose breakfast');
     }));
@@ -460,7 +460,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       var container = angular.element(parent[0].querySelector('.md-dialog-container'));
-      var contentBody = container[0].querySelector('._md-dialog-content-body');
+      var contentBody = container[0].querySelector('.md-dialog-content-body');
 
       expect(contentBody.textContent).toBe('{{1 + 1}}');
     }));
@@ -663,7 +663,7 @@ describe('$mdDialog', function() {
       var mdDialog = mdContainer.find('md-dialog');
       var mdContent = mdDialog.find('md-dialog-content');
       var title = mdContent.find('h2');
-      var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
+      var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
       var inputElement = mdContent.find('input');
       var buttons = parent.find('md-button');
       var theme = mdDialog.attr('md-theme');
@@ -1441,7 +1441,7 @@ describe('$mdDialog', function() {
       $rootScope.$apply();
 
       // It should add two focus traps to the document around the dialog content.
-      var focusTraps = parent.querySelectorAll('._md-dialog-focus-trap');
+      var focusTraps = parent.querySelectorAll('.md-dialog-focus-trap');
       expect(focusTraps.length).toBe(2);
 
       var topTrap = focusTraps[0];
@@ -1466,7 +1466,7 @@ describe('$mdDialog', function() {
       runAnimation();
 
       // All of the focus traps should be removed when the dialog is closed.
-      focusTraps = document.querySelectorAll('._md-dialog-focus-trap');
+      focusTraps = document.querySelectorAll('.md-dialog-focus-trap');
       expect(focusTraps.length).toBe(0);
 
       // Clean up our modifications to the DOM.
@@ -1524,7 +1524,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdDialog = mdContainer.find('md-dialog');
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
-    var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
+    var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
     var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 
@@ -1551,7 +1551,7 @@ describe('$mdDialog with custom interpolation symbols', function() {
     var mdDialog = mdContainer.find('md-dialog');
     var mdContent = mdDialog.find('md-dialog-content');
     var title = mdContent.find('h2');
-    var contentBody = mdContent[0].querySelector('._md-dialog-content-body');
+    var contentBody = mdContent[0].querySelector('.md-dialog-content-body');
     var mdActions = angular.element(mdDialog[0].querySelector('md-dialog-actions'));
     var buttons = mdActions.find('md-button');
 

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -44,7 +44,7 @@
       resetActionIndex();
 
       // Add an animations waiting class so we know not to run
-      $element.addClass('_md-animations-waiting');
+      $element.addClass('md-animations-waiting');
     }
 
     function setupListeners() {
@@ -144,7 +144,7 @@
         // Fire our animation
         $animate.addClass($element, '_md-animations-ready').then(function() {
           // Remove the waiting class
-          $element.removeClass('_md-animations-waiting');
+          $element.removeClass('md-animations-waiting');
         });
       }
 

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -122,7 +122,7 @@
 
     function runAnimation(element) {
       // Don't run if we are still waiting and we are not ready
-      if (element.hasClass('_md-animations-waiting') && !element.hasClass('_md-animations-ready')) {
+      if (element.hasClass('md-animations-waiting') && !element.hasClass('_md-animations-ready')) {
         return;
       }
 

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -125,7 +125,7 @@ md-fab-speed-dial {
   }
 
   // For the initial animation, set the duration to be instant
-  &.md-fling._md-animations-waiting {
+  &.md-fling.md-animations-waiting {
     .md-fab-action-item {
       opacity: 0;
       transition-duration: 0s;

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -75,8 +75,8 @@
     return {
       restrict: 'E',
       transclude: true,
-      template: '<div class="_md-fab-toolbar-wrapper">' +
-      '  <div class="_md-fab-toolbar-content" ng-transclude></div>' +
+      template: '<div class="md-fab-toolbar-wrapper">' +
+      '  <div class="md-fab-toolbar-content" ng-transclude></div>' +
       '</div>',
 
       scope: {
@@ -97,7 +97,7 @@
 
       // Prepend the background element to the trigger's button
       element.find('md-fab-trigger').find('button')
-        .prepend('<div class="_md-fab-toolbar-background"></div>');
+        .prepend('<div class="md-fab-toolbar-background"></div>');
     }
   }
 
@@ -113,7 +113,7 @@
       var ctrl = element.controller('mdFabToolbar');
 
       // Grab the relevant child elements
-      var backgroundElement = el.querySelector('._md-fab-toolbar-background');
+      var backgroundElement = el.querySelector('.md-fab-toolbar-background');
       var triggerElement = el.querySelector('md-fab-trigger button');
       var toolbarElement = el.querySelector('md-toolbar');
       var iconElement = el.querySelector('md-fab-trigger button md-icon');

--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -12,7 +12,7 @@ md-fab-toolbar {
   /*
    * Closed styling
    */
-  ._md-fab-toolbar-wrapper {
+  .md-fab-toolbar-wrapper {
     display: block;
     position: relative;
     overflow: hidden;
@@ -29,7 +29,7 @@ md-fab-toolbar {
       overflow: visible !important;
     }
 
-    ._md-fab-toolbar-background {
+    .md-fab-toolbar-background {
       display: block;
       position: absolute;
       z-index: $z-index-fab + 1;

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -10,7 +10,7 @@ md-input-container.md-THEME_NAME-theme {
   }
 
   label,
-  ._md-placeholder {
+  .md-placeholder {
     color: '{{foreground-3}}';
   }
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -137,7 +137,7 @@ function labelDirective() {
     restrict: 'E',
     require: '^?mdInputContainer',
     link: function(scope, element, attr, containerCtrl) {
-      if (!containerCtrl || attr.mdNoFloat || element.hasClass('_md-container-ignore')) return;
+      if (!containerCtrl || attr.mdNoFloat || element.hasClass('md-container-ignore')) return;
 
       containerCtrl.label = element;
       scope.$on('$destroy', function() {

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -107,7 +107,7 @@ md-input-container {
     }
   }
 
-  label:not(._md-container-ignore) {
+  label:not(.md-container-ignore) {
     position: absolute;
     bottom: 100%;
     @include rtl(left, 0, auto);
@@ -120,8 +120,8 @@ md-input-container {
     }
   }
 
-  label:not(.md-no-float):not(._md-container-ignore),
-  ._md-placeholder {
+  label:not(.md-no-float):not(.md-container-ignore),
+  .md-placeholder {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -141,19 +141,19 @@ md-input-container {
 
     @include rtl(transform-origin, left top, right top);
   }
-  ._md-placeholder {
+  .md-placeholder {
     position: absolute;
     top: 0;
     opacity: 0;
     transition-property: opacity, transform;
     transform: translate3d(0, $input-placeholder-offset + $baseline-grid * 0.75, 0);
   }
-  &.md-input-focused ._md-placeholder {
+  &.md-input-focused .md-placeholder {
     opacity: 1;
     transform: translate3d(0, $input-placeholder-offset, 0);
   }
   // Placeholder should immediately disappear when the user starts typing
-  &.md-input-has-value ._md-placeholder {
+  &.md-input-has-value .md-placeholder {
     transition: none;
     opacity: 0;
   }
@@ -345,7 +345,7 @@ md-input-container {
   &.md-icon-left,
   &.md-icon-right {
     > label {
-      &:not(.md-no-float):not(._md-container-ignore),
+      &:not(.md-no-float):not(.md-container-ignore),
       .md-placeholder {
         width: calc(100% - #{$icon-offset} - #{$input-label-float-width});
       }
@@ -379,7 +379,7 @@ md-input-container {
     padding-right: $icon-offset;
 
     > label {
-      &:not(.md-no-float):not(._md-container-ignore),
+      &:not(.md-no-float):not(.md-container-ignore),
       .md-placeholder {
         width: calc(100% - (#{$icon-offset} * 2));
       }

--- a/src/components/list/demoListControls/style.css
+++ b/src/components/list/demoListControls/style.css
@@ -7,9 +7,9 @@ md-list {
     padding-top:0;
 }
 md-list-item > p,
-md-list-item > ._md-list-item-inner > p,
-md-list-item ._md-list-item-inner > p,
-md-list-item ._md-list-item-inner > ._md-list-item-inner > p {
+md-list-item > .md-list-item-inner > p,
+md-list-item .md-list-item-inner > p,
+md-list-item .md-list-item-inner > .md-list-item-inner > p {
     -webkit-user-select: none; /* Chrome all / Safari all */
     -moz-user-select: none; /* Firefox all */
     -ms-user-select: none; /* IE 10+ */

--- a/src/components/list/list-theme.scss
+++ b/src/components/list/list-theme.scss
@@ -8,7 +8,7 @@ md-list.md-THEME_NAME-theme {
       color: '{{foreground-2}}';
     }
   }
-  ._md-proxy-focus.md-focused div._md-no-style {
+  .md-proxy-focus.md-focused div.md-no-style {
     background-color: '{{background-100}}';
   }
 

--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -243,7 +243,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         if (hasProxiedElement) {
           wrapIn('div');
         } else if (!tEl[0].querySelector('md-button:not(.md-secondary):not(.md-exclude)')) {
-          tEl.addClass('_md-no-proxy');
+          tEl.addClass('md-no-proxy');
         }
       }
 
@@ -272,7 +272,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       function setupProxiedMenu() {
         var menuEl = angular.element(proxyElement);
 
-        var isEndAligned = menuEl.parent().hasClass('_md-secondary-container') ||
+        var isEndAligned = menuEl.parent().hasClass('md-secondary-container') ||
                            proxyElement.parentNode.firstElementChild !== proxyElement;
 
         var xAxisPosition = 'left';
@@ -300,20 +300,20 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
 
       function wrapIn(type) {
         if (type == 'div') {
-          itemContainer = angular.element('<div class="_md-no-style _md-list-item-inner">');
+          itemContainer = angular.element('<div class="md-no-style md-list-item-inner">');
           itemContainer.append(tEl.contents());
-          tEl.addClass('_md-proxy-focus');
+          tEl.addClass('md-proxy-focus');
         } else {
           // Element which holds the default list-item content.
           itemContainer = angular.element(
-            '<div class="md-button _md-no-style">'+
-            '   <div class="_md-list-item-inner"></div>'+
+            '<div class="md-button md-no-style">'+
+            '   <div class="md-list-item-inner"></div>'+
             '</div>'
           );
 
           // Button which shows ripple and executes primary action.
           var buttonWrap = angular.element(
-            '<md-button class="_md-no-style"></md-button>'
+            '<md-button class="md-no-style"></md-button>'
           );
 
           buttonWrap[0].setAttribute('aria-label', tEl[0].textContent);
@@ -339,7 +339,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       }
 
       function wrapSecondaryItems() {
-        var secondaryItemsWrapper = angular.element('<div class="_md-secondary-container">');
+        var secondaryItemsWrapper = angular.element('<div class="md-secondary-container">');
 
         angular.forEach(secondaryItems, function(secondaryItem) {
           wrapSecondaryItem(secondaryItem, secondaryItemsWrapper);
@@ -435,7 +435,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
         computeProxies();
         computeClickable();
 
-        if ($element.hasClass('_md-proxy-focus') && proxies.length) {
+        if ($element.hasClass('md-proxy-focus') && proxies.length) {
           angular.forEach(proxies, function(proxy) {
             proxy = angular.element(proxy);
 
@@ -477,7 +477,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
             $element.addClass('md-clickable');
 
             if (!hasClick) {
-              ctrl.attachRipple($scope, angular.element($element[0].querySelector('._md-no-style')));
+              ctrl.attachRipple($scope, angular.element($element[0].querySelector('.md-no-style')));
             }
           }
         }

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -51,7 +51,7 @@ md-list {
   &.md-dense {
     md-list-item {
       &,
-      ._md-list-item-inner {
+      .md-list-item-inner {
         min-height: $list-item-dense-height;
         @include ie11-min-height-flexbug($list-item-dense-height);
 
@@ -78,7 +78,7 @@ md-list {
 
       &.md-2-line,
       &.md-3-line {
-        &, & > ._md-no-style {
+        &, & > .md-no-style {
           .md-list-item-text {
             &.md-offset {
               @include rtl-prop(margin-left, margin-right, $list-item-primary-width);
@@ -99,7 +99,7 @@ md-list {
       }
 
       &.md-2-line {
-        &, & > ._md-no-style {
+        &, & > .md-no-style {
           min-height: $list-item-dense-two-line-height;
           @include ie11-min-height-flexbug($list-item-dense-two-line-height);
 
@@ -110,7 +110,7 @@ md-list {
       }
 
       &.md-3-line {
-        &, & > ._md-no-style {
+        &, & > .md-no-style {
           
           min-height: $list-item-dense-three-line-height;
           @include ie11-min-height-flexbug($list-item-dense-three-line-height);
@@ -129,7 +129,7 @@ md-list-item {
   // Ensure nested dividers are properly positioned
   position: relative;
 
-  &._md-proxy-focus.md-focused ._md-no-style {
+  &.md-proxy-focus.md-focused .md-no-style {
     transition: background-color 0.15s linear;
   }
 
@@ -163,7 +163,7 @@ md-list-item {
         padding: 0;
       }
 
-      ._md-list-item-inner {
+      .md-list-item-inner {
         // The list item content should fill the complete width.
         width: 100%;
         height: 100%;
@@ -173,8 +173,8 @@ md-list-item {
 
   }
 
-  &._md-no-proxy,
-  ._md-no-style {
+  &.md-no-proxy,
+  .md-no-style {
     position: relative;
     padding: $list-item-padding-vertical $list-item-padding-horizontal;
     flex: 1 1 auto;
@@ -216,7 +216,7 @@ md-list-item {
   }
 
   &,
-  ._md-list-item-inner {
+  .md-list-item-inner {
     display: flex;
     justify-content: flex-start;
     align-items: center;
@@ -280,7 +280,7 @@ md-list-item {
       margin-top: 16px;
     }
 
-    ._md-secondary-container {
+    .md-secondary-container {
       display: flex;
       align-items: center;
 
@@ -321,7 +321,7 @@ md-list-item {
       }
     }
 
-    & > p, & > ._md-list-item-inner > p {
+    & > p, & > .md-list-item-inner > p {
       flex: 1 1 auto;
       margin: 0;
     }
@@ -329,7 +329,7 @@ md-list-item {
 
   &.md-2-line,
   &.md-3-line {
-    &, & > ._md-no-style {
+    &, & > .md-no-style {
       align-items: flex-start;
       justify-content: center;
 
@@ -380,7 +380,7 @@ md-list-item {
   }
 
   &.md-2-line {
-    &, & > ._md-no-style {
+    &, & > .md-no-style {
       height: auto;
 
       min-height: $list-item-two-line-height;
@@ -401,7 +401,7 @@ md-list-item {
   }
 
   &.md-3-line {
-    &, & > ._md-no-style {
+    &, & > .md-no-style {
       height: auto;
 
       min-height: $list-item-three-line-height;

--- a/src/components/list/list.spec.js
+++ b/src/components/list/list.spec.js
@@ -296,7 +296,7 @@ describe('mdListItem directive', function() {
     expect(firstChild.children().length).toBe(3);
 
     var secondaryContainer = firstChild.children().eq(2);
-    expect(secondaryContainer).toHaveClass('_md-secondary-container');
+    expect(secondaryContainer).toHaveClass('md-secondary-container');
 
     // The secondary container should contain the md-icon,
     // which has been transformed to an icon button.
@@ -321,7 +321,7 @@ describe('mdListItem directive', function() {
     expect(firstChild.children().length).toBe(3);
 
     var secondaryContainer = firstChild.children().eq(2);
-    expect(secondaryContainer).toHaveClass('_md-secondary-container');
+    expect(secondaryContainer).toHaveClass('md-secondary-container');
 
     // The secondary container should contain the md-icon,
     // which has been transformed to an icon button.
@@ -353,7 +353,7 @@ describe('mdListItem directive', function() {
     expect(firstChild.children().length).toBe(3);
 
     var secondaryContainer = firstChild.children().eq(2);
-    expect(secondaryContainer).toHaveClass('_md-secondary-container');
+    expect(secondaryContainer).toHaveClass('md-secondary-container');
 
     // The secondary container should hold the two secondary items.
     expect(secondaryContainer.children().length).toBe(2);
@@ -375,7 +375,7 @@ describe('mdListItem directive', function() {
       '  <md-button class="md-exclude" ng-click="sayHello()">Hello</md-button>' +
       '</md-list-item>'
     );
-    expect(listItem.hasClass('_md-no-proxy')).toBeTruthy();
+    expect(listItem.hasClass('md-no-proxy')).toBeTruthy();
   });
 
   it('should copy md-icon.md-secondary attributes to the button', function() {

--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -147,13 +147,13 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
   this.onIsOpenChanged = function(isOpen) {
     if (isOpen) {
       menuContainer.attr('aria-hidden', 'false');
-      $element[0].classList.add('_md-open');
+      $element[0].classList.add('md-open');
       angular.forEach(self.nestedMenus, function(el) {
-        el.classList.remove('_md-open');
+        el.classList.remove('md-open');
       });
     } else {
       menuContainer.attr('aria-hidden', 'true');
-      $element[0].classList.remove('_md-open');
+      $element[0].classList.remove('md-open');
     }
     $scope.$mdMenuIsOpen = self.isOpen;
   };

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -213,7 +213,7 @@ function MenuDirective($mdUtil) {
     var mdMenuCtrl = ctrls[0];
     var isInMenuBar = ctrls[1] != undefined;
     // Move everything into a md-menu-container and pass it to the controller
-    var menuContainer = angular.element( '<div class="_md _md-open-menu-container md-whiteframe-z2"></div>');
+    var menuContainer = angular.element( '<div class="_md md-open-menu-container md-whiteframe-z2"></div>');
     var menuContents = element.children()[1];
 
     element.addClass('_md');     // private md component indicator for styling

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -55,7 +55,7 @@ function MenuProvider($$interimElementProvider) {
       }
 
       if (options.hasBackdrop) {
-        options.backdrop = $mdUtil.createBackdrop(scope, "_md-menu-backdrop _md-click-catcher");
+        options.backdrop = $mdUtil.createBackdrop(scope, "md-menu-backdrop md-click-catcher");
 
         $animate.enter(options.backdrop, $document[0].body);
       }
@@ -88,14 +88,14 @@ function MenuProvider($$interimElementProvider) {
        * For forced closes (like $destroy events), skip the animations
        */
       function animateRemoval() {
-        return $animateCss(element, {addClass: '_md-leave'}).start();
+        return $animateCss(element, {addClass: 'md-leave'}).start();
       }
 
       /**
        * Detach the element
        */
       function detachAndClean() {
-        element.removeClass('_md-active');
+        element.removeClass('md-active');
         detachElement(element, opts);
         opts.alreadyOpen = false;
       }
@@ -134,12 +134,12 @@ function MenuProvider($$interimElementProvider) {
         return $q(function(resolve) {
           var position = calculateMenuPosition(element, opts);
 
-          element.removeClass('_md-leave');
+          element.removeClass('md-leave');
 
           // Animate the menu scaling, and opacity [from its position origin (default == top-left)]
           // to normal scale.
           $animateCss(element, {
-            addClass: '_md-active',
+            addClass: 'md-active',
             from: animator.toCss(position),
             to: animator.toCss({transform: ''})
           })
@@ -198,7 +198,7 @@ function MenuProvider($$interimElementProvider) {
        * clicks, keypresses, backdrop closing, etc.
        */
       function activateInteraction() {
-        element.addClass('_md-clickable');
+        element.addClass('md-clickable');
 
         // close on backdrop click
         if (opts.backdrop) opts.backdrop.on('click', onBackdropClick);
@@ -223,7 +223,7 @@ function MenuProvider($$interimElementProvider) {
         focusTarget && focusTarget.focus();
 
         return function cleanupInteraction() {
-          element.removeClass('_md-clickable');
+          element.removeClass('md-clickable');
           if (opts.backdrop) opts.backdrop.off('click', onBackdropClick);
           opts.menuContentEl.off('keydown', onMenuKeyDown);
           opts.menuContentEl[0].removeEventListener('click', captureClickListener, true);

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -5,7 +5,7 @@ $dense-menu-item-height: 4 * $baseline-grid !default;
 $max-menu-height: 2 * $baseline-grid + $max-visible-items * $menu-item-height !default;
 $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-item-height !default;
 
-._md-open-menu-container {
+.md-open-menu-container {
   position: fixed;
   left: 0;
   top: 0;
@@ -27,12 +27,12 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
   }
 
   // Don't let the user click something until it's animated
-  &:not(._md-clickable) {
+  &:not(.md-clickable) {
     pointer-events: none;
   }
 
   // enter: menu scales in, then list fade in.
-  &._md-active {
+  &.md-active {
     opacity: 1;
     transition: $swift-ease-out;
     transition-duration: 200ms;
@@ -44,7 +44,7 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
     }
   }
   // leave: the container fades out
-  &._md-leave {
+  &.md-leave {
     opacity: 0;
     transition: $swift-ease-in;
     transition-duration: 250ms;

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -16,7 +16,7 @@ describe('material.components.menu', function() {
     });
     attachedElements = [];
 
-    var abandonedMenus = $document[0].querySelectorAll('._md-open-menu-container');
+    var abandonedMenus = $document[0].querySelectorAll('.md-open-menu-container');
     angular.element(abandonedMenus).remove();
   }));
 
@@ -288,7 +288,7 @@ describe('material.components.menu', function() {
     var res;
     el = (el instanceof angular.element) ? el[0] : el;
     inject(function($document) {
-      var container = $document[0].querySelector('._md-open-menu-container');
+      var container = $document[0].querySelector('.md-open-menu-container');
       if (container && container.style.display == 'none') {
         res = [];
       } else {

--- a/src/components/menuBar/js/menuBarController.js
+++ b/src/components/menuBar/js/menuBarController.js
@@ -36,8 +36,8 @@ MenuBarController.prototype.init = function() {
 
   deregisterFns.push(this.$rootScope.$on('$mdMenuOpen', function(event, el) {
     if (self.getMenus().indexOf(el[0]) != -1) {
-      $element[0].classList.add('_md-open');
-      el[0].classList.add('_md-open');
+      $element[0].classList.add('md-open');
+      el[0].classList.add('md-open');
       self.currentlyOpenMenu = el.controller('mdMenu');
       self.currentlyOpenMenu.registerContainerProxy(self.handleKeyDown);
       self.enableOpenOnHover();
@@ -47,8 +47,8 @@ MenuBarController.prototype.init = function() {
   deregisterFns.push(this.$rootScope.$on('$mdMenuClose', function(event, el, opts) {
     var rootMenus = self.getMenus();
     if (rootMenus.indexOf(el[0]) != -1) {
-      $element[0].classList.remove('_md-open');
-      el[0].classList.remove('_md-open');
+      $element[0].classList.remove('md-open');
+      el[0].classList.remove('md-open');
     }
 
     if ($element[0].contains(el[0])) {
@@ -76,8 +76,8 @@ MenuBarController.prototype.init = function() {
 };
 
 MenuBarController.prototype.setKeyboardMode = function(enabled) {
-  if (enabled) this.$element[0].classList.add('_md-keyboard-mode');
-  else this.$element[0].classList.remove('_md-keyboard-mode');
+  if (enabled) this.$element[0].classList.add('md-keyboard-mode');
+  else this.$element[0].classList.remove('md-keyboard-mode');
 };
 
 MenuBarController.prototype.enableOpenOnHover = function() {
@@ -232,7 +232,7 @@ MenuBarController.prototype.getFocusedMenuIndex = function() {
 MenuBarController.prototype.getOpenMenuIndex = function() {
   var menus = this.getMenus();
   for (var i = 0; i < menus.length; ++i) {
-    if (menus[i].classList.contains('_md-open')) return i;
+    if (menus[i].classList.contains('md-open')) return i;
   }
   return -1;
 };

--- a/src/components/menuBar/js/menuBarDirective.js
+++ b/src/components/menuBar/js/menuBarDirective.js
@@ -114,7 +114,7 @@ function MenuBarDirective($mdUtil, $mdTheming) {
           }
           var contentEls = $mdUtil.nodesToArray(menuEl.querySelectorAll('md-menu-content'));
           angular.forEach(contentEls, function(contentEl) {
-            contentEl.classList.add('_md-menu-bar-menu');
+            contentEl.classList.add('md-menu-bar-menu');
             contentEl.classList.add('md-dense');
             if (!contentEl.hasAttribute('width')) {
               contentEl.setAttribute('width', 5);

--- a/src/components/menuBar/menu-bar-theme.scss
+++ b/src/components/menuBar/menu-bar-theme.scss
@@ -4,16 +4,16 @@ md-menu-bar.md-THEME_NAME-theme {
     border-radius: 2px;
   }
 
-  md-menu._md-open > button, md-menu > button:focus {
+  md-menu.md-open > button, md-menu > button:focus {
     outline: none;
     background: '{{background-200}}';
   }
 
-  &._md-open:not(._md-keyboard-mode) md-menu:hover > button {
+  &.md-open:not(.md-keyboard-mode) md-menu:hover > button {
     background-color: '{{ background-500-0.2}}';
   }
 
-  &:not(._md-keyboard-mode):not(._md-open) {
+  &:not(.md-keyboard-mode):not(.md-open) {
     md-menu button:hover,
     md-menu button:focus {
       background: transparent;
@@ -26,7 +26,7 @@ md-menu-content.md-THEME_NAME-theme {
     color: '{{background-A200-0.54}}';
   }
 
-  .md-menu._md-open > .md-button {
+  .md-menu.md-open > .md-button {
     background-color: '{{ background-500-0.2}}';
   }
 }

--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -26,12 +26,12 @@ md-menu-bar {
     height: 5 * $baseline-grid;
   }
 
-  md-backdrop._md-menu-backdrop {
+  md-backdrop.md-menu-backdrop {
     z-index: -2;
   }
 }
 
-md-menu-content._md-menu-bar-menu.md-dense {
+md-menu-content.md-menu-bar-menu.md-dense {
   max-height: none;
   padding: 2 * $baseline-grid 0;
   md-menu-item.md-indent {

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -100,7 +100,7 @@ describe('material.components.menuBar', function() {
         }
 
         function getOpenSubMenu() {
-          var containers = document.body.querySelectorAll('._md-open-menu-container._md-active');
+          var containers = document.body.querySelectorAll('.md-open-menu-container.md-active');
           var lastContainer = containers.item(containers.length - 1);
 
           return angular.element(lastContainer.querySelector('md-menu-content'));

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1228,7 +1228,7 @@ MdPanelRef.prototype._updatePosition = function(opt_init) {
 MdPanelRef.prototype._focusOnOpen = function() {
   if (this._config['focusOnOpen']) {
     // Wait for the template to finish rendering to guarantee md-autofocus has
-    // finished adding the class _md-autofocus, otherwise the focusable element
+    // finished adding the class md-autofocus, otherwise the focusable element
     // isn't available to focus.
     var self = this;
     this._$rootScope['$$postDigest'](function() {

--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -59,7 +59,7 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
   var MODE_DETERMINATE = 'determinate';
   var MODE_INDETERMINATE = 'indeterminate';
   var DISABLED_CLASS = '_md-progress-circular-disabled';
-  var INDETERMINATE_CLASS = '_md-mode-indeterminate';
+  var INDETERMINATE_CLASS = 'md-mode-indeterminate';
 
   return {
     restrict: 'E',

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -13,7 +13,7 @@ md-progress-circular {
         visibility: hidden;
     }
 
-    &._md-mode-indeterminate svg {
+    &.md-mode-indeterminate svg {
         animation: indeterminate-rotate $progress-circular-indeterminate-duration linear infinite;
     }
 

--- a/src/components/progressLinear/progress-linear-theme.scss
+++ b/src/components/progressLinear/progress-linear-theme.scss
@@ -1,46 +1,46 @@
 md-progress-linear.md-THEME_NAME-theme {
-  ._md-container {
+  .md-container {
     background-color: '{{primary-100}}';
   }
 
-  ._md-bar {
+  .md-bar {
     background-color: '{{primary-color}}';
   }
 
   &.md-warn {
-    ._md-container {
+    .md-container {
       background-color: '{{warn-100}}';
     }
 
-    ._md-bar {
+    .md-bar {
       background-color: '{{warn-color}}';
     }
   }
 
   &.md-accent {
-    ._md-container {
+    .md-container {
       background-color: '{{accent-A100}}';
     }
 
-    ._md-bar {
+    .md-bar {
       background-color: '{{accent-color}}';
     }
   }
 
   &[md-mode=buffer] {
     &.md-warn {
-      ._md-bar1 {
+      .md-bar1 {
         background-color: '{{warn-100}}';
       }
-      ._md-dashed:before {
+      .md-dashed:before {
         background: radial-gradient('{{warn-100}}' 0%, '{{warn-100}}' 16%, transparent 42%);
       }
     }
     &.md-accent {
-      ._md-bar1 {
+      .md-bar1 {
         background-color: '{{accent-A100}}';
       }
-      ._md-dashed:before {
+      .md-dashed:before {
         background: radial-gradient('{{accent-A100}}' 0%, '{{accent-A100}}' 16%, transparent 42%);
       }
     }

--- a/src/components/progressLinear/progress-linear.js
+++ b/src/components/progressLinear/progress-linear.js
@@ -66,10 +66,10 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
 
   return {
     restrict: 'E',
-    template: '<div class="_md-container">' +
-      '<div class="_md-dashed"></div>' +
-      '<div class="_md-bar _md-bar1"></div>' +
-      '<div class="_md-bar _md-bar2"></div>' +
+    template: '<div class="md-container">' +
+      '<div class="md-dashed"></div>' +
+      '<div class="md-bar md-bar1"></div>' +
+      '<div class="md-bar md-bar2"></div>' +
       '</div>',
     compile: compile
   };
@@ -87,9 +87,9 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
     var lastMode;
     var isDisabled = attr.hasOwnProperty('disabled');
     var toVendorCSS = $mdUtil.dom.animator.toCss;
-    var bar1 = angular.element(element[0].querySelector('._md-bar1'));
-    var bar2 = angular.element(element[0].querySelector('._md-bar2'));
-    var container = angular.element(element[0].querySelector('._md-container'));
+    var bar1 = angular.element(element[0].querySelector('.md-bar1'));
+    var bar2 = angular.element(element[0].querySelector('.md-bar2'));
+    var container = angular.element(element[0].querySelector('.md-container'));
 
     element
       .attr('md-mode', mode())
@@ -132,10 +132,10 @@ function MdProgressLinearDirective($mdTheming, $mdUtil, $log) {
           case MODE_BUFFER:
           case MODE_DETERMINATE:
           case MODE_INDETERMINATE:
-            container.addClass( lastMode = "_md-mode-" + mode );
+            container.addClass( lastMode = "md-mode-" + mode );
             break;
           default:
-            container.addClass( lastMode = "_md-mode-" + MODE_INDETERMINATE );
+            container.addClass( lastMode = "md-mode-" + MODE_INDETERMINATE );
             break;
         }
       });

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -13,7 +13,7 @@ md-progress-linear {
     visibility: hidden;
   }
 
-  ._md-container {
+  .md-container {
     display:block;
     position: relative;
     overflow: hidden;
@@ -23,7 +23,7 @@ md-progress-linear {
 
     transform: translate(0, 0) scale(1, 1);
 
-    ._md-bar {
+    .md-bar {
       position: absolute;
 
       left: 0;
@@ -34,7 +34,7 @@ md-progress-linear {
       height: $progress-linear-bar-height;
     }
 
-    ._md-dashed:before {
+    .md-dashed:before {
       content: "";
       display: none;
       position: absolute;
@@ -48,7 +48,7 @@ md-progress-linear {
       background-position: 0px -23px;
     }
 
-    ._md-bar1, ._md-bar2 {
+    .md-bar1, .md-bar2 {
 
       // Just set the transition information here.
       // Note: the actual transform values are calculated in JS
@@ -60,28 +60,28 @@ md-progress-linear {
     // Animations for modes: Determinate, InDeterminate, and Query
     // ************************************************************
 
-    &._md-mode-query {
-        ._md-bar1 {
+    &.md-mode-query {
+        .md-bar1 {
           display: none;
         }
-        ._md-bar2 {
+        .md-bar2 {
           transition: all 0.2s linear;
           animation: query .8s infinite cubic-bezier(0.390, 0.575, 0.565, 1.000);
         }
       }
 
-    &._md-mode-determinate {
-      ._md-bar1 {
+    &.md-mode-determinate {
+      .md-bar1 {
         display: none;
       }
     }
 
-    &._md-mode-indeterminate {
-      ._md-bar1 {
+    &.md-mode-indeterminate {
+      .md-bar1 {
         animation: md-progress-linear-indeterminate-scale-1 4s infinite,
                    md-progress-linear-indeterminate-1 4s infinite;
       }
-      ._md-bar2 {
+      .md-bar2 {
         animation: md-progress-linear-indeterminate-scale-2 4s infinite,
                    md-progress-linear-indeterminate-2 4s infinite;
       }
@@ -91,10 +91,10 @@ md-progress-linear {
     ._md-progress-linear-disabled & {
       animation: none;
 
-      ._md-bar1 {
+      .md-bar1 {
         animation-name: none;
       }
-      ._md-bar2 {
+      .md-bar2 {
         animation-name: none;
       }
     }
@@ -102,12 +102,12 @@ md-progress-linear {
 
   // Special animations for the `buffer` mode
 
-  ._md-container._md-mode-buffer {
+  .md-container.md-mode-buffer {
     background-color: transparent !important;
 
     transition: all 0.2s linear;
 
-    ._md-dashed:before {
+    .md-dashed:before {
       display: block;
       animation: buffer 3s infinite linear;
     }

--- a/src/components/progressLinear/progress-linear.spec.js
+++ b/src/components/progressLinear/progress-linear.spec.js
@@ -59,7 +59,7 @@ describe('mdProgressLinear', function() {
 
   it('should set not transform if mode is undefined', function() {
     var element = makeElement('value="{{progress}}" md-mode="{{mode}}"');
-    var bar2 = element[0].querySelector('._md-bar2');
+    var bar2 = element[0].querySelector('.md-bar2');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
@@ -71,7 +71,7 @@ describe('mdProgressLinear', function() {
 
   it('should set transform based on value', function() {
     var element = makeElement('value="{{progress}}" md-mode="determinate"');
-    var bar2 = element[0].querySelector('._md-bar2');
+    var bar2 = element[0].querySelector('.md-bar2');
 
     $rootScope.$apply('progress = 50');
     expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toEqual('translateX(-25%) scale(0.5, 1)');
@@ -87,7 +87,7 @@ describe('mdProgressLinear', function() {
 
   it('should set transform based on buffer value', function() {
     var element = makeElement('value="{{progress}}" md-buffer-value="{{progress2}}" md-mode="buffer"');
-    var bar1 = element[0].querySelector('._md-bar1');
+    var bar1 = element[0].querySelector('.md-bar1');
 
     $rootScope.$apply(function() {
       $rootScope.progress = 50;
@@ -99,7 +99,7 @@ describe('mdProgressLinear', function() {
 
   it('should not set transform in query mode', function() {
     var element = makeElement('md-mode="query" value="{{progress}}"');
-    var bar2 = element[0].querySelector('._md-bar2');
+    var bar2 = element[0].querySelector('.md-bar2');
 
     $rootScope.$apply('progress = 80');
     expect(bar2.style[$mdConstant.CSS.TRANSFORM]).toBeFalsy();
@@ -114,8 +114,8 @@ describe('mdProgressLinear', function() {
 
     it('should toggle the mode on the container', function() {
       var element = makeElement('md-mode="query" ng-disabled="isDisabled"');
-      var container = angular.element(element[0].querySelector('._md-container'));
-      var modeClass = '_md-mode-query';
+      var container = angular.element(element[0].querySelector('.md-container'));
+      var modeClass = 'md-mode-query';
 
       expect(container.hasClass(modeClass)).toBe(true);
 

--- a/src/components/radioButton/radio-button-theme.scss
+++ b/src/components/radioButton/radio-button-theme.scss
@@ -1,19 +1,19 @@
 
 md-radio-button.md-THEME_NAME-theme {
-  ._md-off {
+  .md-off {
     border-color: '{{foreground-2}}';
   }
 
-  ._md-on {
+  .md-on {
     background-color: '{{accent-color-0.87}}';
   }
-  &.md-checked ._md-off {
+  &.md-checked .md-off {
     border-color: '{{accent-color-0.87}}';
   }
   &.md-checked .md-ink-ripple {
     color: '{{accent-color-0.87}}';
   }
-  ._md-container .md-ripple {
+  .md-container .md-ripple {
     color: '{{accent-A700}}';
   }
 }
@@ -24,12 +24,12 @@ md-radio-button.md-THEME_NAME-theme {
   &:not([disabled]) {
     .md-primary,
     &.md-primary {
-      ._md-on {
+      .md-on {
         background-color: '{{primary-color-0.87}}';
       }
       .md-checked,
       &.md-checked {
-        ._md-off {
+        .md-off {
           border-color: '{{primary-color-0.87}}';
         }
       }
@@ -39,19 +39,19 @@ md-radio-button.md-THEME_NAME-theme {
           color: '{{primary-color-0.87}}';
         }
       }
-      ._md-container .md-ripple {
+      .md-container .md-ripple {
         color: '{{primary-600}}';
       }
     }
 
     .md-warn,
     &.md-warn {
-      ._md-on {
+      .md-on {
         background-color: '{{warn-color-0.87}}';
       }
       .md-checked,
       &.md-checked {
-        ._md-off {
+        .md-off {
           border-color: '{{warn-color-0.87}}';
         }
       }
@@ -61,7 +61,7 @@ md-radio-button.md-THEME_NAME-theme {
           color: '{{warn-color-0.87}}';
         }
       }
-      ._md-container .md-ripple {
+      .md-container .md-ripple {
         color: '{{warn-600}}';
       }
     }
@@ -71,10 +71,10 @@ md-radio-button.md-THEME_NAME-theme {
   &[disabled] {
     color: '{{foreground-3}}';
 
-    ._md-container ._md-off {
+    .md-container .md-off {
       border-color: '{{foreground-3}}';
     }
-    ._md-container ._md-on {
+    .md-container .md-on {
       border-color: '{{foreground-3}}';
     }
   }
@@ -93,15 +93,15 @@ md-radio-group.md-THEME_NAME-theme {
 }
 
 md-radio-group.md-THEME_NAME-theme.md-focused:not(:empty) {
-  .md-checked ._md-container:before {
+  .md-checked .md-container:before {
     background-color: '{{accent-color-0.26}}';
   }
-  &.md-primary .md-checked ._md-container:before,
-  .md-checked.md-primary ._md-container:before {
+  &.md-primary .md-checked .md-container:before,
+  .md-checked.md-primary .md-container:before {
     background-color: '{{primary-color-0.26}}';
   }
-  &.md-warn .md-checked ._md-container:before,
-  .md-checked.md-warn ._md-container:before {
+  &.md-warn .md-checked .md-container:before,
+  .md-checked.md-warn .md-container:before {
     background-color: '{{warn-color-0.26}}';
   }
 }

--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -249,11 +249,11 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
     restrict: 'E',
     require: '^mdRadioGroup',
     transclude: true,
-    template: '<div class="_md-container" md-ink-ripple md-ink-ripple-checkbox>' +
-                '<div class="_md-off"></div>' +
-                '<div class="_md-on"></div>' +
+    template: '<div class="md-container" md-ink-ripple md-ink-ripple-checkbox>' +
+                '<div class="md-off"></div>' +
+                '<div class="md-on"></div>' +
               '</div>' +
-              '<div ng-transclude class="_md-label"></div>',
+              '<div ng-transclude class="md-label"></div>',
     link: link
   };
 

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -16,12 +16,12 @@ md-radio-button {
   &[disabled] {
     cursor: default;
 
-    ._md-container {
+    .md-container {
       cursor: default;
     }
   }
 
-  ._md-container {
+  .md-container {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -61,11 +61,11 @@ md-radio-button {
     }
   }
 
-  &.md-align-top-left > div._md-container {
+  &.md-align-top-left > div.md-container {
      top: $radio-top-left;
    }
 
-  ._md-off {
+  .md-off {
     box-sizing: border-box;
     position: absolute;
     top: 0;
@@ -78,7 +78,7 @@ md-radio-button {
     transition: border-color ease 0.28s;
   }
 
-  ._md-on {
+  .md-on {
     box-sizing: border-box;
     position: absolute;
     top: 0;
@@ -90,11 +90,11 @@ md-radio-button {
     transform: scale(0);
   }
 
-  &.md-checked ._md-on {
+  &.md-checked .md-on {
     transform: scale(0.50);
   }
 
-  ._md-label {
+  .md-label {
     box-sizing: border-box;
     position: relative;
     display: inline-block;
@@ -143,7 +143,7 @@ md-radio-group {
     outline: none;
   }
   &.md-focused {
-    .md-checked ._md-container:before {
+    .md-checked .md-container:before {
       left: -8px;
       top: -8px;
       right: -8px;
@@ -167,7 +167,7 @@ md-radio-group {
 }
 
 @media screen and (-ms-high-contrast: active) {
-  md-radio-button.md-default-theme ._md-on {
+  md-radio-button.md-default-theme .md-on {
     background-color: #fff;
   }
 }

--- a/src/components/select/demoSelectHeader/index.html
+++ b/src/components/select/demoSelectHeader/index.html
@@ -12,7 +12,7 @@
             <input ng-model="searchTerm"
                    type="search"
                    placeholder="Search for a vegetable.."
-                   class="demo-header-searchbox _md-text">
+                   class="demo-header-searchbox md-text">
           </md-select-header>
           <md-optgroup label="vegetables">
             <md-option ng-value="vegetable" ng-repeat="vegetable in vegetables |

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -2,9 +2,9 @@ md-input-container {
   &.md-input-focused {
     &:not(.md-input-has-value) {
       md-select.md-THEME_NAME-theme {
-        ._md-select-value {
+        .md-select-value {
           color: '{{primary-color}}';
-          &._md-select-placeholder {
+          &.md-select-placeholder {
             color: '{{primary-color}}';
           }
         }
@@ -13,63 +13,63 @@ md-input-container {
   }
 
   &.md-input-invalid {
-    md-select.md-THEME_NAME-theme ._md-select-value {
+    md-select.md-THEME_NAME-theme .md-select-value {
       color: '{{warn-A700}}' !important;
       border-bottom-color: '{{warn-A700}}' !important;
     }
 
-    md-select.md-THEME_NAME-theme.md-no-underline ._md-select-value {
+    md-select.md-THEME_NAME-theme.md-no-underline .md-select-value {
       border-bottom-color: transparent !important;
     }
   }
 }
 
 md-select.md-THEME_NAME-theme {
-  &[disabled] ._md-select-value {
+  &[disabled] .md-select-value {
     border-bottom-color: transparent;
     background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
     background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
   }
-  ._md-select-value {
-    &._md-select-placeholder {
+  .md-select-value {
+    &.md-select-placeholder {
       color: '{{foreground-3}}';
     }
     border-bottom-color: '{{foreground-4}}';
   }
-  &.md-no-underline ._md-select-value {
+  &.md-no-underline .md-select-value {
     border-bottom-color: transparent !important;
   }
   &.ng-invalid.ng-touched {
-    ._md-select-value {
+    .md-select-value {
       color: '{{warn-A700}}' !important;
       border-bottom-color: '{{warn-A700}}' !important;
     }
-    &.md-no-underline ._md-select-value {
+    &.md-no-underline .md-select-value {
       border-bottom-color: transparent !important;
     }
   }
   &:not([disabled]):focus {
-    ._md-select-value {
+    .md-select-value {
       border-bottom-color: '{{primary-color}}';
       color: '{{ foreground-1 }}';
-      &._md-select-placeholder {
+      &.md-select-placeholder {
         color: '{{ foreground-1 }}';
       }
     }
-    &.md-no-underline ._md-select-value {
+    &.md-no-underline .md-select-value {
       border-bottom-color: transparent !important;
     }
-    &.md-accent ._md-select-value {
+    &.md-accent .md-select-value {
       border-bottom-color: '{{accent-color}}';
     }
-    &.md-warn ._md-select-value {
+    &.md-warn .md-select-value {
       border-bottom-color: '{{warn-color}}';
     }
   }
   &[disabled] {
-    ._md-select-value {
+    .md-select-value {
       color: '{{foreground-3}}';
-      &._md-select-placeholder {
+      &.md-select-placeholder {
         color: '{{foreground-3}}';
       }
     }
@@ -88,7 +88,7 @@ md-select-menu.md-THEME_NAME-theme {
       color: '{{background-900-0.87}}';
 
       &[disabled] {
-        ._md-text {
+        .md-text {
           color: '{{background-400-0.87}}';
         }
       }
@@ -116,10 +116,10 @@ md-select-menu.md-THEME_NAME-theme {
   }
 }
 
-._md-checkbox-enabled.md-THEME_NAME-theme {
+.md-checkbox-enabled.md-THEME_NAME-theme {
   @include checkbox-primary('[selected]');
 
-  md-option ._md-text {
+  md-option .md-text {
     color: '{{background-900-0.87}}';
   }
 }

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -13,7 +13,7 @@
 var SELECT_EDGE_MARGIN = 8;
 var selectNextId = 0;
 var CHECKBOX_SELECTION_INDICATOR =
-  angular.element('<div class="_md-container"><div class="_md-icon"></div></div>');
+  angular.element('<div class="md-container"><div class="md-icon"></div></div>');
 
 angular.module('material.components.select', [
     'material.core',
@@ -77,7 +77,7 @@ angular.module('material.components.select', [
  * @param md-no-asterisk {boolean=} When set to true, an asterisk will not be appended to the floating label.
  * @param {string=} aria-label Optional label for accessibility. Only necessary if no placeholder or
  * explicit label is present.
- * @param {string=} md-container-class Class list to get applied to the `._md-select-menu-container`
+ * @param {string=} md-container-class Class list to get applied to the `.md-select-menu-container`
  * element (for custom styling).
  *
  * @usage
@@ -182,8 +182,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
   function compile(element, attr) {
     // add the select value that will hold our placeholder or selected option value
     var valueEl = angular.element('<md-select-value><span></span></md-select-value>');
-    valueEl.append('<span class="_md-select-icon" aria-hidden="true"></span>');
-    valueEl.addClass('_md-select-value');
+    valueEl.append('<span class="md-select-icon" aria-hidden="true"></span>');
+    valueEl.addClass('md-select-value');
     if (!valueEl[0].hasAttribute('id')) {
       valueEl.attr('id', 'select_value_label_' + $mdUtil.nextUid());
     }
@@ -214,7 +214,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     }
 
     if (attr.name) {
-      var autofillClone = angular.element('<select class="_md-visually-hidden">');
+      var autofillClone = angular.element('<select class="md-visually-hidden">');
       autofillClone.attr({
         'name': attr.name,
         'aria-hidden': 'true',
@@ -245,7 +245,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
     // Use everything that's left inside element.contents() as the contents of the menu
     var multipleContent = isMultiple ? 'multiple' : '';
     var selectTemplate = '' +
-      '<div class="_md-select-menu-container" aria-hidden="true">' +
+      '<div class="md-select-menu-container" aria-hidden="true">' +
       '<md-select-menu {0}>{1}</md-select-menu>' +
       '</div>';
 
@@ -342,14 +342,14 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       mdSelectCtrl.setIsPlaceholder = function(isPlaceholder) {
         if (isPlaceholder) {
-          valueEl.addClass('_md-select-placeholder');
+          valueEl.addClass('md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.addClass('_md-placeholder');
+            containerCtrl.label.addClass('md-placeholder');
           }
         } else {
-          valueEl.removeClass('_md-select-placeholder');
+          valueEl.removeClass('md-select-placeholder');
           if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.removeClass('_md-placeholder');
+            containerCtrl.label.removeClass('md-placeholder');
           }
         }
       };
@@ -509,7 +509,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       function findSelectContainer() {
         selectContainer = angular.element(
-          element[0].querySelector('._md-select-menu-container')
+          element[0].querySelector('.md-select-menu-container')
         );
         selectScope = scope;
         if (attr.mdContainerClass) {
@@ -764,7 +764,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdTheming) {
 
             // Remove the checkbox container, because it will cause the label to wrap inside of the placeholder.
             // It should be not displayed inside of the label element.
-            var checkboxContainer = el.querySelector('._md-container');
+            var checkboxContainer = el.querySelector('.md-container');
             if (checkboxContainer) {
               html = html.replace(checkboxContainer.outerHTML, '');
             }
@@ -884,7 +884,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
 
   function compile(element, attr) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
-    element.append(angular.element('<div class="_md-text">').append(element.contents()));
+    element.append(angular.element('<div class="md-text">').append(element.contents()));
 
     element.attr('tabindex', attr.tabindex || '0');
 
@@ -907,7 +907,7 @@ function OptionDirective($mdButtonInkRipple, $mdUtil) {
     var selectCtrl = ctrls[1];
 
     if (selectCtrl.isMultiple) {
-      element.addClass('_md-checkbox-enabled');
+      element.addClass('md-checkbox-enabled');
       element.prepend(CHECKBOX_SELECTION_INDICATOR.clone());
     }
 
@@ -1024,7 +1024,7 @@ function OptgroupDirective() {
         labelElement = angular.element('<label>');
         el.prepend(labelElement);
       }
-      labelElement.addClass('_md-container-ignore');
+      labelElement.addClass('md-container-ignore');
       if (attrs.label) labelElement.text(attrs.label);
     }
   }
@@ -1077,7 +1077,7 @@ function SelectProvider($$interimElementProvider) {
        * skip the animations
        */
       function animateRemoval() {
-        return $animateCss(element, {addClass: '_md-leave'}).start();
+        return $animateCss(element, {addClass: 'md-leave'}).start();
       }
 
       /**
@@ -1085,7 +1085,7 @@ function SelectProvider($$interimElementProvider) {
        */
       function cleanElement() {
 
-        element.removeClass('_md-active');
+        element.removeClass('md-active');
         element.attr('aria-hidden', 'true');
         element[0].style.display = 'none';
 
@@ -1133,7 +1133,7 @@ function SelectProvider($$interimElementProvider) {
 
           try {
 
-            $animateCss(element, {removeClass: '_md-leave', duration: 0})
+            $animateCss(element, {removeClass: 'md-leave', duration: 0})
               .start()
               .then(positionAndFocusMenu)
               .then(resolve);
@@ -1159,7 +1159,7 @@ function SelectProvider($$interimElementProvider) {
           info.dropDown.element.css(animator.toCss(info.dropDown.styles));
 
           $$rAF(function() {
-            element.addClass('_md-active');
+            element.addClass('md-active');
             info.dropDown.element.css(animator.toCss({transform: ''}));
 
             autoFocus(opts.focusedNode);
@@ -1185,7 +1185,7 @@ function SelectProvider($$interimElementProvider) {
 
         if (options.hasBackdrop) {
           // Override duration to immediately show invisible backdrop
-          options.backdrop = $mdUtil.createBackdrop(scope, "_md-select-backdrop _md-click-catcher");
+          options.backdrop = $mdUtil.createBackdrop(scope, "md-select-backdrop md-click-catcher");
           $animate.enter(options.backdrop, $document[0].body, null, {duration: 0});
         }
 
@@ -1288,7 +1288,7 @@ function SelectProvider($$interimElementProvider) {
         var dropDown = opts.selectEl;
         var selectCtrl = dropDown.controller('mdSelectMenu') || {};
 
-        element.addClass('_md-clickable');
+        element.addClass('md-clickable');
 
         // Close on backdrop click
         opts.backdrop && opts.backdrop.on('click', onBackdropClick);
@@ -1303,7 +1303,7 @@ function SelectProvider($$interimElementProvider) {
           dropDown.off('keydown', onMenuKeyDown);
           dropDown.off('click', checkCloseMenu);
 
-          element.removeClass('_md-clickable');
+          element.removeClass('md-clickable');
           opts.isRemoved = true;
         };
 
@@ -1501,7 +1501,7 @@ function SelectProvider($$interimElementProvider) {
 
       // Remove padding before we compute the position of the menu
       if (isScrollable) {
-        selectNode.classList.add('_md-overflow');
+        selectNode.classList.add('md-overflow');
       }
 
       var focusedNode = centeredNode;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -11,21 +11,21 @@ $select-max-visible-options: 5 !default;
 // Fixes the animations with the floating label when select is inside an input container
 md-input-container {
   &:not([md-no-float]) {
-    ._md-select-placeholder span:first-child {
+    .md-select-placeholder span:first-child {
       transition: transform $swift-ease-out-duration $swift-ease-out-timing-function;
       @include rtl(transform-origin, left top, right top);
     }
   }
   &.md-input-focused {
     &:not([md-no-float]) {
-      ._md-select-placeholder span:first-child {
+      .md-select-placeholder span:first-child {
         transform: translateY(-22px) translateX(-2px) scale(0.75);
       }
     }
   }
 }
 
-._md-select-menu-container {
+.md-select-menu-container {
   position: fixed;
   left: 0;
   top: 0;
@@ -37,7 +37,7 @@ md-input-container {
   transform: translateY(-1px);
 
   // Don't let the user select a new choice while it's animating
-  &:not(._md-clickable) {
+  &:not(.md-clickable) {
     pointer-events: none;
   }
 
@@ -48,7 +48,7 @@ md-input-container {
 
 
   // enter: md-select scales in, then options fade in.
-  &._md-active {
+  &.md-active {
     display: block;
     opacity: 1;
     md-select-menu {
@@ -64,7 +64,7 @@ md-input-container {
   }
 
   // leave: the container fades out
-  &._md-leave {
+  &.md-leave {
     opacity: 0;
     transition: $swift-ease-in;
     transition-duration: 250ms;
@@ -83,7 +83,7 @@ md-input-container > md-select {
 // asterisk denoting that it is required
 md-input-container:not(.md-input-has-value) {
   md-select[required], md-select.ng-required {
-    ._md-select-value span:first-child:after {
+    .md-select-value span:first-child:after {
       content: ' *';
       font-size: 13px;
       vertical-align: top;
@@ -93,7 +93,7 @@ md-input-container:not(.md-input-has-value) {
 
 md-input-container.md-input-invalid {
   md-select {
-    ._md-select-value {
+    .md-select-value {
       border-bottom-style: solid;
       padding-bottom: 1px;
     }
@@ -106,7 +106,7 @@ md-select {
 
   &[required], &.ng-required {
     &.ng-invalid {
-      ._md-select-value span:first-child:after {
+      .md-select-value span:first-child:after {
         content: ' *';
         font-size: 13px;
         vertical-align: top;
@@ -114,7 +114,7 @@ md-select {
     }
   }
 
-  &[disabled] ._md-select-value {
+  &[disabled] .md-select-value {
     background-position: 0 bottom;
     // This background-size is coordinated with a linear-gradient set in select-theme.scss
     // to create a dotted line under the input.
@@ -134,19 +134,19 @@ md-select {
       cursor: pointer
     }
     &.ng-invalid.ng-touched {
-      ._md-select-value {
+      .md-select-value {
         border-bottom-style: solid;
         padding-bottom: 1px;
       }
     }
     &:focus {
-      ._md-select-value {
+      .md-select-value {
         border-bottom-width: 2px;
         border-bottom-style: solid;
         padding-bottom: 0;
       }
       &.ng-invalid.ng-touched {
-        ._md-select-value {
+        .md-select-value {
           padding-bottom: 0;
         }
       }
@@ -155,13 +155,13 @@ md-select {
 }
 
 // Fix value by 1px to align with standard text inputs (and spec)
-md-input-container.md-input-has-value ._md-select-value {
-  > span:not(._md-select-icon) {
+md-input-container.md-input-has-value .md-select-value {
+  > span:not(.md-select-icon) {
     transform: translate3d(0, 1px, 0);
   }
 }
 
-._md-select-value {
+.md-select-value {
   display: flex;
   align-items: center;
   padding: 2px 2px 1px;
@@ -175,19 +175,19 @@ md-input-container.md-input-has-value ._md-select-value {
   flex-grow: 1;
 
 
-  > span:not(._md-select-icon) {
+  > span:not(.md-select-icon) {
     max-width: 100%;
     flex: 1 1 auto;
     text-overflow: ellipsis;
     white-space: nowrap;
     overflow: hidden;
 
-    ._md-text {
+    .md-text {
       display: inline;
     }
   }
 
-  ._md-select-icon {
+  .md-select-icon {
     display: block;
     align-items: flex-end;
     text-align: end;
@@ -197,7 +197,7 @@ md-input-container.md-input-has-value ._md-select-value {
     font-size: 1.2rem;
   }
 
-  ._md-select-icon:after {
+  .md-select-icon:after {
     display: block;
     content: '\25BC';
     position: relative;
@@ -207,7 +207,7 @@ md-input-container.md-input-has-value ._md-select-value {
     transform: scaleY(0.6) scaleX(1);
   }
 
-  &._md-select-placeholder {
+  &.md-select-placeholder {
     display: flex;
     order: 1;
     pointer-events: none;
@@ -224,7 +224,7 @@ md-select-menu {
     flex-direction: column-reverse;
   }
 
-  &:not(._md-overflow) {
+  &:not(.md-overflow) {
     md-content {
       padding-top: $baseline-grid;
       padding-bottom: $baseline-grid;
@@ -267,7 +267,7 @@ md-option {
     outline: none;
   }
 
-  ._md-text {
+  .md-text {
     @include not-selectable();
     width: auto;
     white-space: nowrap;
@@ -294,7 +294,7 @@ md-optgroup {
 }
 
 @media screen and (-ms-high-contrast: active) {
-  ._md-select-backdrop {
+  .md-select-backdrop {
     background-color: transparent;
   }
   md-select-menu {
@@ -303,13 +303,13 @@ md-optgroup {
 }
 
 md-select-menu[multiple] {
-  md-option._md-checkbox-enabled {
+  md-option.md-checkbox-enabled {
     @include rtl(padding-left, $select-option-padding * 2.5, $select-option-padding);
     @include rtl(padding-right, $select-option-padding, $select-option-padding * 2.5);
 
     @include checkbox-container('[selected]');
 
-    ._md-container {
+    .md-container {
       @include rtl(margin-left, $select-option-padding * (2 / 3), auto);
       @include rtl(margin-right, auto, $select-option-padding * (2 / 3));
     }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -11,7 +11,7 @@ describe('<md-select>', function() {
 
   afterEach(inject(function ($document) {
     var body = $document[0].body;
-    var children = body.querySelectorAll('._md-select-menu-container');
+    var children = body.querySelectorAll('.md-select-menu-container');
     for (var i = 0; i < children.length; i++) {
       angular.element(children[i]).remove();
     }
@@ -63,7 +63,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val" md-container-class="test"').find('md-select');
     openSelect(select);
 
-    var container = $document[0].querySelector('._md-select-menu-container');
+    var container = $document[0].querySelector('.md-select-menu-container');
     expect(container).toBeTruthy();
     expect(container.classList.contains('test')).toBe(true);
   }));
@@ -72,7 +72,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val" data-md-container-class="test"').find('md-select');
     openSelect(select);
 
-    var container = $document[0].querySelector('._md-select-menu-container');
+    var container = $document[0].querySelector('.md-select-menu-container');
     expect(container).toBeTruthy();
     expect(container.classList.contains('test')).toBe(true);
   }));
@@ -81,7 +81,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val" x-md-container-class="test"').find('md-select');
     openSelect(select);
 
-    var container = $document[0].querySelector('._md-select-menu-container');
+    var container = $document[0].querySelector('.md-select-menu-container');
     expect(container).toBeTruthy();
     expect(container.classList.contains('test')).toBe(true);
   }));
@@ -90,7 +90,7 @@ describe('<md-select>', function() {
     var select = setupSelect('ng-model="val"').find('md-select');
     var ownsId = select.attr('aria-owns');
     expect(ownsId).toBeTruthy();
-    var containerId = select[0].querySelector('._md-select-menu-container').getAttribute('id');
+    var containerId = select[0].querySelector('.md-select-menu-container').getAttribute('id');
     expect(ownsId).toBe(containerId);
   });
 
@@ -327,7 +327,7 @@ describe('<md-select>', function() {
       var select = setupSelect('ng-model="someVal" placeholder="Hello world"', null, true).find('md-select');
       var label = select.find('md-select-value');
       expect(label.text()).toBe('Hello world');
-      expect(label.hasClass('_md-select-placeholder')).toBe(true);
+      expect(label.hasClass('md-select-placeholder')).toBe(true);
     });
 
     it('sets itself to the selected option\'s label', inject(function($rootScope, $compile) {
@@ -351,8 +351,8 @@ describe('<md-select>', function() {
 
       // Ensure every md-option element does not have a checkbox prepended to it.
       for (var i = 0; i < options.length; i++) {
-        var checkBoxContainer = options[i].querySelector('._md-container');
-        var checkBoxIcon = options[i].querySelector('._md-icon');
+        var checkBoxContainer = options[i].querySelector('.md-container');
+        var checkBoxIcon = options[i].querySelector('.md-icon');
         expect(checkBoxContainer).toBe(null);
         expect(checkBoxIcon).toBe(null);
       }
@@ -399,8 +399,8 @@ describe('<md-select>', function() {
 
       // Ensure every md-option element has a checkbox prepended to it.
       for (var i = 0; i < options.length; i++) {
-        var checkBoxContainer = options[i].querySelector('._md-container');
-        var checkBoxIcon = options[i].querySelector('._md-icon');
+        var checkBoxContainer = options[i].querySelector('.md-container');
+        var checkBoxIcon = options[i].querySelector('.md-icon');
         expect(checkBoxContainer).not.toBe(null);
         expect(checkBoxIcon).not.toBe(null);
       }
@@ -448,7 +448,7 @@ describe('<md-select>', function() {
             '  </md-select>' +
             '</md-input-container>')($rootScope);
 
-        var optgroupLabel = select[0].querySelector('._md-container-ignore');
+        var optgroupLabel = select[0].querySelector('.md-container-ignore');
 
         expect(optgroupLabel).toBe(null);
       }));
@@ -1326,9 +1326,9 @@ describe('<md-select>', function() {
 
   function expectSelectClosed(element) {
     inject(function($document) {
-      var menu = angular.element($document[0].querySelector('._md-select-menu-container'));
+      var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
       if (menu.length) {
-        if (menu.hasClass('_md-active') || menu.attr('aria-hidden') == 'false') {
+        if (menu.hasClass('md-active') || menu.attr('aria-hidden') == 'false') {
           throw Error('Expected select to be closed');
         }
       }
@@ -1337,8 +1337,8 @@ describe('<md-select>', function() {
 
   function expectSelectOpen(element) {
     inject(function($document) {
-      var menu = angular.element($document[0].querySelector('._md-select-menu-container'));
-      if (!(menu.hasClass('_md-active') && menu.attr('aria-hidden') == 'false')) {
+      var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
+      if (!(menu.hasClass('md-active') && menu.attr('aria-hidden') == 'false')) {
         throw Error('Expected select to be open');
       }
     });

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -249,7 +249,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     },
     controller: '$mdSidenavController',
     compile: function(element) {
-      element.addClass('_md-closed');
+      element.addClass('md-closed');
       element.attr('tabIndex', '-1');
       return postLink;
     }
@@ -277,7 +277,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
 
     // Only create the backdrop if the backdrop isn't disabled.
     if (!angular.isDefined(attr.mdDisableBackdrop)) {
-      backdrop = $mdUtil.createBackdrop(scope, "_md-sidenav-backdrop md-opaque ng-enter");
+      backdrop = $mdUtil.createBackdrop(scope, "md-sidenav-backdrop md-opaque ng-enter");
     }
 
     element.addClass('_md');     // private md component indicator for styling
@@ -310,12 +310,12 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
     function updateIsLocked(isLocked, oldValue) {
       scope.isLockedOpen = isLocked;
       if (isLocked === oldValue) {
-        element.toggleClass('_md-locked-open', !!isLocked);
+        element.toggleClass('md-locked-open', !!isLocked);
       } else {
-        $animate[isLocked ? 'addClass' : 'removeClass'](element, '_md-locked-open');
+        $animate[isLocked ? 'addClass' : 'removeClass'](element, 'md-locked-open');
       }
       if (backdrop) {
-        backdrop.toggleClass('_md-locked-open', !!isLocked);
+        backdrop.toggleClass('md-locked-open', !!isLocked);
       }
     }
 
@@ -343,7 +343,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
       return promise = $q.all([
         isOpen && backdrop ? $animate.enter(backdrop, parent) : backdrop ?
                              $animate.leave(backdrop) : $q.when(true),
-        $animate[isOpen ? 'removeClass' : 'addClass'](element, '_md-closed')
+        $animate[isOpen ? 'removeClass' : 'addClass'](element, 'md-closed')
       ]).then(function() {
         // Perform focus when animations are ALL done...
         if (scope.isOpen) {

--- a/src/components/sidenav/sidenav.scss
+++ b/src/components/sidenav/sidenav.scss
@@ -18,50 +18,50 @@ md-sidenav {
     list-style: none;
   }
 
-  &._md-closed {
+  &.md-closed {
     display: none;
   }
-  &._md-closed-add,
-  &._md-closed-remove {
+  &.md-closed-add,
+  &.md-closed-remove {
     display: flex;
     transition: 0.2s ease-in all;
   }
 
-  &._md-closed-add._md-closed-add-active,
-  &._md-closed-remove._md-closed-remove-active {
+  &.md-closed-add.md-closed-add-active,
+  &.md-closed-remove.md-closed-remove-active {
     transition: $swift-ease-out;
   }
 
-  &._md-locked-open-add,
-  &._md-locked-open-remove {
+  &.md-locked-open-add,
+  &.md-locked-open-remove {
     position: static;
     display: flex;
     transform: translate3d(0, 0, 0);
   }
 
-  &._md-locked-open,
-  &._md-locked-open._md-closed,
-  &._md-locked-open._md-closed.md-sidenav-left,
-  &._md-locked-open._md-closed.md-sidenav-right,
-  &._md-locked-open-remove._md-closed {
+  &.md-locked-open,
+  &.md-locked-open.md-closed,
+  &.md-locked-open.md-closed.md-sidenav-left,
+  &.md-locked-open.md-closed.md-sidenav-right,
+  &.md-locked-open-remove.md-closed {
     position: static;
     display: flex;
     transform: translate3d(0, 0, 0);
   }
-  &._md-locked-open-remove-active {
+  &.md-locked-open-remove-active {
     transition: width $swift-ease-in-duration $swift-ease-in-timing-function,
                 min-width $swift-ease-in-duration $swift-ease-in-timing-function;
     width: 0 !important;
     min-width: 0 !important;
   }
 
-  &._md-closed._md-locked-open-add {
+  &.md-closed.md-locked-open-add {
     width: 0 !important;
     min-width: 0 !important;
     transform: translate3d(0%, 0, 0);
   }
 
-  &._md-closed._md-locked-open-add-active {
+  &.md-closed.md-locked-open-add-active {
     transition: width $swift-ease-in-duration $swift-ease-in-timing-function,
                 min-width $swift-ease-in-duration $swift-ease-in-timing-function;
     width: $sidenav-mobile-width;
@@ -71,7 +71,7 @@ md-sidenav {
 
   @extend .md-sidenav-left;
 }
-._md-sidenav-backdrop._md-locked-open {
+.md-sidenav-backdrop.md-locked-open {
   display: none;
 }
 
@@ -79,7 +79,7 @@ md-sidenav {
   left: 0;
   top: 0;
   transform: translate3d(0%, 0, 0);
-  &._md-closed {
+  &.md-closed {
     transform: translate3d(-100%, 0, 0);
   }
 }
@@ -88,7 +88,7 @@ md-sidenav {
   left: 100%;
   top: 0;
   transform: translate(-100%, 0);
-  &._md-closed {
+  &.md-closed {
     transform: translate(0%, 0);
   }
 }

--- a/src/components/sidenav/sidenav.spec.js
+++ b/src/components/sidenav/sidenav.spec.js
@@ -27,12 +27,12 @@ describe('mdSidenav', function() {
       $rootScope.$apply('show = true');
 
       $material.flushOutstandingAnimations();
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
       expect(el.parent().find('md-backdrop').length).toBe(1);
 
       $rootScope.$apply('show = false');
       $material.flushOutstandingAnimations();
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
       expect(el.parent().find('md-backdrop').length).toBe(0);
     }));
 
@@ -145,12 +145,12 @@ describe('mdSidenav', function() {
 
     it('should lock open when is-locked-open is true', inject(function($rootScope, $material, $document) {
       var el = setup('md-is-open="show" md-is-locked-open="lock"');
-      expect(el.hasClass('_md-locked-open')).toBe(false);
+      expect(el.hasClass('md-locked-open')).toBe(false);
       $rootScope.$apply('lock = true');
-      expect(el.hasClass('_md-locked-open')).toBe(true);
+      expect(el.hasClass('md-locked-open')).toBe(true);
       $rootScope.$apply('show = true');
       $material.flushOutstandingAnimations();
-      expect(el.parent().find('md-backdrop').hasClass('_md-locked-open')).toBe(true);
+      expect(el.parent().find('md-backdrop').hasClass('md-locked-open')).toBe(true);
     }));
 
     it('should expose $mdMedia service as $media local in is-locked-open attribute', function() {
@@ -179,22 +179,22 @@ describe('mdSidenav', function() {
       var controller = el.controller('mdSidenav');
 
       // Should start closed
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
 
       controller.open();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
 
       controller.close();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
 
       controller.toggle();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
     }));
 
   });
@@ -277,7 +277,7 @@ describe('mdSidenav', function() {
       flush();
       expect(openDone).toBe(2);
       expect(closeDone).toBe(0);
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
 
       controller
         .close()
@@ -286,7 +286,7 @@ describe('mdSidenav', function() {
       flush();
       expect(openDone).toBe(2);
       expect(closeDone).toBe(1);
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
     });
 
   });
@@ -309,22 +309,22 @@ describe('mdSidenav', function() {
       instance.open();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
 
       instance.close();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
 
       instance.toggle();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(false);
+      expect(el.hasClass('md-closed')).toBe(false);
 
       instance.toggle();
       scope.$apply();
 
-      expect(el.hasClass('_md-closed')).toBe(true);
+      expect(el.hasClass('md-closed')).toBe(true);
     }));
 
     it('exposes state', inject(function($mdSidenav) {

--- a/src/components/slider/slider-theme.scss
+++ b/src/components/slider/slider-theme.scss
@@ -1,38 +1,38 @@
 md-slider.md-THEME_NAME-theme {
 
-  ._md-track {
+  .md-track {
     background-color: '{{foreground-3}}';
   }
-  ._md-track-ticks {
+  .md-track-ticks {
     color: '{{background-contrast}}';
   }
-  ._md-focus-ring {
+  .md-focus-ring {
     background-color: '{{accent-A200-0.2}}';
   }
-  ._md-disabled-thumb {
+  .md-disabled-thumb {
     border-color: '{{background-color}}';
     background-color: '{{background-color}}';
   }
 
-  &._md-min {
-    ._md-thumb:after {
+  &.md-min {
+    .md-thumb:after {
       background-color: '{{background-color}}';
       border-color: '{{foreground-3}}';
     }
 
-    ._md-focus-ring {
+    .md-focus-ring {
       background-color: '{{foreground-3-0.38}}';
     }
 
     &[md-discrete] {
-      ._md-thumb {
+      .md-thumb {
         &:after {
           background-color: '{{background-contrast}}';
           border-color: transparent;
         }
       }
 
-      ._md-sign {
+      .md-sign {
         background-color: '{{background-400}}';
         &:after {
           border-top-color: '{{background-400}}';
@@ -40,7 +40,7 @@ md-slider.md-THEME_NAME-theme {
       }
 
       &[md-vertical] {
-        ._md-sign:after {
+        .md-sign:after {
           border-top-color: transparent;
           border-left-color: '{{background-400}}';
         }
@@ -48,14 +48,14 @@ md-slider.md-THEME_NAME-theme {
     }
   }
 
-  ._md-track._md-track-fill {
+  .md-track.md-track-fill {
     background-color: '{{accent-color}}';
   }
-  ._md-thumb:after {
+  .md-thumb:after {
     border-color: '{{accent-color}}';
     background-color: '{{accent-color}}';
   }
-  ._md-sign {
+  .md-sign {
     background-color: '{{accent-color}}';
     &:after {
       border-top-color: '{{accent-color}}';
@@ -63,28 +63,28 @@ md-slider.md-THEME_NAME-theme {
   }
 
   &[md-vertical] {
-    ._md-sign:after {
+    .md-sign:after {
       border-top-color: transparent;
       border-left-color: '{{accent-color}}';
     }
   }
 
-  ._md-thumb-text {
+  .md-thumb-text {
     color: '{{accent-contrast}}';
   }
 
   &.md-warn {
-    ._md-focus-ring {
+    .md-focus-ring {
       background-color: '{{warn-200-0.38}}';
     }
-    ._md-track._md-track-fill {
+    .md-track.md-track-fill {
       background-color: '{{warn-color}}';
     }
-    ._md-thumb:after {
+    .md-thumb:after {
       border-color: '{{warn-color}}';
       background-color: '{{warn-color}}';
     }
-    ._md-sign {
+    .md-sign {
       background-color: '{{warn-color}}';
 
       &:after {
@@ -93,29 +93,29 @@ md-slider.md-THEME_NAME-theme {
     }
 
     &[md-vertical] {
-      ._md-sign:after {
+      .md-sign:after {
         border-top-color: transparent;
         border-left-color: '{{warn-color}}';
       }
     }
 
-    ._md-thumb-text {
+    .md-thumb-text {
       color: '{{warn-contrast}}';
     }
   }
 
   &.md-primary {
-    ._md-focus-ring {
+    .md-focus-ring {
       background-color: '{{primary-200-0.38}}';
     }
-    ._md-track._md-track-fill {
+    .md-track.md-track-fill {
       background-color: '{{primary-color}}';
     }
-    ._md-thumb:after {
+    .md-thumb:after {
       border-color: '{{primary-color}}';
       background-color: '{{primary-color}}';
     }
-    ._md-sign {
+    .md-sign {
       background-color: '{{primary-color}}';
 
       &:after {
@@ -124,23 +124,23 @@ md-slider.md-THEME_NAME-theme {
     }
 
     &[md-vertical] {
-      ._md-sign:after {
+      .md-sign:after {
         border-top-color: transparent;
         border-left-color: '{{primary-color}}';
       }
     }
 
-    ._md-thumb-text {
+    .md-thumb-text {
       color: '{{primary-contrast}}';
     }
   }
 
   &[disabled] {
-    ._md-thumb:after {
+    .md-thumb:after {
       border-color: transparent;
     }
-    &:not(._md-min), &[md-discrete] {
-      ._md-thumb:after {
+    &:not(.md-min), &[md-discrete] {
+      .md-thumb:after {
         background-color: '{{foreground-3}}';
         border-color: transparent;
       }
@@ -148,7 +148,7 @@ md-slider.md-THEME_NAME-theme {
   }
 
   &[disabled][readonly] {
-    ._md-sign {
+    .md-sign {
       background-color: '{{background-400}}';
       &:after {
         border-top-color: '{{background-400}}';
@@ -156,13 +156,13 @@ md-slider.md-THEME_NAME-theme {
     }
 
     &[md-vertical] {
-      ._md-sign:after {
+      .md-sign:after {
         border-top-color: transparent;
         border-left-color: '{{background-400}}';
       }
     }
 
-    ._md-disabled-thumb {
+    .md-disabled-thumb {
       border-color: transparent;
       background-color: transparent;
     }

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -139,21 +139,21 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     scope: {},
     require: ['?ngModel', '?^mdSliderContainer'],
     template:
-      '<div class="_md-slider-wrapper">' +
-        '<div class="_md-slider-content">' +
-          '<div class="_md-track-container">' +
-            '<div class="_md-track"></div>' +
-            '<div class="_md-track _md-track-fill"></div>' +
-            '<div class="_md-track-ticks"></div>' +
+      '<div class="md-slider-wrapper">' +
+        '<div class="md-slider-content">' +
+          '<div class="md-track-container">' +
+            '<div class="md-track"></div>' +
+            '<div class="md-track md-track-fill"></div>' +
+            '<div class="md-track-ticks"></div>' +
           '</div>' +
-          '<div class="_md-thumb-container">' +
-            '<div class="_md-thumb"></div>' +
-            '<div class="_md-focus-thumb"></div>' +
-            '<div class="_md-focus-ring"></div>' +
-            '<div class="_md-sign">' +
-              '<span class="_md-thumb-text"></span>' +
+          '<div class="md-thumb-container">' +
+            '<div class="md-thumb"></div>' +
+            '<div class="md-focus-thumb"></div>' +
+            '<div class="md-focus-ring"></div>' +
+            '<div class="md-sign">' +
+              '<span class="md-thumb-text"></span>' +
             '</div>' +
-            '<div class="_md-disabled-thumb"></div>' +
+            '<div class="md-disabled-thumb"></div>' +
           '</div>' +
         '</div>' +
       '</div>',
@@ -165,7 +165,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
   // **********************************************************
 
   function compile (tElement, tAttrs) {
-    var wrapper = angular.element(tElement[0].getElementsByClassName('_md-slider-wrapper'));
+    var wrapper = angular.element(tElement[0].getElementsByClassName('md-slider-wrapper'));
 
     var tabIndex = tAttrs.tabindex || 0;
     wrapper.attr('tabindex', tabIndex);
@@ -199,14 +199,14 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
           return element[0].hasAttribute('disabled');
         };
 
-    var thumb = angular.element(element[0].querySelector('._md-thumb'));
-    var thumbText = angular.element(element[0].querySelector('._md-thumb-text'));
+    var thumb = angular.element(element[0].querySelector('.md-thumb'));
+    var thumbText = angular.element(element[0].querySelector('.md-thumb-text'));
     var thumbContainer = thumb.parent();
-    var trackContainer = angular.element(element[0].querySelector('._md-track-container'));
-    var activeTrack = angular.element(element[0].querySelector('._md-track-fill'));
-    var tickContainer = angular.element(element[0].querySelector('._md-track-ticks'));
-    var wrapper = angular.element(element[0].getElementsByClassName('_md-slider-wrapper'));
-    var content = angular.element(element[0].getElementsByClassName('_md-slider-content'));
+    var trackContainer = angular.element(element[0].querySelector('.md-track-container'));
+    var activeTrack = angular.element(element[0].querySelector('.md-track-fill'));
+    var tickContainer = angular.element(element[0].querySelector('.md-track-ticks'));
+    var wrapper = angular.element(element[0].getElementsByClassName('md-slider-wrapper'));
+    var content = angular.element(element[0].getElementsByClassName('md-slider-content'));
     var throttledRefreshDimensions = $mdUtil.throttle(refreshSliderDimensions, 5000);
 
     // Default values, overridable by attrs
@@ -400,7 +400,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
 
     function blurListener() {
       wrapper.removeClass('md-focused');
-      element.removeClass('_md-active');
+      element.removeClass('md-active');
       clearTicks();
     }
 
@@ -468,8 +468,8 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       
       activeTrack.css(vertical ? 'height' : 'width', activeTrackPercent);
 
-      element.toggleClass((invert ? '_md-max' : '_md-min'), percent === 0);
-      element.toggleClass((invert ? '_md-min' : '_md-max'), percent === 1);
+      element.toggleClass((invert ? 'md-max' : 'md-min'), percent === 0);
+      element.toggleClass((invert ? 'md-min' : 'md-max'), percent === 1);
     }
 
     /**
@@ -480,7 +480,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     function onPressDown(ev) {
       if (isDisabled()) return;
 
-      element.addClass('_md-active');
+      element.addClass('md-active');
       element[0].focus();
       refreshSliderDimensions();
 
@@ -494,7 +494,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     function onPressUp(ev) {
       if (isDisabled()) return;
 
-      element.removeClass('_md-dragging');
+      element.removeClass('md-dragging');
 
       var exactVal = percentToValue( positionToPercent( vertical ? ev.pointer.y : ev.pointer.x ));
       var closestVal = minMaxValidator( stepValidator(exactVal) );
@@ -509,7 +509,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
 
       ev.stopPropagation();
 
-      element.addClass('_md-dragging');
+      element.addClass('md-dragging');
       setSliderFromEvent(ev);
     }
     function onDrag(ev) {

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -85,42 +85,42 @@ md-slider {
     box-sizing: border-box;
   }
 
-  ._md-slider-wrapper {
+  .md-slider-wrapper {
     outline: none;
     width: 100%;
     height: 100%;
   }
 
-  ._md-slider-content {
+  .md-slider-content {
     position: relative;
   }
 
   /**
    * Track
    */
-  ._md-track-container {
+  .md-track-container {
     width: 100%;
     position: absolute;
     top: ($slider-size / 2) - ($slider-track-height) / 2;
     height: $slider-track-height;
   }
-  ._md-track {
+  .md-track {
     position: absolute;
     left: 0;
     right: 0;
     height: 100%;
   }
-  ._md-track-fill {
+  .md-track-fill {
     transition: all .4s cubic-bezier(.25,.8,.25,1);
     transition-property: width, height;
   }
-  ._md-track-ticks {
+  .md-track-ticks {
     position: absolute;
     left: 0;
     right: 0;
     height: 100%;
   }
-  ._md-track-ticks canvas {
+  .md-track-ticks canvas {
     // Restrict the width and the height of the canvas so that ticks are rendered correctly
     // when parent elements are resized. Else, the position of the ticks might
     // be incorrect as we only update the canvas width attribute on window resize.
@@ -131,7 +131,7 @@ md-slider {
   /**
    * Slider thumb
    */
-  ._md-thumb-container {
+  .md-thumb-container {
     position: absolute;
     @include rtl-prop(left, right, 0);
     top: 50%;
@@ -139,7 +139,7 @@ md-slider {
     transition: all .4s cubic-bezier(.25,.8,.25,1);
     transition-property: left, right, bottom;
   }
-  ._md-thumb {
+  .md-thumb {
     z-index: 1;
     
     @include slider-thumb-position($slider-thumb-width, $slider-thumb-height);
@@ -163,7 +163,7 @@ md-slider {
   }
 
   /* The sign that's focused in discrete mode */
-  ._md-sign {
+  .md-sign {
 
     /* Center the children (slider-thumb-text) */
     display: flex;
@@ -197,7 +197,7 @@ md-slider {
       transition: all 0.2s $swift-ease-in-out-timing-function;
     }
 
-    ._md-thumb-text {
+    .md-thumb-text {
       z-index: 1;
       font-size: 12px;
       font-weight: bold;
@@ -207,14 +207,14 @@ md-slider {
   /**
    * The border/background that comes in when focused in non-discrete mode
    */
-  ._md-focus-ring {
+  .md-focus-ring {
     @include slider-thumb-position($slider-focus-thumb-width, $slider-focus-thumb-height);
     transform: scale(.7);
     opacity: 0;
     // using a custom duration to match the spec example video
     transition: all ($slider-thumb-focus-duration / 2) $swift-ease-in-out-timing-function;
   }
-  ._md-disabled-thumb {
+  .md-disabled-thumb {
     @include slider-thumb-position(
       $slider-thumb-width + $slider-thumb-disabled-border * 2,
       $slider-thumb-height + $slider-thumb-disabled-border * 2
@@ -225,8 +225,8 @@ md-slider {
     display: none;
   }
 
-  &._md-min {
-    ._md-sign {
+  &.md-min {
+    .md-sign {
       opacity: 0;
     }
   }
@@ -236,40 +236,40 @@ md-slider {
   }
 
   /* Don't animate left/right while panning */
-  &._md-dragging {
-    ._md-thumb-container,
-    ._md-track-fill {
+  &.md-dragging {
+    .md-thumb-container,
+    .md-track-fill {
       transition: none;
     }
   }
 
   &:not([md-discrete]) {
     /* Hide the sign and ticks in non-discrete mode */
-    ._md-track-ticks,
-    ._md-sign {
+    .md-track-ticks,
+    .md-sign {
       display: none;
     }
 
     &:not([disabled]) {
-      ._md-slider-wrapper {
-        ._md-thumb:hover {
+      .md-slider-wrapper {
+        .md-thumb:hover {
           transform: scale($slider-thumb-hover-scale);
         }
 
         &.md-focused {
-          ._md-focus-ring {
+          .md-focus-ring {
             transform: scale(1);
             opacity: 1;
           }
-          ._md-thumb {
+          .md-thumb {
             animation: sliderFocusThumb $slider-thumb-focus-duration $swift-ease-in-out-timing-function;
           }
         }
       }
 
-      &._md-active {
-        ._md-slider-wrapper {
-          ._md-thumb {
+      &.md-active {
+        .md-slider-wrapper {
+          .md-thumb {
             transform: scale($slider-thumb-focus-scale);
           }
         }
@@ -279,24 +279,24 @@ md-slider {
 
   &[md-discrete] {
     &:not([disabled]) {
-      ._md-slider-wrapper {
+      .md-slider-wrapper {
         &.md-focused {
-          ._md-focus-ring {
+          .md-focus-ring {
             transform: scale(0);
             animation: sliderDiscreteFocusRing .5s $swift-ease-in-out-timing-function;
           }
-          ._md-thumb {
+          .md-thumb {
             animation: sliderDiscreteFocusThumb .5s $swift-ease-in-out-timing-function;
           }
         }
       }
-      ._md-slider-wrapper.md-focused,
-      &._md-active {
-        ._md-thumb {
+      .md-slider-wrapper.md-focused,
+      &.md-active {
+        .md-thumb {
           transform: scale(0);
         }
-        ._md-sign,
-        ._md-sign:after {
+        .md-sign,
+        .md-sign:after {
           opacity: 1;
           transform: translate3d(0,0,0) scale(1.0);
         }
@@ -304,11 +304,11 @@ md-slider {
     }
 
     &[disabled][readonly] {
-      ._md-thumb {
+      .md-thumb {
         transform: scale(0);
       }
-      ._md-sign,
-      ._md-sign:after {
+      .md-sign,
+      .md-sign:after {
         opacity: 1;
         transform: translate3d(0,0,0) scale(1.0);
       }
@@ -316,19 +316,19 @@ md-slider {
   }
 
   &[disabled] {
-    ._md-track-fill {
+    .md-track-fill {
       display: none;
     }
-    ._md-track-ticks {
+    .md-track-ticks {
       opacity: 0;
     }
-    &:not([readonly]) ._md-sign {
+    &:not([readonly]) .md-sign {
       opacity: 0;
     }
-    ._md-thumb {
+    .md-thumb {
       transform: scale($slider-thumb-disabled-scale);
     }
-    ._md-disabled-thumb {
+    .md-disabled-thumb {
       display: block;
     }
   }
@@ -338,7 +338,7 @@ md-slider {
     min-height: $slider-min-size;
     min-width: 0;
     
-    ._md-slider-wrapper {
+    .md-slider-wrapper {
       flex: 1;
       padding-top: 12px;
       padding-bottom: 12px;
@@ -348,34 +348,34 @@ md-slider {
       justify-content: center;
     }
 
-    ._md-track-container {
+    .md-track-container {
       height: 100%;
       width: $slider-track-height;
       top: 0;
       left: calc(50% - (#{$slider-track-height} / 2));
     }
 
-    ._md-thumb-container {
+    .md-thumb-container {
       top: auto;
       margin-bottom: ($slider-size / 2) - ($slider-track-height) / 2;
       left: calc(50% - 1px);
       bottom: 0;
 
-      ._md-thumb:after {
+      .md-thumb:after {
         left: 1px;
       }
 
-      ._md-focus-ring {
+      .md-focus-ring {
         left: -(($slider-focus-thumb-width / 2) - ($slider-track-height / 2));
       }
     }
 
-    ._md-track-fill {
+    .md-track-fill {
       bottom: 0;
     }
 
     &[md-discrete] {
-      ._md-sign {
+      .md-sign {
         $sign-top: -($slider-sign-top / 2) + 1;
 
         left: -$slider-sign-height - 12;
@@ -398,40 +398,40 @@ md-slider {
           transition: all 0.2s ease-in-out;
         }
 
-        ._md-thumb-text {
+        .md-thumb-text {
           z-index: 1;
           font-size: 12px;
           font-weight: bold;
         }
       }
 
-      &._md-active,
+      &.md-active,
       .md-focused,
       &[disabled][readonly]{
-        ._md-sign:after {
+        .md-sign:after {
           top: 0;
         }
       }
     }
 
     &[disabled][readonly] {
-      ._md-thumb {
+      .md-thumb {
         transform: scale(0);
       }
-      ._md-sign,
-      ._md-sign:after {
+      .md-sign,
+      .md-sign:after {
         opacity: 1;
         transform: translate3d(0,0,0) scale(1.0);
       }
     }
   }
   &[md-invert] {
-    &:not([md-vertical]) ._md-track-fill {
+    &:not([md-vertical]) .md-track-fill {
       @include rtl-prop(left, right, auto);
       @include rtl-prop(right, left, 0);
     }
     &[md-vertical] {
-      ._md-track-fill {
+      .md-track-fill {
         bottom: auto;
         top: 0;
       }
@@ -489,7 +489,7 @@ md-slider-container {
 }
 
 @media screen and (-ms-high-contrast: active) {
-  md-slider.md-default-theme ._md-track {
+  md-slider.md-default-theme .md-track {
     border-bottom: 1px solid #fff;
   }
 }

--- a/src/components/slider/slider.spec.js
+++ b/src/components/slider/slider.spec.js
@@ -19,7 +19,7 @@ describe('md-slider', function() {
 
     slider = $compile('<md-slider ' + (attrs || '') + '>')(pageScope);
     spyOn(
-      slider[0].querySelector('._md-track-container'),
+      slider[0].querySelector('.md-track-container'),
       'getBoundingClientRect'
     ).and.returnValue(angular.extend({
       width: 100,
@@ -40,7 +40,7 @@ describe('md-slider', function() {
   }
 
   function getWrapper(slider) {
-    return angular.element(slider[0].querySelector('._md-slider-wrapper'));
+    return angular.element(slider[0].querySelector('.md-slider-wrapper'));
   }
 
 
@@ -141,21 +141,21 @@ describe('md-slider', function() {
     var wrapper = getWrapper(slider);
 
     pageScope.$apply('value = 30');
-    expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('30');
+    expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
     wrapper.triggerHandler({
       type: 'keydown',
       keyCode: $mdConstant.KEY_CODE.LEFT_ARROW
     });
     $timeout.flush();
-    expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('29');
+    expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('29');
 
     wrapper.triggerHandler({type: '$md.pressdown', pointer: { x: 30 }});
-    expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('30');
+    expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
     wrapper.triggerHandler({type: '$md.dragstart', pointer: { x: 31 }});
     wrapper.triggerHandler({type: '$md.drag', pointer: { x: 31 }});
-    expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('31');
+    expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('31');
   });
 
   it('should update the thumb text with the model value when using ng-change', function() {
@@ -169,7 +169,7 @@ describe('md-slider', function() {
     wrapper.triggerHandler({type: '$md.pressdown', pointer: { x: 30 }});
     $timeout.flush();
     expect(pageScope.value).toBe(50);
-    expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('50');
+    expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('50');
   });
 
   it('should call $log.warn if aria-label isn\'t provided', function() {
@@ -215,15 +215,15 @@ describe('md-slider', function() {
       type: '$md.pressdown',
       pointer: {}
     });
-    expect(slider).not.toHaveClass('_md-active');
+    expect(slider).not.toHaveClass('md-active');
 
     // Doesn't remove active class up on pressup when disabled
-    slider.addClass('_md-active');
+    slider.addClass('md-active');
     wrapper.triggerHandler({
       type: '$md.pressup',
       pointer: {}
     });
-    expect(slider).toHaveClass('_md-active');
+    expect(slider).toHaveClass('md-active');
   });
 
   it('should disable via the `disabled` attribute', function() {
@@ -238,52 +238,52 @@ describe('md-slider', function() {
       type: '$md.pressdown',
       pointer: {}
     });
-    expect(slider).not.toHaveClass('_md-active');
+    expect(slider).not.toHaveClass('md-active');
   });
 
   it('should add active class on pressdown and remove on blur', function() {
     var slider = setup();
     var wrapper = getWrapper(slider);
 
-    expect(slider).not.toHaveClass('_md-active');
+    expect(slider).not.toHaveClass('md-active');
 
     wrapper.triggerHandler({
       type: '$md.pressdown',
       pointer: {}
     });
-    expect(slider).toHaveClass('_md-active');
+    expect(slider).toHaveClass('md-active');
 
     wrapper.triggerHandler({
       type: 'blur',
       pointer: {}
     });
-    expect(slider).not.toHaveClass('_md-active');
+    expect(slider).not.toHaveClass('md-active');
   });
 
-  it('should add _md-min class only when at min value', function() {
+  it('should add md-min class only when at min value', function() {
     var slider = setup('ng-model="model" min="0" max="30"');
     var wrapper = getWrapper(slider);
 
     pageScope.$apply('model = 0');
-    expect(slider).toHaveClass('_md-min');
+    expect(slider).toHaveClass('md-min');
 
     wrapper.triggerHandler({type: '$md.dragstart', pointer: {x: 0}});
     wrapper.triggerHandler({type: '$md.drag', pointer: {x: 10}});
     $timeout.flush();
-    expect(slider).not.toHaveClass('_md-min');
+    expect(slider).not.toHaveClass('md-min');
   });
 
-  it('should add _md-max class only when at max value', function() {
+  it('should add md-max class only when at max value', function() {
     var slider = setup('ng-model="model" min="0" max="30"');
     var wrapper = getWrapper(slider);
 
     pageScope.$apply('model = 30');
-    expect(slider).toHaveClass('_md-max');
+    expect(slider).toHaveClass('md-max');
 
     wrapper.triggerHandler({type: '$md.dragstart', pointer: {x: 30}});
     wrapper.triggerHandler({type: '$md.drag', pointer: {x: 10}});
     $timeout.flush();
-    expect(slider).not.toHaveClass('_md-max');
+    expect(slider).not.toHaveClass('md-max');
   });
 
   it('should increment at a predictable step', function() {
@@ -407,47 +407,47 @@ describe('md-slider', function() {
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('value = 30');
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('30');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
       wrapper.triggerHandler({
         type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.DOWN_ARROW
       });
       $timeout.flush();
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('29');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('29');
 
       wrapper.triggerHandler({type: '$md.pressdown', pointer: { y: 70 }});
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('30');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: { y: 93 }});
       wrapper.triggerHandler({type: '$md.drag', pointer: { y: 93 }});
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('7');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('7');
     });
 
-    it('should add _md-min class only when at min value', function() {
+    it('should add md-min class only when at min value', function() {
       var slider = setup('md-vertical ng-model="model" min="0" max="30"');
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('model = 0');
-      expect(slider).toHaveClass('_md-min');
+      expect(slider).toHaveClass('md-min');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: {y: 0}});
       wrapper.triggerHandler({type: '$md.drag', pointer: {y: 10}});
       $timeout.flush();
-      expect(slider).not.toHaveClass('_md-min');
+      expect(slider).not.toHaveClass('md-min');
     });
 
-    it('should add _md-max class only when at max value', function() {
+    it('should add md-max class only when at max value', function() {
       var slider = setup('md-vertical ng-model="model" min="0" max="30"');
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('model = 30');
-      expect(slider).toHaveClass('_md-max');
+      expect(slider).toHaveClass('md-max');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: {y: 30}});
       wrapper.triggerHandler({type: '$md.drag', pointer: {y: 10}});
       $timeout.flush();
-      expect(slider).not.toHaveClass('_md-max');
+      expect(slider).not.toHaveClass('md-max');
     });
 
     it('should increment at a predictable step', function() {
@@ -505,7 +505,7 @@ describe('md-slider', function() {
         type: '$md.pressdown',
         pointer: {}
       });
-      expect(slider).not.toHaveClass('_md-active');
+      expect(slider).not.toHaveClass('md-active');
     });
 
     it('should disable via the `ngDisabled` attribute', function() {
@@ -519,7 +519,7 @@ describe('md-slider', function() {
         type: '$md.pressdown',
         pointer: {}
       });
-      expect(slider).toHaveClass('_md-active');
+      expect(slider).toHaveClass('md-active');
 
       // Removing focus from the slider
       wrapper.triggerHandler({
@@ -533,7 +533,7 @@ describe('md-slider', function() {
         type: '$md.pressdown',
         pointer: {}
       });
-      expect(slider).not.toHaveClass('_md-active');
+      expect(slider).not.toHaveClass('md-active');
     });
 
     it('should disable related inputs', inject(function($compile) {
@@ -640,47 +640,47 @@ describe('md-slider', function() {
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('value = 30');
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('30');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('30');
 
       wrapper.triggerHandler({
         type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.DOWN_ARROW
       });
       $timeout.flush();
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('31');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('31');
 
       wrapper.triggerHandler({type: '$md.pressdown', pointer: { y: 70 }});
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('70');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('70');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: { y: 93 }});
       wrapper.triggerHandler({type: '$md.drag', pointer: { y: 93 }});
-      expect(slider[0].querySelector('._md-thumb-text').textContent).toBe('93');
+      expect(slider[0].querySelector('.md-thumb-text').textContent).toBe('93');
     });
 
-    it('should add _md-min class only when at min value', function() {
+    it('should add md-min class only when at min value', function() {
       var slider = setup('md-vertical md-invert ng-model="model" min="0" max="30"');
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('model = 0');
-      expect(slider).toHaveClass('_md-min');
+      expect(slider).toHaveClass('md-min');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: {y: 0}});
       wrapper.triggerHandler({type: '$md.drag', pointer: {y: 10}});
       $timeout.flush();
-      expect(slider).not.toHaveClass('_md-min');
+      expect(slider).not.toHaveClass('md-min');
     });
 
-    it('should add _md-max class only when at max value', function() {
+    it('should add md-max class only when at max value', function() {
       var slider = setup('md-vertical md-invert ng-model="model" min="0" max="30"');
       var wrapper = getWrapper(slider);
 
       pageScope.$apply('model = 30');
-      expect(slider).toHaveClass('_md-max');
+      expect(slider).toHaveClass('md-max');
 
       wrapper.triggerHandler({type: '$md.dragstart', pointer: {y: 30}});
       wrapper.triggerHandler({type: '$md.drag', pointer: {y: 10}});
       $timeout.flush();
-      expect(slider).not.toHaveClass('_md-max');
+      expect(slider).not.toHaveClass('md-max');
     });
 
     it('should increment at a predictable step', function() {

--- a/src/components/sticky/sticky.js
+++ b/src/components/sticky/sticky.js
@@ -128,7 +128,7 @@ function MdSticky($mdConstant, $$rAF, $mdUtil, $compile) {
      ***************/
     // Add an element and its sticky clone to this content's sticky collection
     function add(element, stickyClone) {
-      stickyClone.addClass('_md-sticky-clone');
+      stickyClone.addClass('md-sticky-clone');
 
       var item = {
         element: element,

--- a/src/components/sticky/sticky.scss
+++ b/src/components/sticky/sticky.scss
@@ -1,4 +1,4 @@
-._md-sticky-clone {
+.md-sticky-clone {
   z-index: 2;
   top: 0;
   left: 0;
@@ -9,7 +9,7 @@
 
   &[sticky-state="active"] {
     transform: translate3d(0, 0, 0);
-    &:not(.md-sticky-no-effect) ._md-subheader-inner {
+    &:not(.md-sticky-no-effect) .md-subheader-inner {
       animation: subheaderStickyHoverIn 0.3s ease-out both;
     }
   }

--- a/src/components/sticky/sticky.spec.js
+++ b/src/components/sticky/sticky.spec.js
@@ -26,7 +26,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(scope);
@@ -68,7 +68,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('_md-sticky-clone')[0];
+        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(cloneScope);

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -48,8 +48,8 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     transclude: true,
     template: (
     '<div class="md-subheader _md">' +
-    '  <div class="_md-subheader-inner">' +
-    '    <div class="_md-subheader-content"></div>' +
+    '  <div class="md-subheader-inner">' +
+    '    <div class="md-subheader-content"></div>' +
     '  </div>' +
     '</div>'
     ),
@@ -60,7 +60,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
       var outerHTML = element[0].outerHTML;
 
       function getContent(el) {
-        return angular.element(el[0].querySelector('._md-subheader-content'));
+        return angular.element(el[0].querySelector('.md-subheader-content'));
       }
 
       // Transclude the user-given contents of the subheader
@@ -77,7 +77,7 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
           // compiled clone below will only be a comment tag (since they replace their elements with
           // a comment) which cannot be properly passed to the $mdSticky; so we wrap it in our own
           // DIV to ensure we have something $mdSticky can use
-          var wrapper = $compile('<div class="_md-subheader-wrapper">' + outerHTML + '</div>')(scope);
+          var wrapper = $compile('<div class="md-subheader-wrapper">' + outerHTML + '</div>')(scope);
 
           // Delay initialization until after any `ng-if`/`ng-repeat`/etc has finished before
           // attempting to create the clone

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -22,7 +22,7 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   }
 }
 
-._md-subheader-wrapper {
+.md-subheader-wrapper {
 
   &:not(.md-sticky-no-effect) {
     .md-subheader {
@@ -39,7 +39,7 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
       margin-top: -2px;
     }
 
-    &:not(.md-sticky-clone)[sticky-prev-state="active"] ._md-subheader-inner:after {
+    &:not(.md-sticky-clone)[sticky-prev-state="active"] .md-subheader-inner:after {
       animation: subheaderStickyHoverOut 0.3s ease-out both;
     }
   }
@@ -54,12 +54,12 @@ $subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
   margin: $subheader-margin;
   position: relative;
 
-  ._md-subheader-inner {
+  .md-subheader-inner {
     display: block;
     padding: $subheader-padding;
   }
 
-  ._md-subheader-content {
+  .md-subheader-content {
     display: block;
     z-index: 1;
     position: relative;

--- a/src/components/subheader/subheader.spec.js
+++ b/src/components/subheader/subheader.spec.js
@@ -154,7 +154,7 @@ describe('mdSubheader', function() {
       '</div>'
     );
 
-    var cloneContent = getCloneElement()[0].querySelector('._md-subheader-content');
+    var cloneContent = getCloneElement()[0].querySelector('.md-subheader-content');
 
     expect(cloneContent.children.length).toBe(4);
   });
@@ -197,9 +197,9 @@ describe('mdSubheader', function() {
   }
 
   function getCloneElement() {
-    // We search for the clone element by using the _md-sticky-clone class, which will be automatically added
+    // We search for the clone element by using the md-sticky-clone class, which will be automatically added
     // by the $mdSticky service.
-    return angular.element(contentElement[0].querySelector('._md-sticky-clone .md-subheader'));
+    return angular.element(contentElement[0].querySelector('.md-sticky-clone .md-subheader'));
   }
 
   function getElement() {
@@ -213,7 +213,7 @@ describe('mdSubheader', function() {
       var item = items[index];
       if (!item) return;
 
-      return item.parentNode.classList.contains('_md-sticky-clone') ? checkSubheader(index + 1) : item;
+      return item.parentNode.classList.contains('md-sticky-clone') ? checkSubheader(index + 1) : item;
     }
   }
 

--- a/src/components/switch/switch-theme.scss
+++ b/src/components/switch/switch-theme.scss
@@ -2,10 +2,10 @@ md-switch.md-THEME_NAME-theme {
   .md-ink-ripple {
     color: '{{background-500}}';
   }
-  ._md-thumb {
+  .md-thumb {
     background-color: '{{background-50}}';
   }
-  ._md-bar {
+  .md-bar {
     background-color: '{{background-500}}';
   }
 
@@ -13,13 +13,13 @@ md-switch.md-THEME_NAME-theme {
     .md-ink-ripple {
       color: '{{accent-color}}';
     }
-    ._md-thumb {
+    .md-thumb {
       background-color: '{{accent-color}}';
     }
-    ._md-bar {
+    .md-bar {
       background-color: '{{accent-color-0.5}}';
     }
-    &.md-focused ._md-thumb:before {
+    &.md-focused .md-thumb:before {
       background-color: '{{accent-color-0.26}}';
     }
 
@@ -27,13 +27,13 @@ md-switch.md-THEME_NAME-theme {
       .md-ink-ripple {
         color: '{{primary-color}}';
       }
-      ._md-thumb {
+      .md-thumb {
         background-color: '{{primary-color}}';
       }
-      ._md-bar {
+      .md-bar {
         background-color: '{{primary-color-0.5}}';
       }
-      &.md-focused ._md-thumb:before {
+      &.md-focused .md-thumb:before {
         background-color: '{{primary-color-0.26}}';
       }
     }
@@ -42,23 +42,23 @@ md-switch.md-THEME_NAME-theme {
       .md-ink-ripple {
         color: '{{warn-color}}';
       }
-      ._md-thumb {
+      .md-thumb {
         background-color: '{{warn-color}}';
       }
-      ._md-bar {
+      .md-bar {
         background-color: '{{warn-color-0.5}}';
       }
-      &.md-focused ._md-thumb:before {
+      &.md-focused .md-thumb:before {
         background-color: '{{warn-color-0.26}}';
       }
     }
   }
 
   &[disabled] {
-    ._md-thumb {
+    .md-thumb {
       background-color: '{{background-400}}';
     }
-    ._md-bar {
+    .md-bar {
       background-color: '{{foreground-4}}';
     }
   }

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -54,13 +54,13 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
     priority: 210, // Run before ngAria
     transclude: true,
     template:
-      '<div class="_md-container">' +
-        '<div class="_md-bar"></div>' +
-        '<div class="_md-thumb-container">' +
-          '<div class="_md-thumb" md-ink-ripple md-ink-ripple-checkbox></div>' +
+      '<div class="md-container">' +
+        '<div class="md-bar"></div>' +
+        '<div class="md-thumb-container">' +
+          '<div class="md-thumb" md-ink-ripple md-ink-ripple-checkbox></div>' +
         '</div>'+
       '</div>' +
-      '<div ng-transclude class="_md-label"></div>',
+      '<div ng-transclude class="md-label"></div>',
     require: '?ngModel',
     compile: mdSwitchCompile
   };
@@ -68,7 +68,7 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
   function mdSwitchCompile(element, attr) {
     var checkboxLink = checkboxDirective.compile(element, attr);
     // No transition on initial load.
-    element.addClass('_md-dragging');
+    element.addClass('md-dragging');
 
     return function (scope, element, attr, ngModel) {
       ngModel = ngModel || $mdUtil.fakeNgModel();
@@ -80,12 +80,12 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
         disabledGetter = $parse(attr.ngDisabled);
       }
 
-      var thumbContainer = angular.element(element[0].querySelector('._md-thumb-container'));
-      var switchContainer = angular.element(element[0].querySelector('._md-container'));
+      var thumbContainer = angular.element(element[0].querySelector('.md-thumb-container'));
+      var switchContainer = angular.element(element[0].querySelector('.md-container'));
 
       // no transition on initial load
       $$rAF(function() {
-        element.removeClass('_md-dragging');
+        element.removeClass('md-dragging');
       });
 
       checkboxLink(scope, element, attr, ngModel);
@@ -109,7 +109,7 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
         if (disabledGetter && disabledGetter(scope)) return;
         ev.stopPropagation();
 
-        element.addClass('_md-dragging');
+        element.addClass('md-dragging');
         drag = {width: thumbContainer.prop('offsetWidth')};
       }
 
@@ -133,7 +133,7 @@ function MdSwitch(mdCheckboxDirective, $mdUtil, $mdConstant, $parse, $$rAF, $mdG
         if (!drag) return;
         ev.stopPropagation();
 
-        element.removeClass('_md-dragging');
+        element.removeClass('md-dragging');
         thumbContainer.css($mdConstant.CSS.TRANSFORM, '');
 
         // We changed if there is no distance (this is a click a click),

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -33,12 +33,12 @@ md-switch {
   &[disabled] {
     cursor: default;
 
-    ._md-container {
+    .md-container {
       cursor: default;
     }
   }
 
-  ._md-container {
+  .md-container {
     cursor: grab;
     width: $switch-width;
     height: $switch-height;
@@ -50,14 +50,14 @@ md-switch {
 
   // If the user moves his mouse off the switch, stil display grabbing cursor
   &:not([disabled]) {
-    ._md-dragging,
-    &._md-dragging ._md-container {
+    .md-dragging,
+    &.md-dragging .md-container {
       cursor: grabbing;
     }
   }
 
   &.md-focused:not([disabled]) {
-    ._md-thumb:before {
+    .md-thumb:before {
       left: -8px;
       top: -8px;
       right: -8px;
@@ -65,19 +65,19 @@ md-switch {
     }
 
     &:not(.md-checked) {
-      ._md-thumb:before {
+      .md-thumb:before {
         background-color: rgba(0, 0, 0, 0.12);
       }
     }
   }
 
-  ._md-label {
+  .md-label {
     border-color: transparent;
     border-width: 0;
     float: left;
   }
 
-  ._md-bar {
+  .md-bar {
     left: 1px;
     width: $switch-width - 2px;
     top: $switch-height / 2 - $switch-bar-height / 2;
@@ -86,7 +86,7 @@ md-switch {
     position: absolute;
   }
 
-  ._md-thumb-container {
+  .md-thumb-container {
     top: $switch-height / 2 - $switch-thumb-size / 2;
     left: 0;
     width: $switch-width - $switch-thumb-size;
@@ -94,11 +94,11 @@ md-switch {
     transform: translate3d(0,0,0);
     z-index: 1;
   }
-  &.md-checked ._md-thumb-container {
+  &.md-checked .md-thumb-container {
     transform: translate3d(100%,0,0);
   }
 
-  ._md-thumb {
+  .md-thumb {
     position: absolute;
     margin: 0;
     left: 0;
@@ -136,15 +136,15 @@ md-switch {
     }
   }
 
-  &:not(._md-dragging) {
-    ._md-bar,
-    ._md-thumb-container,
-    ._md-thumb {
+  &:not(.md-dragging) {
+    .md-bar,
+    .md-thumb-container,
+    .md-thumb {
       transition: $swift-linear;
       transition-property: transform, background-color;
     }
-    ._md-bar,
-    ._md-thumb {
+    .md-bar,
+    .md-thumb {
       transition-delay: 0.05s;
     }
   }
@@ -152,13 +152,13 @@ md-switch {
 }
 
 @media screen and (-ms-high-contrast: active) {
-  md-switch.md-default-theme ._md-bar {
+  md-switch.md-default-theme .md-bar {
     background-color: #666;
   }
-  md-switch.md-default-theme.md-checked ._md-bar {
+  md-switch.md-default-theme.md-checked .md-bar {
     background-color: #9E9E9E;
   }
-  md-switch.md-default-theme ._md-thumb {
+  md-switch.md-default-theme .md-thumb {
     background-color: #fff;
   }
 }

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -154,7 +154,7 @@ function MdTabs ($$mdSvgRegistry) {
                   'md-scope="::tab.parent"></md-tab-item> ' +
               '<md-ink-bar></md-ink-bar> ' +
             '</md-pagination-wrapper> ' +
-            '<md-tabs-dummy-wrapper class="_md-visually-hidden md-dummy-wrapper"> ' +
+            '<md-tabs-dummy-wrapper class="md-visually-hidden md-dummy-wrapper"> ' +
               '<md-dummy-tab ' +
                   'class="md-tab" ' +
                   'tabindex="-1" ' +

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -393,8 +393,7 @@ function MdToastProvider($$interimElementProvider) {
           return;
         }
 
-        element.addClass('_md-' + swipe);
-
+        element.addClass('md-' + swipe);
         $mdUtil.nextTick($mdToast.cancel);
       };
       options.openClass = toastOpenClass(options.position);
@@ -410,24 +409,24 @@ function MdToastProvider($$interimElementProvider) {
       }
 
       element.on(SWIPE_EVENTS, options.onSwipe);
-      element.addClass(isSmScreen ? '_md-bottom' : options.position.split(' ').map(function(pos) {
-        return '_md-' + pos;
+      element.addClass(isSmScreen ? 'md-bottom' : options.position.split(' ').map(function(pos) {
+        return 'md-' + pos;
       }).join(' '));
 
-      if (options.parent) options.parent.addClass('_md-toast-animating');
+      if (options.parent) options.parent.addClass('md-toast-animating');
       return $animate.enter(element, options.parent).then(function() {
-        if (options.parent) options.parent.removeClass('_md-toast-animating');
+        if (options.parent) options.parent.removeClass('md-toast-animating');
       });
     }
 
     function onRemove(scope, element, options) {
       element.off(SWIPE_EVENTS, options.onSwipe);
-      if (options.parent) options.parent.addClass('_md-toast-animating');
+      if (options.parent) options.parent.addClass('md-toast-animating');
       if (options.openClass) options.parent.removeClass(options.openClass);
 
       return ((options.$destroy == true) ? element.remove() : $animate.leave(element))
         .then(function () {
-          if (options.parent) options.parent.removeClass('_md-toast-animating');
+          if (options.parent) options.parent.removeClass('md-toast-animating');
           if ($mdUtil.hasComputedStyle(options.parent, 'position', 'static')) {
             options.parent.css('position', '');
           }
@@ -437,10 +436,10 @@ function MdToastProvider($$interimElementProvider) {
     function toastOpenClass(position) {
       // For mobile, always open full-width on bottom
       if (!$mdMedia('gt-xs')) {
-        return '_md-toast-open-bottom';
+        return 'md-toast-open-bottom';
       }
 
-      return '_md-toast-open-' +
+      return 'md-toast-open-' +
         (position.indexOf('top') > -1 ? 'top' : 'bottom');
     }
   }

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -66,10 +66,10 @@ md-toast {
   }
 
   /* Transition differently when swiping */
-  &._md-swipeleft,
-  &._md-swiperight,
-  &._md-swipeup,
-  &._md-swipedown {
+  &.md-swipeleft,
+  &.md-swiperight,
+  &.md-swipeup,
+  &.md-swipedown {
     .md-toast-content {
       transition: $swift-ease-out;
     }
@@ -80,7 +80,7 @@ md-toast {
     .md-toast-content {
       transform: translate3d(0, 100%, 0);
     }
-    &._md-top {
+    &.md-top {
       .md-toast-content {
         transform: translate3d(0, -100%, 0);
       }
@@ -102,17 +102,17 @@ md-toast {
       transform: translate3d(0, 100%, 0);
     }
 
-    &._md-swipeup {
+    &.md-swipeup {
       .md-toast-content {
         transform: translate3d(0, -50%, 0);
       }
     }
-    &._md-swipedown {
+    &.md-swipedown {
       .md-toast-content {
         transform: translate3d(0, 50%, 0);
       }
     }
-    &._md-top {
+    &.md-top {
       .md-toast-content {
         transform: translate3d(0, -100%, 0);
       }
@@ -147,12 +147,12 @@ md-toast {
     padding: 0;
 
     &.ng-leave.ng-leave-active {
-      &._md-swipeup {
+      &.md-swipeup {
         .md-toast-content {
           transform: translate3d(0, -50%, 0);
         }
       }
-      &._md-swipedown {
+      &.md-swipedown {
         .md-toast-content {
           transform: translate3d(0, 50%, 0);
         }
@@ -164,16 +164,16 @@ md-toast {
 @media (min-width: $layout-breakpoint-sm) {
   md-toast {
     min-width: 288px + $toast-margin * 2;
-    &._md-bottom {
+    &.md-bottom {
       bottom: 0;
     }
-    &._md-left {
+    &.md-left {
       left: 0;
     }
-    &._md-right {
+    &.md-right {
       right: 0;
     }
-    &._md-top {
+    &.md-top {
       top: 0;
     }
 
@@ -191,12 +191,12 @@ md-toast {
    * make it rotate when the user swipes it away
    */
     &.ng-leave.ng-leave-active {
-      &._md-swipeleft {
+      &.md-swipeleft {
         .md-toast-content {
           transform: translate3d(-50%, 0, 0);
         }
       }
-      &._md-swiperight {
+      &.md-swiperight {
         .md-toast-content {
           transform: translate3d(50%, 0, 0);
         }
@@ -221,6 +221,6 @@ md-toast {
 
 
 // While animating, set the toast parent's overflow to hidden so scrollbars do not appear
-._md-toast-animating {
+.md-toast-animating {
   overflow: hidden !important;
 }

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -243,8 +243,8 @@ describe('$mdToast service', function() {
         });
         var toast = $rootElement.find('md-toast');
         $timeout.flush();
-        expect(toast.hasClass('_md-top')).toBe(true);
-        expect(toast.hasClass('_md-left')).toBe(true);
+        expect(toast.hasClass('md-top')).toBe(true);
+        expect(toast.hasClass('md-left')).toBe(true);
       }));
 
       it('should wrap toast content with .md-toast-content', inject(function($rootElement, $timeout) {
@@ -280,7 +280,7 @@ describe('$mdToast service', function() {
           setup({
             template: '<md-toast>'
           });
-          expect($rootElement.hasClass('_md-toast-open-bottom')).toBe(true);
+          expect($rootElement.hasClass('md-toast-open-bottom')).toBe(true);
 
           $material.flushInterimElement();
 
@@ -288,7 +288,7 @@ describe('$mdToast service', function() {
             template: '<md-toast>',
             position: 'top'
           });
-          expect($rootElement.hasClass('_md-toast-open-bottom')).toBe(true);
+          expect($rootElement.hasClass('md-toast-open-bottom')).toBe(true);
         }));
       });
     });
@@ -438,7 +438,7 @@ describe('$mdToast service', function() {
       setup({
         template: '<md-toast>'
       });
-      expect($rootElement.hasClass('_md-toast-open-bottom')).toBe(true);
+      expect($rootElement.hasClass('md-toast-open-bottom')).toBe(true);
 
       $material.flushInterimElement();
 
@@ -446,7 +446,7 @@ describe('$mdToast service', function() {
         template: '<md-toast>',
         position: 'top'
       });
-      expect($rootElement.hasClass('_md-toast-open-top')).toBe(true);
+      expect($rootElement.hasClass('md-toast-open-top')).toBe(true);
     }));
   });
 

--- a/src/components/tooltip/tooltip-theme.scss
+++ b/src/components/tooltip/tooltip-theme.scss
@@ -1,6 +1,6 @@
 md-tooltip.md-THEME_NAME-theme {
   color: '{{background-A100}}';
-  ._md-content {
+  .md-content {
     background-color: '{{foreground-2}}';
   }
 }

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -45,7 +45,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     restrict: 'E',
     transclude: true,
     priority: 210, // Before ngAria
-    template: '<div class="_md-content _md" ng-transclude></div>',
+    template: '<div class="md-content _md" ng-transclude></div>',
     scope: {
       delay: '=?mdDelay',
       visible: '=?mdVisible',
@@ -66,7 +66,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     $mdTheming(element);
 
     var parent        = $mdUtil.getParentWithPointerEvents(element),
-        content       = angular.element(element[0].getElementsByClassName('_md-content')[0]),
+        content       = angular.element(element[0].getElementsByClassName('md-content')[0]),
         tooltipParent = angular.element(document.body),
         showTimeout   = null,
         debouncedOnResize = $$rAF.throttle(function () { updatePosition(); });
@@ -321,15 +321,15 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
       updatePosition();
 
       angular.forEach([element, content], function (element) {
-        $animate.addClass(element, '_md-show');
+        $animate.addClass(element, 'md-show');
       });
     }
 
     function hideTooltip() {
         var promises = [];
         angular.forEach([element, content], function (it) {
-          if (it.parent() && it.hasClass('_md-show')) {
-            promises.push($animate.removeClass(it, '_md-show'));
+          if (it.parent() && it.hasClass('md-show')) {
+            promises.push($animate.removeClass(it, 'md-show'));
           }
         });
 

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -21,7 +21,7 @@ md-tooltip {
     font-size: $tooltip-fontsize-lg;
   }
 
-  ._md-content {
+  .md-content {
     position: relative;
     white-space: nowrap;
     overflow: hidden;
@@ -39,32 +39,32 @@ md-tooltip {
       padding-left: $tooltip-lr-padding-lg;
       padding-right: $tooltip-lr-padding-lg;
     }
-    &._md-show-add {
+    &.md-show-add {
       transition: $swift-ease-out;
       transition-duration: .2s;
       transform: scale(0);
       opacity: 0;
     }
-    &._md-show, &._md-show-add-active {
+    &.md-show, &.md-show-add-active {
       transform: scale(1);
       opacity: 1;
       transform-origin: center top;
     }
-    &._md-show-remove {
+    &.md-show-remove {
       transition: $swift-ease-out;
       transition-duration: .2s;
-      &._md-show-remove-active {
+      &.md-show-remove-active {
         transform: scale(0);
         opacity: 0;
       }
     }
   }
 
-  &._md-hide {
+  &.md-hide {
     transition: $swift-ease-in;
   }
 
-  &._md-show {
+  &.md-show {
     transition: $swift-ease-out;
     pointer-events: auto;
   }

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -158,7 +158,7 @@ describe('<md-tooltip> directive', function() {
       showTooltip(true);
 
       expect(findTooltip().length).toBe(1);
-      expect(findTooltip().hasClass('_md-show')).toBe(true);
+      expect(findTooltip().hasClass('md-show')).toBe(true);
 
       showTooltip(false);
 
@@ -248,7 +248,7 @@ describe('<md-tooltip> directive', function() {
       showTooltip(true);
 
       expect(findTooltip().length).toBe(1);
-      expect(findTooltip().hasClass('_md-show')).toBe(true);
+      expect(findTooltip().hasClass('md-show')).toBe(true);
     });
 
     it('should set visible on focus and blur', function() {

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -176,7 +176,7 @@
   $height: $checkbox-height,
   $border-width: $checkbox-border-width,
   $border-radius: $checkbox-border-radius) {
-  ._md-container {
+  .md-container {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -228,7 +228,7 @@
   }
 
   // unchecked
-  ._md-icon {
+  .md-icon {
     box-sizing: border-box;
     transition: 240ms;
     position: absolute;
@@ -241,7 +241,7 @@
     border-radius: $border-radius;
   }
 
-  &#{$checkedSelector} ._md-icon {
+  &#{$checkedSelector} .md-icon {
     border: none;
 
     &:after {
@@ -266,7 +266,7 @@
     cursor: default;
   }
 
-  &.md-indeterminate ._md-icon {
+  &.md-indeterminate .md-icon {
     &:after {
       box-sizing: border-box;
       position: absolute;

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -15,8 +15,8 @@ body {
   padding: 10px;
 }
 
-a._md-no-style,
-button._md-no-style {
+a.md-no-style,
+button.md-no-style {
   font-weight: normal;
   background-color: inherit;
   text-align: left;
@@ -66,7 +66,7 @@ input {
   }
 }
 
-._md-visually-hidden {
+.md-visually-hidden {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;

--- a/src/core/util/autofocus.js
+++ b/src/core/util/autofocus.js
@@ -103,6 +103,6 @@ function postLink(scope, element, attrs) {
 
   // Setup a watcher on the proper attribute to update a class we can check for in $mdUtil
   scope.$watch(attr, function(canAutofocus) {
-    element.toggleClass('_md-autofocus', canAutofocus);
+    element.toggleClass('md-autofocus', canAutofocus);
   });
 }

--- a/src/core/util/autofocus.spec.js
+++ b/src/core/util/autofocus.spec.js
@@ -1,4 +1,4 @@
-describe('_md-autofocus', function() {
+describe('md-autofocus', function() {
   var $rootScope, pageScope, element;
 
   beforeEach(module('material.core'));
@@ -10,43 +10,43 @@ describe('_md-autofocus', function() {
     it('supports true', function() {
       build('<input id="test" type="text" md-autofocus="true">');
 
-      expect(element).toHaveClass('_md-autofocus');
+      expect(element).toHaveClass('md-autofocus');
     });
 
     it('supports false', function() {
       build('<input id="test" type="text" md-autofocus="false">');
 
-      expect(element).not.toHaveClass('_md-autofocus');
+      expect(element).not.toHaveClass('md-autofocus');
     });
 
     it('supports variables', function() {
       build('<input id="test" type="text" md-autofocus="shouldAutoFocus">');
 
       // By default, we assume an undefined value for the expression is true
-      expect(element).toHaveClass('_md-autofocus');
+      expect(element).toHaveClass('md-autofocus');
 
       // Set the expression to false
       pageScope.$apply('shouldAutoFocus=false');
-      expect(element).not.toHaveClass('_md-autofocus');
+      expect(element).not.toHaveClass('md-autofocus');
 
       // Set the expression to true
       pageScope.$apply('shouldAutoFocus=true');
-      expect(element).toHaveClass('_md-autofocus');
+      expect(element).toHaveClass('md-autofocus');
     });
 
     it('supports expressions', function() {
       build('<input id="test" type="text" md-autofocus="shouldAutoFocus==1">');
 
       // By default, the expression should be false
-      expect(element).not.toHaveClass('_md-autofocus');
+      expect(element).not.toHaveClass('md-autofocus');
 
       // Make the expression false
       pageScope.$apply('shouldAutoFocus=0');
-      expect(element).not.toHaveClass('_md-autofocus');
+      expect(element).not.toHaveClass('md-autofocus');
 
       // Make the expression true
       pageScope.$apply('shouldAutoFocus=1');
-      expect(element).toHaveClass('_md-autofocus');
+      expect(element).toHaveClass('md-autofocus');
     });
   });
 

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -184,9 +184,9 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           items.length && angular.forEach(items, function(it) {
             it = angular.element(it);
 
-            // Check the element for the _md-autofocus class to ensure any associated expression
+            // Check the element for the md-autofocus class to ensure any associated expression
             // evaluated to true.
-            var isFocusable = it.hasClass('_md-autofocus');
+            var isFocusable = it.hasClass('md-autofocus');
             if (isFocusable) elFound = it;
           });
         }


### PR DESCRIPTION
Revert previous changes to privatize much of our CSS.

> See public announcement [**Revisiting the decision to rename private CSS classes in 1.1**](https://groups.google.com/forum/#!msg/ngmaterial/mLJrRW9qrLA/C_Ni3LSrBQAJ)

Also fixes an erroneously passing chips test.