### PR TITLE
fix(md-checkbox) remove bounce when transitioning to unchecked

### DIFF
--- a/src/components/checkbox/checkbox-theme.scss
+++ b/src/components/checkbox/checkbox-theme.scss
@@ -19,7 +19,7 @@ md-checkbox.md-THEME_NAME-theme {
     color: '{{accent-color-0.87}}';
   }
 
-  .md-icon {
+  &:not(.md-checked) .md-icon {
     border-color: '{{foreground-2}}';
   }
 
@@ -49,7 +49,7 @@ md-checkbox.md-THEME_NAME-theme {
         color: '{{warn-color-0.87}}';
       }
 
-      .md-icon {
+      &:not(.md-checked) .md-icon {
         border-color: '{{foreground-2}}';
       }
 
@@ -68,7 +68,7 @@ md-checkbox.md-THEME_NAME-theme {
   }
 
   &[disabled] {
-    .md-icon {
+    &:not(.md-checked) .md-icon {
       border-color: '{{foreground-3}}';
     }
 

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -242,14 +242,14 @@
   }
 
   &#{$checkedSelector} .md-icon {
-    border: none;
+    border-color: transparent;
 
     &:after {
       box-sizing: border-box;
       transform: rotate(45deg);
       position: absolute;
-      left: $width / 3;
-      top: $width / 9;
+      left: $width / 3 - $border-width;
+      top: $width / 9 - $border-width;
       display: table;
       width: $width / 3;
       height: $width * 2 / 3;
@@ -306,7 +306,7 @@
     color: '{{primary-color-0.87}}';
   }
 
-  ._md-icon {
+  &:not(.md-checked) ._md-icon {
     border-color: '{{foreground-2}}';
   }
 


### PR DESCRIPTION
Keep the border present when changing to checked state. Instead of removing, set it to transparent instead.

Fixes #8866