### PR TITLE
docs: Add mobile-specific styles for better usability.

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -934,3 +934,36 @@ table.md-api-table  tr  td:first-child {
   padding-top: 10px;
   padding-bottom: 10px;
 }
+
+/* Provide some layout/padding enhancements for mobile/small devices */
+@media(max-width: 500px) {
+  /* Reduce the size of the nav logo/header */
+  .docs-logo > img {
+    height: 75px;
+    margin-top: 10px;
+  }
+
+  .docs-logo h1 {
+    font-size: 18px;
+    line-height: 2rem;
+  }
+
+  /* Reduce the padding around standard doc content */
+  .docs-ng-view .doc-content {
+    margin: 8px;
+    padding: 0;
+  }
+
+  /* Reduce the padding around doc demos */
+  .docs-ng-view docs-demo {
+    padding: 0;
+  }
+
+  .docs-ng-view docs-demo:first-child {
+    margin-top: 0;
+  }
+
+  .docs-ng-view docs-demo .doc-demo-content {
+    margin: 0;
+  }
+}

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -154,7 +154,7 @@
     </md-toolbar>
 
     <md-content md-scroll-y layout="column" flex>
-      <div ng-view layout-padding flex="noshrink"></div>
+      <div ng-view layout-padding flex="noshrink" class="docs-ng-view"></div>
 
       <div layout="row" flex="noshrink" layout-align="center center">
         <div id="license-footer" flex>


### PR DESCRIPTION
 - Reduce the margins/padding around doc content and demos so that
   the content/demos utilize more of the screen.

 - Reduce the size of the sidenav logo/header so more of the actual
   navigation can be seen.

Fixes #8677.