### PR TITLE
docs: Add how to reset md-autocomplete value

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -19,6 +19,8 @@ angular
  *     no matches were found.  You can do this by wrapping your template in `md-item-template` and
  *     adding a tag for `md-not-found`.  An example of this is shown below.
  *
+ * To reset the displayed value you must clear both values for `md-search-text` and `md-selected-item`.
+ *
  * ### Validation
  *
  * You can use `ng-messages` to include validation the same way that you would normally validate;


### PR DESCRIPTION
I spent a lot of time trying to figure out how to reset the displayed value of an autocomplete that I was (re)using in a drawer. I eventually found the answer in issue https://github.com/angular/material/issues/3084.

So this update attempts to prevent others from struggling with this issue, which to me seems basic enough for it to be in the docs.