### PR TITLE
chore: Update GitHub New Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,20 @@
-**Actual behavior**:
--  What is the issue? *
--  What is the expected behavior?
+**Actual Behavior**:
+ -  `What is the issue?` *
+ -  `What is the expected behavior?`
 
-**CodePen** or Steps to reproduce the issue: *
--  CodePen Demo which shows your issue :
--  Details:
+**CodePen** (or steps to reproduce the issue): *
+ -  `CodePen Demo which shows your issue:`
+ -  `Details:`
 
 **Angular Versions**: *
--  Angular Version:
--  Angular Material Version:
+ -  `Angular Version:`
+ -  `Angular Material Version:`
 
 **Additional Information**:
--  Browser Type: *
--  Browser Version: *
--  OS: *
--  Stack Traces:
+ -  `Browser Type: *`
+ -  `Browser Version: *`
+ -  `OS: *`
+ -  `Stack Traces:`
 
 ----
 Shortcut to create a [new CodePen Demo](http://codepen.io/team/AngularMaterial/pen/bEGJdd).


### PR DESCRIPTION
Update the formatting of GitHub's New Issue template to make the questions stand out a bit better when reading the submitted issue.

Additionally fix some spacing/capitalization/formatting issues.

Fixes #8882.