### PR TITLE
fix(chips): Fix static chips remove padding.

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1067,6 +1067,14 @@ describe('<md-chips>', function() {
         expect(chipArray[1].innerHTML).toContain('2');
         expect(chipArray[2].innerHTML).toContain('3');
       });
+
+      it('does not allow removal of chips', function() {
+        scope.chipItem = 'Football';
+        var element = buildChips(STATIC_CHIPS_TEMPLATE);
+        var wrap = element.find('md-chips-wrap');
+
+        expect(wrap).not.toHaveClass('md-removable');
+      });
     });
 
     describe('<md-chip-remove>', function() {

--- a/src/components/chips/demoBasicUsage/index.html
+++ b/src/components/chips/demoBasicUsage/index.html
@@ -62,8 +62,7 @@
     <br/>
     <md-checkbox ng-model="ctrl.readonly">Readonly</md-checkbox>
     <md-checkbox ng-model="ctrl.removable">
-      Removable
-      <span ng-if="ctrl.removable === undefined">(Currently is <code>undefined</code>)</span>
+      Removable (<code>{{ctrl.removable === undefined ? 'undefined' : ctrl.removable}}</code>)
     </md-checkbox>
     <p class="md-caption">
       <b>Note</b>: When md-removable is undefined, readonly automatically sets md-removable to false.

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -184,6 +184,11 @@ MdChipsCtrl.prototype.isEditingChip = function() {
 
 
 MdChipsCtrl.prototype.isRemovable = function() {
+  // Return false if we have static chips
+  if (!this.ngModelCtrl) {
+    return false;
+  }
+
   return this.readonly ? this.removable :
          angular.isDefined(this.removable) ? this.removable : true;
 };


### PR DESCRIPTION
Static chips had some erroneous "remove" padding due to some recent changes with the new `md-removable` feature.

Fix by updating the `isRemovable()` method to also check if the component has an `ng-model` supplied and return false if not.

Also, minor change to demo to provide slightly better feedback to the user.

Fixes #8887.