### PR TITLE
fix(mdPanel): fix error when opening a previously closed panel

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1284,7 +1284,7 @@ MdPanelRef.prototype._removeEventListeners = function() {
   this._removeListeners && this._removeListeners.forEach(function(removeFn) {
     removeFn();
   });
-  this._removeListeners = null;
+  this._removeListeners = [];
 };
 
 


### PR DESCRIPTION
Ensures the `_removeListeners` collection is reset with a new array literal instead of null.

Closes #8894