### PR TITLE
fix(panel): Click outside to close when disable parent scrolling is enabled

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1119,7 +1119,10 @@ MdPanelRef.prototype._createPanel = function() {
 
           if (self._config['disableParentScroll']) {
             self._restoreScroll = self._$mdUtil.disableScrollAround(
-                null, self._panelContainer);
+              null,
+              self._panelContainer,
+              { doNotCreateScrollMaskElement: true }
+            );
           }
 
           self._panelEl = angular.element(
@@ -1197,12 +1200,12 @@ MdPanelRef.prototype._updatePosition = function(opt_init) {
 
   if (positionConfig) {
     positionConfig._setPanelPosition(this._panelEl);
-    
+
     // Hide the panel now that position is known.
     if (opt_init) {
       this._panelContainer.addClass(MD_PANEL_HIDDEN);
     }
-    
+
     this._panelEl.css('top', positionConfig.getTop());
     this._panelEl.css('bottom', positionConfig.getBottom());
     this._panelEl.css('left', positionConfig.getLeft());

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1121,7 +1121,7 @@ MdPanelRef.prototype._createPanel = function() {
             self._restoreScroll = self._$mdUtil.disableScrollAround(
               null,
               self._panelContainer,
-              { doNotCreateScrollMaskElement: true }
+              { disableScrollMask: true }
             );
           }
 

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -200,7 +200,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * @param {!Element|!angular.JQLite} parent Element to disable scrolling within.
      *   Defaults to body if none supplied.
      * @param options Object of options to modify functionality
-     *   - doNotCreateScrollMaskElement Boolean of whether or not to create a scroll mask element or
+     *   - disableScrollMask Boolean of whether or not to create a scroll mask element or
      *     use the passed parent element.
      */
     disableScrollAround: function(element, parent, options) {
@@ -223,7 +223,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       function disableElementScroll(element) {
         element = angular.element(element || body);
         var scrollMask;
-        if (options && options.doNotCreateScrollMaskElement) {
+        if (options && options.disableScrollMask) {
           scrollMask = element;
         } else {
           element = element[0];

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -199,8 +199,11 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * @param element Unused
      * @param {!Element|!angular.JQLite} parent Element to disable scrolling within.
      *   Defaults to body if none supplied.
+     * @param options Object of options to modify functionality
+     *   - doNotCreateScrollMaskElement Boolean of whether or not to create a scroll mask element or
+     *     use the passed parent element.
      */
-    disableScrollAround: function(element, parent) {
+    disableScrollAround: function(element, parent, options) {
       $mdUtil.disableScrollAround._count = $mdUtil.disableScrollAround._count || 0;
       ++$mdUtil.disableScrollAround._count;
       if ($mdUtil.disableScrollAround._enableScrolling) return $mdUtil.disableScrollAround._enableScrolling;
@@ -218,12 +221,18 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
       // Creates a virtual scrolling mask to absorb touchmove, keyboard, scrollbar clicking, and wheel events
       function disableElementScroll(element) {
-        element = angular.element(element || body)[0];
-        var scrollMask = angular.element(
-          '<div class="md-scroll-mask">' +
-          '  <div class="md-scroll-mask-bar"></div>' +
-          '</div>');
-        element.appendChild(scrollMask[0]);
+        element = angular.element(element || body);
+        var scrollMask;
+        if (options && options.doNotCreateScrollMaskElement) {
+          scrollMask = element;
+        } else {
+          element = element[0];
+          scrollMask = angular.element(
+            '<div class="md-scroll-mask">' +
+            '  <div class="md-scroll-mask-bar"></div>' +
+            '</div>');
+          element.appendChild(scrollMask[0]);
+        }
 
         scrollMask.on('wheel', preventDefault);
         scrollMask.on('touchmove', preventDefault);
@@ -240,8 +249,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         }
       }
 
-      // Converts the body to a position fixed block and translate it to the proper scroll
-      // position
+      // Converts the body to a position fixed block and translate it to the proper scroll position
       function disableBodyScroll() {
         var htmlNode = body.parentNode;
         var restoreHtmlStyle = htmlNode.style.cssText || '';
@@ -707,19 +715,19 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       var stickyProps = ['sticky', '-webkit-sticky'];
       for (var i = 0; i < stickyProps.length; ++i) {
         testEl.css({
-          position: stickyProps[i], 
-          top: 0, 
+          position: stickyProps[i],
+          top: 0,
           'z-index': 2
         });
-        
+
         if (testEl.css('position') == stickyProps[i]) {
           stickyProp = stickyProps[i];
           break;
         }
       }
-      
+
       testEl.remove();
-      
+
       return stickyProp;
     },
 
@@ -740,9 +748,9 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
     /**
      * Returns true if the parent form of the element has been submitted.
-     * 
+     *
      * @param element An Angular or HTML5 element.
-     * 
+     *
      * @returns {boolean}
      */
     isParentFormSubmitted: function(element) {
@@ -783,4 +791,3 @@ angular.element.prototype.blur = angular.element.prototype.blur || function() {
     }
     return this;
   };
-


### PR DESCRIPTION
- Added options to the `$mdUtil.disableScrollAround` function, the only option so far is `disableScrollMask`, a boolean that when passed in as true will force the function to not create the `md-scroll-mask` element and instead use the passed-in parent element.
- Modified the `MdPanelRef.prototype._createPanel` function to use the new `disableScrollMask` option.

Fixes #8891.