### PR TITLE
feat(autocomplete): optionally replace input while using up and down keys

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -2261,4 +2261,51 @@ describe('<md-autocomplete>', function() {
     element.remove();
   });
 
+  describe('replace text on select', function() {
+    it('does not change searchText on item select', inject(function($timeout, $mdConstant, $material) {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-replace-text-on-select="true"\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+
+      $material.flushInterimElement();
+
+      expect(scope.searchText).toBe('');
+      expect(scope.selectedItem).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      scope.$apply('searchText = "b"');
+      $timeout.flush();
+      waitForVirtualRepeat(element);
+
+      // Check expectations
+      expect(scope.searchText).toBe('b');
+      expect(scope.match(scope.searchText).length).toBe(2);
+
+      expect(ul.find('li').length).toBe(2);
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $timeout.flush();
+
+      expect(input[0].value).toBe('bar');
+      expect(scope.searchText).toBe('b');
+
+      element.remove();
+    }));
+  });
 });

--- a/src/components/autocomplete/demoBasicUsage/index.html
+++ b/src/components/autocomplete/demoBasicUsage/index.html
@@ -4,6 +4,8 @@
       <p>Use <code>md-autocomplete</code> to search for matches from local or remote data sources.</p>
       <md-autocomplete
           ng-disabled="ctrl.isDisabled"
+          md-escape-options="clear"
+          md-replace-text-on-select="true"
           md-no-cache="ctrl.noCache"
           md-selected-item="ctrl.selectedItem"
           md-search-text-change="ctrl.searchTextChange(ctrl.searchText)"

--- a/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
+++ b/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
@@ -15,6 +15,8 @@
       <form ng-submit="$event.preventDefault()">
         <p>Use <code>md-autocomplete</code> to search for matches from local or remote data sources.</p>
         <md-autocomplete
+            md-escape-options="clear"
+            md-replace-text-on-select="true"
             md-selected-item="ctrl.selectedItem"
             md-search-text="ctrl.searchText"
             md-items="item in ctrl.querySearch(ctrl.searchText)"

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -22,7 +22,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       lastCount            = 0,
       fetchesInProgress    = 0,
       enableWrapScroll     = null,
-      inputModelCtrl       = null;
+      inputModelCtrl       = null,
+      suggestedInputText   = '';
 
   // Public Exported Variables with handlers
   defineProperty('hidden', handleHiddenChange, true);
@@ -66,7 +67,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Initialize the controller, setup watchers, gather elements
    */
   function init () {
-    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: '', selectedItem: null });
+    $mdUtil.initOptionalProperties($scope, $attrs, { inputText: '', searchText: '', selectedItem: null });
     $mdTheming($element);
     configureWatchers();
     $mdUtil.nextTick(function () {
@@ -189,6 +190,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     $attrs.$observe('disabled', function (value) { ctrl.isDisabled = $mdUtil.parseAttributeBoolean(value, false); });
     $attrs.$observe('required', function (value) { ctrl.isRequired = $mdUtil.parseAttributeBoolean(value, false); });
     $attrs.$observe('readonly', function (value) { ctrl.isReadonly = $mdUtil.parseAttributeBoolean(value, false); });
+    $scope.$watch('inputText', handleInputText);
     $scope.$watch('searchText', wait ? $mdUtil.debounce(handleSearchText, wait) : handleSearchText);
     $scope.$watch('selectedItem', selectedItemChange);
     angular.element($window).on('resize', positionDropdown);
@@ -397,7 +399,26 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   }
 
   /**
-   * Handles changes to the searchText property.
+   * Handles changes to the inputText property.
+   * @param inputText
+   * @param previousInputText
+   */
+  function handleInputText (inputText, previousInputText) {
+    // Only continue if display text was changed by user
+    if (suggestedInputText === inputText) return;
+    ctrl.index = getDefaultIndex();
+    suggestedInputText = undefined;
+
+    // do nothing on init
+    if (inputText === previousInputText) return;
+    if (inputText === $scope.searchText) return;
+    $scope.$evalAsync(function() {
+      $scope.searchText = inputText;
+    });
+  }
+
+  /**
+   * Handles calls from the searchText watcher.
    * @param searchText
    * @param previousSearchText
    */
@@ -407,27 +428,38 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     // do nothing on init
     if (searchText === previousSearchText) return;
 
-    updateModelValidators();
+    if ($scope.inputText != searchText) {
+      $scope.$evalAsync(function () {
+        $scope.inputText = searchText;
+        suggestedInputText = searchText;
+        processChange();
+      });
+      return;
+    }
+    processChange();
 
-    getDisplayValue($scope.selectedItem).then(function (val) {
-      // clear selected item if search text no longer matches it
-      if (searchText !== val) {
-        $scope.selectedItem = null;
+    function processChange() {
+      updateModelValidators();
+      getDisplayValue($scope.selectedItem).then(function (val) {
+        // clear selected item if search text no longer matches it
 
-        // trigger change event if available
-        if (searchText !== previousSearchText) announceTextChange();
+        if (searchText !== val) {
+          $scope.selectedItem = null;
 
-        // cancel results if search text is not long enough
-        if (!isMinLengthMet()) {
-          ctrl.matches = [];
-          setLoading(false);
-          updateMessages();
-        } else {
-          handleQuery();
+          // trigger change event if available
+          if (searchText !== previousSearchText) announceTextChange();
+
+          // cancel results if search text is not long enough
+          if (!isMinLengthMet()) {
+            ctrl.matches = [];
+            setLoading(false);
+            updateMessages();
+          } else {
+            handleQuery();
+          }
         }
-      }
-    });
-
+      });
+    }
   }
 
   /**
@@ -482,6 +514,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         ctrl.index   = Math.min(ctrl.index + 1, ctrl.matches.length - 1);
         updateScroll();
         updateMessages();
+        if ($scope.replaceTextOnSelect) updateInputText();
         break;
       case $mdConstant.KEY_CODE.UP_ARROW:
         if (ctrl.loading) return;
@@ -490,6 +523,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         ctrl.index   = ctrl.index < 0 ? ctrl.matches.length - 1 : Math.max(0, ctrl.index - 1);
         updateScroll();
         updateMessages();
+        if ($scope.replaceTextOnSelect) updateInputText();
         break;
       case $mdConstant.KEY_CODE.TAB:
         // If we hit tab, assume that we've left the list so it will close
@@ -511,14 +545,21 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         event.stopPropagation();
 
         clearSelectedItem();
-        if ($scope.searchText && hasEscapeOption('clear')) {
-          clearSearchText();
+        var willBlur = hasEscapeOption('blur');
+        var willClear = hasEscapeOption('clear');
+
+        if (isTextClearable()) {
+          if ($scope.replaceTextOnSelect && $scope.inputText != $scope.searchText && !willBlur) {
+            $scope.inputText = $scope.searchText;
+          } else if (willClear) {
+            clearSearchText();
+          }
         }
 
         // Manually hide (needed for mdNotFound support)
         ctrl.hidden = true;
 
-        if (hasEscapeOption('blur')) {
+        if (willBlur) {
           // Force the component to blur if they hit escape
           doBlur(true);
         }
@@ -622,7 +663,16 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * @returns {boolean}
    */
   function shouldProcessEscape() {
-    return hasEscapeOption('blur') || !ctrl.hidden || ctrl.loading || hasEscapeOption('clear') && $scope.searchText;
+    return hasEscapeOption('blur') || !ctrl.hidden || ctrl.loading || hasEscapeOption('clear')
+           && isTextClearable();
+  }
+
+  /**
+   * Determines if there is text that can cleared
+   * @returns {boolean}
+   */
+  function isTextClearable() {
+    return $scope.searchText || $scope.inputText || elements.input.value;
   }
 
   /**
@@ -708,6 +758,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     //-- force form to update state for validation
     $mdUtil.nextTick(function () {
       getDisplayValue(ctrl.matches[ index ]).then(function (val) {
+        suggestedInputText = val;
         var ngModel = elements.$.input.controller('ngModel');
         ngModel.$setViewValue(val);
         ngModel.$render();
@@ -736,7 +787,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   }
 
   /**
-   * Clears the searchText value
+   * Clears searchText, inputText, and input value
    */
   function clearSearchText () {
     // Set the loading to true so we don't see flashes of content.
@@ -744,6 +795,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     // So the loading process will stop when the results had been retrieved.
     setLoading(true);
 
+    $scope.inputText = '';
     $scope.searchText = '';
 
     // Normally, triggering the change / input event is unnecessary, because the browser detects it properly.
@@ -758,7 +810,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     // $scope.searchText has a space character at the end, so we blank it one more time and then
     // focus.
     elements.input.blur();
-    $scope.searchText = '';
+    $scope.inputText = '';
     elements.input.focus();
   }
 
@@ -847,6 +899,18 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     } else if (bot > scrollTop + hgt) {
       scrollTo(bot - hgt);
     }
+  }
+
+  /**
+   * Update displayed text to currently selected item
+   */
+  function updateInputText () {
+    getCurrentDisplayValue().then(function (val) {
+      if (!val) return;
+      // Flag that we changed the inputText, not the user
+      suggestedInputText = val
+      $scope.inputText = val;
+    });
   }
 
   function isPromiseFetching() {

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -86,6 +86,7 @@ angular
  *     the dropdown.<br/><br/>
  *     When the dropdown doesn't fit into the viewport, the dropdown will shrink
  *     as less as possible.
+ * @param {boolean=} md-replace-text-on-select If true, displayed text will be replaced on item select
  *
  * @usage
  * ### Basic Example
@@ -148,29 +149,30 @@ function MdAutocomplete ($$mdSvgRegistry) {
     controller:   'MdAutocompleteCtrl',
     controllerAs: '$mdAutocompleteCtrl',
     scope:        {
-      inputName:        '@mdInputName',
-      inputMinlength:   '@mdInputMinlength',
-      inputMaxlength:   '@mdInputMaxlength',
-      searchText:       '=?mdSearchText',
-      selectedItem:     '=?mdSelectedItem',
-      itemsExpr:        '@mdItems',
-      itemText:         '&mdItemText',
-      placeholder:      '@placeholder',
-      noCache:          '=?mdNoCache',
-      requireMatch:     '=?mdRequireMatch',
-      selectOnMatch:    '=?mdSelectOnMatch',
-      matchInsensitive: '=?mdMatchCaseInsensitive',
-      itemChange:       '&?mdSelectedItemChange',
-      textChange:       '&?mdSearchTextChange',
-      minLength:        '=?mdMinLength',
-      delay:            '=?mdDelay',
-      autofocus:        '=?mdAutofocus',
-      floatingLabel:    '@?mdFloatingLabel',
-      autoselect:       '=?mdAutoselect',
-      menuClass:        '@?mdMenuClass',
-      inputId:          '@?mdInputId',
-      escapeOptions:    '@?mdEscapeOptions',
-      dropdownItems:    '=?mdDropdownItems'
+      inputName:           '@mdInputName',
+      inputMinlength:      '@mdInputMinlength',
+      inputMaxlength:      '@mdInputMaxlength',
+      searchText:          '=?mdSearchText',
+      selectedItem:        '=?mdSelectedItem',
+      itemsExpr:           '@mdItems',
+      itemText:            '&mdItemText',
+      placeholder:         '@placeholder',
+      noCache:             '=?mdNoCache',
+      requireMatch:        '=?mdRequireMatch',
+      selectOnMatch:       '=?mdSelectOnMatch',
+      matchInsensitive:    '=?mdMatchCaseInsensitive',
+      itemChange:          '&?mdSelectedItemChange',
+      textChange:          '&?mdSearchTextChange',
+      minLength:           '=?mdMinLength',
+      delay:               '=?mdDelay',
+      autofocus:           '=?mdAutofocus',
+      floatingLabel:       '@?mdFloatingLabel',
+      autoselect:          '=?mdAutoselect',
+      menuClass:           '@?mdMenuClass',
+      inputId:             '@?mdInputId',
+      escapeOptions:       '@?mdEscapeOptions',
+      dropdownItems:       '=?mdDropdownItems',
+      replaceTextOnSelect: '=?mdReplaceTextOnSelect'
     },
     compile: function(tElement, tAttrs) {
       var attributes = ['md-select-on-focus', 'md-no-asterisk', 'ng-trim'];
@@ -274,7 +276,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   ng-minlength="inputMinlength"\
                   ng-maxlength="inputMaxlength"\
                   ng-disabled="$mdAutocompleteCtrl.isDisabled"\
-                  ng-model="$mdAutocompleteCtrl.scope.searchText"\
+                  ng-model="$mdAutocompleteCtrl.scope.inputText"\
                   ng-model-options="{ allowInvalid: true }"\
                   ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                   ng-blur="$mdAutocompleteCtrl.blur($event)"\
@@ -299,7 +301,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-required="$mdAutocompleteCtrl.isRequired"\
                 ng-disabled="$mdAutocompleteCtrl.isDisabled"\
                 ng-readonly="$mdAutocompleteCtrl.isReadonly"\
-                ng-model="$mdAutocompleteCtrl.scope.searchText"\
+                ng-model="$mdAutocompleteCtrl.scope.inputText"\
                 ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1028,7 +1028,9 @@ describe('<md-chips>', function() {
           input.val('    ');
           input.triggerHandler('input');
 
-          expect(input.controller('ngModel').$modelValue).toBe('');
+          // Use toBeFalsy since IE reports 'undefined' instead of ''
+          expect(input.controller('ngModel').$modelValue).toBeFalsy();
+
           // Since the `md-chips` component is testing the backspace select previous chip functionality by
           // checking the current caret / cursor position, we have to set the cursor to the end of the current
           // value.


### PR DESCRIPTION
Creates an option for replacing the input text with the selected dropdown
item when using keyboard navigation

* Add `md-replace-text-on-select` option
* Update docs to show replace text behavior
* Create a new model called `inputText` representing the input box text
* Do not change `searchText` unless user types a change
* Allow users to accept replaced text with Enter or Tab

Note: This creates added complexity to autocomplete, since the user changes
the `inputText` model, and then the `searchText` is updated. Essentially,
this will decouple the text that exists inside the input box from the text
from which queries are run against. This will facilitate the implementation
of an "append text" autocomplete interaction.

Autocomplete UX Research: https://docs.google.com/document/d/1t60A2_Qni3IOSZDRqwwum3r5EVPjANJAkvFuMoqGfQA/