### PR TITLE
Fix(bottomSheet): md-bottom-sheet grid list has spacing issue within list item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 /.idea/
 .nvmrc
 tmp/
+.editorconfig

--- a/src/components/bottomSheet/bottom-sheet.scss
+++ b/src/components/bottomSheet/bottom-sheet.scss
@@ -115,7 +115,7 @@ md-bottom-sheet {
           }
         }
       }
-      
+
       @media (max-width: $layout-breakpoint-sm) {
         @include grid-items-per-row(3, true);
       }
@@ -132,7 +132,10 @@ md-bottom-sheet {
         @include grid-items-per-row(7);
       }
 
-
+      // Override of the IE11 fix from @mixin ie11-min-height-flexbug, line 109 mixins.scss
+      &::before {
+        display: none;
+      }
 
       .md-list-item-content {
         display: flex;

--- a/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
+++ b/src/components/bottomSheet/demoBasicUsage/bottom-sheet-grid-template.html
@@ -6,10 +6,10 @@
     <md-list flex layout="row" layout-align="center center">
       <md-list-item ng-repeat="item in items">
         <div>
-        <md-button class="md-grid-item-content" ng-click="listItemClick($index)">
-          <md-icon md-svg-src="{{item.icon}}"></md-icon>
-          <div class="md-grid-text"> {{ item.name }} </div>
-        </md-button>
+          <md-button class="md-grid-item-content" ng-click="listItemClick($index)">
+            <md-icon md-svg-src="{{item.icon}}"></md-icon>
+            <div class="md-grid-text"> {{ item.name }} </div>
+          </md-button>
         </div>
       </md-list-item>
     </md-list>


### PR DESCRIPTION
Tested this fix within IE 11 where the addition of the pseudo-before element was meant to fix an issue with min-height and flex containers in IE11, and the pseudo-before element was causing a spacing issue of the exact height as the min-height setting of the pseudo element at the top of each bottom sheet grid list item.

Ignoring the pseudo item fixed the spacing issue and didn't break the flex layout of IE 11 due to the fact that the `md-list` is built with the same configuration as the fix described here: https://codepen.io/chriswrightdesign/pen/emQNGZ.

Fixes #8913.