### PR TITLE
feat(md-virtual-repeat): Add DOM scope events for removal and addition of elements

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -767,6 +767,13 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
         this.blocks[maxIndex] && this.blocks[maxIndex].element[0].nextSibling);
   }
 
+  function broadcastMdVirtualRepeatItemReattached(block) {
+    if (!block.new){
+      block.scope.$broadcast('$mdVirtualRepeatItemReattached');
+    }
+  }
+  angular.forEach(newStartBlocks.concat(newEndBlocks), broadcastMdVirtualRepeatItemReattached);
+
   // Restore $$checkUrlChange.
   this.$browser.$$checkUrlChange = this.browserCheckUrlChange;
 
@@ -850,9 +857,11 @@ VirtualRepeatController.prototype.updateScope_ = function(scope, index) {
  * @private
  */
 VirtualRepeatController.prototype.poolBlock_ = function(index) {
-  this.pooledBlocks.push(this.blocks[index]);
-  this.parentNode.removeChild(this.blocks[index].element[0]);
+  var block = this.blocks[index];
+  this.pooledBlocks.push(block);
+  this.parentNode.removeChild(block.element[0]);
   delete this.blocks[index];
+  block.scope.$broadcast('$mdVirtualRepeatItemDetached');
 };
 
 

--- a/src/components/virtualRepeat/virtual-repeater.spec.js
+++ b/src/components/virtualRepeat/virtual-repeater.spec.js
@@ -661,6 +661,64 @@ describe('<md-virtual-repeat>', function() {
     expect(getTransform(offsetter)).toBe('translateY(880px)');
   });
 
+  it('should broadcast $mdVirtualRepeatItemDetached when an element is removed from the DOM', function() {
+    createRepeater();
+    scope.items = createItems(NUM_ITEMS);
+    scope.$apply();
+    $$rAF.flush();
+    scroller[0].scrollTop = 100;
+    scroller.triggerHandler('scroll');
+
+    var scopes = Array.prototype.map.call(getRepeated(), function(elem) {
+      var s = angular.element(elem).scope();
+      spyOn(s, '$broadcast').and.callThrough();
+      return s;
+    });
+
+    // Scroll up by one.
+    // Expect only the last (index 15) scope to have $broadcast the event.
+    scroller[0].scrollTop = 90;
+    scroller.triggerHandler('scroll');
+    expect(scopes[15].$broadcast).toHaveBeenCalledWith('$mdVirtualRepeatItemDetached');
+    expect(scopes[14].$broadcast).not.toHaveBeenCalled();
+
+    // Scroll down by two.
+    // Expect only the first scope to have $broadcast the event.
+    scroller[0].scrollTop = 110;
+    scroller.triggerHandler('scroll');
+    expect(scopes[0].$broadcast).toHaveBeenCalledWith('$mdVirtualRepeatItemDetached');
+    expect(scopes[1].$broadcast).not.toHaveBeenCalled();
+  });
+  
+  it('should broadcast $mdVirtualRepeatItemReattached when an element is reattached to the DOM', function() {
+    createRepeater();
+    scope.items = createItems(NUM_ITEMS);
+    scope.$apply();
+    $$rAF.flush();
+    scroller[0].scrollTop = 100;
+    scroller.triggerHandler('scroll');
+
+    var scopes = Array.prototype.map.call(getRepeated(), function(elem) {
+      var s = angular.element(elem).scope();
+      spyOn(s, '$broadcast').and.callThrough();
+      return s;
+    });
+
+    // Scroll up by one.
+    // This should remove the last element from the DOM.
+    scroller[0].scrollTop = 90;
+    scroller.triggerHandler('scroll');
+    expect(scopes[15].$broadcast).toHaveBeenCalledWith('$mdVirtualRepeatItemDetached');
+
+    // Scroll down by two.
+    // Expect only the last element to have $broadcast the event.
+    scroller[0].scrollTop = 110;
+    scroller.triggerHandler('scroll');
+    expect(scopes[14].$broadcast).not.toHaveBeenCalled();
+    expect(scopes[15].$broadcast).toHaveBeenCalledWith('$mdVirtualRepeatItemReattached');
+  });
+
+
   describe('md-on-demand', function() {
 
     it('should validate an empty md-on-demand attribute value correctly', inject(function() {


### PR DESCRIPTION
I am building a UI where elements inside a virtual-repeater list, display pins on a map. These pins change size depending on their visibility.

I required a way to detect when the element was no longer visible in the virtual-repeat list. Hopefully this is a welcome addition to the project.

    The $mdVirtualRepeatItemDetached event is $broadcast with no arguments,
    on the scope of elements which are removed from the DOM.

    The $mdVirtualRepeatItemReattached event is $broadcast with no arguments,
    on the scope of elements which are re-attached to the DOM.