### PR TITLE
fix(radio): disabled radio-group should notify child radio buttons

### DIFF
--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -69,21 +69,27 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
     rgCtrl.init(ngModelCtrl);
 
     scope.mouseActive = false;
-    element.attr({
-              'role': 'radiogroup',
-              'tabIndex': element.attr('tabindex') || '0'
-            })
-            .on('keydown', keydownListener)
-            .on('mousedown', function(event) {
-              scope.mouseActive = true;
-              $timeout(function() {
-                scope.mouseActive = false;
-              }, 100);
-            })
-            .on('focus', function() {
-              if(scope.mouseActive === false) { rgCtrl.$element.addClass('md-focused'); }
-            })
-            .on('blur', function() { rgCtrl.$element.removeClass('md-focused'); });
+
+    element
+      .attr({
+        'role': 'radiogroup',
+        'tabIndex': element.attr('tabindex') || '0'
+      })
+      .on('keydown', keydownListener)
+      .on('mousedown', function(event) {
+        scope.mouseActive = true;
+        $timeout(function() {
+          scope.mouseActive = false;
+        }, 100);
+      })
+      .on('focus', function() {
+        if(scope.mouseActive === false) {
+          rgCtrl.$element.addClass('md-focused');
+        }
+      })
+      .on('blur', function() {
+        rgCtrl.$element.removeClass('md-focused');
+      });
 
     /**
      *
@@ -174,6 +180,9 @@ function mdRadioGroupDirective($mdUtil, $mdConstant, $mdTheming, $timeout) {
       },
       setActiveDescendant: function (radioId) {
         this.$element.attr('aria-activedescendant', radioId);
+      },
+      isDisabled: function() {
+        return this.$element[0].hasAttribute('disabled');
       }
     };
   }
@@ -268,9 +277,9 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
     /**
      *
      */
-    function initialize(controller) {
-      if ( !rgCtrl ) {
-        throw 'RadioGroupController not found.';
+    function initialize() {
+      if (!rgCtrl) {
+        throw 'RadioButton: No RadioGroupController could be found.';
       }
 
       rgCtrl.add(render);
@@ -287,7 +296,7 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
      *
      */
     function listener(ev) {
-      if (element[0].hasAttribute('disabled')) return;
+      if (element[0].hasAttribute('disabled') || rgCtrl.isDisabled()) return;
 
       scope.$apply(function() {
         rgCtrl.setViewValue(attr.value, ev && ev.type);

--- a/src/components/radioButton/radio-button.scss
+++ b/src/components/radioButton/radio-button.scss
@@ -4,6 +4,14 @@ $radio-text-margin: 10px !default;
 $radio-top-left: 12px !default;
 $radio-margin: 16px !default;
 
+@mixin md-radio-button-disabled {
+  cursor: default;
+
+  .md-container {
+    cursor: default;
+  }
+}
+
 md-radio-button {
   box-sizing: border-box;
   display: block;
@@ -12,13 +20,9 @@ md-radio-button {
   cursor: pointer;
   position: relative;
 
-  // disabled
+  // When the radio-button is disabled.
   &[disabled] {
-    cursor: default;
-
-    .md-container {
-      cursor: default;
-    }
+    @include md-radio-button-disabled();
   }
 
   .md-container {
@@ -110,6 +114,7 @@ md-radio-button {
 }
 
 md-radio-group {
+  /** Layout adjustments for the radio group. */
   &.layout-column,
   &.layout-xs-column, &.layout-gt-xs-column,
   &.layout-sm-column, &.layout-gt-sm-column,
@@ -139,9 +144,11 @@ md-radio-group {
       }
     }
   }
+
   &:focus {
     outline: none;
   }
+
   &.md-focused {
     .md-checked .md-container:before {
       left: -8px;
@@ -149,6 +156,10 @@ md-radio-group {
       right: -8px;
       bottom: -8px;
     }
+  }
+
+  &[disabled] md-radio-button {
+    @include md-radio-button-disabled();
   }
 }
 

--- a/src/components/radioButton/radio-button.spec.js
+++ b/src/components/radioButton/radio-button.spec.js
@@ -1,223 +1,282 @@
-describe('radioButton', function() {
+describe('mdRadioButton component', function() {
+
   var CHECKED_CSS = 'md-checked';
 
   beforeEach(module('material.components.radioButton'));
 
-  it('should have `._md` class indicator',inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                               '<md-radio-button value="blue"></md-radio-button>' +
-                               '<md-radio-button value="green"></md-radio-button>' +
-                             '</md-radio-group>')($rootScope);
+  describe('md-radio-group', function() {
 
-    expect(element.hasClass('_md')).toBe(true);
-  }));
+    it('should have `._md` class indicator',inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-  it('should set checked css class', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+      expect(element.hasClass('_md')).toBe(true);
+    }));
 
-    $rootScope.$apply(function(){
-      $rootScope.color = 'green';
-    });
+    it('should correctly apply the checked class', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbElements = element.find('md-radio-button');
+      $rootScope.$apply('color = "green"');
 
-    expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toEqual(false);
-    expect(rbElements.eq(1).hasClass(CHECKED_CSS)).toEqual(true);
-  }));
+      var radioButtons = element.find('md-radio-button');
 
-  it('should support mixed values', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="value">' +
-                            '<md-radio-button value="1"></md-radio-button>' +
-                            '<md-radio-button value="2"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toEqual(false);
+      expect(radioButtons.eq(1).hasClass(CHECKED_CSS)).toEqual(true);
+    }));
 
-    $rootScope.$apply(function(){
-      $rootScope.value = 1;
-    });
+    it('should support mixed values', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="value">' +
+          '<md-radio-button value="1"></md-radio-button>' +
+          '<md-radio-button value="2"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbElements = element.find('md-radio-button');
-    expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toEqual(true);
-  }));
+      $rootScope.$apply('value = 1');
 
-  it('should set roles', inject(function($compile, $rootScope) {
+      var radioButtons = element.find('md-radio-button');
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toEqual(true);
+    }));
 
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+    it('should set the role attribute', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbGroupElement = element;
-    expect(rbGroupElement.eq(0).attr('role')).toEqual('radiogroup');
-    expect(rbGroupElement.find('md-radio-button').eq(0).attr('role')).toEqual('radio');
-  }));
+      var radioButton = element.find('md-radio-button').eq(0);
 
-  it('should set aria states', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+      expect(element.eq(0).attr('role')).toEqual('radiogroup');
+      expect(radioButton.attr('role')).toEqual('radio');
+    }));
 
-    $rootScope.$apply(function(){
-      $rootScope.color = 'green';
-    });
+    it('should apply aria state attributes', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbElements = element.find('md-radio-button');
+      $rootScope.$apply('color = "green"');
 
-    expect(rbElements.eq(0).attr('aria-checked')).toEqual('false');
-    expect(rbElements.eq(1).attr('aria-checked')).toEqual('true');
+      var radioButtons = element.find('md-radio-button');
 
-    expect(element.attr('aria-activedescendant')).toEqual(rbElements.eq(1).attr('id'));
-    expect(element.attr('aria-activedescendant')).not.toEqual(rbElements.eq(0).attr('id'));
-  }));
+      expect(radioButtons.eq(0).attr('aria-checked')).toEqual('false');
+      expect(radioButtons.eq(1).attr('aria-checked')).toEqual('true');
 
-  it('should warn developers they need a label', inject(function($compile, $rootScope, $log){
-    spyOn($log, "warn");
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+      expect(element.attr('aria-activedescendant')).toEqual(radioButtons.eq(1).attr('id'));
+      expect(element.attr('aria-activedescendant')).not.toEqual(radioButtons.eq(0).attr('id'));
+    }));
 
-    expect($log.warn).toHaveBeenCalled();
-  }));
+    it('should warn developers if no label is specified', inject(function($compile, $rootScope, $log) {
+      spyOn($log, "warn");
 
-  it('should create an aria label from provided text', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue">Blue</md-radio-button>' +
-                            '<md-radio-button value="green">Green</md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+      $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbElements = element.find('md-radio-button');
-    expect(rbElements.eq(0).attr('aria-label')).toEqual('Blue');
-  }));
+      expect($log.warn).toHaveBeenCalled();
+    }));
 
-  it('should preserve tabindex', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<md-radio-group ng-model="color" tabindex="3">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
+    it('should create an aria label from provided text', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue">Blue</md-radio-button>' +
+          '<md-radio-button value="green">Green</md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbGroupElement = element.eq(0);
-    expect(rbGroupElement.attr('tabindex')).toEqual('3');
-  }));
+      var radioButtons = element.find('md-radio-button');
+      expect(radioButtons.eq(0).attr('aria-label')).toEqual('Blue');
+    }));
 
-  it('should be operable via arrow keys', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
-    $rootScope.$apply(function(){
-      $rootScope.color = 'blue';
-    });
+    it('should disable all child radio buttons', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color" ng-disabled="isDisabled">' +
+          '<md-radio-button value="white"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    var rbGroupElement = element.eq(0);
-    rbGroupElement.triggerHandler({
-      type: 'keydown',
-      keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW,
-      currentTarget: rbGroupElement[0],
-      target: rbGroupElement[0]
-    });
+      var radioButton = element.find('md-radio-button');
 
-    expect($rootScope.color).toEqual('green');
-  }));
+      $rootScope.$apply('isDisabled = true');
+      $rootScope.$apply('color = null');
+      radioButton.triggerHandler('click');
 
-  it('should not set focus state on mousedown', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
-    $rootScope.$apply();
-    element.triggerHandler('mousedown');
-    expect(element[0]).not.toHaveClass('md-focused');
-  }));
+      expect($rootScope.color).toBe(null);
 
-  it('should set focus state on focus and remove on blur', inject(function($compile, $rootScope) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
-    $rootScope.$apply();
-    element.triggerHandler('focus');
-    expect(element[0]).toHaveClass('md-focused');
-    element.triggerHandler('blur');
-    expect(element[0]).not.toHaveClass('md-focused');
-  }));
+      $rootScope.$apply('isDisabled = false');
+      radioButton.triggerHandler('click');
 
-  it('should set focus state on keyboard interaction after clicking', inject(function($compile, $rootScope, $mdConstant) {
-    var element = $compile('<md-radio-group ng-model="color">' +
-                            '<md-radio-button value="blue"></md-radio-button>' +
-                            '<md-radio-button value="green"></md-radio-button>' +
-                          '</md-radio-group>')($rootScope);
-    $rootScope.$apply();
-    element.triggerHandler('mousedown');
-    element.triggerHandler({
-      type: 'keydown',
-      keyCode: $mdConstant.KEY_CODE.DOWN_ARROW,
-      currentTarget: element[0],
-      target: element[0]
-    });
-    expect(element[0]).toHaveClass('md-focused');
-  }));
+      expect($rootScope.color).toBe('white');
+    }));
 
-  describe('ng core radio button tests', function() {
+    it('should preserve tabindex', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color" tabindex="3">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
 
-    it('should noop with no model', inject(function($compile, $rootScope) {
-      var el;
+      expect(element.attr('tabindex')).toEqual('3');
+    }));
+
+    it('should be operable via arrow keys', inject(function($compile, $rootScope, $mdConstant) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      $rootScope.$apply('color = "blue"');
+
+      element.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW,
+        currentTarget: element[0],
+        target: element[0]
+      });
+
+      expect($rootScope.color).toEqual('green');
+    }));
+
+    it('should not set focus state on mousedown', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      $rootScope.$apply();
+      element.triggerHandler('mousedown');
+
+      expect(element).not.toHaveClass('md-focused');
+    }));
+
+    it('should apply focus class on focus and remove on blur', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      $rootScope.$apply();
+      element.triggerHandler('focus');
+
+      expect(element[0]).toHaveClass('md-focused');
+
+      element.triggerHandler('blur');
+      expect(element[0]).not.toHaveClass('md-focused');
+    }));
+
+    it('should apply focus class on keyboard interaction', inject(function($compile, $rootScope, $mdConstant) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+          '<md-radio-button value="green"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      $rootScope.$apply();
+
+      element.triggerHandler('mousedown');
+      element.triggerHandler({
+        type: 'keydown',
+        keyCode: $mdConstant.KEY_CODE.DOWN_ARROW,
+        currentTarget: element[0],
+        target: element[0]
+      });
+
+      expect(element[0]).toHaveClass('md-focused');
+    }));
+
+  });
+
+  describe('md-radio-button', function() {
+
+    it('should be static with no model', inject(function($compile, $rootScope) {
+      var element;
       expect(function() {
-        el = $compile('<md-radio-group>' +
-                              '<md-radio-button value="white">' +
-                              '</md-radio-group>')($rootScope);
+        element = $compile(
+          '<md-radio-group>' +
+            '<md-radio-button value="white">' +
+          '</md-radio-group>')
+        ($rootScope);
       }).not.toThrow();
-      var rbElements = el.find('md-radio-button');
+
+      var radioButtons = element.find('md-radio-button');
 
       // Fire off the render function with no ngModel, make sure nothing
       // goes unexpectedly.
       expect(function() {
-        rbElements.eq(0).triggerHandler('click');
+        radioButtons.eq(0).triggerHandler('click');
       }).not.toThrow();
     }));
 
     it('should update the model', inject(function($compile, $rootScope) {
-      var element = $compile('<md-radio-group ng-model="color">' +
-                              '<md-radio-button value="white"></md-radio-button>' +
-                              '<md-radio-button value="red"></md-radio-button>' +
-                              '<md-radio-button value="blue"></md-radio-button>' +
-                            '</md-radio-group>')($rootScope);
-      var rbElements = element.find('md-radio-button');
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="white"></md-radio-button>' +
+          '<md-radio-button value="red"></md-radio-button>' +
+          '<md-radio-button value="blue"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      var radioButtons = element.find('md-radio-button');
 
       $rootScope.$apply("color = 'white'");
-      expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toBe(true);
-      expect(rbElements.eq(1).hasClass(CHECKED_CSS)).toBe(false);
-      expect(rbElements.eq(2).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toBe(true);
+      expect(radioButtons.eq(1).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(2).hasClass(CHECKED_CSS)).toBe(false);
 
       $rootScope.$apply("color = 'red'");
-      expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toBe(false);
-      expect(rbElements.eq(1).hasClass(CHECKED_CSS)).toBe(true);
-      expect(rbElements.eq(2).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(1).hasClass(CHECKED_CSS)).toBe(true);
+      expect(radioButtons.eq(2).hasClass(CHECKED_CSS)).toBe(false);
 
-      rbElements.eq(2).triggerHandler('click');
+      radioButtons.eq(2).triggerHandler('click');
 
       expect($rootScope.color).toBe('blue');
     }));
 
-    it('should trigger a submit', inject(function($compile, $rootScope, $mdConstant) {
+    it('should trigger a submit action', inject(function($compile, $rootScope, $mdConstant) {
 
       $rootScope.testValue = false;
-      $rootScope.submitFn = function(){
-        $rootScope.testValue = true;
-      };
-      var element = $compile('<div><form ng-submit="submitFn()">' +
-                              '<md-radio-group ng-model="color">' +
-                              '<md-radio-button value="white"></md-radio-button>' +
-                              '</md-radio-group>' +
-                            '</form></div>')($rootScope);
 
-      var formElement = element.find('form'),
-          rbGroupElement = element.find('md-radio-group');
+      var element = $compile(
+        '<div>' +
+          '<form ng-submit="testValue = true">' +
+            '<md-radio-group ng-model="color">' +
+              '<md-radio-button value="white"></md-radio-button>' +
+            '</md-radio-group>' +
+          '</form>' +
+        '</div>')
+      ($rootScope);
 
-      rbGroupElement.triggerHandler({
+      var radioGroupElement = element.find('md-radio-group');
+
+      expect($rootScope.testValue).toBeFalsy();
+
+      radioGroupElement.triggerHandler({
         type: 'keydown',
         keyCode: $mdConstant.KEY_CODE.ENTER
       });
@@ -225,66 +284,81 @@ describe('radioButton', function() {
       expect($rootScope.testValue).toBe(true);
     }));
 
-    it('should be disabled', inject(function($compile, $rootScope) {
-      var element = $compile('<md-radio-group ng-model="color">' +
-                              '<md-radio-button value="white" ng-disabled="isDisabled"></md-radio-button>' +
-                              '</md-radio-group>')($rootScope);
-      var radio = element.find('md-radio-button');
+    it('should correctly disable the button', inject(function($compile, $rootScope) {
+      var element = $compile(
+        '<md-radio-group ng-model="color">' +
+          '<md-radio-button value="white" ng-disabled="isDisabled"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      var radioButton = element.find('md-radio-button');
 
       $rootScope.$apply('isDisabled = true');
       $rootScope.$apply('color = null');
-      radio.triggerHandler('click');
+      radioButton.triggerHandler('click');
+
       expect($rootScope.color).toBe(null);
 
       $rootScope.$apply('isDisabled = false');
-      radio.triggerHandler('click');
+      radioButton.triggerHandler('click');
+
       expect($rootScope.color).toBe('white');
     }));
 
     it('should skip disabled on arrow key', inject(function($compile, $rootScope, $mdConstant) {
       var element = $compile(
         '<md-radio-group ng-model="color">' +
-        '  <md-radio-button value="red"   ></md-radio-button>' +
-        '  <md-radio-button value="white" ng-disabled="isDisabled"></md-radio-button>' +
-        '  <md-radio-button value="blue" ></md-radio-button>' +
+          '<md-radio-button value="red"   ></md-radio-button>' +
+          '<md-radio-button value="white" ng-disabled="isDisabled"></md-radio-button>' +
+          '<md-radio-button value="blue" ></md-radio-button>' +
         '</md-radio-group>'
       )($rootScope);
-      var rbGroupElement = element.eq(0);
 
       $rootScope.$apply('isDisabled = true');
       $rootScope.$apply('color = "red"');
       expect($rootScope.color).toBe("red");
 
 
-      rightArrow();   expect($rootScope.color).toEqual('blue');
-      rightArrow();   expect($rootScope.color).toEqual('red');
-      rightArrow();   expect($rootScope.color).toEqual('blue');
+      rightArrow();
+      expect($rootScope.color).toEqual('blue');
 
+      rightArrow();
+      expect($rootScope.color).toEqual('red');
+
+      rightArrow();
+      expect($rootScope.color).toEqual('blue');
 
       $rootScope.$apply('isDisabled = false');
 
       rightArrow();
-      rightArrow();   expect($rootScope.color).toEqual('white');
-      rightArrow();   expect($rootScope.color).toEqual('blue');
+
+      rightArrow();
+      expect($rootScope.color).toEqual('white');
+
+      rightArrow();
+      expect($rootScope.color).toEqual('blue');
 
       function rightArrow() {
-          rbGroupElement.triggerHandler({
-            type: 'keydown',
-            target: rbGroupElement[0],
-            currentTarget: rbGroupElement[0],
-            keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW
-          });
-        }
+        element.triggerHandler({
+          type: 'keydown',
+          target: element[0],
+          currentTarget: element[0],
+          keyCode: $mdConstant.KEY_CODE.RIGHT_ARROW
+        });
+      }
     }));
 
-
-    it('should allow {{expr}} as value', inject(function($compile, $rootScope) {
+    it('should allow interpolation as a value', inject(function($compile, $rootScope) {
       $rootScope.some = 11;
-      var element = $compile('<md-radio-group ng-model="value">' +
+
+      var element = $compile(
+        '<md-radio-group ng-model="value">' +
           '<md-radio-button value="{{some}}"></md-radio-button>' +
-          '<md-radio-button value="{{other}}"></<md-radio-button>' +
-          '</md-radio-group>')($rootScope);
-      var rbElements = element.find('md-radio-button');
+          '<md-radio-button value="{{other}}"></md-radio-button>' +
+        '</md-radio-group>')
+      ($rootScope);
+
+      var radioButtons = element.find('md-radio-button');
 
       $rootScope.$apply(function() {
         $rootScope.value = 'blue';
@@ -292,16 +366,16 @@ describe('radioButton', function() {
         $rootScope.other = 'red';
       });
 
-      expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toBe(true);
-      expect(rbElements.eq(1).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toBe(true);
+      expect(radioButtons.eq(1).hasClass(CHECKED_CSS)).toBe(false);
 
-      rbElements.eq(1).triggerHandler('click');
+      radioButtons.eq(1).triggerHandler('click');
       expect($rootScope.value).toBe('red');
 
       $rootScope.$apply("other = 'non-red'");
 
-      expect(rbElements.eq(0).hasClass(CHECKED_CSS)).toBe(false);
-      expect(rbElements.eq(1).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(0).hasClass(CHECKED_CSS)).toBe(false);
+      expect(radioButtons.eq(1).hasClass(CHECKED_CSS)).toBe(false);
     }));
 
   });


### PR DESCRIPTION
* When disabling the md-radio-group then the child md-radio-buttons should also disable the click listener.
* Cleaned up the tests and a few things in the source (not fully cleaned the source)

@ThomasBurleson This is not a risky change, since the most PR modification comes from the cleaned tests.

Fixes #8939.