### PR TITLE
fix(toolbar): use variables for height.

### DIFF
--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -1,20 +1,14 @@
 // Standard/Desktop Heights
-$toolbar-tools-height: 64px !default;
-$toolbar-height: 64px !default;
-$toolbar-medium-tall-height: 88px !default;
-$toolbar-tall-height: 128px !default;
+$md-toolbar-height: $baseline-grid * 8 !default;
+$md-toolbar-medium-tall-height: 88px !default;
+$md-toolbar-tall-height: 128px !default;
 
-// Mobile portrait heights
-$toolbar-tools-height-mobile-portrait: 56px !default;
-$toolbar-height-mobile-portrait: 56px !default;
+// Mobile device heights
+$md-toolbar-height-mobile-portrait: 56px !default;
+$md-toolbar-height-mobile-landscape: 48px !default;
 
-// Mobile landscape heights
-$toolbar-tools-height-mobile-landscape: 48px !default;
-$toolbar-height-mobile-landscape: 48px !default;
-
-
-$toolbar-indent-margin: 64px !default;
-$toolbar-padding: 16px !default;
+$md-toolbar-indent-margin: 64px !default;
+$md-toolbar-padding: 16px !default;
 
 $icon-button-margin-offset: rem(-0.800) !default;
 
@@ -27,7 +21,7 @@ md-toolbar {
   z-index: 2;
 
   font-size: rem(2.0);
-  min-height: $baseline-grid * 8;
+  min-height: $md-toolbar-height;
   width: 100%;
 
   &._md-toolbar-transitions {
@@ -58,15 +52,15 @@ md-toolbar {
   }
 
   &.md-tall {
-    height: $toolbar-tall-height;
-    min-height: $toolbar-tall-height;
-    max-height: $toolbar-tall-height;
+    height: $md-toolbar-tall-height;
+    min-height: $md-toolbar-tall-height;
+    max-height: $md-toolbar-tall-height;
   }
 
   &.md-medium-tall {
-    height: $toolbar-medium-tall-height;
-    min-height: $toolbar-medium-tall-height;
-    max-height: $toolbar-medium-tall-height;
+    height: $md-toolbar-medium-tall-height;
+    min-height: $md-toolbar-medium-tall-height;
+    max-height: $md-toolbar-medium-tall-height;
 
     .md-toolbar-tools {
       height: 48px;
@@ -76,7 +70,7 @@ md-toolbar {
   }
 
   > .md-indent {
-    @include rtl-prop(margin-left, margin-right, $toolbar-indent-margin);
+    @include rtl-prop(margin-left, margin-right, $md-toolbar-indent-margin);
   }
 
   ~ md-content {
@@ -102,9 +96,9 @@ md-toolbar {
   flex-direction: row;
 
   width: 100%;
-  height: $toolbar-tools-height;
-  max-height: $toolbar-tools-height;
-  padding: 0 $toolbar-padding;
+  height: $md-toolbar-height;
+  max-height: $md-toolbar-height;
+  padding: 0 $md-toolbar-padding;
   margin: 0;
 
   h1, h2, h3 {
@@ -160,24 +154,24 @@ md-toolbar {
 // Handle mobile portrait
 @media (min-width: 0) and (max-width: $layout-breakpoint-sm - 1) and (orientation: portrait) {
   md-toolbar {
-    min-height: $toolbar-height-mobile-portrait;
+    min-height: $md-toolbar-height-mobile-portrait;
   }
 
   .md-toolbar-tools {
-    height: $toolbar-height-mobile-portrait;
-    max-height: $toolbar-height-mobile-portrait;
+    height: $md-toolbar-height-mobile-portrait;
+    max-height: $md-toolbar-height-mobile-portrait;
   }
 }
 
 // Handle mobile landscape
 @media (min-width: 0) and (max-width: $layout-breakpoint-sm - 1) and (orientation: landscape) {
   md-toolbar {
-    min-height: $toolbar-height-mobile-landscape;
+    min-height: $md-toolbar-height-mobile-landscape;
   }
 
   .md-toolbar-tools {
-    height: $toolbar-height-mobile-landscape;
-    max-height: $toolbar-height-mobile-landscape;
+    height: $md-toolbar-height-mobile-landscape;
+    max-height: $md-toolbar-height-mobile-landscape;
   }
 }
 


### PR DESCRIPTION
* Use the SCSS variables for the height instead of inlining the height.
  This allows developers to overwrite those variables from the SCSS file.

* Drops unnecessary variables, which are unused.

Fixes #8941.