### PR TITLE
chore: Fix formatting of ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 **Actual Behavior**:
- -  `What is the issue?` *
+ -  `What is the issue? *`
  -  `What is the expected behavior?`
 
 **CodePen** (or steps to reproduce the issue): *


### PR DESCRIPTION
The issue template was inconsistent on the placement of the asterisk inside/outside of the back-ticks.

Move the inconsistent asterisk inside the back-ticks to match others.

Hat-tip to @bradrich for finding it.