### PR TITLE
wip(tooltip): Tooltip transition to mdPanel

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -108,6 +108,9 @@ angular
  *   - `attachTo` - `{(string|!angular.JQLite|!Element)=}`: The element to
  *     attach the panel to. Defaults to appending to the root element of the
  *     application.
+ *   - `propagateContainerEvents` - `{boolean=}`: Whether pointer or touch
+ *     events should be allowed to propagate 'go through' the container, aka the
+ *     wrapper, of the panel.
  *   - `panelClass` - `{string=}`: A css class to apply to the panel element.
  *     This class should define any borders, box-shadow, etc. for the panel.
  *   - `zIndex` - `{number=}`: The z-index to place the panel at.
@@ -626,6 +629,7 @@ function MdPanelService($rootElement, $rootScope, $injector, $window) {
     focusOnOpen: true,
     fullscreen: false,
     hasBackdrop: false,
+    propagateContainerEvents: false,
     transformTemplate: angular.bind(this, this._wrapTemplate),
     trapFocus: false,
     zIndex: defaultZIndex
@@ -1054,14 +1058,18 @@ MdPanelRef.prototype.hide = function() {
  * Add a class to the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} newClass Class to be added.
+ * @param {boolean} toElement Whether or not to add the class to the panel
+ *    element instead of the container.
  */
-MdPanelRef.prototype.addClass = function(newClass) {
+MdPanelRef.prototype.addClass = function(newClass, toElement) {
   if (!this._panelContainer) {
     throw new Error('Panel does not exist yet. Call open() or attach().');
   }
 
-  if (!this._panelContainer.hasClass(newClass)) {
+  if (!toElement && !this._panelContainer.hasClass(newClass)) {
     this._panelContainer.addClass(newClass);
+  } else if (toElement && !this._panelEl.hasClass(newClass)) {
+    this._panelEl.addClass(newClass);
   }
 };
 
@@ -1070,14 +1078,18 @@ MdPanelRef.prototype.addClass = function(newClass) {
  * Remove a class from the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} oldClass Class to be removed.
+ * @param {boolean} fromElement Whether or not to remove the class from the panel
+ *    element instead of the container.
  */
-MdPanelRef.prototype.removeClass = function(oldClass) {
+MdPanelRef.prototype.removeClass = function(oldClass, fromElement) {
   if (!this._panelContainer) {
     throw new Error('Panel does not exist yet. Call open() or attach().');
   }
 
-  if (this._panelContainer.hasClass(oldClass)) {
+  if (!fromElement && this._panelContainer.hasClass(oldClass)) {
     this._panelContainer.removeClass(oldClass);
+  } else if (fromElement && this._panelEl.hasClass(oldClass)) {
+    this._panelEl.removeClass(oldClass);
   }
 };
 
@@ -1086,13 +1098,19 @@ MdPanelRef.prototype.removeClass = function(oldClass) {
  * Toggle a class on the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} toggleClass The class to toggle.
+ * @param {boolean} onElement Whether or not to toggle the class on the panel
+ *    element instead of the container.
  */
-MdPanelRef.prototype.toggleClass = function(toggleClass) {
+MdPanelRef.prototype.toggleClass = function(toggleClass, onElement) {
   if (!this._panelContainer) {
     throw new Error('Panel does not exist yet. Call open() or attach().');
   }
 
-  this._panelContainer.toggleClass(toggleClass);
+  if (!onElement) {
+    this._panelContainer.toggleClass(toggleClass);
+  } else {
+    this._panelEl.toggleClass(toggleClass);
+  }
 };
 
 
@@ -1125,9 +1143,14 @@ MdPanelRef.prototype._createPanel = function() {
           self._panelEl = angular.element(
               self._panelContainer[0].querySelector('.md-panel'));
 
-          // Add a custom CSS class.
+          // Add a custom CSS class to the panel element.
           if (self._config['panelClass']) {
             self._panelEl.addClass(self._config['panelClass']);
+          }
+
+          // Handle click and touch events for the panel container.
+          if (self._config['propagateContainerEvents']) {
+            self._panelContainer.css('pointer-events', 'none');
           }
 
           // Panel may be outside the $rootElement, tell ngAnimate to animate
@@ -1188,6 +1211,24 @@ MdPanelRef.prototype._addStyles = function() {
 
 
 /**
+ * Update the position configuration of a panel
+ * @param {MdPanelPosition} position
+ */
+MdPanelRef.prototype.updatePosition = function(position) {
+  if (!this._panelContainer) {
+    throw new Error('Panel does not exist yet. Call open() or attach().');
+  }
+
+  var self = this;
+
+  self._config['position'] = position;
+  self._$mdUtil.nextTick(function() {
+    self._updatePosition();
+  });
+};
+
+
+/**
  * Calculates and updates the position of the panel.
  * @param {boolean=} opt_init
  * @private
@@ -1197,12 +1238,12 @@ MdPanelRef.prototype._updatePosition = function(opt_init) {
 
   if (positionConfig) {
     positionConfig._setPanelPosition(this._panelEl);
-    
+
     // Hide the panel now that position is known.
     if (opt_init) {
       this._panelContainer.addClass(MD_PANEL_HIDDEN);
     }
-    
+
     this._panelEl.css('top', positionConfig.getTop());
     this._panelEl.css('bottom', positionConfig.getBottom());
     this._panelEl.css('left', positionConfig.getLeft());

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -309,6 +309,8 @@ angular
  * Adds a class to the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} newClass Class to be added.
+ * @param {boolean} toElement Whether or not to add the class to the panel
+ *    element instead of the container.
  */
 
 /**
@@ -318,6 +320,8 @@ angular
  * Removes a class from the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} oldClass Class to be removed.
+ * @param {boolean} fromElement Whether or not to remove the class from the
+ * panel element instead of the container.
  */
 
 /**
@@ -327,6 +331,17 @@ angular
  * Toggles a class on the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} toggleClass Class to be toggled.
+ * @param {boolean} onElement Whether or not to remove the class from the panel
+ *    element instead of the container.
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#updatePosition
+ * @description
+ * Updates the position configuration of a panel. Use this to update the
+ * position of a panel that is open, without having to close and re-open the
+ * panel.
  */
 
 /**
@@ -1078,8 +1093,8 @@ MdPanelRef.prototype.addClass = function(newClass, toElement) {
  * Remove a class from the panel. DO NOT use this to hide/show the panel.
  *
  * @param {string} oldClass Class to be removed.
- * @param {boolean} fromElement Whether or not to remove the class from the panel
- *    element instead of the container.
+ * @param {boolean} fromElement Whether or not to remove the class from the
+ *    panel element instead of the container.
  */
 MdPanelRef.prototype.removeClass = function(oldClass, fromElement) {
   if (!this._panelContainer) {
@@ -1211,7 +1226,7 @@ MdPanelRef.prototype._addStyles = function() {
 
 
 /**
- * Update the position configuration of a panel
+ * Updates the position configuration of a panel
  * @param {MdPanelPosition} position
  */
 MdPanelRef.prototype.updatePosition = function(position) {

--- a/src/components/tooltipMdPanel/demoBasicUsage/index.html
+++ b/src/components/tooltipMdPanel/demoBasicUsage/index.html
@@ -1,0 +1,76 @@
+<div ng-controller="AppCtrl as ctrl" ng-cloak>
+
+  <md-toolbar class="md-accent">
+    <div class="md-toolbar-tools">
+      <h2>Awesome Md App</h2>
+      <span flex></span>
+      <md-button class="md-icon-button test-tooltip" aria-label="Refresh">
+        <md-tooltip-md-panel md-direction="left">Refresh</md-tooltip-md-panel>
+        <md-icon md-svg-src="img/icons/ic_refresh_24px.svg" style="width: 24px; height: 24px;"></md-icon>
+      </md-button>
+    </div>
+  </md-toolbar>
+  <md-content layout-padding style="margin-left: 20px; margin-right: 20px;">
+    <div>
+
+      <p>
+        The tooltip is visible when the button is hovered, focused, or touched.
+      </p>
+
+      <div layout="row" layout-align="space-between">
+        <md-button class="md-fab" aria-label="Insert Drive">
+          <md-tooltip-md-panel md-visible="demo.showTooltip" md-direction="{{demo.tipDirection}}">Insert Drive</md-tooltip-md-panel>
+          <md-icon md-svg-src="img/icons/ic_insert_drive_file_24px.svg"></md-icon>
+        </md-button>
+        <md-button class="md-fab" aria-label="Photos">
+          <md-tooltip-md-panel>Photos</md-tooltip-md-panel>
+          <md-icon md-svg-src="img/icons/ic_photo_24px.svg"></md-icon>
+        </md-button>
+      </div>
+
+      <div style="margin-top: 40px; margin-bottom: -5px">
+        <p>
+          <code>md-direction</code> attribute can be used to dynamically change the direction of the tooltip.<br />
+          Note: the direction default value is 'bottom'.
+        </p>
+        <div style="padding-left: 30px;">
+          <md-radio-group ng-model="demo.tipDirection">
+            <md-radio-button value="left">Left</md-radio-button>
+            <md-radio-button value="top">Top</md-radio-button>
+            <md-radio-button value="bottom">Bottom</md-radio-button>
+            <md-radio-button value="right">Right</md-radio-button>
+          </md-radio-group>
+        </div>
+      </div>
+
+      <div style="margin-top: 35px;">
+        <p>
+          Additionally, the Tooltip's <code>md-visible</code> attribute can use data-binding to programmatically
+          show/hide itself. Toggle the checkbox below...
+        </p>
+        <div style="padding-left: 30px;">
+          <md-checkbox ng-model="demo.showTooltip" style="padding-left: 30px;">Insert Drive</md-checkbox>
+        </div>
+      </div>
+
+      <div style="margin-top: 20px; margin-bottom: -5px;">
+        <p>
+          Additionally, the Tooltip's <code>md-delay</code> attribute can use data-binding to delay the show animation.
+          the default value is 0 milliseconds...
+        </p>
+        <div style="padding-left: 30px;">
+          <md-input-container>
+            <label>Tooltip Delay</label>
+            <input ng-model="demo.delayTooltip" />
+          </md-input-container>
+          <md-button class="md-fab" aria-label="Photos with Tooltip Delay" style="margin-top: -24px;">
+            <md-tooltip-md-panel md-delay="demo.delayTooltip">Photos with Tooltip Delay {{demo.delayTooltip}} msecs</md-tooltip-md-panel>
+            <md-icon md-svg-src="img/icons/ic_photo_24px.svg"></md-icon>
+          </md-button>
+        </div>
+      </div>
+
+    </div>
+  </md-content>
+
+</div>

--- a/src/components/tooltipMdPanel/demoBasicUsage/script.js
+++ b/src/components/tooltipMdPanel/demoBasicUsage/script.js
@@ -1,0 +1,20 @@
+angular.module('tooltipPanelDemo', [ 'ngMaterial' ])
+  .controller('AppCtrl', AppCtrl);
+
+function AppCtrl($scope) {
+  $scope.demo = {
+    showTooltip: false,
+    tipDirection: ''
+  };
+
+  $scope.demo.delayTooltip = undefined;
+  $scope.$watch('demo.delayTooltip', function(val) {
+    $scope.demo.delayTooltip = parseInt(val, 10) || 0;
+  });
+
+  $scope.$watch('demo.tipDirection', function(val) {
+    if (val && val.length) {
+      $scope.demo.showTooltip = true;
+    }
+  });
+}

--- a/src/components/tooltipMdPanel/tooltip.js
+++ b/src/components/tooltipMdPanel/tooltip.js
@@ -1,0 +1,346 @@
+/**
+ * @ngdoc module
+ * @name material.components.tooltipMdPanel
+ */
+angular
+  .module('material.components.tooltipMdPanel', [ 'material.core' ])
+  .directive('mdTooltipMdPanel', MdTooltipDirective);
+
+/**
+* @ngdoc directive
+* @name mdTooltip
+* @module material.components.tooltip
+* @description
+* Tooltips are used to describe elements that are interactive and primarily graphical (not textual).
+*
+* Place a `<md-tooltip>` as a child of the element it describes.
+*
+* A tooltip will activate when the user focuses, hovers over, or touches the parent.
+*
+* @usage
+* <hljs lang="html">
+* <md-button class="md-fab md-accent" aria-label="Play">
+*   <md-tooltip>
+*     Play Music
+*   </md-tooltip>
+*   <md-icon icon="img/icons/ic_play_arrow_24px.svg"></md-icon>
+* </md-button>
+* </hljs>
+*
+* @param {expression=} md-visible Boolean bound to whether the tooltip is currently visible.
+* @param {number=} md-delay How many milliseconds to wait to show the tooltip after the user focuses, hovers, or touches the
+* parent. Defaults to 0ms on non-touch devices and 75ms on touch.
+* @param {boolean=} md-autohide If present or provided with a boolean value, the tooltip will hide on mouse leave, regardless of focus
+* @param {string=} md-direction Which direction would you like the tooltip to go?  Supports left, right, top, and bottom.  Defaults to bottom.
+*/
+function MdTooltipDirective($$rAF, $timeout, $window, $document, $q, $interpolate, $rootElement,
+  $mdTheming, $mdUtil, $mdPanel) {
+
+  var ENTER_EVENTS = 'focus touchstart mouseenter';
+  var LEAVE_EVENTS = 'blur touchcancel mouseleave';
+  var TOOLTIP_SHOW_DELAY = 0;
+
+  return {
+    restrict: 'E',
+    transclude: true,
+    priority: 210, // Before ngAria
+    template: '<div class="_md-content _md" ng-transclude></div>',
+    scope: {
+      delay: '=?mdDelay',
+      visible: '=?mdVisible',
+      autohide: '=?mdAutoHide',
+      direction: '@?mdDirection' // Only expect raw or interpolated string value; not expression
+    },
+    link: linkFunc
+  };
+
+  function linkFunc(scope, element, attr) {
+
+    $mdTheming(element);
+
+    var parent = $mdUtil.getParentWithPointerEvents(element),
+        attachTo = angular.element(document.body),
+        showTimeout = null,
+        debouncedOnResize = $$rAF.throttle(function() {
+          updatePosition();
+        }),
+        origin = null,
+        position = null,
+        panelPosition = null,
+        panelAnimation = null,
+        panelConfig = null,
+        panelRef = null;
+
+    // Initialize element
+    setDefaults();
+    manipulateElement();
+    updatePosition();
+    bindEvents();
+    configureWatchers();
+    addAriaLabel();
+
+
+    function setDefaults() {
+      scope.delay = scope.delay || TOOLTIP_SHOW_DELAY;
+    }
+
+    function manipulateElement() {
+      element.detach();
+      element.attr('role', 'tooltip');
+    }
+
+    function updatePosition() {
+      var direction = scope.direction || 'bottom';
+
+      if (panelRef) panelRef.removeClass(origin, true);
+
+      origin = '_md-origin-' + direction;
+
+      switch (direction) {
+        case 'top'    : position = { x: 'CENTER',       y: 'ABOVE' };   break;
+        case 'right'  : position = { x: 'OFFSET_END',   y: 'CENTER' };  break;
+        case 'bottom' : position = { x: 'CENTER',       y: 'BELOW' };   break;
+        case 'left'   : position = { x: 'OFFSET_START', y: 'CENTER' };  break;
+      }
+
+      panelPosition = $mdPanel.newPanelPosition()
+        .relativeTo(parent)
+        .addPanelPosition($mdPanel.xPosition[position.x], $mdPanel.yPosition[position.y]);
+
+      if (panelRef) {
+        panelRef.addClass(origin, true);
+        panelRef.updatePosition(panelPosition);
+      }
+    }
+
+    function bindEvents() {
+      var mouseActive = false;
+
+      // Add an mutationObserver when there is support for it
+      // and the need for it in the form of viable host(parent[0])
+      if (parent[0] && 'MutationObserver' in $window) {
+        // Use an mutationObserver to tackle #2602
+        var attributeObserver = new MutationObserver(function(mutations) {
+          if (mutations.some(function(mutation) {
+            return (mutation.attributeName === 'disabled' && parent[0].disabled);
+          })) {
+            $mdUtil.nextTick(function() {
+              setVisible(false);
+            });
+          }
+        });
+
+        attributeObserver.observe(parent[0], { attributes: true });
+      }
+
+      // Store whether the element was focused when the window loses focus
+      var windowBlurHandler = function() {
+        elementFocusedOnWindowBlur = document.activeElement === parent[0];
+      };
+      var elementFocusedOnWindowBlur = false;
+
+      function windowScrollHandler() {
+        setVisible(false);
+      }
+
+      angular.element($window)
+        .on('blur', windowBlurHandler)
+        .on('resize', debouncedOnResize);
+
+      document.addEventListener('scroll', windowScrollHandler, true);
+      scope.$on('$destroy', function() {
+        angular.element($window)
+          .off('blur', windowBlurHandler)
+          .off('resize', debouncedOnResize);
+
+        parent
+          .off(ENTER_EVENTS, enterHandler)
+          .off(LEAVE_EVENTS, leaveHandler)
+          .off('mousedown', mousedownHandler);
+
+        // Trigger the handler in case the tooltip was still visible.
+        leaveHandler();
+        document.removeEventListener('scroll', windowScrollHandler, true);
+        attributeObserver && attributeObserver.disconnect();
+      });
+
+      var enterHandler = function(e) {
+        // Prevent the tooltip from showing when the window is receiving focus.
+        if (e.type === 'focus' && elementFocusedOnWindowBlur) {
+          elementFocusedOnWindowBlur = false;
+        } else if (!scope.visible) {
+          parent.on(LEAVE_EVENTS, leaveHandler);
+          setVisible(true);
+
+          // If the user is on a touch device, we should bind the tap away after
+          // the 'touched' in order to prevent the tooltip being removed immediately
+          if (e.type === 'touchstart') {
+            parent.one('touchend', function() {
+              $mdUtil.nextTick(function() {
+                $document.one('touchend', leaveHandler);
+              });
+            });
+          }
+        }
+      };
+
+      var leaveHandler = function() {
+        var autohide = scope.hasOwnProperty('autohide') ? scope.autohide : attr.hasOwnProperty('mdAutoHide');
+
+        if (autohide || mouseActive || $document[0].activeElement !== parent[0]) {
+          // When a show timeout is currently in progress, then we have to cancel it,
+          // otherwise the tooltip will remain showing without focus or hover.
+          if (showTimeout) {
+            $timeout.cancel(showTimeout);
+            setVisible.queued = false;
+            showTimeout = null;
+          }
+
+          parent.off(LEAVE_EVENTS, leaveHandler);
+          parent.triggerHandler('blur');
+          setVisible(false);
+        }
+        mouseActive = false;
+      };
+
+      var mousedownHandler = function() {
+        mouseActive = true;
+      };
+
+      // To avoid 'synthetic clicks' we listen to mousedown instead of 'click'
+      parent.on('mousedown', mousedownHandler);
+      parent.on(ENTER_EVENTS, enterHandler);
+    }
+
+    function onVisibleChanged(isVisible) {
+      if (isVisible) showTooltip();
+      else hideTooltip();
+    }
+
+    function configureWatchers() {
+      if (element[0] && 'MutationObserver' in $window) {
+        var attributeObserver = new MutationObserver(function(mutations) {
+          mutations.forEach(function(mutation) {
+            if (mutation.attributeName === 'md-visible') {
+              if (!scope.visibleWatcher) scope.visibleWatcher = scope.$watch('visible', onVisibleChanged);
+            }
+            if (mutation.attributeName === 'md-direction') {
+              updatePosition();
+            }
+          });
+        });
+
+        attributeObserver.observe(element[0], { attributes: true });
+
+        // Build watcher only if mdVisible is being used
+        if (attr.hasOwnProperty('mdVisible')) {
+          scope.visibleWatcher = scope.$watch('visible', onVisibleChanged);
+        }
+      } else { // MutationObserver not supported
+        scope.visibleWatcher = scope.$watch('visible', onVisibleChanged);
+        scope.$watch('direction', updatePosition);
+      }
+
+      var onElementDestroy = function() {
+        scope.$destroy();
+      };
+
+      // Clean up if the element or parent was removed via jqLite's .remove.
+      // A couple of notes:
+      // - In these cases the scope might not have been destroyed, which is why we
+      // destroy it manually. An example of this can be having 'md-visible="false"' and
+      // adding tooltips while they're invisible. If 'md-visible' become true, at some
+      // point, you'd usually get a lot of inputs.
+      // - We use '.one', not '.on', because this only needs to fire once. If we were
+      // using '.on', it would get thrown into an infinite loop.
+      // - This kicks off the scope's '$destroy' event which finishes the cleanup.
+      element.one('$destroy', onElementDestroy);
+      parent.one('$destroy', onElementDestroy);
+      scope.$on('$destroy', function() {
+        setVisible(false);
+        element.remove();
+        attributeObserver && attributeObserver.disconnect();
+      });
+
+      // Updates the aria-label when the element text changes. This watch doesn't
+      // need to be set up if the element doesn't have any data bindings.
+      if (element.text().indexOf($interpolate.startSymbol()) > -1) {
+        scope.$watch(function() {
+          return element.text().trim();
+        }, addAriaLabel);
+      }
+    }
+
+    function addAriaLabel(override) {
+      if ((override || !parent.attr('aria-label')) && !parent.text().trim()) {
+        var rawText = override || element.text().trim();
+        var interpolatedText = $interpolate(rawText)(parent.scope());
+        parent.attr('aria-label', interpolatedText);
+      }
+    }
+
+    function setVisible(value) {
+      // Break if passed value is already in queue or there is no queue and
+      // passed value is current in the scope
+      if (setVisible.queued && setVisible.value === !!value || !setVisible.queued && scope.visible === !!value) return;
+      setVisible.value = !!value;
+
+      if (!setVisible.queued) {
+        if (value) {
+          setVisible.queued = true;
+          showTimeout = $timeout(function() {
+            scope.visible = setVisible.value;
+            setVisible.queued = false;
+            showTimeout = null;
+
+            if (!scope.visibleWatcher) {
+              onVisibleChanged(scope.visible);
+            }
+          }, scope.delay);
+        } else {
+          $mdUtil.nextTick(function() {
+            scope.visible = false;
+            if (!scope.visibleWatcher) onVisibleChanged(false);
+          });
+        }
+      }
+    }
+
+    function showTooltip() {
+      // Do not show the tooltip if the text is empty.
+      if (!element[0].textContent.trim()) return;
+
+      panelAnimation = $mdPanel.newPanelAnimation()
+        .openFrom(parent)
+        .closeTo(parent)
+        .withAnimation({
+          open: '_md-show',
+          close: '_md-hide'
+        });
+
+      panelConfig = {
+        attachTo: attachTo,
+        template: element.html().replace(' ng-transclude=""', '').replace(' class="ng-scope"', ''),
+        propagateContainerEvents: true,
+        panelClass: 'md-tooltip-md-panel ' + origin,
+        animation: panelAnimation,
+        position: panelPosition,
+        zIndex: 100,
+        focusOnOpen: false
+      };
+
+      panelRef = $mdPanel.create(panelConfig);
+      // We are creating the panelRef before opening it due to the issue of having to wait for the open
+      // to completely finish before assigning it to the panelRef variable. If you have to wait, then
+      // there is a possibility of the panelRef not being defined before you need to close it, and this
+      // causes the panel to remain open.
+      panelRef.open();
+    }
+
+    function hideTooltip() {
+      panelRef && panelRef.close();
+    }
+
+  }
+
+}

--- a/src/components/tooltipMdPanel/tooltipMdPanel-theme.scss
+++ b/src/components/tooltipMdPanel/tooltipMdPanel-theme.scss
@@ -1,0 +1,6 @@
+.md-tooltip-md-panel.md-THEME_NAME-theme {
+  color: '{{background-A100}}';
+  ._md-content {
+    background-color: '{{foreground-2}}';
+  }
+}

--- a/src/components/tooltipMdPanel/tooltipMdPanel.scss
+++ b/src/components/tooltipMdPanel/tooltipMdPanel.scss
@@ -1,0 +1,101 @@
+$tooltip-fontsize-lg: rem(1) !default;
+$tooltip-fontsize-sm: rem(1.4) !default;
+$tooltip-height-lg: rem(2.2) !default;
+$tooltip-height-sm: rem(3.2) !default;
+$tooltip-top-margin-lg: rem(1.4) !default;
+$tooltip-top-margin-sm: rem(2.4) !default;
+$tooltip-lr-padding-lg: rem(0.8) !default;
+$tooltip-lr-padding-sm: rem(1.6) !default;
+$tooltip-max-width: rem(3.2) !default;
+
+.md-tooltip-md-panel {
+  overflow: hidden;
+  pointer-events: none;
+
+  font-weight: 500;
+  font-size: $tooltip-fontsize-sm;
+  @media (min-width: $layout-breakpoint-sm) {
+    font-size: $tooltip-fontsize-lg;
+  }
+
+  ._md-content {
+    position: relative;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-radius: 4px;
+
+    transform-origin: center top; // This is the default for when the tooltip opens below the parent
+    transform: scale(0);
+    opacity: 0;
+
+    height: $tooltip-height-sm;
+    line-height: $tooltip-height-sm;
+    padding-left: $tooltip-lr-padding-sm;
+    padding-right: $tooltip-lr-padding-sm;
+    @media (min-width: $layout-breakpoint-sm) {
+      height: $tooltip-height-lg;
+      line-height: $tooltip-height-lg;
+      padding-left: $tooltip-lr-padding-lg;
+      padding-right: $tooltip-lr-padding-lg;
+    }
+  }
+
+  &._md-origin-top {
+    margin-top: -$tooltip-top-margin-sm;
+    @media (min-width: $layout-breakpoint-sm) {
+      margin-top: -$tooltip-top-margin-lg;
+    }
+    ._md-content {
+      transform-origin: center bottom;
+    }
+  }
+  &._md-origin-right {
+    margin-left: $tooltip-top-margin-sm;
+    @media (min-width: $layout-breakpoint-sm) {
+      margin-left: $tooltip-top-margin-lg;
+    }
+    ._md-content {
+      transform-origin: left center;
+    }
+  }
+  &._md-origin-bottom {
+    margin-top: $tooltip-top-margin-sm;
+    @media (min-width: $layout-breakpoint-sm) {
+      margin-top: $tooltip-top-margin-lg;
+    }
+    ._md-content {
+      transform-origin: center top;
+    }
+  }
+  &._md-origin-left {
+    margin-left: -$tooltip-top-margin-sm;
+    @media (min-width: $layout-breakpoint-sm) {
+      margin-left: -$tooltip-top-margin-lg;
+    }
+    ._md-content {
+      transform-origin: right center;
+    }
+  }
+
+  &._md-show {
+    transition: $swift-ease-out;
+    opacity: 1;
+    ._md-content {
+      transition: $swift-ease-out;
+      transform: scale(1);
+      opacity: 1;
+    }
+  }
+
+  &._md-hide {
+    transition: $swift-ease-in;
+    opacity: 0;
+    ._md-content {
+      transition: $swift-ease-in;
+      transition-duration: .1s;
+      transform: scale(0);
+      opacity: 0;
+    }
+  }
+}


### PR DESCRIPTION
This is a WIP function that will transition the tooltip component to the mdPanel API.

Many of the core pieces of functionality of the original tooltip are still used due to the number of issues that they overcame.

The primary changes were to allow the mdPanel to position, animate, create, open and close the tooltip, instead of relying on proprietary logic within the tooltip code to do those things.

**Needs:**
 - Spec tests
 - Removal of the old tooltip component and renaming of this tooltip to `md-tooltip` instead of `md-tooltip-md-panel`