### PR TITLE
feat(theme): add `md-themes-disabled` directive to disable themes

### DIFF
--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -174,8 +174,8 @@
     * @ngInject
     */
    function detectDisabledLayouts() {
-    var items = document.querySelectorAll('[md-layouts-disabled]');
-    if ( items.length ) config.enabled = false;
+     var isDisabled = !!document.querySelector('[md-layouts-disabled]');
+     config.enabled = !isDisabled;
    }
 
   /**

--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -101,8 +101,25 @@
 
     // Register other, special directive functions for the Layout features:
     module
-      .directive('mdLayoutCss'  , disableLayoutDirective )
-      .directive('ngCloak'      ,  buildCloakInterceptor('ng-cloak'))
+
+      .provider('$$mdLayout'     , function() {
+        // Publish internal service for Layouts
+        return {
+          $get : angular.noop,
+          validateAttributeValue : validateAttributeValue,
+          validateAttributeUsage : validateAttributeUsage,
+          /**
+           * Easy way to disable/enable the Layout API.
+           * When disabled, this stops all attribute-to-classname generations
+           */
+          disableLayouts  : function(isDisabled) {
+            config.enabled =  (isDisabled !== true);
+          }
+        };
+      })
+
+      .directive('mdLayoutCss'        , disableLayoutDirective )
+      .directive('ngCloak'            , buildCloakInterceptor('ng-cloak'))
 
       .directive('layoutWrap'   , attributeWithoutValue('layout-wrap'))
       .directive('layoutNowrap' , attributeWithoutValue('layout-nowrap'))
@@ -126,7 +143,10 @@
       .directive('hideLtMd'       , warnAttrNotSupported('hide-lt-md'))
       .directive('hideLtLg'       , warnAttrNotSupported('hide-lt-lg'))
       .directive('showLtMd'       , warnAttrNotSupported('show-lt-md'))
-      .directive('showLtLg'       , warnAttrNotSupported('show-lt-lg'));
+      .directive('showLtLg'       , warnAttrNotSupported('show-lt-lg'))
+
+      // Determine if
+      .config( detectDisabledLayouts );
 
     /**
      * Converts snake_case to camelCase.
@@ -142,6 +162,21 @@
     }
 
   }
+
+
+  /**
+    * Detect if any of the HTML tags has a [md-layouts-disabled] attribute;
+    * If yes, then immediately disable all layout API features
+    *
+    * Note: this attribute should be specified on either the HTML or BODY tags
+    */
+   /**
+    * @ngInject
+    */
+   function detectDisabledLayouts() {
+    var items = document.querySelectorAll('[md-layouts-disabled]');
+    if ( items.length ) config.enabled = false;
+   }
 
   /**
    * Special directive that will disable ALL Layout conversions of layout
@@ -164,13 +199,12 @@
    *
    */
   function disableLayoutDirective() {
+    // Return a 1x-only, first-match attribute directive
+    config.enabled = false;
+
     return {
       restrict : 'A',
-      priority : '900',
-      compile  : function(element, attr) {
-        config.enabled = false;
-        return angular.noop;
-      }
+      priority : '900'
     };
   }
 

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -1,336 +1,379 @@
-describe('layout directives', function() {
-  var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl', 'print'],
-    $mdUtil, $compile, pageScope;
+describe("Layout API ", function() {
 
-  beforeEach(module('material.core', 'material.core.layout'));
+  describe("can be globally disabled with 'md-layouts-disabled' ", function() {
+    var disableLayouts = angular.noop,
+        activateLayouts = function() {
+          var el = document.getElementsByTagName('body')[0];
+              el.removeAttribute('md-layouts-disabled');
 
-  beforeEach(inject(function(_$compile_, _$rootScope_, _$mdUtil_) {
-    $mdUtil = _$mdUtil_;
-    $compile = _$compile_;
-    pageScope = _$rootScope_.$new();
-  }));
+          disableLayouts(false);
+        };
 
-  describe('using [layout] attributes', function() {
+    beforeEach(function() {
+      var el = document.getElementsByTagName('body')[0];
+          el.setAttribute('md-layouts-disabled', '');
 
-    it("should support attribute without value '<div layout>'", function() {
-      var element = $compile('<div layout>Layout</div>')(pageScope);
-      expect(element.hasClass("layout")).toBeFalsy();
-      expect(element.hasClass("layout-row")).toBeTruthy();
-    });
-
-    it('should ignore invalid values', function() {
-      var element = $compile('<div layout="humpty">Layout</div>')(pageScope);
-
-      expect( element.attr('layout') ).toBe('humpty');        // original attribute value unmodified
-      expect(element.hasClass('layout-humpty')).toBeFalsy();
-      expect(element.hasClass("layout-row")).toBeTruthy();    // injected className based on fallback value
-    });
-
-    it('should support interpolated values layout-gt-sm="{{direction}}"', function() {
-      var element = $compile('<div layout-gt-sm="{{direction}}">Layout</div>')(pageScope);
-
-      pageScope.$apply('direction = "row"');
-      expect(element.hasClass('layout-gt-sm-row')).toBeTruthy();
-
-      pageScope.$apply('direction = undefined');
-      expect(element.hasClass('layout-gt-sm-row')).toBeTruthy();
-
-      pageScope.$apply('direction = "column"');
-      expect(element.hasClass('layout-gt-sm-column')).toBeTruthy();
-    });
-
-
-    /**
-     * For all breakpoints,
-     *  - Test percentage values
-     *  - Test valid non-numerics
-     *
-     * NOTE: include the '' suffix:  layout='' === layout-row
-     */
-    var directionValues = ['row', 'column'];
-
-    angular.forEach(directionValues, function(direction) {
-      angular.forEach([''].concat(suffixes), function(suffix) {
-        var className = suffix ? 'layout-' + suffix : 'layout';
-        testWithValue(className, direction);
+      // Load the core module
+      module('material.core', function($$mdLayoutProvider) {
+          disableLayouts = angular.bind($$mdLayoutProvider, $$mdLayoutProvider.disableLayouts);
       });
     });
 
-  });
+    afterEach(activateLayouts);
 
-  describe('using [flex] attributes', function() {
-    var allowedValues = [
-      'grow', 'initial', 'auto', 'none',
-      0, 5, 10, 15, 20, 25,
-      30, 33, 34, 35, 40, 45,
-      50, 55, 60, 65, 66, 67,
-      70, 75, 80, 85, 90, 95, 100
-    ];
+    it('should not set any classnames', inject(function($compile, $rootScope) {
+      var el = $compile('<div layout>content</div>')($rootScope.$new());
 
-    it('should support attribute without value "<div flex>"', function() {
-      var element = $compile('<div flex>Layout</div>')(pageScope);
-      expect(element.hasClass("flex")).toBeTruthy();
-      expect(element.hasClass("flex-flex")).toBeFalsy();
-    });
+      expect(el[0].getAttribute('layout')).toBe('');
 
-    it('should ignore invalid values non-numericals like flex="flex"', function() {
-      var element = $compile('<div flex="flex">Layout</div>')(pageScope);
-      expect(element.hasClass("flex")).toBeTruthy();
-      expect(element.hasClass('flex-flex')).toBeFalsy();
-    });
-
-    it('should support interpolated values flex-gt-sm="{{columnSize}}"', function() {
-      var scope = pageScope,
-        element = $compile('<div flex-gt-sm="{{columnSize}}">Layout</div>')(scope);
-
-      scope.$apply('columnSize = 33');
-      expect(element.hasClass('flex-gt-sm-33')).toBeTruthy();
-
-      scope.$apply('columnSize = undefined');
-      expect(element.hasClass('flex-gt-sm')).toBeTruthy();
-    });
-
-    it('should observe the attribute value and update the layout class(es)', inject(function($rootScope, $compile) {
-      var scope = pageScope;
-      var element = angular.element($compile('<div flex-gt-md="{{size}}"></div>')(scope));
-
-      expect(element.hasClass('flex-gt-md')).toBe(true);
-      expect(element.hasClass('flex-gt-md-size')).toBe(false);
-
-      scope.$apply(function() {
-        scope.size = 32;
-      });
-
-      expect(element.hasClass('flex-gt-md-32')).toBe(true);
-
-      scope.$apply(function() {
-        // This should be rejected/ignored and the fallback "" value used
-        scope.size = "fishCheeks";
-      });
-
-      expect(element.hasClass('flex-gt-md')).toBe(true);
-      expect(element.hasClass('flex-gt-md-fishCheeks')).toBe(false);
+      expect(el.hasClass("layout")).toBeFalsy();
+      expect(el.hasClass("layout-row")).toBeFalsy();
+      expect(el.hasClass("layout-column")).toBeFalsy();
     }));
 
-    testAllSuffixesWithValues("flex", allowedValues);
+    it('should not set any classnames for layout="column" ', inject(function($compile, $rootScope) {
+      var el = $compile('<div layout="column">content</div>')($rootScope.$new());
+
+      expect(el[0].getAttribute('layout')).toBe('column');
+
+      expect(el.hasClass("layout")).toBeFalsy();
+      expect(el.hasClass("layout-row")).toBeFalsy();
+      expect(el.hasClass("layout-column")).toBeFalsy();
+    }));
   });
 
-  describe('using [flex-order] attributes', function() {
-    var flexOrderValues = [
-      -9, -8, -7, -6, -5, -4, -3, -2, -1,
-      0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-    ];
+  describe('layout directives', function() {
+    var suffixes = ['xs', 'gt-xs', 'sm', 'gt-sm', 'md', 'gt-md', 'lg', 'gt-lg', 'xl', 'print'],
+      $mdUtil, $compile, pageScope;
 
-    it('should support attribute without value "<div flex-order>"', function() {
-      var element = $compile('<div flex-order>Layout</div>')(pageScope);
-      expect(element.hasClass("flex-order-0")).toBeTruthy();
-      expect(element.hasClass("flex-order")).toBeFalsy();
-    });
+    beforeEach(inject(function(_$compile_, _$rootScope_, _$mdUtil_) {
+      $mdUtil = _$mdUtil_;
+      $compile = _$compile_;
+      pageScope = _$rootScope_.$new();
+    }));
 
-    it('should ignore invalid values non-numericals like flex-order="humpty"', function() {
-      var element = $compile('<div flex-order="humpty">Layout</div>')(pageScope);
-      expect(element.hasClass("flex-order-0")).toBeTruthy();
-      expect(element.hasClass('flex-order-humpty')).toBeFalsy();
-    });
+    describe('using [layout] attributes', function() {
 
-    it('should support interpolated values flex-order-gt-sm="{{index}}"', function() {
-      var scope = pageScope,
-        element = $compile('<div flex-order-gt-sm="{{index}}">Layout</div>')(scope);
-
-      scope.$apply('index = 3');
-      expect(element.hasClass('flex-order-gt-sm-3')).toBeTruthy();
-    });
-
-    testAllSuffixesWithValues("flex-order", flexOrderValues);
-  });
-
-  describe('using [flex-offset] attributes', function() {
-    var offsetValues = [
-      5, 10, 15, 20, 25,
-      30, 35, 40, 45, 50,
-      55, 60, 65, 70, 75,
-      80, 85, 90, 95,
-      33, 34, 66, 67
-    ];
-
-    it('should support attribute without value "<div flex-offset>"', function() {
-      var element = $compile('<div flex-offset>Layout</div>')(pageScope);
-      expect(element.hasClass("flex-offset-0")).toBeTruthy();
-      expect(element.hasClass("flex-offset")).toBeFalsy();
-    });
-
-    it('should ignore invalid values non-numericals like flex-offset="humpty"', function() {
-      var element = $compile('<div flex-offset="humpty">Layout</div>')(pageScope);
-      expect(element.hasClass("flex-offset-0")).toBeTruthy();
-      expect(element.hasClass('flex-offset-humpty')).toBeFalsy();
-    });
-
-    it('should support interpolated values flex-offset-gt-sm="{{padding}}"', function() {
-      var scope = pageScope,
-        element = $compile('<div flex-offset-gt-sm="{{padding}}">Layout</div>')(scope);
-
-      scope.$apply('padding = 15');
-      expect(element.hasClass('flex-offset-gt-sm-15')).toBeTruthy();
-    });
-
-    testAllSuffixesWithValues("flex-offset", offsetValues);
-  });
-
-  describe('using [layout-align] attributes', function() {
-    var attrName = "layout-align";
-    var alignmentValues = [
-      "start start", "start center", "start end",
-      "center stretch", "center start", "center center", "center end",
-      "end stretch", "end center", "end start", "end end",
-      "space-around stretch", "space-around start", "space-around center", "space-around end",
-      "space-between stretch", "space-between start", "space-between center", "space-between end"
-    ];
-
-    it('should support attribute without value "<div layout-align>"', function() {
-      var markup = $mdUtil.supplant('<div {0}>Layout</div>', [attrName]);
-      var element = $compile(markup)(pageScope);
-
-      expect(element.hasClass(attrName + "-start-stretch")).toBeTruthy();
-      expect(element.hasClass(attrName)).toBeFalsy();
-    });
-
-    it('should ignore invalid values non-numericals like layout-align="humpty"', function() {
-      var markup = $mdUtil.supplant('<div {0}="humpty">Layout</div>', [attrName]);
-      var element = $compile(markup)(pageScope);
-
-      expect(element.hasClass(attrName + "-start-stretch")).toBeTruthy();
-      expect(element.hasClass(attrName + '-humpty')).toBeFalsy();
-    });
-
-    it('should support interpolated values layout-align-gt-sm="{{alignItems}}"', function() {
-      var scope = pageScope,
-        markup = $mdUtil.supplant('<div {0}-gt-sm="{{alignItems}}">Layout</div>', [attrName]),
-        element = $compile(markup)(scope);
-
-      scope.$apply('alignItems = "center center"');
-      expect(element.hasClass(attrName + '-gt-sm-center-center')).toBeTruthy();
-    });
-
-    testAllSuffixesWithValues(attrName, alignmentValues);
-  });
-
-  describe('using [layout-] padding, fill, margin, wrap, and nowrap attributes', function() {
-    var allowedAttrsNoValues = [
-      "layout-padding",
-      "layout-margin",
-      "layout-fill",
-      "layout-wrap",
-      "layout-no-wrap",
-      "layout-nowrap"
-    ];
-
-    angular.forEach(allowedAttrsNoValues, function(name) {
-      testNoValueAllowed(name);
-    })
-  });
-
-  describe('using [hide] attributes', function() {
-    var attrName = "hide",
-      breakpoints = [''].concat(suffixes);
-
-    angular.forEach(breakpoints, function(suffix) {
-      var className = suffix ? attrName + "-" + suffix : attrName;
-      testNoValueAllowed(className);
-    });
-
-  });
-
-  describe('using [show] attributes', function() {
-    var attrName = "show",
-      breakpoints = [''].concat(suffixes);
-
-    angular.forEach(breakpoints, function(suffix) {
-      var className = suffix ? attrName + "-" + suffix : attrName;
-      testNoValueAllowed(className);
-    });
-
-  });
-
-  // *****************************************************************
-  // Internal Test methods for the angular.forEach( ) loops
-  // *****************************************************************
-
-  /**
-   * For the specified attrName (e.g. flex) test all breakpoints
-   * with all allowed values.
-   */
-  function testAllSuffixesWithValues(attrName, allowedValues) {
-    var breakpoints = [''].concat(suffixes);
-
-    angular.forEach(breakpoints, function(suffix) {
-      angular.forEach(allowedValues, function(value) {
-        var className = suffix ? attrName + "-" + suffix : attrName;
-        testWithValue(className, value, attrName);
+      it("should support attribute without value '<div layout>'", function() {
+        var element = $compile('<div layout>Layout</div>')(pageScope);
+        expect(element.hasClass("layout")).toBeFalsy();
+        expect(element.hasClass("layout-row")).toBeTruthy();
       });
-    });
-  }
 
-  /**
-   * Test other Layout directives (e.g. flex, flex-order, flex-offset)
-   */
-  function testWithValue(className, value, raw) {
-    var title = 'should allow valid values `' + className + '=' + value + '`';
+      it('should ignore invalid values', function() {
+        var element = $compile('<div layout="humpty">Layout</div>')(pageScope);
 
-    it(title, function() {
+        expect( element.attr('layout') ).toBe('humpty');        // original attribute value unmodified
+        expect(element.hasClass('layout-humpty')).toBeFalsy();
+        expect(element.hasClass("layout-row")).toBeTruthy();    // injected className based on fallback value
+      });
 
-      var expected = $mdUtil.supplant('{0}-{1}', [className, value ? String(value).replace(/\s+/g, "-") : value]);
-      var markup = $mdUtil.supplant('<div {0}="{1}">Layout</div>', [className, value]);
+      it('should support interpolated values layout-gt-sm="{{direction}}"', function() {
+        var element = $compile('<div layout-gt-sm="{{direction}}">Layout</div>')(pageScope);
 
-      var element = $compile(markup)(pageScope);
-      if ( !element.hasClass(expected) ) {
-        expect(expected).toBe(element[0].classList[1]);
-      }
+        pageScope.$apply('direction = "row"');
+        expect(element.hasClass('layout-gt-sm-row')).toBeTruthy();
 
-      if (raw) {
-        // Is the raw value also present?
-        expect(element.hasClass(raw)).toBeFalsy();
-      }
+        pageScope.$apply('direction = undefined');
+        expect(element.hasClass('layout-gt-sm-row')).toBeTruthy();
 
-    });
-  }
+        pageScope.$apply('direction = "column"');
+        expect(element.hasClass('layout-gt-sm-column')).toBeTruthy();
+      });
 
-  /**
-   * Layout directives do NOT support values nor breakpoint usages:
-   *
-   * - layout-margin,
-   * - layout-padding,
-   * - layout-fill,
-   * - layout-wrap,
-   * - layout-nowrap
-   *
-   */
-  function testNoValueAllowed(attrName) {
 
-    it('should support attribute without value "<div ' + attrName + '>"', function() {
-      var markup = $mdUtil.supplant('<div {0}>Layout</div>', [attrName]);
-      var element = $compile(markup)(pageScope);
+      /**
+       * For all breakpoints,
+       *  - Test percentage values
+       *  - Test valid non-numerics
+       *
+       * NOTE: include the '' suffix:  layout='' === layout-row
+       */
+      var directionValues = ['row', 'column'];
 
-      expect(element.hasClass(attrName)).toBeTruthy();
-    });
-
-    it('should ignore invalid values non-numericals like ' + attrName + '="humpty"', function() {
-      var markup = $mdUtil.supplant('<div {0}="humpty">Layout</div>', [attrName]);
-      var element = $compile(markup)(pageScope);
-
-      expect(element.hasClass(attrName)).toBeTruthy();
-      expect(element.hasClass(attrName + '-humpty')).toBeFalsy();
-    });
-
-    it('should ignore interpolated values ' + attrName + '="{{someVal}}"', function() {
-      var markup = $mdUtil.supplant('<div {0}="{{someVal}}">Layout</div>', [attrName]),
-        element = $compile(markup)(pageScope);
-
-      pageScope.$apply('someVal = "30"');
-
-      expect(element.hasClass(attrName)).toBeTruthy();
-      expect(element.hasClass($mdUtil.supplant("{0}-30", [attrName]))).toBeFalsy();
+      angular.forEach(directionValues, function(direction) {
+        angular.forEach([''].concat(suffixes), function(suffix) {
+          var className = suffix ? 'layout-' + suffix : 'layout';
+          testWithValue(className, direction);
+        });
+      });
 
     });
-  }
 
+    describe('using [flex] attributes', function() {
+      var allowedValues = [
+        'grow', 'initial', 'auto', 'none',
+        0, 5, 10, 15, 20, 25,
+        30, 33, 34, 35, 40, 45,
+        50, 55, 60, 65, 66, 67,
+        70, 75, 80, 85, 90, 95, 100
+      ];
+
+      it('should support attribute without value "<div flex>"', function() {
+        var element = $compile('<div flex>Layout</div>')(pageScope);
+        expect(element.hasClass("flex")).toBeTruthy();
+        expect(element.hasClass("flex-flex")).toBeFalsy();
+      });
+
+      it('should ignore invalid values non-numericals like flex="flex"', function() {
+        var element = $compile('<div flex="flex">Layout</div>')(pageScope);
+        expect(element.hasClass("flex")).toBeTruthy();
+        expect(element.hasClass('flex-flex')).toBeFalsy();
+      });
+
+      it('should support interpolated values flex-gt-sm="{{columnSize}}"', function() {
+        var scope = pageScope,
+          element = $compile('<div flex-gt-sm="{{columnSize}}">Layout</div>')(scope);
+
+        scope.$apply('columnSize = 33');
+        expect(element.hasClass('flex-gt-sm-33')).toBeTruthy();
+
+        scope.$apply('columnSize = undefined');
+        expect(element.hasClass('flex-gt-sm')).toBeTruthy();
+      });
+
+      it('should observe the attribute value and update the layout class(es)', inject(function($rootScope, $compile) {
+        var scope = pageScope;
+        var element = angular.element($compile('<div flex-gt-md="{{size}}"></div>')(scope));
+
+        expect(element.hasClass('flex-gt-md')).toBe(true);
+        expect(element.hasClass('flex-gt-md-size')).toBe(false);
+
+        scope.$apply(function() {
+          scope.size = 32;
+        });
+
+        expect(element.hasClass('flex-gt-md-32')).toBe(true);
+
+        scope.$apply(function() {
+          // This should be rejected/ignored and the fallback "" value used
+          scope.size = "fishCheeks";
+        });
+
+        expect(element.hasClass('flex-gt-md')).toBe(true);
+        expect(element.hasClass('flex-gt-md-fishCheeks')).toBe(false);
+      }));
+
+      testAllSuffixesWithValues("flex", allowedValues);
+    });
+
+    describe('using [flex-order] attributes', function() {
+      var flexOrderValues = [
+        -9, -8, -7, -6, -5, -4, -3, -2, -1,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+      ];
+
+      it('should support attribute without value "<div flex-order>"', function() {
+        var element = $compile('<div flex-order>Layout</div>')(pageScope);
+        expect(element.hasClass("flex-order-0")).toBeTruthy();
+        expect(element.hasClass("flex-order")).toBeFalsy();
+      });
+
+      it('should ignore invalid values non-numericals like flex-order="humpty"', function() {
+        var element = $compile('<div flex-order="humpty">Layout</div>')(pageScope);
+        expect(element.hasClass("flex-order-0")).toBeTruthy();
+        expect(element.hasClass('flex-order-humpty')).toBeFalsy();
+      });
+
+      it('should support interpolated values flex-order-gt-sm="{{index}}"', function() {
+        var scope = pageScope,
+          element = $compile('<div flex-order-gt-sm="{{index}}">Layout</div>')(scope);
+
+        scope.$apply('index = 3');
+        expect(element.hasClass('flex-order-gt-sm-3')).toBeTruthy();
+      });
+
+      testAllSuffixesWithValues("flex-order", flexOrderValues);
+    });
+
+    describe('using [flex-offset] attributes', function() {
+      var offsetValues = [
+        5, 10, 15, 20, 25,
+        30, 35, 40, 45, 50,
+        55, 60, 65, 70, 75,
+        80, 85, 90, 95,
+        33, 34, 66, 67
+      ];
+
+      it('should support attribute without value "<div flex-offset>"', function() {
+        var element = $compile('<div flex-offset>Layout</div>')(pageScope);
+        expect(element.hasClass("flex-offset-0")).toBeTruthy();
+        expect(element.hasClass("flex-offset")).toBeFalsy();
+      });
+
+      it('should ignore invalid values non-numericals like flex-offset="humpty"', function() {
+        var element = $compile('<div flex-offset="humpty">Layout</div>')(pageScope);
+        expect(element.hasClass("flex-offset-0")).toBeTruthy();
+        expect(element.hasClass('flex-offset-humpty')).toBeFalsy();
+      });
+
+      it('should support interpolated values flex-offset-gt-sm="{{padding}}"', function() {
+        var scope = pageScope,
+          element = $compile('<div flex-offset-gt-sm="{{padding}}">Layout</div>')(scope);
+
+        scope.$apply('padding = 15');
+        expect(element.hasClass('flex-offset-gt-sm-15')).toBeTruthy();
+      });
+
+      testAllSuffixesWithValues("flex-offset", offsetValues);
+    });
+
+    describe('using [layout-align] attributes', function() {
+      var attrName = "layout-align";
+      var alignmentValues = [
+        "start start", "start center", "start end",
+        "center stretch", "center start", "center center", "center end",
+        "end stretch", "end center", "end start", "end end",
+        "space-around stretch", "space-around start", "space-around center", "space-around end",
+        "space-between stretch", "space-between start", "space-between center", "space-between end"
+      ];
+
+      it('should support attribute without value "<div layout-align>"', function() {
+        var markup = $mdUtil.supplant('<div {0}>Layout</div>', [attrName]);
+        var element = $compile(markup)(pageScope);
+
+        expect(element.hasClass(attrName + "-start-stretch")).toBeTruthy();
+        expect(element.hasClass(attrName)).toBeFalsy();
+      });
+
+      it('should ignore invalid values non-numericals like layout-align="humpty"', function() {
+        var markup = $mdUtil.supplant('<div {0}="humpty">Layout</div>', [attrName]);
+        var element = $compile(markup)(pageScope);
+
+        expect(element.hasClass(attrName + "-start-stretch")).toBeTruthy();
+        expect(element.hasClass(attrName + '-humpty')).toBeFalsy();
+      });
+
+      it('should support interpolated values layout-align-gt-sm="{{alignItems}}"', function() {
+        var scope = pageScope,
+          markup = $mdUtil.supplant('<div {0}-gt-sm="{{alignItems}}">Layout</div>', [attrName]),
+          element = $compile(markup)(scope);
+
+        scope.$apply('alignItems = "center center"');
+        expect(element.hasClass(attrName + '-gt-sm-center-center')).toBeTruthy();
+      });
+
+      testAllSuffixesWithValues(attrName, alignmentValues);
+    });
+
+    describe('using [layout-] padding, fill, margin, wrap, and nowrap attributes', function() {
+      var allowedAttrsNoValues = [
+        "layout-padding",
+        "layout-margin",
+        "layout-fill",
+        "layout-wrap",
+        "layout-no-wrap",
+        "layout-nowrap"
+      ];
+
+      angular.forEach(allowedAttrsNoValues, function(name) {
+        testNoValueAllowed(name);
+      })
+    });
+
+    describe('using [hide] attributes', function() {
+      var attrName = "hide",
+        breakpoints = [''].concat(suffixes);
+
+      angular.forEach(breakpoints, function(suffix) {
+        var className = suffix ? attrName + "-" + suffix : attrName;
+        testNoValueAllowed(className);
+      });
+
+    });
+
+    describe('using [show] attributes', function() {
+      var attrName = "show",
+        breakpoints = [''].concat(suffixes);
+
+      angular.forEach(breakpoints, function(suffix) {
+        var className = suffix ? attrName + "-" + suffix : attrName;
+        testNoValueAllowed(className);
+      });
+
+    });
+
+    // *****************************************************************
+    // Internal Test methods for the angular.forEach( ) loops
+    // *****************************************************************
+
+    /**
+     * For the specified attrName (e.g. flex) test all breakpoints
+     * with all allowed values.
+     */
+    function testAllSuffixesWithValues(attrName, allowedValues) {
+      var breakpoints = [''].concat(suffixes);
+
+      angular.forEach(breakpoints, function(suffix) {
+        angular.forEach(allowedValues, function(value) {
+          var className = suffix ? attrName + "-" + suffix : attrName;
+          testWithValue(className, value, attrName);
+        });
+      });
+    }
+
+    /**
+     * Test other Layout directives (e.g. flex, flex-order, flex-offset)
+     */
+    function testWithValue(className, value, raw) {
+      var title = 'should allow valid values `' + className + '=' + value + '`';
+
+      it(title, function() {
+
+        var expected = $mdUtil.supplant('{0}-{1}', [className, value ? String(value).replace(/\s+/g, "-") : value]);
+        var markup = $mdUtil.supplant('<div {0}="{1}">Layout</div>', [className, value]);
+
+        var element = $compile(markup)(pageScope);
+        if ( !element.hasClass(expected) ) {
+          expect(expected).toBe(element[0].classList[1]);
+        }
+
+        if (raw) {
+          // Is the raw value also present?
+          expect(element.hasClass(raw)).toBeFalsy();
+        }
+
+      });
+    }
+
+    /**
+     * Layout directives do NOT support values nor breakpoint usages:
+     *
+     * - layout-margin,
+     * - layout-padding,
+     * - layout-fill,
+     * - layout-wrap,
+     * - layout-nowrap
+     *
+     */
+    function testNoValueAllowed(attrName) {
+
+      it('should support attribute without value "<div ' + attrName + '>"', function() {
+        var markup = $mdUtil.supplant('<div {0}>Layout</div>', [attrName]);
+        var element = $compile(markup)(pageScope);
+
+        expect(element.hasClass(attrName)).toBeTruthy();
+      });
+
+      it('should ignore invalid values non-numericals like ' + attrName + '="humpty"', function() {
+        var markup = $mdUtil.supplant('<div {0}="humpty">Layout</div>', [attrName]);
+        var element = $compile(markup)(pageScope);
+
+        expect(element.hasClass(attrName)).toBeTruthy();
+        expect(element.hasClass(attrName + '-humpty')).toBeFalsy();
+      });
+
+      it('should ignore interpolated values ' + attrName + '="{{someVal}}"', function() {
+        var markup = $mdUtil.supplant('<div {0}="{{someVal}}">Layout</div>', [attrName]),
+          element = $compile(markup)(pageScope);
+
+        pageScope.$apply('someVal = "30"');
+
+        expect(element.hasClass(attrName)).toBeTruthy();
+        expect(element.hasClass($mdUtil.supplant("{0}-30", [attrName]))).toBeFalsy();
+
+      });
+    }
+
+  });
 });

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -22,8 +22,8 @@ angular.module('material.core.theming', ['material.core.theming.palette'])
  * @ngInject
  */
 function detectDisabledThemes($mdThemingProvider) {
- var isDisabled = document.querySelectorAll('[md-themes-disabled]').length > 0;
- $mdThemingProvider.disableTheming(isDisabled);
+  var isDisabled = !!document.querySelector('[md-themes-disabled]');
+  $mdThemingProvider.disableTheming(isDisabled);
 }
 
 /**

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -352,9 +352,11 @@ describe('$mdThemeProvider with custom styles', function() {
       $mdThemingProvider.theme('register-custom-styles');
     });
 
-    // Verify that $MD_THEME_CSS is still set to '/**/' in the test environment.
-    // Check angular-material-mocks.js for $MD_THEME_CSS latest value if this test starts to fail.
-    inject(function($MD_THEME_CSS) { expect($MD_THEME_CSS).toBe('/**/'); });
+    inject(function($MD_THEME_CSS) {
+      // Verify that $MD_THEME_CSS is still set to '/**/' in the test environment.
+      // Check angular-material-mocks.js for $MD_THEME_CSS latest value if this test starts to fail.
+      expect($MD_THEME_CSS).toBe('/**/');
+    });
 
     // Find the string '/**//*test*/' in the head tag.
     expect(document.head.innerHTML).toContain('/*test*/');
@@ -433,6 +435,83 @@ describe('$mdThemeProvider with a theme that ends in a newline', function() {
     var style = document.head.querySelector('style[md-theme-style]');
     expect(style.innerText).not.toContain('}}');
     style.parentNode.removeChild(style);
+  });
+});
+
+describe('$mdThemeProvider with disabled themes', function() {
+
+  function getThemeStyleElements() {
+    return document.head.querySelectorAll('style[md-theme-style]');
+  }
+
+  function cleanThemeStyleElements() {
+    angular.forEach(getThemeStyleElements(), function(style) {
+      document.head.removeChild(style);
+    });
+  }
+  beforeEach(function() {
+
+    module('material.core', function($provide, $mdThemingProvider) {
+      // Use a single simple style rule for which we can check presence / absense.
+      $provide.constant('$MD_THEME_CSS', "sparkle.md-THEME_NAME-theme { color: '{{primary-color}}' }");
+
+      $mdThemingProvider
+        .theme('belarus')
+        .primaryPalette('red')
+        .accentPalette('green');
+
+    });
+  });
+
+  afterEach(function() {
+    cleanThemeStyleElements();
+  });
+
+  describe('can disable themes programmatically', function() {
+    beforeEach(function() {
+      cleanThemeStyleElements();
+
+      module('material.core', function($mdThemingProvider) {
+        $mdThemingProvider.disableTheming();
+      });
+    });
+
+    it('should not add any theme styles', function() {
+      var styles = getThemeStyleElements();
+      expect(styles.length).toBe(0);
+    });
+  });
+
+  describe('can disable themes declaratively', function() {
+    beforeEach(function() {
+      // Set the body attribute BEFORE the theming module is loaded
+      var el = document.getElementsByTagName('body')[0];
+          el.setAttribute('md-themes-disabled', '');
+    });
+
+    afterEach(function() {
+      var el = document.getElementsByTagName('body')[0];
+          el.removeAttribute('md-themes-disabled');
+    });
+
+    it('should not set any classnames', function() {
+      inject(function($rootScope, $compile, $mdTheming) {
+        el = $compile('<h1>Test</h1>')($rootScope);
+        $mdTheming(el);
+        expect(el.hasClass('md-default-theme')).toBe(false);
+      });
+    });
+
+    it('should not inject any styles', function() {
+      inject(function($rootScope, $compile, $mdTheming) {
+        el = $compile('<h1>Test</h1>')($rootScope);
+        $mdTheming(el);
+
+        var styles = getThemeStyleElements();
+        expect(styles.length).toBe(0);
+      });
+    });
+
   });
 });
 


### PR DESCRIPTION
Similar to `md-layout-css`, this attribute directive would disable
all runtime, startup theme sytle generation and DOM injections