### PR TITLE
fix(select): Failing tests on Angular 1.6 (snapshot).

### DIFF
--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -266,11 +266,15 @@ describe('<md-select>', function() {
       openSelect(select);
       waitForSelectOpen();
       clickOption(select, 0);
+      closeSelect();
+      waitForSelectClose();
       expect(el).toHaveClass('md-input-has-value');
 
       openSelect(select);
       waitForSelectOpen();
       clickOption(select, 1);
+      closeSelect();
+      waitForSelectClose();
       expect(el).toHaveClass('md-input-has-value');
 
       el.remove();
@@ -284,7 +288,7 @@ describe('<md-select>', function() {
         '<md-option ng-value></md-option>',
         '<md-option ng-value>None</md-option>',
         '<md-option value=""></md-option>',
-        '<md-option ng-value=""></md-option>',
+        '<md-option ng-value=""></md-option>'
       ];
       
       templates.forEach(function(template) {
@@ -298,11 +302,15 @@ describe('<md-select>', function() {
         openSelect(select);
         waitForSelectOpen();
         clickOption(select, 1);
+        closeSelect();
+        waitForSelectClose();
         expect(el).toHaveClass('md-input-has-value');
 
         openSelect(select);
         waitForSelectOpen();
         clickOption(select, 0);
+        closeSelect();
+        waitForSelectClose();
         expect(el).not.toHaveClass('md-input-has-value');
 
         el.remove();


### PR DESCRIPTION
For unknown reasons, the Material tests were failing on Angular 1.6, but not 1.3/4/5. Update test to ensure select is fully closed before attempting to open again to fix the tests.