### PR TITLE
docs(input): ngMessage elements should be block

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -39,6 +39,10 @@ angular.module('material.components.input', [
  * <b>Exception:</b> Hidden inputs (`<input type="hidden" />`) are ignored and will not throw an error, so
  * you may combine these with other inputs.
  *
+ * <b>Note:</b> When using `ngMessages` with your input element, make sure the message and container elements
+ * are *block* elements, otherwise animations applied to the messages will not look as intended. Either use a `div` and
+ * apply the `ng-message` and `ng-messages` classes respectively, or use the `md-block` class on your element.
+ *
  * @param md-is-error {expression=} When the given expression evaluates to true, the input container
  *   will go into error state. Defaults to erroring if the input has been touched and is invalid.
  * @param md-no-float {boolean=} When present, `placeholder` attributes on the input will not be converted to floating


### PR DESCRIPTION
ngMessage and ngMessages elements need to be block-level, otherwise animations applied to them through the input directive will not look right.
Closes #8880