### PR TITLE
update(components): replace Layout attributes with flexbox css

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -64,13 +64,26 @@ md-autocomplete {
     }
   }
   md-autocomplete-wrap {
-    display: block;
+
+    // Layout [layout='row']
+    display: flex;
+    flex-direction: row;
+    box-sizing: border-box;
+
     position: relative;
     overflow: visible;
     height: 40px;
     &.md-menu-showing {
       z-index: $z-index-backdrop + 1;
     }
+
+    md-input-container, input {
+      // Layout [flex]
+      flex:1 1 0%;
+      box-sizing:border-box;
+      min-width :0;
+    }
+
     md-progress-linear {
       position: absolute;
       bottom: -2px;

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -177,7 +177,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
 
       return '\
         <md-autocomplete-wrap\
-            layout="row"\
             ng-class="{ \'md-whiteframe-z1\': !floatingLabel, \'md-menu-showing\': !$mdAutocompleteCtrl.hidden }">\
           ' + getInputElement() + '\
           <md-progress-linear\
@@ -233,7 +232,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
       function getInputElement () {
         if (attr.mdFloatingLabel) {
           return '\
-            <md-input-container flex ng-if="floatingLabel">\
+            <md-input-container ng-if="floatingLabel">\
               <label>{{floatingLabel}}</label>\
               <input type="search"\
                   ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
@@ -263,7 +262,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
             </md-input-container>';
         } else {
           return '\
-            <input flex type="search"\
+            <input type="search"\
                 ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
                 id="{{ inputId || \'input-\' + $mdAutocompleteCtrl.id }}"\
                 name="{{inputName}}"\

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -137,7 +137,7 @@ md-list-item {
     position: relative;
 
     > div.md-button:first-child {
-      // Vertically align the item content.
+      // Layout - Vertically align the item content.
       display: flex;
       align-items: center;
       justify-content: flex-start;
@@ -177,6 +177,8 @@ md-list-item {
   .md-no-style {
     position: relative;
     padding: $list-item-padding-vertical $list-item-padding-horizontal;
+
+    // Layout [flex='auto']
     flex: 1 1 auto;
 
     &.md-button {
@@ -217,6 +219,8 @@ md-list-item {
 
   &,
   .md-list-item-inner {
+
+    // Layout [flex layout-align='start center']
     display: flex;
     justify-content: flex-start;
     align-items: center;

--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -106,7 +106,7 @@ function MdNavBar($mdAria) {
     template:
       '<div class="md-nav-bar">' +
         '<nav role="navigation">' +
-          '<ul class="_md-nav-bar-list" layout="row" ng-transclude role="listbox"' +
+          '<ul class="_md-nav-bar-list" ng-transclude role="listbox"' +
             'tabindex="0"' +
             'ng-focus="ctrl.onFocus()"' +
             'ng-blur="ctrl.onBlur()"' +

--- a/src/components/navBar/navBar.scss
+++ b/src/components/navBar/navBar.scss
@@ -13,6 +13,11 @@ $md-nav-bar-height: 48px;
   list-style: none;
   margin: 0;
   padding: 0;
+
+  // Layout [layout='row']
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
 }
 
 .md-nav-item:first-of-type {

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -283,7 +283,7 @@ function MdToastProvider($$interimElementProvider) {
           template:
             '<md-toast md-theme="{{ toast.theme }}" ng-class="{\'md-capsule\': toast.capsule}">' +
             '  <div class="md-toast-content">' +
-            '    <span flex class="md-toast-text" role="alert" aria-relevant="all" aria-atomic="true">' +
+            '    <span class="md-toast-text" role="alert" aria-relevant="all" aria-atomic="true">' +
             '      {{ toast.content }}' +
             '    </span>' +
             '    <md-button class="md-action" ng-if="toast.action" ng-click="toast.resolve()" ' +

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -26,6 +26,7 @@ md-toast {
 
   .md-toast-content {
     display: flex;
+    direction: row;
     align-items: center;
 
     max-height: 7 * $toast-height;
@@ -49,6 +50,13 @@ md-toast {
     transition: $swift-ease-out;
 
     @include rtl(justify-content, flex-start, flex-end);
+
+    span {
+      // Layout  [flex]
+      flex:1 1 0%;
+      box-sizing:border-box;
+      min-width :0;
+    }
   }
 
   &.md-capsule {


### PR DESCRIPTION
With new support to disable the Layouts API globally, the md components now use flexbox css instead of the Layout API. This CSS can be easily overriden with future releases of the Layout Flexbox engine.