### PR TITLE
Remove $mdMedia references from mdDialog example

### DIFF
--- a/src/components/dialog/demoBasicUsage/index.html
+++ b/src/components/dialog/demoBasicUsage/index.html
@@ -25,9 +25,6 @@
     </md-button>
   </div>
   <p class="footer">Note: The <b>Confirm</b> dialog does not use <code>$mdDialog.clickOutsideToClose(true)</code>.</p>
-  <div hide-gt-sm layout="row" layout-align="center center" flex>
-      <md-checkbox ng-model="customFullscreen" aria-label="Fullscreen Custom Dialog">Force Custom Dialog Fullscreen</md-checkbox>
-    </div>
 
   <div ng-if="status" id="status">
     <b layout="row" layout-align="center center" class="md-padding">
@@ -38,6 +35,8 @@
   <div class="dialog-demo-prerendered">
     <md-checkbox ng-model="listPrerenderedButton">Show Pre-Rendered Dialog</md-checkbox>
     <p class="md-caption">Sometimes you may not want to compile the dialogs template on each opening.</p>
+    <md-checkbox ng-model="customFullscreen" aria-label="Fullscreen custom dialog">Use full screen mode for custom dialog</md-checkbox>
+    <p class="md-caption">Allows the dialog to consume all available space on small devices</p>
   </div>
 
 

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -62,7 +62,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
       parent: angular.element(document.body),
       targetEvent: ev,
       clickOutsideToClose: true,
-      fullscreen: true  // only applies for screen size xs and sm
+      fullscreen: true // Fullscreen only applies for -xs, -sm breakpoints.
     })
     .then(function(answer) {
       $scope.status = 'You said the information was "' + answer + '".';

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -2,7 +2,6 @@ angular.module('dialogDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope, $mdDialog, $mdMedia) {
   $scope.status = '  ';
-  $scope.customFullscreen = $mdMedia('xs') || $mdMedia('sm');
 
   $scope.showAlert = function(ev) {
     // Appending dialog to document.body to cover sidenav in docs app
@@ -57,30 +56,19 @@ angular.module('dialogDemo1', ['ngMaterial'])
   };
 
   $scope.showAdvanced = function(ev) {
-    var useFullScreen = ($mdMedia('sm') || $mdMedia('xs'))  && $scope.customFullscreen;
-
     $mdDialog.show({
       controller: DialogController,
       templateUrl: 'dialog1.tmpl.html',
       parent: angular.element(document.body),
       targetEvent: ev,
-      clickOutsideToClose:true,
-      fullscreen: useFullScreen
+      clickOutsideToClose: true,
+      fullscreen: true  // only applies for screen size xs and sm
     })
     .then(function(answer) {
       $scope.status = 'You said the information was "' + answer + '".';
     }, function() {
       $scope.status = 'You cancelled the dialog.';
     });
-
-
-
-    $scope.$watch(function() {
-      return $mdMedia('xs') || $mdMedia('sm');
-    }, function(wantsFullScreen) {
-      $scope.customFullscreen = (wantsFullScreen === true);
-    });
-
   };
 
   $scope.showTabDialog = function(ev) {

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -1,7 +1,8 @@
 angular.module('dialogDemo1', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdDialog, $mdMedia) {
+.controller('AppCtrl', function($scope, $mdDialog) {
   $scope.status = '  ';
+  $scope.customFullscreen = true;
 
   $scope.showAlert = function(ev) {
     // Appending dialog to document.body to cover sidenav in docs app
@@ -61,8 +62,8 @@ angular.module('dialogDemo1', ['ngMaterial'])
       templateUrl: 'dialog1.tmpl.html',
       parent: angular.element(document.body),
       targetEvent: ev,
-      clickOutsideToClose: true,
-      fullscreen: true // Fullscreen only applies for -xs, -sm breakpoints.
+      clickOutsideToClose:true,
+      fullscreen: $scope.customFullscreen // Only for -xs, -sm breakpoints.
     })
     .then(function(answer) {
       $scope.status = 'You said the information was "' + answer + '".';

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -2,7 +2,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope, $mdDialog) {
   $scope.status = '  ';
-  $scope.customFullscreen = true;
+  $scope.customFullscreen = false;
 
   $scope.showAlert = function(ev) {
     // Appending dialog to document.body to cover sidenav in docs app


### PR DESCRIPTION
cleanup $mdMedia references in example. fullscreen only applies when the screen is xs and sm even when set to true.

See also https://github.com/angular/material/issues/5924