### PR TITLE
fix(progress-circular): wrapper not expanding layout

### DIFF
--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -8,6 +8,7 @@ $progress-circular-indeterminate-duration: 2.9s !default;
 // Used to avoid unnecessary layout
 md-progress-circular {
     position: relative;
+    display: block;
 
     &._md-progress-circular-disabled {
         visibility: hidden;


### PR DESCRIPTION
Since `md-progress-circular` is a custom element type, it is set to `display: inline` by default. This causes it to ignore it's specified width and height.

Fixes #9031.