### PR TITLE
chore: change closure module prefix

### DIFF
--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -196,7 +196,9 @@ exports.buildNgMaterialDefinition = function() {
 };
 
 function moduleNameToClosureName(name) {
-  return 'ng.' + name;
+  // For Closure, all modules start with "ngmaterial". We specifically don't use `ng.`
+  // because it conflicts with other packages under `ng.`.
+  return 'ng' + name;
 }
 exports.addJsWrapper = function(enforce) {
   return through2.obj(function(file, enc, next) {


### PR DESCRIPTION
I'm changing the Closure namespaces from `ng.material.xxxx` to `ngmaterial.xxxx`. As it is now, the `ng.` prefix collides with some other code. 