### PR TITLE
fix(list): only fill minimum required height.

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -166,7 +166,7 @@ md-list-item {
       .md-list-item-inner {
         // The list item content should fill the complete width.
         width: 100%;
-        height: 100%;
+        min-height: inherit;
       }
 
     }


### PR DESCRIPTION
* The list currently always expects the list items inner content to have a height of `100%`.
   In some specific browser cases the inner content, will calculate the `100%` in relative to the top element.
   Which causes the list items to be as big as the browsers screen height.

* The inner content, should only have a min-height, which is the same as the defined height on the `md-list-item` item.
   Just inheriting the min-height will automatically use the correct value.

Fixes #8956.