### PR TITLE
chore(gulp): disable watch for spec files

### DIFF
--- a/gulp/tasks/watch-demo.js
+++ b/gulp/tasks/watch-demo.js
@@ -16,5 +16,5 @@ exports.task = function() {
       '--', gutil.colors.green('"dist/demos/' + name + '/"'), 'in your browser to develop.'
   );
 
-  return gulp.watch('src/**/*', ['build-demo']);
+  return gulp.watch('src/**/!(*.spec)', ['build-demo']);
 };

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -3,5 +3,5 @@ var gulp = require('gulp');
 exports.dependencies = ['docs'];
 
 exports.task = function() {
-  gulp.watch(['docs/**/*', 'src/**/*'], ['docs']);
+  gulp.watch(['docs/**/*', 'src/**/!(*.spec)'], ['docs']);
 };


### PR DESCRIPTION
When developing locally, either with `gulp watch-demo` or `gulp watch`, Gulp unnecessarily watches and runs a build when the unit tests change.