### PR TITLE
fix(datepicker): add missing import

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -53,7 +53,7 @@
    * </hljs>
    *
    */
-  function datePickerDirective($$mdSvgRegistry) {
+  function datePickerDirective($$mdSvgRegistry, $mdAria) {
     return {
       template: function(tElement, tAttrs) {
         // Buttons are not in the tab order because users can open the calendar via keyboard


### PR DESCRIPTION
The datepicker is using $mdAria, however it wasn't importing it, causing an error in some cases.