### PR TITLE
feat(interimElement): properly handle multiple interims.

### DIFF
--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1607,6 +1607,8 @@ describe('$mdDialog', function() {
       document.body.appendChild(parent);
 
       $mdDialog.show({template: template, parent: parent});
+      runAnimation();
+
       $rootScope.$apply();
 
       // It should add two focus traps to the document around the dialog content.

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -34,7 +34,7 @@ function MenuProvider($$interimElementProvider) {
       disableParentScroll: true,
       skipCompile: true,
       preserveScope: true,
-      skipHide: true,
+      multiple: true,
       themable: true
     };
 

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -339,7 +339,16 @@ function InterimElementProvider() {
        *
        */
       function hide(reason, options) {
+
         if (!showingInterims.length) {
+          // When there are still interim's opening, then wait for the first interim element to
+          // finish its opening.
+          if (showPromises.length) {
+            return showPromises.shift().finally(function() {
+              return service.hide(reason, options)
+            });
+          }
+
           return $q.when(reason);
         }
 

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -295,7 +295,7 @@ function InterimElementProvider() {
         // When an interim element is currently showing, we have to cancel it.
         // Just hiding it, will resolve the InterimElement's promise, the promise should be
         // rejected instead.
-        var hideAction = options.multiple ? $q.when(true) : $q.all(showPromises);
+        var hideAction = options.multiple ? $q.resolve() : $q.all(showPromises);
 
         if (!options.multiple) {
           // Wait for all opening interim's to finish their transition.
@@ -346,10 +346,10 @@ function InterimElementProvider() {
           return $q.all(showingInterims.slice().reverse().map(closeElement));
         } else if (options.closeTo !== undefined) {
           return $q.all(showingInterims.slice(options.closeTo).map(closeElement));
-        } else {
-          var interim = showingInterims.pop();
-          return closeElement(interim);
         }
+
+        // Hide the latest showing interim element.
+        return closeElement(showingInterims.pop());
 
         function closeElement(interim) {
 

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -430,7 +430,7 @@ function InterimElementProvider() {
 
           // Note: This function might be called when the element already has been removed,
           // in which case we won't find any matches.
-          if (filtered.length > 0) {
+          if (filtered.length) {
             interim = filtered[0];
             showingInterims.splice(showingInterims.indexOf(interim), 1);
           }

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -342,6 +342,80 @@ describe('$$interimElement service', function() {
 
       }));
 
+      it('should show multiple interim elements', function() {
+        var showCount = 0;
+
+        showInterim();
+        expect(showCount).toBe(1);
+
+        showInterim();
+        expect(showCount).toBe(2);
+
+        function showInterim() {
+          Service.show({
+            template: '<div>First Interim</div>',
+            onShow: function() {
+              showCount++;
+            },
+            onRemove: function() {
+              showCount--;
+            },
+            multiple: true
+          });
+        }
+      });
+
+
+      it('should not show multiple interim elements by default', function() {
+        var showCount = 0;
+
+        showInterim();
+        expect(showCount).toBe(1);
+
+        showInterim();
+        expect(showCount).toBe(1);
+
+        function showInterim() {
+          Service.show({
+            template: '<div>First Interim</div>',
+            onShow: function() {
+              showCount++;
+            },
+            onRemove: function() {
+              showCount--;
+            }
+          });
+        }
+      });
+
+      it('should cancel a previous interim after it completes hiding', inject(function($q, $timeout) {
+        var hidePromise = $q.defer();
+        var isShown = false;
+
+        Service.show({
+          template: '<div>First Interim</div>',
+          onRemove: function() {
+            return hidePromise.promise;
+          }
+        });
+
+        // Once we show the second interim, the first interim should be cancelled and new interim
+        // will successfully show up after the first interim hides completely.
+        Service.show({
+          template: '<div>Second Interim</div>',
+          onShow: function() {
+            isShown = true;
+          }
+        });
+
+        expect(isShown).toBe(false);
+
+        hidePromise.resolve();
+        $timeout.flush();
+
+        expect(isShown).toBe(true);
+      }));
+
       it('should cancel a previous shown interim element', inject(function() {
         var isCancelled = false;
 

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -388,7 +388,7 @@ describe('$$interimElement service', function() {
         }
       });
 
-      it('should cancel a previous interim after it completes hiding', inject(function($q, $timeout) {
+      it('should cancel a previous interim after a second shows up', inject(function($q, $timeout) {
         var hidePromise = $q.defer();
         var isShown = false;
 


### PR DESCRIPTION
* Adds support for multiple interim elements (like dialog)
* When single interim (default) is enabled, then interims should hide properly (as in toasts).

---
When opening interim elements, by rapidly clicking on the open button as an example, the toasts / interims will overlap. But those shouldn't overlap. This is against the specs.

> See https://material.angularjs.org/HEAD/demo/toast

@ThomasBurleson Nothing really changed for the components. It just fixed the issue with overlapping and opens the door of having multiple interims (this was just included into that fix)

Fixes #8624. References #9166 References #8630.