### PR TITLE
fix(menu): remove padding from menu

### DIFF
--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -126,10 +126,6 @@ md-menu-item {
   }
 }
 
-.md-menu {
-  padding: $baseline-grid 0;
-}
-
 md-toolbar {
   .md-menu {
     height: auto;


### PR DESCRIPTION
* The menu component shouldn't have any additional padding, since the trigger element (mostly a button) already takes care of the padding.
   Having a special padding for the menu, is breaking alignment for containers without any specific flexbox vertical alignment.

Fixes #8196.