### PR TITLE
revert(.md-no-flicker): Do not automatically apply the `.md-no-flicker` class to content.

### DIFF
--- a/src/components/content/content.js
+++ b/src/components/content/content.js
@@ -32,14 +32,12 @@ angular.module('material.components.content', [
  * momentum scrolling is disabled. Momentum scrolling can cause flickering issues while scrolling
  * SVG icons and some other components.
  *
- * Additionally, we now also automatically apply a new `md-no-flicker` class to the `<md-content>`
- * which applies a Webkit-specific transform of `translateX(0)` to help reduce the flicker. If you
- * need to disable this for any reason, you can do so globally with the following code, or on a
- * case-by-case basis by ensuring your CSS operator is more specific than our global class.
+ * Additionally, we now also offer the `md-no-flicker` class which can be applied to any element
+ * and uses a Webkit-specific filter of `blur(0px)` that forces GPU rendering of all elements
+ * inside (which eliminates the flicker on iOS devices).
  *
- * <hljs lang="css">
- *   .md-no-flicker { -webkit-transform: none }
- * </hljs>
+ * _<b>Note:</b> Forcing an element to render on the GPU can have unintended side-effects, especially
+ * related to the z-index of elements. Please use with caution and only on the elements needed._
  *
  * @usage
  *
@@ -58,7 +56,6 @@ function mdContentDirective($mdTheming) {
     controller: ['$scope', '$element', ContentController],
     link: function(scope, element) {
       element.addClass('_md');     // private md component indicator for styling
-      element.addClass('md-no-flicker'); // add a class that helps prevent flickering on iOS devices
 
       $mdTheming(element);
       scope.$broadcast('$mdContentLoaded', element);

--- a/src/core/style/structure.scss
+++ b/src/core/style/structure.scss
@@ -182,9 +182,9 @@ input {
 }
 
 // Add a class to help reduce flicker
-// @see issue #7078
+// @see issue #7078 and #8649
 .md-no-flicker {
-  -webkit-transform: translateX(0);
+  -webkit-filter: blur(0px);
 }
 
 @media (min-width: $layout-breakpoint-sm) {


### PR DESCRIPTION
Due to some unintended side-effects of the `.md-no-flicker` CSS class, we no longer automatically apply this class to the `<md-content>` element. If you wish to use this class, please apply it yourself but beware that it may cause some issues with the `z-index` of existing elements.

Note: In previous RCs we used `-webkit-transform: translateX(0)`, but using `-webkit-filtler: blur(0px)` achieves the same thing and is less likely to be used/cause conflict.

Fixes #8649.