### PR TITLE
perf(datepicker, input, select): avoid unnecessary DOM lookups

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -285,7 +285,7 @@ function labelDirective() {
 function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture) {
   return {
     restrict: 'E',
-    require: ['^?mdInputContainer', '?ngModel'],
+    require: ['^?mdInputContainer', '?ngModel', '?^form'],
     link: postLink
   };
 
@@ -294,6 +294,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
     var containerCtrl = ctrls[0];
     var hasNgModel = !!ctrls[1];
     var ngModelCtrl = ctrls[1] || $mdUtil.fakeNgModel();
+    var parentForm = ctrls[2];
     var isReadonly = angular.isDefined(attr.readonly);
     var mdNoAsterisk = $mdUtil.parseAttributeBoolean(attr.mdNoAsterisk);
     var tagName = element[0].tagName.toLowerCase();
@@ -341,7 +342,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
     }
 
     var isErrorGetter = containerCtrl.isErrorGetter || function() {
-      return ngModelCtrl.$invalid && (ngModelCtrl.$touched || $mdUtil.isParentFormSubmitted(element));
+      return ngModelCtrl.$invalid && (ngModelCtrl.$touched || (parentForm && parentForm.$submitted));
     };
 
     scope.$watch(isErrorGetter, containerCtrl.setInvalid);

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -85,7 +85,7 @@ describe('md-input-container directive', function() {
       '</div>' +
       '</form>';
 
-    var parentForm = $compile(template)(pageScope);
+    var parentForm = $compile(template)(pageScope).find('div');
     pageScope.$apply();
 
     expect(parentForm.find('md-input-container')).not.toHaveClass('md-input-invalid');

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -36,7 +36,7 @@ angular.module('material.components.select', [
  *
  * When the select is required and uses a floating label, then the label will automatically contain
  * an asterisk (`*`). This behavior can be disabled by using the `md-no-asterisk` attribute.
- * 
+ *
  * By default, the select will display with an underline to match other form elements. This can be
  * disabled by applying the `md-no-underline` CSS class.
  *
@@ -46,7 +46,7 @@ angular.module('material.components.select', [
  * select and put it back in it's default state. You may supply this attribute on any option you
  * wish, however, it is automatically applied to an option whose `value` or `ng-value` are not
  * defined.
- * 
+ *
  * **Automatically Applied**
  *
  *  - `<md-option>`
@@ -54,7 +54,7 @@ angular.module('material.components.select', [
  *  - `<md-option value="">`
  *  - `<md-option ng-value>`
  *  - `<md-option ng-value="">`
- *  
+ *
  * **NOT Automatically Applied**
  *
  *  - `<md-option ng-value="1">`
@@ -272,7 +272,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdTheming, $mdAria, $compile, $par
 
       if (containerCtrl) {
         var isErrorGetter = containerCtrl.isErrorGetter || function() {
-          return ngModelCtrl.$invalid && (ngModelCtrl.$touched || $mdUtil.isParentFormSubmitted(element));
+          return ngModelCtrl.$invalid && (ngModelCtrl.$touched || (formCtrl && formCtrl.$submitted));
         };
 
         if (containerCtrl.input) {


### PR DESCRIPTION
In order to mark form controls as invalid on form submit, the datepicker, input and select components were traversing the DOM unnecessarily (potentially) on every digest. This change switches to using the directive's `require` to get a hold of the parent form.