### PR TITLE
fix(nav-bar): null check tabs when updating nav-bar

### DIFF
--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -222,6 +222,11 @@ MdNavBarController.prototype._initTabs = function() {
 MdNavBarController.prototype._updateTabs = function(newValue, oldValue) {
   var self = this;
   var tabs = this._getTabs();
+
+  // this._getTabs can return null if nav-bar has not yet been initialized
+  if(!tabs)
+    return;
+
   var oldIndex = -1;
   var newIndex = -1;
   var newTab = this._getTabByName(newValue);
@@ -266,11 +271,12 @@ MdNavBarController.prototype._updateInkBarStyles = function(tab, newIndex, oldIn
  * @private
  */
 MdNavBarController.prototype._getTabs = function() {
-  var linkArray = Array.prototype.slice.call(
-      this._navBarEl.querySelectorAll('.md-nav-item'));
-  return linkArray.map(function(el) {
-    return angular.element(el).controller('mdNavItem');
-  });
+  var controllers = Array.prototype.slice.call(
+    this._navBarEl.querySelectorAll('.md-nav-item'))
+    .map(function(el) {
+      return angular.element(el).controller('mdNavItem')
+    });
+  return controllers.indexOf(undefined) ? controllers : null;
 };
 
 /**

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -175,6 +175,17 @@ describe('mdNavBar', function() {
           expect(getTab('tab2').attr('ui-sref-opts'))
               .toBe('{"reload":true,"notify":true}');
         });
+
+    it('does not update tabs if tab controller is undefined', function() {
+      $scope.selectedTabRoute = 'tab1';
+
+      spyOn(Object.getPrototypeOf(ctrl), '_updateInkBarStyles');
+      spyOn(Object.getPrototypeOf(ctrl), '_getTabs').and.returnValue(null);
+      createTabs();
+
+      expect(ctrl._updateInkBarStyles)
+        .not.toHaveBeenCalled();
+    });
   });
 
   describe('inkbar', function() {


### PR DESCRIPTION
It is possible that _getTabs returns an array of undefined when mapping over linkArray as .controller('mdNavItem') can return undefined if it cannot find the corresponding controller which will cause an error to be shown in the console during the digest cycle.

This change assures that we do not attempt to update the tabs in the case that tabs is an undefined array.
