### PR TITLE
fix(datepicker): align errors relative to the input inside a md-input-container

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -5,6 +5,7 @@ $md-date-arrow-size: 5px !default; // Size of the triangle on the right side of 
 $md-datepicker-open-animation-duration: 0.2s !default;
 $md-datepicker-triangle-button-width: 36px !default;
 $md-datepicker-input-mask-height: 40px !default;
+$md-datepicker-button-padding: 8px !default;
 
 
 md-datepicker {
@@ -43,14 +44,6 @@ md-datepicker {
 
 // If the datepicker is inside of a md-input-container
 ._md-datepicker-floating-label {
-  > label:not(.md-no-float):not(.md-container-ignore) {
-    $width-offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap;
-    $offset: $md-datepicker-triangle-button-width / 2;
-    @include rtl(right, $offset, auto);
-    @include rtl(left, auto, $offset);
-    width: calc(100% - #{$width-offset});
-  }
-
   > md-datepicker {
     // Prevents the ripple on the triangle from being clipped.
     overflow: visible;
@@ -63,6 +56,21 @@ md-datepicker {
       // Prevents the button from wrapping around.
       @include rtl(float, left, right);
       margin-top: -$md-datepicker-border-bottom-gap / 2;
+    }
+  }
+
+  &._md-datepicker-has-calendar-icon {
+    > label:not(.md-no-float):not(.md-container-ignore) {
+      $width-offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap;
+      $offset: $md-datepicker-triangle-button-width / 2;
+      @include rtl(right, $offset, auto);
+      @include rtl(left, auto, $offset);
+      width: calc(100% - #{$width-offset});
+    }
+
+    .md-input-message-animation {
+      $margin: $md-datepicker-triangle-button-width + $md-datepicker-button-padding * 2 + $md-datepicker-button-gap;
+      @include rtl-prop(margin-left, margin-right, $margin);
     }
   }
 }
@@ -192,6 +200,7 @@ md-datepicker {
   height: $md-datepicker-triangle-button-width;
   width: $md-datepicker-triangle-button-width;
   position: absolute;
+  padding: $md-datepicker-button-padding;
 }
 
 // Disabled state for all elements of the picker.

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -66,7 +66,7 @@
           <md-datepicker ng-model="myDate" name="dateField" md-min-date="minDate"
             md-max-date="maxDate"></md-datepicker>
 
-          <div class="validation-messages" ng-messages="myOtherForm.dateField.$error">
+          <div ng-messages="myOtherForm.dateField.$error">
             <div ng-message="valid">The entered value is not a date!</div>
             <div ng-message="required">This date is required!</div>
             <div ng-message="mindate">Date is too early!</div>

--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -135,8 +135,10 @@
           }
 
           mdInputContainer.setHasPlaceholder(attr.mdPlaceholder);
-          mdInputContainer.element.addClass(INPUT_CONTAINER_CLASS);
           mdInputContainer.input = element;
+          mdInputContainer.element
+            .addClass(INPUT_CONTAINER_CLASS)
+            .toggleClass(HAS_ICON_CLASS, attr.mdHideIcons !== 'calendar' && attr.mdHideIcons !== 'all');
 
           if (!mdInputContainer.label) {
             $mdAria.expect(element, 'aria-label', attr.mdPlaceholder);
@@ -171,6 +173,9 @@
 
   /** Class applied to the md-input-container, if a datepicker is placed inside it */
   var INPUT_CONTAINER_CLASS = '_md-datepicker-floating-label';
+
+  /** Class to be applied when the calendar icon is enabled. */
+  var HAS_ICON_CLASS = '_md-datepicker-has-calendar-icon';
 
   /** Default time in ms to debounce input event by. */
   var DEFAULT_DEBOUNCE_INTERVAL = 500;


### PR DESCRIPTION
When a datepicker is inside of a `md-input-container`, aligns the errors messages according to the input, rather than sticking them to the left of the container.

Fixes #9057.