### PR TITLE
perf(virtual-repeat): fix performance issue in IE

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -620,7 +620,7 @@ VirtualRepeatController.prototype.containerUpdated = function() {
         this.repeatListExpression,
         angular.bind(this, function(items) {
           if (items && items.length) {
-            this.$$rAF(angular.bind(this, this.readItemSize_));
+            this.readItemSize_();
           }
         }));
     if (!this.$rootScope.$$phase) this.$scope.$digest();


### PR DESCRIPTION
Removes a requestAnimationFrame call, that for some reason, was taking a really long time. It seems counter-intuitive, but it appears to be consistently slower across all browsers.

For reference, here's some average timings. The way I tested it was to measure the time spent inside the `readItemSize_` method for 10 times in a row, in each browser. Both with and without the rAF.

| Browser       | rAF             | No rAF          |
| ------------- | ----------------| ----------------|
| Chrome        | 119.22ms        | 8.22ms          |
| Firefox       | 92.78ms         | 34.44ms         |
| IE            | 13894.44ms      | 28.89ms         |
| Edge          | 1877.56ms       | 19.33ms         |
| **Average**   | **3996.00ms**   | **22.72ms**     |



Fixes #9081.