### PR TITLE
chore(package.json): add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "git://github.com/angular/material.git"
   },
   "private": true,
+  "main": "./dist/angular-material.js",
   "style": "./dist/angular-material.css",
   "scss": "./dist/angular-material.scss",
   "devDependencies": {


### PR DESCRIPTION
Include entry point of module in package.json.
Necessary if angular material was installed from git branch into a project using webpack.
Without this field, webpack is unable to resolve the module.