### PR TITLE
fix(input): don't throw for nested controls in input container

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -305,7 +305,11 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
       element.attr('aria-hidden', 'true');
       return;
     } else if (containerCtrl.input) {
-      throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
+      if (containerCtrl.input[0].contains(element[0])) {
+        return;
+      } else {
+        throw new Error("<md-input-container> can only have *one* <input>, <textarea> or <md-select> child element!");
+      }
     }
     containerCtrl.input = element;
 


### PR DESCRIPTION
The `md-input-container` was throwing an error if an input is nested inside of another control (e.g. a select). This change checks if the element is a child of the already registered input, before throwing the error.

Fixes #9091.