### PR TITLE
perf(virtual-repeat): avoid unnecessary DOM lookups

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -127,9 +127,9 @@ function VirtualRepeatContainerController(
     this.topIndex = 0;
   }
 
-  this.scroller = $element[0].getElementsByClassName('md-virtual-repeat-scroller')[0];
-  this.sizer = this.scroller.getElementsByClassName('md-virtual-repeat-sizer')[0];
-  this.offsetter = this.scroller.getElementsByClassName('md-virtual-repeat-offsetter')[0];
+  this.scroller = $element[0].querySelector('.md-virtual-repeat-scroller');
+  this.sizer = this.scroller.querySelector('.md-virtual-repeat-sizer');
+  this.offsetter = this.scroller.querySelector('.md-virtual-repeat-offsetter');
 
   // After the dom stablizes, measure the initial size of the container and
   // make a best effort at re-measuring as it changes.


### PR DESCRIPTION
The virtual repeater was looking up a collection of elements, but only using the first one. This change switches it to only look for the first element via `querySelector`.