### PR TITLE
update(autocomplete): md-require-match only turn invalid if search text is provided

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -1326,7 +1326,10 @@ describe('<md-autocomplete>', function() {
       var element = compile(template, scope);
       var ctrl = element.find('md-autocomplete').controller('mdAutocomplete');
 
-      element.scope().searchText = 'fo';
+      // Flush the element gathering.
+      $timeout.flush();
+
+      scope.$apply('searchText = "fo"');
       $timeout.flush();
 
       ctrl.select(0);
@@ -1339,14 +1342,48 @@ describe('<md-autocomplete>', function() {
 
       expect(scope.form.autocomplete.$error['md-require-match']).toBeFalsy();
 
-      ctrl.clear();
+      scope.$apply('searchText = "food"');
+      $timeout.flush();
 
-      scope.$apply();
-
-      expect(scope.searchText).toBe('');
-      expect(scope.selectedItem).toBe(null);
+      expect(scope.searchText).toBe('food');
+      expect(scope.selectedItem).toBeNull();
       expect(scope.form.autocomplete.$error['md-require-match']).toBeTruthy();
 
+    }));
+
+    it('should not set to invalid if searchText is empty', inject(function($timeout) {
+      var scope = createScope();
+      var template = '\
+          <form name="form">\
+            <md-autocomplete\
+                md-input-name="autocomplete"\
+                md-selected-item="selectedItem"\
+                md-search-text="searchText"\
+                md-items="item in match(searchText)"\
+                md-item-text="item.display"\
+                placeholder="placeholder"\
+                md-require-match="true">\
+              <span md-highlight-text="searchText">{{item.display}}</span>\
+            </md-autocomplete>\
+          </form>';
+
+      compile(template, scope);
+
+      // Flush the element gathering.
+      $timeout.flush();
+
+      scope.$apply('searchText = "food"');
+      $timeout.flush();
+
+      expect(scope.searchText).toBe('food');
+      expect(scope.selectedItem).toBeNull();
+      expect(scope.form.autocomplete.$error['md-require-match']).toBeTruthy();
+
+      scope.$apply('searchText = ""');
+
+      expect(scope.searchText).toBe('');
+      expect(scope.selectedItem).toBeNull();
+      expect(scope.form.autocomplete.$error['md-require-match']).toBeFalsy();
     }));
 
   });

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -78,7 +78,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
   function updateModelValidators() {
     if (!$scope.requireMatch || !inputModelCtrl) return;
 
-    inputModelCtrl.$setValidity('md-require-match', !!$scope.selectedItem);
+    inputModelCtrl.$setValidity('md-require-match', !!$scope.selectedItem || !$scope.searchText);
   }
 
   /**


### PR DESCRIPTION
* Currently the `md-require-match` attribute checks whether an item is selected or not. The validity shouldn't be set to false, if the searchText is empty.

Closes #9072.

**Breaking Change**: The autocomplete validator `md-require-match` no longer matches if the search text is empty