### PR TITLE
fix(dialog): register close listeners before animation

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -707,10 +707,10 @@ function MdDialogProvider($$interimElementProvider) {
       captureParentAndFromToElements(options);
       configureAria(dialogElement, options);
       showBackdrop(scope, element, options);
+      activateListeners(element, options);
 
       return dialogPopIn(element, options)
         .then(function() {
-          activateListeners(element, options);
           lockScreenReader(element, options);
           warnDeprecatedActions();
           focusOnOpen();

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -979,6 +979,31 @@ describe('$mdDialog', function() {
       expect(parent.find('md-dialog').length).toBe(0);
     }));
 
+    it('should close on escape before the animation started',
+      inject(function($mdDialog, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
+        var parent = angular.element('<div>');
+
+        $mdDialog.show({
+          template: '<md-dialog></md-dialog>',
+          parent: parent,
+          escapeToClose: true
+        });
+
+        $rootScope.$apply();
+
+        expect(parent.find('md-dialog').length).toBe(1);
+
+        parent.triggerHandler({
+          type: 'keydown',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+        $timeout.flush();
+
+        runAnimation();
+
+        expect(parent.find('md-dialog').length).toBe(0);
+      }));
+
     it('should escapeToClose == false', inject(function($mdDialog, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
       var parent = angular.element('<div>');
       $mdDialog.show({


### PR DESCRIPTION
* Registering the close listeners before the animation has started improves the UX.
  If the user presses escape before the dialog is actually open, it feels like a freeze and non-response.

R: @EladBezalel 

Fixes #9096.