### PR TITLE
docs(theming): Add more visible nonce note.

### DIFF
--- a/docs/content/Theming/01_introduction.md
+++ b/docs/content/Theming/01_introduction.md
@@ -12,6 +12,10 @@ etc) you will need to either write CSS rules with custom selectors, or build a
 custom version of the `angular-material.css` file using SASS and custom
 variables.
 
+> <b>Note:</b> The Material Theming system provides the
+  [`$mdThemingProvider.setNonce()`](./api/service/$mdThemingProvider) method to meet the
+  requirements of a CSP-policy enabled application.
+
 <img src="https://cloud.githubusercontent.com/assets/210413/4816236/bf7783dc-5edd-11e4-88ef-1f8b6e87e1d7.png" alt="color palette" style="max-width: 100%;">
 
 ## Theming Approach

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -104,7 +104,7 @@ function detectDisabledThemes($mdThemingProvider) {
  * @ngdoc method
  * @name $mdThemingProvider#setNonce
  * @param {string} nonceValue The nonce to be added as an attribute to the theme style tags.
- * Setting a value allows the use CSP policy without using the unsafe-inline directive.
+ * Setting a value allows the use of CSP policy without using the unsafe-inline directive.
  */
 
 /**


### PR DESCRIPTION
Many users have had difficulty finding the `$mdThemingProvider.setNonce()` method which enables compliance with a CSP-policy enabled application.

Add a note/link to the Theming Introduction docs to make this more visible.

Also fix typo in `setNonce()` ng-docs.

Fixes #7780.