### PR TITLE
fix(build): -webkit- prefix for layouts

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -71,7 +71,7 @@ function buildJs () {
 
 function autoprefix () {
   return autoprefixer({browsers: [
-    'last 2 versions', 'last 4 Android versions'
+    'last 2 versions', 'last 4 Android versions', 'Safari >= 8'
   ]});
 }
 


### PR DESCRIPTION
Fixes the layout CSS not getting the `-webkit-` prefixes.

**Note:** @ThomasBurleson it's currently working as it's supposed to on master. It wasn't adding the webkit prefix, because none of the browsers we had in the config (last 2 versions of all browsers, in addition to the last 4 Android versions) need it anymore. 

Fixes #8999.