### PR TITLE
fix(input): ignore hidden inputs when determinating icon orientation

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -80,11 +80,20 @@ function mdInputContainerDirective($mdTheming, $parse) {
 
   var INPUT_TAGS = ['INPUT', 'TEXTAREA', 'SELECT', 'MD-SELECT'];
 
+  var HIDDEN_INPUT_SELECTORS = ':not([hidden=""])'
+        + ':not([hidden="true"])'
+        + ':not([type="hidden"])'
+        + ':not([aria-hidden=""])'
+        + ':not([aria-hidden="true"])'
+        + ':not(.md-visually-hidden)';
+
   var LEFT_SELECTORS = INPUT_TAGS.reduce(function(selectors, isel) {
+    isel = isel + HIDDEN_INPUT_SELECTORS;
     return selectors.concat(['md-icon ~ ' + isel, '.md-icon ~ ' + isel]);
   }, []).join(",");
 
   var RIGHT_SELECTORS = INPUT_TAGS.reduce(function(selectors, isel) {
+    isel = isel + HIDDEN_INPUT_SELECTORS;
     return selectors.concat([isel + ' ~ md-icon', isel + ' ~ .md-icon']);
   }, []).join(",");
 

--- a/src/components/input/input.spec.js
+++ b/src/components/input/input.spec.js
@@ -906,5 +906,44 @@ describe('md-input-container directive', function() {
         expect(el.hasClass('md-icon-right')).toBeTruthy();
       });
     });
+
+    [
+      'type="hidden"',
+      'aria-hidden="true"',
+      'aria-hidden',
+      'hidden',
+      'hidden="true"',
+      'class="md-visually-hidden"',
+    ].forEach(function(attribute) {
+      it('ignores all hidden inputs when adding icon classes', function() {
+        var el = compile(
+          '<md-input-container>' +
+          '  <input type="text" name="text">' +
+          '  <md-icon>help</md-icon>' +
+          '  <select ' + attribute + ' >' +
+          '</md-input-container>'
+        );
+
+        expect(el.hasClass('md-icon-left')).toBe(false);
+        expect(el.hasClass('md-icon-right')).toBe(true);
+      });
+    });
+
+    [
+      'aria-hidden="false"',
+      'hidden="false"',
+    ].forEach(function(attribute) {
+      it('does not ignore inputs with falsy hidden attributes when adding icon classes', function() {
+        var el = compile(
+          '<md-input-container>' +
+          '  <input ' + attribute + ' >' +
+          '  <md-icon>help</md-icon>' +
+          '</md-input-container>'
+        );
+
+        expect(el.hasClass('md-icon-left')).toBe(false);
+        expect(el.hasClass('md-icon-right')).toBe(true);
+      });
+    });
   });
 });

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -507,6 +507,29 @@ describe('<md-select>', function() {
 
         expect(optgroupLabel).toBe(null);
       }));
+
+      it('ignores hidden select input when adding icon classes', inject(function($rootScope, $compile) {
+        $rootScope.val = [1];
+        var select = $compile(
+            '<md-input-container>' +
+            '  <label>Label</label>' +
+            '  <md-select multiple ng-model="val" placeholder="Hello World" name="testName">' +
+            '    <md-select-header class="demo-select-header">' +
+            '      <span>Hello World</span>' +
+            '    </md-select-header>' +
+            '    <md-optgroup label="stuff">' +
+            '      <md-option value="1">One</md-option>' +
+            '      <md-option value="2">Two</md-option>' +
+            '      <md-option value="3">Three</md-option>' +
+            '    </md-optgroup>' +
+            '  </md-select>' +
+            '  <md-icon>help</md-icon>' +
+            '</md-input-container>')($rootScope);
+
+        expect(select.find('select').length).toBe(1);
+        expect(select.hasClass('md-icon-left')).toBe(false);
+        expect(select.hasClass('md-icon-right')).toBe(true);
+      }));
     });
 
     it('does not allow keydown events to propagate from inside the md-select-menu', inject(function($rootScope, $compile) {


### PR DESCRIPTION
The `md-icon-left` check gives a false position when using `md-select`
with an `md-icon` element at the right. This occurs because `md-select`
creates a hidden `select` element, resulting in the logic incorrectly
creating both `md-icon-left` and `md-icon-right` classes.
- Add check for hidden inputs via CSS selectors

Fixes #8899
