### PR TITLE
feat(mixin) Improved `input-placeholder-color` mixin

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -7,7 +7,6 @@ md-input-container.md-THEME_NAME-theme {
     }
     color: '{{foreground-1}}';
     border-color: '{{foreground-4}}';
-    text-shadow: '{{foreground-shadow}}';
   }
 
   > md-icon {

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -1,8 +1,13 @@
 md-input-container.md-THEME_NAME-theme {
   .md-input {
-    @include input-placeholder-color('\'{{foreground-3}}\'');
+    $placeholder-color: '{{foreground-3}}';
+    $placeholder-color-focused: $placeholder-color * .9;
+    @include input-placeholder-color('#{$placeholder-color}', (focus: '#{$placeholder-color-focused}')) {
+      transition: color .2s ease-in-out;
+    }
     color: '{{foreground-1}}';
     border-color: '{{foreground-4}}';
+    text-shadow: '{{foreground-shadow}}';
   }
 
   > md-icon {

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -14,7 +14,7 @@
   user-select: $value;
 }
 
-@mixin input-placeholder-color($color) {
+@mixin input-placeholder-color($color, $target-pseudo-colors: (), $contentInBase: true) {
   $pseudos: '::-webkit-input-placeholder', ':-moz-placeholder', '::-moz-placeholder',
             ':-ms-input-placeholder',  '::-webkit-input-placeholder';
 
@@ -23,6 +23,17 @@
   @each $pseudo in $pseudos {
     &#{$pseudo} {
       color: unquote($color);
+      @if ($contentInBase) {
+        @content;
+      }
+    }
+    @each $target-pseudo, $target-pseudo-color in $target-pseudo-colors {
+      &:#{$target-pseudo}#{$pseudo} {
+        color: unquote($target-pseudo-color);
+        @if (not $contentInBase) {
+          @content;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Allows to set style for input state selectors (e.g. :hover, :active, :focus)

Examples:
  
```scss
@include input-placeholder-color(#faf);
```

```scss
@include input-placeholder-color(#faf, (hover: #ff0));
```

```scss
@include input-placeholder-color(#faf, (hover: #ff0, active: #0ff)) {
  transition: all .2s ease-in-out;
}
```