### PR TITLE
fix(virtual-repeat): add -webkit-overflow-scrolling

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.scss
+++ b/src/components/virtualRepeat/virtual-repeater.scss
@@ -18,6 +18,7 @@ $virtual-repeat-scrollbar-width: 16px !default;
     position: absolute;
     right: 0;
     top: 0;
+    -webkit-overflow-scrolling: touch;
   }
 
   .md-virtual-repeat-sizer {


### PR DESCRIPTION
Adds `-webkit-overflow-scrolling: touch` to the virtual repeater for a better scroll experience on touch devices.

Fixes #5322.