### PR TITLE
fix(select): cast number model values to string hash keys.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -823,8 +823,19 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         // the current option, which will be added, then we can be sure, that the validation
         // of the option has occurred before the option was added properly.
         // This means, that we have to manually trigger a new validation of the current option.
-        if (angular.isDefined(self.ngModel.$modelValue) && self.hashGetter(self.ngModel.$modelValue) === hashKey) {
-          self.ngModel.$validate();
+        if (angular.isDefined(self.ngModel.$modelValue)) {
+          var modelValue = self.ngModel.$modelValue;
+
+          // In some cases the $modelValue mismatches the type of the current hashKey.
+          // That can happen if the $modelValue was set to a number, which actually represents a
+          // possible value.
+          if (typeof modelValue !== typeof hashKey && typeof modelValue === 'number') {
+            modelValue = '' + modelValue;
+          }
+
+          if (self.hashGetter(modelValue) === hashKey) {
+            self.ngModel.$validate();
+          }
         }
 
         self.refreshViewValue();

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -958,6 +958,53 @@ describe('<md-select>', function() {
         expect($rootScope.testForm.$valid).toBe(true);
       }));
 
+      it('should cast number model values to strings to match hash keys', inject(function($rootScope, $compile) {
+        var template =
+          '<form name="testForm">' +
+          '  <md-select ng-model="model" required="required">' +
+          '    <md-option value="1">Option 1</md-option>' +
+          '    <md-option value="2">Option 2</md-option>' +
+          '  </md-select>' +
+          '</form>';
+
+        $compile(template)($rootScope);
+
+        $rootScope.model = 2;
+        $rootScope.$digest();
+        expect($rootScope.testForm.$valid).toBe(true);
+
+        $rootScope.model = 0;
+        $rootScope.$digest();
+        expect($rootScope.testForm.$valid).toBe(false);
+      }));
+
+      it('should not cast number model values when using ng-value', inject(function($rootScope, $compile) {
+        var template =
+          '<form name="testForm">' +
+          '  <md-select ng-model="model" required="required">' +
+          '    <md-option ng-value="1">Option 1</md-option>' +
+          '    <md-option ng-value="2">Option 2</md-option>' +
+          '    <md-option ng-value="\'2\'">Option 3</md-option>' +
+          '  </md-select>' +
+          '</form>';
+
+        $compile(template)($rootScope);
+
+        // Number Two as an string is also its own option.
+        $rootScope.model = '2';
+        $rootScope.$digest();
+        expect($rootScope.testForm.$valid).toBe(true);
+
+        // Number two as a normal number is its own option.
+        $rootScope.model = 2;
+        $rootScope.$digest();
+        expect($rootScope.testForm.$valid).toBe(true);
+
+        $rootScope.model = 0;
+        $rootScope.$digest();
+        expect($rootScope.testForm.$valid).toBe(false);
+      }));
+
       it('properly validates required attribute with object options', inject(function($rootScope, $compile) {
         var template =
           '<form name="testForm">' +


### PR DESCRIPTION
* Currently when using the `value` attribute, which is designed to only accept string values. In some cases a number is also a valid option.
  When the developer sets the model to the specific number (number type), to select the given option (number in string), the select will turn invalid.
  Once the types mismatch, we can easily cast it to a string, to be able to compare it properly.

R: @topherfangio 

Fixes #9124.