### PR TITLE
fix(input): Add missing Polyfill for ng1.3 and fix tests.

### DIFF
--- a/src/core/util/animation/animateCss.js
+++ b/src/core/util/animation/animateCss.js
@@ -132,6 +132,22 @@ if (angular.version.minor >= 4) {
       }
     };
 
+    // Polyfill AnimateRunner.all which is used by input animations
+    AnimateRunner.all = function(runners, callback) {
+      var count = 0;
+      var status = true;
+      forEach(runners, function(runner) {
+        runner.done(onProgress);
+      });
+
+      function onProgress(response) {
+        status = status && response;
+        if (++count === runners.length) {
+          callback(status);
+        }
+      }
+    };
+
     return AnimateRunner;
   }];
 


### PR DESCRIPTION
Angular 1.3 apparently did not include the `AnimateRunner.all()` method. Grab it from latest 1.5.8 code and add to our 1.3 polyfills.

Additional, our $animateCss polyfill for 1.3 modifies the `to` and `from` options that are passed in and sets them to `null`. This was causing the tests to fail. Fix by keeping a cloned reference for test purposes.