### PR TITLE
feat(bottom-sheet): add isLockedOpen option; general cleanup

### DIFF
--- a/src/components/bottomSheet/bottom-sheet.js
+++ b/src/components/bottomSheet/bottom-sheet.js
@@ -90,6 +90,9 @@ function MdBottomSheetDirective($mdBottomSheet) {
  *   - `disableBackdrop` - `{boolean=}`: When set to true, the bottomsheet will not show a backdrop.
  *   - `escapeToClose` - `{boolean=}`: Whether the user can press escape to close the bottom sheet.
  *     Default true.
+ *   - `isLockedOpen` - `{boolean=}`: Disables all default ways of closing the bottom sheet. **Note:** this will override
+ *     the `clickOutsideToClose` and `escapeToClose` options, leaving only the `hide` and `cancel`
+ *     methods as ways of closing the bottom sheet. Defaults to false.
  *   - `resolve` - `{object=}`: Similar to locals, except it takes promises as values
  *   and the bottom sheet will not open until the promises resolve.
  *   - `controllerAs` - `{string=}`: An alias to assign the controller to on the scope.
@@ -150,7 +153,8 @@ function MdBottomSheetProvider($$interimElementProvider) {
       disableBackdrop: false,
       escapeToClose: true,
       clickOutsideToClose: true,
-      disableParentScroll: true
+      disableParentScroll: true,
+      isLockedOpen: false
     };
 
 
@@ -159,13 +163,20 @@ function MdBottomSheetProvider($$interimElementProvider) {
       element = $mdUtil.extractElementByName(element, 'md-bottom-sheet');
 
       // prevent tab focus or click focus on the bottom-sheet container
-      element.attr('tabindex',"-1");
+      element.attr('tabindex', '-1');
 
       // Once the md-bottom-sheet has `ng-cloak` applied on his template the opening animation will not work properly.
       // This is a very common problem, so we have to notify the developer about this.
       if (element.hasClass('ng-cloak')) {
-        var message = '$mdBottomSheet: using `<md-bottom-sheet ng-cloak >` will affect the bottom-sheet opening animations.';
+        var message = '$mdBottomSheet: using `<md-bottom-sheet ng-cloak>` will affect the bottom-sheet opening animations.';
         $log.warn( message, element[0] );
+      }
+
+      if (options.isLockedOpen) {
+        options.clickOutsideToClose = false;
+        options.escapeToClose = false;
+      } else {
+        options.cleanupGestures = registerGestures(element, options.parent);
       }
 
       if (!options.disableBackdrop) {
@@ -175,7 +186,6 @@ function MdBottomSheetProvider($$interimElementProvider) {
         // Prevent mouse focus on backdrop; ONLY programatic focus allowed.
         // This allows clicks on backdrop to propogate to the $rootElement and
         // ESC key events to be detected properly.
-        
         backdrop[0].tabIndex = -1;
 
         if (options.clickOutsideToClose) {
@@ -189,16 +199,13 @@ function MdBottomSheetProvider($$interimElementProvider) {
         $animate.enter(backdrop, options.parent, null);
       }
 
-      var bottomSheet = new BottomSheet(element, options.parent);
-      options.bottomSheet = bottomSheet;
-
-      $mdTheming.inherit(bottomSheet.element, options.parent);
+      $mdTheming.inherit(element, options.parent);
 
       if (options.disableParentScroll) {
-        options.restoreScroll = $mdUtil.disableScrollAround(bottomSheet.element, options.parent);
+        options.restoreScroll = $mdUtil.disableScrollAround(element, options.parent);
       }
 
-      return $animate.enter(bottomSheet.element, options.parent, backdrop)
+      return $animate.enter(element, options.parent, backdrop)
         .then(function() {
           var focusable = $mdUtil.findFocusTarget(element) || angular.element(
             element[0].querySelector('button') ||
@@ -221,40 +228,35 @@ function MdBottomSheetProvider($$interimElementProvider) {
     }
 
     function onRemove(scope, element, options) {
-
-      var bottomSheet = options.bottomSheet;
-
       if (!options.disableBackdrop) $animate.leave(backdrop);
-      return $animate.leave(bottomSheet.element).then(function() {
+
+      return $animate.leave(element).then(function() {
         if (options.disableParentScroll) {
           options.restoreScroll();
           delete options.restoreScroll;
         }
 
-        bottomSheet.cleanup();
+        options.cleanupGestures && options.cleanupGestures();
       });
     }
 
     /**
-     * BottomSheet class to apply bottom-sheet behavior to an element
+     * Adds the drag gestures to the bottom sheet.
      */
-    function BottomSheet(element, parent) {
+    function registerGestures(element, parent) {
       var deregister = $mdGesture.register(parent, 'drag', { horizontal: false });
       parent.on('$md.dragstart', onDragStart)
         .on('$md.drag', onDrag)
         .on('$md.dragend', onDragEnd);
 
-      return {
-        element: element,
-        cleanup: function cleanup() {
-          deregister();
-          parent.off('$md.dragstart', onDragStart);
-          parent.off('$md.drag', onDrag);
-          parent.off('$md.dragend', onDragEnd);
-        }
+      return function cleanupGestures() {
+        deregister();
+        parent.off('$md.dragstart', onDragStart);
+        parent.off('$md.drag', onDrag);
+        parent.off('$md.dragend', onDragEnd);
       };
 
-      function onDragStart(ev) {
+      function onDragStart() {
         // Disable transitions on transform so that it feels fast
         element.css($mdConstant.CSS.TRANSITION_DURATION, '0ms');
       }

--- a/src/components/bottomSheet/bottom-sheet.spec.js
+++ b/src/components/bottomSheet/bottom-sheet.spec.js
@@ -1,9 +1,19 @@
 describe('$mdBottomSheet service', function () {
-  beforeEach(module('material.components.bottomSheet'));
+  var $mdBottomSheet, $rootElement, $rootScope, $material, $mdConstant;
 
-  describe('#build()', function () {
-    it('should have `._md` class indicator',
-      inject(function ($mdBottomSheet, $rootElement, $material) {
+  beforeEach(function() {
+    module('material.components.bottomSheet');
+    inject(function(_$mdBottomSheet_, _$rootElement_, _$rootScope_, _$material_, _$mdConstant_) {
+      $mdBottomSheet = _$mdBottomSheet_;
+      $rootElement = _$rootElement_;
+      $rootScope = _$rootScope_;
+      $material = _$material_;
+      $mdConstant = _$mdConstant_;
+    });
+  });
+
+  describe('#build()', function() {
+    it('should have `._md` class indicator', function() {
         var parent = angular.element('<div>');
         $mdBottomSheet.show({
           template: '<md-bottom-sheet>',
@@ -13,57 +23,55 @@ describe('$mdBottomSheet service', function () {
 
         var sheet = parent.find('md-bottom-sheet');
         expect(sheet.hasClass('_md')).toBe(true);
-    }));
+    });
 
-    it('should close when `clickOutsideToClose == true`',
-      inject(function ($mdBottomSheet, $rootElement, $material) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          clickOutsideToClose: true
-        });
+    it('should close when `clickOutsideToClose == true`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        clickOutsideToClose: true
+      });
 
-        $material.flushOutstandingAnimations();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        var backdrop = parent.find('md-backdrop');
+      var backdrop = parent.find('md-backdrop');
 
-        backdrop.triggerHandler({
-          type: 'click',
-          target: backdrop[0]
-        });
+      backdrop.triggerHandler({
+        type: 'click',
+        target: backdrop[0]
+      });
 
-        $material.flushInterimElement();
-        expect(parent.find('md-bottom-sheet').length).toBe(0);
-      }));
+      $material.flushInterimElement();
+      expect(parent.find('md-bottom-sheet').length).toBe(0);
+    });
 
-    it('should not close when `clickOutsideToClose == false`',
-      inject(function ($mdBottomSheet, $rootElement, $material) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          clickOutsideToClose: false
-        });
+    it('should not close when `clickOutsideToClose == false`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        clickOutsideToClose: false
+      });
 
-        $material.flushOutstandingAnimations();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        var backdrop = parent.find('md-backdrop');
+      var backdrop = parent.find('md-backdrop');
 
-        backdrop.triggerHandler({
-          type: 'click',
-          target: backdrop[0]
-        });
+      backdrop.triggerHandler({
+        type: 'click',
+        target: backdrop[0]
+      });
 
-        $material.flushInterimElement();
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
-      }));
+      $material.flushInterimElement();
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
+    });
 
-    it('should warn if the template contains a `ng-cloak`', inject(function($mdBottomSheet, $material, $log) {
+    it('should warn if the template contains a `ng-cloak`', inject(function($log) {
       var parent = angular.element('<div>');
 
       // Enable spy on $log.warn
@@ -82,99 +90,94 @@ describe('$mdBottomSheet service', function () {
       expect($log.warn).toHaveBeenCalled();
     }));
 
-    it('should not append any backdrop when `disableBackdrop === true`',
-      inject(function($mdBottomSheet, $rootElement, $material) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          disableBackdrop: true
-        });
+    it('should not append any backdrop when `disableBackdrop === true`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        disableBackdrop: true
+      });
 
-        $material.flushOutstandingAnimations();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        var backdrop = parent.find('md-backdrop');
-        expect(backdrop.length).toBe(0);
-      }));
+      var backdrop = parent.find('md-backdrop');
+      expect(backdrop.length).toBe(0);
+    });
 
-    it('should append a backdrop by default to the bottomsheet',
-      inject(function($mdBottomSheet, $rootElement, $material) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent
-        });
+    it('should append a backdrop by default to the bottomsheet', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent
+      });
 
-        $material.flushOutstandingAnimations();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        var backdrop = parent.find('md-backdrop');
-        expect(backdrop.length).toBe(1);
-      }));
+      var backdrop = parent.find('md-backdrop');
+      expect(backdrop.length).toBe(1);
+    });
 
-    it('should close when `escapeToClose == true`',
-      inject(function ($mdBottomSheet, $rootElement, $material, $mdConstant) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          escapeToClose: true
-        });
+    it('should close when `escapeToClose == true`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        escapeToClose: true
+      });
 
-        $material.flushOutstandingAnimations();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        $rootElement.triggerHandler({
-          type: 'keyup',
-          keyCode: $mdConstant.KEY_CODE.ESCAPE
-        });
+      $rootElement.triggerHandler({
+        type: 'keyup',
+        keyCode: $mdConstant.KEY_CODE.ESCAPE
+      });
 
-        $material.flushInterimElement();
-        expect(parent.find('md-bottom-sheet').length).toBe(0);
-      }));
+      $material.flushInterimElement();
+      expect(parent.find('md-bottom-sheet').length).toBe(0);
+    });
 
-    it('should not close when `escapeToClose == false`',
-      inject(function ($mdBottomSheet, $rootScope, $rootElement, $timeout, $animate, $mdConstant) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          escapeToClose: false
-        });
-        $rootScope.$apply();
+    it('should not close when `escapeToClose == false`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        escapeToClose: false
+      });
+      $rootScope.$apply();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        $rootElement.triggerHandler({type: 'keyup', keyCode: $mdConstant.KEY_CODE.ESCAPE});
+      $rootElement.triggerHandler({type: 'keyup', keyCode: $mdConstant.KEY_CODE.ESCAPE});
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
-      }));
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
+    });
 
-    it('should close when navigation fires `scope.$destroy()`',
-      inject(function ($mdBottomSheet, $rootScope, $rootElement, $timeout, $material) {
-        var parent = angular.element('<div>');
-        $mdBottomSheet.show({
-          template: '<md-bottom-sheet>',
-          parent: parent,
-          escapeToClose: false
-        });
+    it('should close when navigation fires `scope.$destroy()`', function() {
+      var parent = angular.element('<div>');
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent,
+        escapeToClose: false
+      });
 
-        $rootScope.$apply();
-        $material.flushOutstandingAnimations();
+      $rootScope.$apply();
+      $material.flushOutstandingAnimations();
 
-        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        $rootScope.$destroy();
-        $material.flushInterimElement();
-        expect(parent.find('md-bottom-sheet').length).toBe(0);
-      }));
+      $rootScope.$destroy();
+      $material.flushInterimElement();
+      expect(parent.find('md-bottom-sheet').length).toBe(0);
+    });
 
     it('should focus child with md-autofocus',
-      inject(function ($rootScope, $animate, $document, $mdBottomSheet) {
+      inject(function ($document) {
         jasmine.mockElementFocus(this);
         var parent = angular.element('<div>');
         var markup = '' +
@@ -204,20 +207,70 @@ describe('$mdBottomSheet service', function () {
 
     // This test is mainly for touch devices as the -webkit-overflow-scrolling causes z-index issues
     // if the scroll mask is appended to the body element
-    it('appends the scroll mask to the same parent',
-      inject(function ($mdBottomSheet, $rootScope) {
-        var parent = angular.element('<div>');
+    it('appends the scroll mask to the same parent', function() {
+      var parent = angular.element('<div>');
 
+      $mdBottomSheet.show({
+        template: '<md-bottom-sheet>',
+        parent: parent
+      });
+
+      $rootScope.$apply();
+
+      var scrollMask = parent[0].querySelector('.md-scroll-mask');
+
+      expect(scrollMask).not.toBeNull();
+    });
+
+    describe('isLockedOpen option', function() {
+      it('should not close, even though `escapeToClose` is true', function() {
+        var parent = angular.element('<div>');
         $mdBottomSheet.show({
           template: '<md-bottom-sheet>',
-          parent: parent
+          parent: parent,
+          escapeToClose: true,
+          isLockedOpen: true
         });
 
-        $rootScope.$apply();
+        $material.flushOutstandingAnimations();
 
-        var scrollMask = parent[0].querySelector('.md-scroll-mask');
+        expect(parent.find('md-bottom-sheet').length).toBe(1);
 
-        expect(scrollMask).not.toBeNull();
-      }));
+        $rootElement.triggerHandler({
+          type: 'keyup',
+          keyCode: $mdConstant.KEY_CODE.ESCAPE
+        });
+
+        $material.flushInterimElement();
+        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      });
+
+      it('should not close, even though `clickOutsideToClose` is true', function() {
+        var parent = angular.element('<div>');
+        $mdBottomSheet.show({
+          template: '<md-bottom-sheet>',
+          parent: parent,
+          clickOutsideToClose: true,
+          isLockedOpen: true
+        });
+
+        $material.flushOutstandingAnimations();
+
+        expect(parent.find('md-bottom-sheet').length).toBe(1);
+
+        var backdrop = parent.find('md-backdrop');
+
+        backdrop.triggerHandler({
+          type: 'click',
+          target: backdrop[0]
+        });
+
+        $material.flushInterimElement();
+        expect(parent.find('md-bottom-sheet').length).toBe(1);
+      });
+
+    });
+
   });
+
 });


### PR DESCRIPTION
- Adds the `isLockedOpen` option to the bottom sheet service, allowing users to disable all non-programmatic ways of closing a bottom sheet.
- Cleans up some redundant logic in the mdBottomSheet service.
- Cleans up the bottom sheet unit test setup.

Fixes #9084.
