### PR TITLE
fix(subheader): do not compile ng-repeat twice.

### DIFF
--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -56,7 +56,11 @@ function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
     link: function postLink(scope, element, attr, controllers, transclude) {
       $mdTheming(element);
       element.addClass('_md');
-      
+
+      // Remove the ngRepeat attribute from the root element, because we don't want to compile
+      // the ngRepeat for the sticky clone again.
+      $mdUtil.prefixer().removeAttribute(element, 'ng-repeat');
+
       var outerHTML = element[0].outerHTML;
 
       function getContent(el) {

--- a/src/components/subheader/subheader.spec.js
+++ b/src/components/subheader/subheader.spec.js
@@ -166,9 +166,7 @@ describe('mdSubheader', function() {
       '</div>'
     );
 
-    // TODO(devversion): Remove this expectation and update to correctly detect 6 subheaders
-    // TODO(devversion) See related issue: https://github.com/angular/material/issues/8647
-    expect(contentElement[0].querySelectorAll('.md-subheader').length).toEqual(12);
+    expect(contentElement[0].querySelectorAll('.md-subheader').length).toEqual(6);
 
     // Check if there were no exceptions caused.
     expect($exceptionHandler.errors).toEqual([]);

--- a/src/core/util/prefixer.js
+++ b/src/core/util/prefixer.js
@@ -22,7 +22,8 @@ function MdPrefixer(initialAttributes, buildSelector) {
   return {
     buildList: _buildList,
     buildSelector: _buildSelector,
-    hasAttribute: _hasAttribute
+    hasAttribute: _hasAttribute,
+    removeAttribute: _removeAttribute
   };
 
   function _buildList(attributes) {
@@ -41,7 +42,7 @@ function MdPrefixer(initialAttributes, buildSelector) {
     attributes = angular.isArray(attributes) ? attributes : [attributes];
 
     return _buildList(attributes)
-      .map(function (item) {
+      .map(function(item) {
         return '[' + item + ']'
       })
       .join(',');
@@ -59,5 +60,13 @@ function MdPrefixer(initialAttributes, buildSelector) {
     }
 
     return false;
+  }
+
+  function _removeAttribute(element, attribute) {
+    element = element[0] || element;
+
+    _buildList(attribute).forEach(function(prefixedAttribute) {
+      element.removeAttribute(prefixedAttribute);
+    });
   }
 }

--- a/src/core/util/prefixer.spec.js
+++ b/src/core/util/prefixer.spec.js
@@ -76,6 +76,34 @@ describe('prefixer', function() {
 
     });
 
+    describe('and removing an attribute', function() {
+
+      it('should remove a prefixed attribute', function() {
+        var element = angular.element('<div data-ng-click="null">')[0];
+
+        prefixer.removeAttribute(element, 'ng-click');
+
+        expect(element.hasAttribute('data-ng-click')).toBeFalsy();
+      });
+
+      it('should remove an un-prefixed attribute', function() {
+        var element = angular.element('<div ng-click="null">')[0];
+
+        prefixer.removeAttribute(element, 'ng-click');
+
+        expect(element.hasAttribute('ng-click')).toBeFalsy();
+      });
+
+      it('should remove prefixed and un-prefixed attributes', function() {
+        var element = angular.element('<div ng-click="null" data-ng-click="null">')[0];
+
+        prefixer.removeAttribute(element, 'ng-click');
+
+        expect(prefixer.hasAttribute(element, 'ng-click')).toBeFalsy();
+      });
+
+    });
+
   });
   
 });


### PR DESCRIPTION
* The subheader component always compiles the outerHTML of the root element (replaced) twice, to be able to create a sticky clone.
* When using ng-repeat on the subheader element, the ngRepeat wil be compiled again and it will result in another repetition.

Fixes #8647.