### PR TITLE
fix(docs): prevent docs from polluting the window

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -1,6 +1,4 @@
-var DocsApp = angular.module('docsApp', [ 'angularytics', 'ngRoute', 'ngMessages', 'ngMaterial' ])
-
-.config([
+angular.module('docsApp', [ 'angularytics', 'ngRoute', 'ngMessages', 'ngMaterial' ], [
   'SERVICES',
   'COMPONENTS',
   'DEMOS',
@@ -11,6 +9,7 @@ var DocsApp = angular.module('docsApp', [ 'angularytics', 'ngRoute', 'ngMessages
   '$mdIconProvider',
 function(SERVICES, COMPONENTS, DEMOS, PAGES,
     $routeProvider, $locationProvider, $mdThemingProvider, $mdIconProvider) {
+
   $locationProvider.html5Mode(true);
 
   $routeProvider
@@ -307,7 +306,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
         url: 'contributors',
         type: 'link'
       } );
-      
+
   sections.push({
     name: 'License',
     url:  'license',
@@ -802,15 +801,15 @@ function($rootScope, $scope, component, demos, $templateRequest) {
       if (!restrict.element && restrict.attribute) {
         return '[' + str + ']';
       }
-      
+
       // If it is restricted to elements and isn't a service
       if (restrict.element && str.indexOf('-') > -1) {
         return '<' + str + '>';
       }
-      
+
       // TODO: Handle class/comment restrictions if we ever have any to document
     }
-    
+
     // Just return the original string if we don't know what to do with it
     return str;
   };

--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -1,5 +1,5 @@
 (function() {
-  DocsApp
+  angular.module('docsApp')
     .factory('codepenDataAdapter', CodepenDataAdapter)
     .factory('codepen', ['$demoAngularScripts', '$document', 'codepenDataAdapter', Codepen]);
 

--- a/docs/app/js/demo.js
+++ b/docs/app/js/demo.js
@@ -1,4 +1,4 @@
-DocsApp
+angular.module('docsApp')
 .directive('layoutAlign', function() { return angular.noop; })
 .directive('layout', function() { return angular.noop; })
 .directive('docsDemo', ['$mdUtil', function($mdUtil) {

--- a/docs/app/js/demoInclude.js
+++ b/docs/app/js/demoInclude.js
@@ -1,13 +1,13 @@
-DocsApp.directive('demoInclude', [
-  '$q', 
-  '$compile', 
+angular.module('docsApp').directive('demoInclude', [
+  '$q',
+  '$compile',
   '$timeout',
 function($q, $compile, $timeout) {
   return {
     restrict: 'E',
     link: postLink
   };
-  
+
   function postLink(scope, element, attr) {
     var demoContainer;
 

--- a/docs/app/js/highlight-angular.js
+++ b/docs/app/js/highlight-angular.js
@@ -1,5 +1,4 @@
-DocsApp
-
+angular.module('docsApp')
 .directive('hljs', ['$timeout', '$q', '$interpolate', function($timeout, $q, $interpolate) {
   return {
     restrict: 'E',

--- a/docs/app/js/ngPanel.js
+++ b/docs/app/js/ngPanel.js
@@ -2,8 +2,7 @@
  * ngPanel by @matsko
  * https://github.com/matsko/ng-panel
  */
-DocsApp
-
+angular.module('docsApp')
   .directive('ngPanel', ['$animate', function($animate) {
     return {
       restrict: 'EA',

--- a/docs/app/js/scripts.js
+++ b/docs/app/js/scripts.js
@@ -1,5 +1,5 @@
 (function() {
-  DocsApp
+  angular.module('docsApp')
     .factory('$demoAngularScripts', ['BUILDCONFIG', DemoAngularScripts]);
 
   function DemoAngularScripts(BUILDCONFIG) {

--- a/docs/config/template/build-config.js
+++ b/docs/config/template/build-config.js
@@ -1,1 +1,1 @@
-DocsApp.constant('BUILDCONFIG', {$ doc.buildConfig | json $});
+angular.module('docsApp').constant('BUILDCONFIG', {$ doc.buildConfig | json $});

--- a/docs/config/template/constant-data.template.js
+++ b/docs/config/template/constant-data.template.js
@@ -1,2 +1,1 @@
-DocsApp
-.constant('{$ doc.name $}', {$ doc.items | json $});
+angular.module('docsApp').constant('{$ doc.name $}', {$ doc.items | json $});

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -96,18 +96,18 @@ angular.module('dialogDemo1', ['ngMaterial'])
       clickOutsideToClose: true
     });
   };
+
+  function DialogController($scope, $mdDialog) {
+    $scope.hide = function() {
+      $mdDialog.hide();
+    };
+
+    $scope.cancel = function() {
+      $mdDialog.cancel();
+    };
+
+    $scope.answer = function(answer) {
+      $mdDialog.hide(answer);
+    };
+  }
 });
-
-function DialogController($scope, $mdDialog) {
-  $scope.hide = function() {
-    $mdDialog.hide();
-  };
-
-  $scope.cancel = function() {
-    $mdDialog.cancel();
-  };
-
-  $scope.answer = function(answer) {
-    $mdDialog.hide(answer);
-  };
-}

--- a/src/components/menu/demoMenuWidth/script.js
+++ b/src/components/menu/demoMenuWidth/script.js
@@ -1,12 +1,8 @@
-angular.module('menuDemoWidth', ['ngMaterial'])
-.config(function($mdIconProvider) {
+angular.module('menuDemoWidth', ['ngMaterial']).config(function($mdIconProvider) {
   $mdIconProvider
     .iconSet("call", 'img/icons/sets/communication-icons.svg', 24)
     .iconSet("social", 'img/icons/sets/social-icons.svg', 24);
-})
-.controller('WidthDemoCtrl', DemoCtrl);
-
-function DemoCtrl($mdDialog) {
+}).controller('WidthDemoCtrl', function($mdDialog) {
   var vm = this;
 
   this.announceClick = function(index) {
@@ -17,5 +13,4 @@ function DemoCtrl($mdDialog) {
         .ok('Nice')
     );
   };
-}
-
+});

--- a/src/components/panel/demoBasicUsage/script.js
+++ b/src/components/panel/demoBasicUsage/script.js
@@ -1,3 +1,6 @@
+(function() {
+'use strict';
+
 angular.module('panelDemo', ['ngMaterial'])
     .controller('BasicDemoCtrl', BasicDemoCtrl)
     .controller('PanelDialogCtrl', PanelDialogCtrl);
@@ -167,3 +170,5 @@ PanelMenuCtrl.prototype.onKeydown = function($event, dessert) {
     return -1;
   }
 };
+
+})();

--- a/src/components/panel/demoPanelAnimations/script.js
+++ b/src/components/panel/demoPanelAnimations/script.js
@@ -1,3 +1,6 @@
+(function() {
+'use strict';
+
 angular.module('panelAnimationsDemo', ['ngMaterial'])
     .controller('AnimationCtrl', AnimationCtrl)
     .controller('DialogCtrl', DialogCtrl);
@@ -94,3 +97,5 @@ function DialogCtrl(mdPanelRef) {
 DialogCtrl.prototype.closeDialog = function() {
   this._mdPanelRef && this._mdPanelRef.close();
 };
+
+})();

--- a/src/components/toolbar/demoScrollShrink/script.js
+++ b/src/components/toolbar/demoScrollShrink/script.js
@@ -1,10 +1,9 @@
-var app = angular.module('toolbarDemo2', ['ngMaterial']);
+angular.module('toolbarDemo2', ['ngMaterial'])
 
-app.controller('TitleController', function($scope) {
+.controller('TitleController', function($scope) {
   $scope.title = 'My App Title';
-});
-
-app.controller('AppCtrl', function($scope) {
+})
+.controller('AppCtrl', function($scope) {
   var imagePath = 'img/list/60.jpeg';
 
   $scope.todos = [];


### PR DESCRIPTION
A few of the docs controllers, as well as the main docs app, were polluting the global `window` object unnecessarily.