### PR TITLE
feat(browser-color): enable browser header coloring

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -68,6 +68,9 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
       .primaryPalette('docs-blue')
       .accentPalette('docs-red');
 
+  $mdThemingProvider
+      .enableBrowserColor();
+
   angular.forEach(PAGES, function(pages, area) {
     angular.forEach(pages, function(page) {
       $routeProvider

--- a/src/core/services/meta/meta.js
+++ b/src/core/services/meta/meta.js
@@ -1,0 +1,120 @@
+/**
+ * @ngdoc service
+ * @name $$mdMeta
+ * @module material.core.meta
+ *
+ * @description
+ *
+ * A provider and a service that simplifies meta tags access
+ *
+ * Note: This is intended only for use with dynamic meta tags such as browser color and title.
+ * Tags that are only processed when the page is rendered (such as `charset`, and `http-equiv`)
+ * will not work since `$$mdMeta` adds the tags after the page has already been loaded.
+ *
+ * ```js
+ * app.config(function($$mdMetaProvider) {
+ *   var removeMeta = $$mdMetaProvider.setMeta('meta-name', 'content');
+ *   var metaValue  = $$mdMetaProvider.getMeta('meta-name'); // -> 'content'
+ *
+ *   removeMeta();
+ * });
+ *
+ * app.controller('myController', function($$mdMeta) {
+ *   var removeMeta = $$mdMeta.setMeta('meta-name', 'content');
+ *   var metaValue  = $$mdMeta.getMeta('meta-name'); // -> 'content'
+ *
+ *   removeMeta();
+ * });
+ * ```
+ *
+ * @returns {$$mdMeta.$service}
+ *
+ */
+angular.module('material.core.meta', [])
+  .provider('$$mdMeta', function () {
+    var head = angular.element(document.head);
+    var metaElements = {};
+
+    /**
+     * Checks if the requested element was written manually and maps it
+     *
+     * @param {string} name meta tag 'name' attribute value
+     * @returns {boolean} returns true if there is an element with the requested name
+     */
+    function mapExistingElement(name) {
+      if (metaElements[name]) {
+        return true;
+      }
+
+      var element = document.getElementsByName(name)[0];
+
+      if (!element) {
+        return false;
+      }
+
+      metaElements[name] = angular.element(element);
+
+      return true;
+    }
+
+    /**
+     * @ngdoc method
+     * @name $$mdMeta#setMeta
+     *
+     * @description
+     * Creates meta element with the 'name' and 'content' attributes,
+     * if the meta tag is already created than we replace the 'content' value
+     *
+     * @param {string} name meta tag 'name' attribute value
+     * @param {string} content meta tag 'content' attribute value
+     * @returns {function} remove function
+     *
+     */
+    function setMeta(name, content) {
+      mapExistingElement(name);
+
+      if (!metaElements[name]) {
+        var newMeta = angular.element('<meta name="' + name + '" content="' + content + '"/>');
+        head.append(newMeta);
+        metaElements[name] = newMeta;
+      }
+      else {
+        metaElements[name].attr('content', content);
+      }
+
+      return function () {
+        metaElements[name].attr('content', '');
+        metaElements[name].remove();
+        delete metaElements[name];
+      };
+    }
+
+    /**
+     * @ngdoc method
+     * @name $$mdMeta#getMeta
+     *
+     * @description
+     * Gets the 'content' attribute value of the wanted meta element
+     *
+     * @param {string} name meta tag 'name' attribute value
+     * @returns {string} content attribute value
+     */
+    function getMeta(name) {
+      if (!mapExistingElement(name)) {
+        throw Error('$$mdMeta: could not find a meta tag with the name \'' + name + '\'');
+      }
+
+      return metaElements[name].attr('content');
+    }
+
+    var module = {
+      setMeta: setMeta,
+      getMeta: getMeta
+    };
+
+    return angular.extend({}, module, {
+      $get: function () {
+        return module;
+      }
+    });
+  });

--- a/src/core/services/meta/meta.spec.js
+++ b/src/core/services/meta/meta.spec.js
@@ -1,0 +1,102 @@
+describe('$$mdMeta', function() {
+  var $$mdMeta;
+
+  beforeEach(module('material.core'));
+
+  beforeEach(function() {
+    inject(function(_$$mdMeta_) {
+      $$mdMeta = _$$mdMeta_;
+    });
+  });
+
+  describe('set meta', function () {
+    beforeEach(function () {
+      angular.element(document.getElementsByTagName('meta')).remove();
+    });
+
+    it('should create the element and append it to the body', function() {
+      var name = 'test';
+      var content = 'value';
+
+      expect(document.getElementsByName(name).length).toEqual(0);
+
+      $$mdMeta.setMeta(name, content);
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+    });
+
+    it('should update the existing meta tag', function() {
+      var name = 'test';
+      var content = 'value';
+
+      $$mdMeta.setMeta(name, content);
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+
+      $$mdMeta.setMeta(name, content + '2');
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content + '2');
+    });
+
+    it('should map existing meta tag', function() {
+      var name = 'test';
+      var content = 'value';
+
+      var element = angular.element('<meta name="' + name + '" content="' + content + '"/>');
+      angular.element(document.head).append(element);
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+
+      $$mdMeta.setMeta(name, content + '2');
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content + '2');
+    });
+
+    it('should return a remove function', function() {
+      var name = 'test';
+      var content = 'value';
+
+      var remove = $$mdMeta.setMeta(name, content);
+
+      expect(document.getElementsByName(name).length).toBe(1);
+
+      remove();
+
+      expect(document.getElementsByName(name).length).toBe(0);
+
+    });
+  });
+
+  describe('get meta', function () {
+    beforeEach(function () {
+      angular.element(document.getElementsByTagName('meta')).remove();
+    });
+
+    it('should return the meta content', function() {
+      var name = 'test';
+      var content = 'value';
+
+      $$mdMeta.setMeta(name, content);
+
+      expect($$mdMeta.getMeta(name)).toBe(content);
+    });
+
+    it('should reject unavailable meta tags', function() {
+      var name = 'test';
+
+      expect(function () {
+        $$mdMeta.getMeta(name);
+      }).toThrowError('$$mdMeta: could not find a meta tag with the name \'' + name + '\'');
+    });
+
+    it('should add not mapped meta tag to the hashmap', function() {
+      var name = 'test';
+      var content = 'value';
+
+      var element = angular.element('<meta name="' + name + '" content="' + content + '"/>');
+      angular.element(document.head).append(element);
+
+      expect($$mdMeta.getMeta(name)).toBe(content);
+    });
+  });
+});

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -343,6 +343,65 @@ describe('$mdThemingProvider', function() {
     });
   });
 
+  describe('browser color', function () {
+    beforeEach(function () {
+      setup();
+      angular.element(document.getElementsByTagName('meta')).remove();
+    });
+
+    it('should use default primary color at the meta tag', function () {
+      var name = 'theme-color';
+      var content = themingProvider._PALETTES.testPalette['800'].hex;
+
+      expect(document.getElementsByName(name).length).toBe(0);
+
+      themingProvider.enableBrowserColor();
+
+      expect(document.getElementsByName(name).length).toBe(1);
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+    });
+
+    it('should use default primary color with hue `200`', function () {
+      var name = 'theme-color';
+
+      var hue = '200';
+
+      var content = themingProvider._PALETTES.testPalette[hue].hex;
+
+      expect(document.getElementsByName(name).length).toBe(0);
+
+      themingProvider.enableBrowserColor({ hue: hue });
+
+      expect(document.getElementsByName(name).length).toBe(1);
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+    });
+
+    it('should use red palette', function () {
+      var name = 'theme-color';
+
+      var content = themingProvider._PALETTES.red['800'].hex;
+
+      expect(document.getElementsByName(name).length).toBe(0);
+
+      themingProvider.enableBrowserColor({ palette: 'red' });
+
+      expect(document.getElementsByName(name).length).toBe(1);
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+    });
+
+    it('should use test theme', function () {
+      var name = 'theme-color';
+
+      var content = themingProvider._PALETTES.testPalette['800'].hex;
+
+      expect(document.getElementsByName(name).length).toBe(0);
+
+      themingProvider.enableBrowserColor({ theme: 'test' });
+
+      expect(document.getElementsByName(name).length).toBe(1);
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+    });
+  })
 });
 
 describe('$mdThemeProvider with custom styles', function() {
@@ -639,6 +698,23 @@ describe('$mdTheming service', function() {
   it('exposes a getter for the default theme', inject(function($mdTheming) {
     expect($mdTheming.defaultTheme()).toBe('default');
   }));
+
+  it('supports changing browser color on the fly', function() {
+    var name = 'theme-color';
+    var primaryPalette = $mdThemingProvider._THEMES.default.colors.primary.name;
+    var primaryColor = $mdThemingProvider._PALETTES[primaryPalette]['800'].hex;
+    var redColor = $mdThemingProvider._PALETTES.red['800'].hex;
+
+    $mdThemingProvider.enableBrowserColor();
+
+    expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(primaryColor);
+
+    inject(function($mdTheming) {
+      $mdTheming.setBrowserColor({ palette: 'red' });
+
+      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(redColor);
+    });
+  });
 });
 
 describe('md-theme directive', function() {


### PR DESCRIPTION
- provides an easy way to set and change the browser color according the material design spec colors and the defined themes

fixes #8062