### PR TITLE
fix(tooltip) correct background and foreground color

### DIFF
--- a/src/components/tooltip/tooltip-theme.scss
+++ b/src/components/tooltip/tooltip-theme.scss
@@ -1,6 +1,6 @@
 md-tooltip.md-THEME_NAME-theme {
-  color: '{{background-A100}}';
+  color: '{{background-700-contrast}}';
   .md-content {
-    background-color: '{{foreground-2}}';
+    background-color: '{{background-700}}';
   }
 }

--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -47,7 +47,7 @@ md-tooltip {
     }
     &.md-show, &.md-show-add-active {
       transform: scale(1);
-      opacity: 1;
+      opacity: 0.9;
       transform-origin: center top;
     }
     &.md-show-remove {


### PR DESCRIPTION
Use Material Design colors for tooltip
 - Set tooltip opacity to 0.90
 - Use background-700 for background color
 - Use background-700-contrast for foreground color

Previously, the background color was set to a foreground-2 and the
foreground color was set to A100 of the background which causes
visibility issues when either changing the background palette from
grey or using a dark theme.

Fixes #9159