### PR TITLE
fix(navBar): Validate tab controller is defined before calling find fn

### DIFF
--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -300,7 +300,7 @@ MdNavBarController.prototype.getFocusedTab = function() {
 MdNavBarController.prototype._findTab = function(fn) {
   var tabs = this._getTabs();
   for (var i = 0; i < tabs.length; i++) {
-    if (fn(tabs[i])) {
+    if (tabs[i] && fn(tabs[i])) {
       return tabs[i];
     }
   }

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -156,6 +156,23 @@ describe('mdNavBar', function() {
 
       expect($scope.selectedTabRoute).toBe('tab2');
     });
+
+    it('does not find tab if no controllers exist on tabs', function() {
+        createTabs();
+
+        // Simulate _getTabs returning undefined tab controllers
+        ctrl._getTabs = function() {
+            return ['tab1', 'tab2', 'tab3'].map(function(tab) {
+                return undefined;
+            });
+        }
+
+        var focusedTab = findTab(function(tab) {
+          return tab.hasFocus();
+        });
+
+        expect(focusedTab).toBeNull();
+    });
   });
 
   describe('inkbar', function() {
@@ -281,6 +298,10 @@ describe('mdNavBar', function() {
       expect(tab2Ctrl.getButtonEl().click).toHaveBeenCalled();
     });
   });
+
+  function findTab(fn) {
+      return ctrl._findTab(fn);
+  }
 
   function getTab(tabName) {
     return angular.element(getTabCtrl(tabName).getButtonEl());


### PR DESCRIPTION
When `_getTabs` is called on a `md-nav-bar` controller, the item's controller may not have been initialized yet. The implementation looks for the controller by using `angular.element` on line 259:

```js
return angular.element(el).controller('mdNavItem')
```

If the controller is not yet defined, we get an `undefined` controller in our list of tab controllers. This means when `_findTab` is called, it will try and call the finder function with `undefined` as the parameter. Since these functions expect prototype methods from the `MdNavItemController`, I end up getting this error:

```
TypeError: Cannot read property 'getName' of undefined
```

This change guards against the tab controller being `undefined` by checking for its existence before calling the finder function.