### PR TITLE
fix(travis): terminate runtime execution when pipeline fails.

### DIFF
--- a/scripts/travis-run-script.sh
+++ b/scripts/travis-run-script.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Terminate the execution if anything fails in the pipeline.
+set -e
+
 # Run our check to make sure all tests will actually run
 gulp ddescribe-iit
 gulp build


### PR DESCRIPTION
* Currently the CI would not alert any error, when the tests fail.<br/>
  This is caused by the introduction of the new  `travis-run-script.sh` file.