### PR TITLE
fix(md-contact-chips): support md-min-length on md-contact-chips.

### DIFF
--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -8,6 +8,7 @@ describe('<md-contact-chips>', function() {
           md-contact-image="image"\
           md-contact-email="email"\
           md-highlight-flags="i"\
+          md-min-length="1"\
           placeholder="To">\
       </md-contact-chips>';
 
@@ -81,6 +82,15 @@ describe('<md-contact-chips>', function() {
 
         expect(chip.find('img').length).toBe(0);
     });
+
+    it('check if minLength on autocomplete controller equals md-min-length attribute on md-contact-chips element', inject(function() {
+        var element = buildChips(CONTACT_CHIPS_TEMPLATE);
+
+        var autocompleteElement = element.find('md-autocomplete');
+        var autocompleteCtrl = autocompleteElement.controller('mdAutocomplete');
+
+        expect(autocompleteCtrl.scope.minLength).toBe(parseInt(element.attr('md-min-length')));
+      }));
 
     describe('filtering selected items', function() {
       it('should filter', inject(function() {

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -83,7 +83,7 @@ describe('<md-contact-chips>', function() {
         expect(chip.find('img').length).toBe(0);
     });
 
-    it('check if minLength on autocomplete controller equals md-min-length attribute on md-contact-chips element', inject(function() {
+    it('should forward md-min-length attribute to the autocomplete', inject(function() {
         var element = buildChips(CONTACT_CHIPS_TEMPLATE);
 
         var autocompleteElement = element.find('md-autocomplete');

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -29,6 +29,8 @@ angular
  *    contact's email address.
  * @param {string} md-contact-image The field name of the contact object representing the
  *    contact's image.
+ * @param {number=} md-min-length Specifies the minimum length of text before autocomplete will
+ *    make suggestions
  *
  *
  * @param {expression=} filter-selected Whether to filter selected contacts from the list of
@@ -63,6 +65,8 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-items="item in $mdContactChipsCtrl.queryContact($mdContactChipsCtrl.searchText)"\
               md-item-text="$mdContactChipsCtrl.itemName(item)"\
               md-no-cache="true"\
+              md-min-length="$mdContactChipsCtrl.minLength"\
+              md-has-not-found="true"\
               md-autoselect\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\
@@ -118,6 +122,7 @@ function MdContactChips($mdTheming, $mdUtil) {
       contactEmail: '@mdContactEmail',
       contacts: '=ngModel',
       requireMatch: '=?mdRequireMatch',
+      minLength: '=?mdMinLength',
       highlightFlags: '@?mdHighlightFlags'
     }
   };

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -66,7 +66,6 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
               md-item-text="$mdContactChipsCtrl.itemName(item)"\
               md-no-cache="true"\
               md-min-length="$mdContactChipsCtrl.minLength"\
-              md-has-not-found="true"\
               md-autoselect\
               placeholder="{{$mdContactChipsCtrl.contacts.length == 0 ?\
                   $mdContactChipsCtrl.placeholder : $mdContactChipsCtrl.secondaryPlaceholder}}">\


### PR DESCRIPTION
Add md-min-length to md-contact-chips and propagate attribute to md-autocomplete.
Add md-has-not-found=true attribute to md-autocomplete.

Fixes #2423.
