### PR TITLE
fix(): refactor rtl-prop mixin to add less CSS

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -16,13 +16,13 @@ md-card {
 
     &:first-child {
       md-card-avatar {
-       @include rtl-prop(margin-right, margin-left, 12px);
+       @include rtl-prop(margin-right, margin-left, 12px, auto);
       }
     }
 
     &:last-child {
       md-card-avatar {
-        @include rtl-prop(margin-left, margin-right, 12px);
+        @include rtl-prop(margin-left, margin-right, 12px, auto);
       }
     }
 
@@ -169,11 +169,11 @@ md-card {
         margin: 0 $baseline-grid * .5;
 
         &:first-of-type {
-          @include rtl-prop(margin-left, margin-right, 0);
+          @include rtl-prop(margin-left, margin-right, 0, auto);
         }
 
         &:last-of-type {
-          @include rtl-prop(margin-right, margin-left, 0);
+          @include rtl-prop(margin-right, margin-left, 0, auto);
         }
       }
 
@@ -182,11 +182,11 @@ md-card {
         margin-right: 3 * $baseline-grid / 4;
 
         &:first-of-type {
-          @include rtl-prop(margin-left, margin-right, 3 * $baseline-grid / 2);
+          @include rtl-prop(margin-left, margin-right, 3 * $baseline-grid / 2, auto);
         }
 
         &:last-of-type {
-          @include rtl-prop(margin-right, margin-left, 3 * $baseline-grid / 2);
+          @include rtl-prop(margin-right, margin-left, 3 * $baseline-grid / 2, auto);
         }
       }
 

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -26,7 +26,7 @@ $contact-chip-name-width: rem(12) !default;
       .md-contact-name {
         display: inline-block;
         height: $chip-height;
-        @include rtl-prop(margin-left, margin-right, rem(0.8));
+        @include rtl-prop(margin-left, margin-right, rem(0.8), auto);
       }
     }
   }
@@ -39,7 +39,7 @@ $contact-chip-name-width: rem(12) !default;
     margin-top: $contact-chip-suggestion-margin;
   }
   .md-contact-name {
-    @include rtl-prop(margin-left, margin-right, $contact-chip-suggestion-margin);
+    @include rtl-prop(margin-left, margin-right, $contact-chip-suggestion-margin, auto);
     width: $contact-chip-name-width;
   }
   .md-contact-name, .md-contact-email {
@@ -71,10 +71,10 @@ $contact-chip-name-width: rem(12) !default;
   &.md-removable {
 
     md-chip {
-      @include rtl-prop(padding-right, padding-left, $chip-remove-padding-right);
+      @include rtl-prop(padding-right, padding-left, $chip-remove-padding-right, 0);
 
       .md-chip-content {
-        @include rtl-prop(padding-right, padding-left, rem(0.4));
+        @include rtl-prop(padding-right, padding-left, rem(0.4), 0);
       }
     }
 
@@ -112,7 +112,7 @@ $contact-chip-name-width: rem(12) !default;
     }
     .md-chip-remove-container {
       position: absolute;
-      @include rtl-prop(right, left, 0);
+      @include rtl-prop(right, left, 0, auto);
       line-height: $chip-remove-line-height;
     }
     .md-chip-remove {

--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -33,11 +33,11 @@ $md-calendar-height:
   // because we want the header background and the month dividing border to
   // extend the entire width of the calendar.
   &:first-child {
-    @include rtl-prop(padding-left, padding-right, $md-calendar-side-padding);
+    @include rtl-prop(padding-left, padding-right, $md-calendar-side-padding, 0);
   }
 
   &:last-child {
-    @include rtl-prop(padding-right, padding-left, $md-calendar-side-padding);
+    @include rtl-prop(padding-right, padding-left, $md-calendar-side-padding, 0);
   }
 }
 

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -15,8 +15,8 @@ md-datepicker {
 
   // Leave room for the down-triangle button to "overflow" it's parent without modifying scrollLeft.
   // This prevents the element from shifting right when opening via the triangle button.
-  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2);
-  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2);
+  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2, 0);
+  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2, auto);
 
   vertical-align: middle;
 }
@@ -83,7 +83,7 @@ md-datepicker {
 
     .md-input-message-animation {
       $margin: $md-datepicker-triangle-button-width + $md-datepicker-button-padding * 2 + $md-datepicker-button-gap;
-      @include rtl-prop(margin-left, margin-right, $margin);
+      @include rtl-prop(margin-left, margin-right, $margin, auto);
     }
   }
 }
@@ -102,7 +102,7 @@ md-datepicker {
   width: auto;
 
   .md-icon-button + & {
-    @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap);
+    @include rtl-prop(margin-left, margin-right, $md-datepicker-button-gap, auto);
   }
 
   &.md-datepicker-focused {
@@ -200,7 +200,7 @@ md-datepicker {
 // Button containing the down "disclosure" triangle/arrow.
 .md-datepicker-triangle-button {
   position: absolute;
-  @include rtl-prop(right, left, 0);
+  @include rtl-prop(right, left, 0, auto);
   top: $md-date-arrow-size;
 
   // TODO(jelbourn): This position isn't great on all platforms.
@@ -238,7 +238,7 @@ md-datepicker[disabled] {
   }
 
   .md-icon-button + .md-datepicker-input-container {
-    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap);
+    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap, auto);
   }
 
   .md-datepicker-input,
@@ -249,7 +249,7 @@ md-datepicker[disabled] {
   // This needs some extra specificity in order to override
   // the focused/invalid border colors.
   input.md-datepicker-input {
-    @include rtl-prop(margin-left, margin-right, 24px);
+    @include rtl-prop(margin-left, margin-right, 24px, auto);
     height: $md-datepicker-input-mask-height;
     border-bottom-color: transparent;
   }

--- a/src/components/divider/divider.scss
+++ b/src/components/divider/divider.scss
@@ -5,7 +5,7 @@ md-divider {
   margin: 0;
 
   &[md-inset] {
-    @include rtl-prop(margin-left, margin-right, $baseline-grid * 10);
+    @include rtl-prop(margin-left, margin-right, $baseline-grid * 10, auto);
   }
 }
 

--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -51,23 +51,23 @@ md-fab-toolbar {
 
   &.md-left {
     md-fab-trigger {
-      @include rtl-prop(right, left, 0);
+      @include rtl-prop(right, left, 0, auto);
     }
 
     .md-toolbar-tools {
       flex-direction: row-reverse;
 
       > .md-button:first-child {
-        @include rtl-prop(margin-right, margin-left, 0.6rem)
+        @include rtl-prop(margin-right, margin-left, 0.6rem, auto)
       }
 
       > .md-button:first-child {
-        @include rtl-prop(margin-left, margin-right, -0.8rem);
+        @include rtl-prop(margin-left, margin-right, -0.8rem, auto);
       }
 
 
       > .md-button:last-child {
-        @include rtl-prop(margin-right, margin-left, 8px);
+        @include rtl-prop(margin-right, margin-left, 8px, auto);
       }
 
     }
@@ -75,7 +75,7 @@ md-fab-toolbar {
 
   &.md-right {
     md-fab-trigger {
-      @include rtl-prop(left, right, 0);
+      @include rtl-prop(left, right, 0, auto);
     }
 
     .md-toolbar-tools {

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -64,10 +64,10 @@ md-list {
         }
 
         > md-icon:first-child:not(.md-avatar-icon) {
-          @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-dense-primary-icon-width);
+          @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-dense-primary-icon-width, auto);
         }
         .md-avatar, .md-avatar-icon {
-          @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-dense-primary-avatar-width);
+          @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-dense-primary-avatar-width, auto);
         }
         .md-avatar {
           flex: none;
@@ -81,7 +81,7 @@ md-list {
         &, & > .md-no-style {
           .md-list-item-text {
             &.md-offset {
-              @include rtl-prop(margin-left, margin-right, $list-item-primary-width);
+              @include rtl-prop(margin-left, margin-right, $list-item-primary-width, auto);
             }
 
             h3,
@@ -111,7 +111,7 @@ md-list {
 
       &.md-3-line {
         &, & > .md-no-style {
-          
+
           min-height: $list-item-dense-three-line-height;
           @include ie11-min-height-flexbug($list-item-dense-three-line-height);
 
@@ -208,10 +208,10 @@ md-list-item {
   md-divider {
     position: absolute;
     bottom: 0;
-    @include rtl-prop(left, right, 0);
+    @include rtl-prop(left, right, 0, auto);
     width: 100%;
     &[md-inset] {
-      @include rtl-prop(left, right, $list-item-inset-divider-offset);
+      @include rtl-prop(left, right, $list-item-inset-divider-offset, auto);
       width: calc(100% - #{$list-item-inset-divider-offset});
       margin: 0 !important;
     }
@@ -251,13 +251,13 @@ md-list-item {
     }
 
     & > md-icon:first-child:not(.md-avatar-icon) {
-      @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-primary-icon-width);
+      @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-primary-icon-width, auto);
     }
 
     & .md-avatar, .md-avatar-icon {
       margin-top: $baseline-grid;
       margin-bottom: $baseline-grid;
-      @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-primary-avatar-width);
+      @include rtl-prop(margin-right, margin-left, $list-item-primary-width - $list-item-primary-avatar-width, auto);
       border-radius: 50%;
       box-sizing: content-box;
     }
@@ -303,7 +303,7 @@ md-list-item {
       .md-button, .md-icon-button {
         &:last-of-type {
           // Reset 6px margin for the button.
-          @include rtl-prop(margin-right, margin-left, 0px);
+          @include rtl-prop(margin-right, margin-left, 0, auto);
         }
       }
 
@@ -313,7 +313,7 @@ md-list-item {
 
         &:last-child {
           width: 3 * $baseline-grid;
-          @include rtl-prop(margin-right, margin-left, 0);
+          @include rtl-prop(margin-right, margin-left, 0, auto);
         }
       }
 
@@ -321,7 +321,7 @@ md-list-item {
         margin-top: 0;
         margin-bottom: 0;
 
-        @include rtl-prop(margin-right, margin-left, -6px);
+        @include rtl-prop(margin-right, margin-left, -6px, auto);
       }
     }
 
@@ -349,7 +349,7 @@ md-list-item {
         overflow: hidden;
 
         &.md-offset {
-          @include rtl-prop(margin-left, margin-right, $list-item-primary-width);
+          @include rtl-prop(margin-left, margin-right, $list-item-primary-width, auto);
         }
 
         h3 {

--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -41,7 +41,7 @@ md-menu-content.md-menu-bar-menu.md-dense {
       padding: 0;
       width: 24px;
       top: 0.75 * $baseline-grid;
-      @include rtl-prop(left, right, 3 * $baseline-grid);
+      @include rtl-prop(left, right, 3 * $baseline-grid, auto);
     }
     > .md-button, .md-menu > .md-button {
       @include rtl(padding, 0 4 * $baseline-grid 0 8 * $baseline-grid, 0 8 * $baseline-grid 0 4 * $baseline-grid);
@@ -78,7 +78,7 @@ md-menu-content.md-menu-bar-menu.md-dense {
       text-transform: none;
       font-weight: normal;
       border-radius: 0px;
-      @include rtl-prop(padding-left, padding-right, 2 * $baseline-grid);
+      @include rtl-prop(padding-left, padding-right, 2 * $baseline-grid, 0);
       &:after {
         display: block;
         content: '\25BC';
@@ -86,7 +86,7 @@ md-menu-content.md-menu-bar-menu.md-dense {
         top: 0px;
         speak: none;
         @include rtl(transform, rotate(270deg) scaleY(0.45) scaleX(0.9), rotate(90deg) scaleY(0.45) scaleX(0.9));
-        @include rtl-prop(right, left, 3.5 * $baseline-grid);
+        @include rtl-prop(right, left, 3.5 * $baseline-grid, auto);
       }
     }
   }

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -64,7 +64,7 @@ $slider-sign-top: ($slider-size / 2) - ($slider-thumb-default-scale * $slider-th
 
 @mixin slider-thumb-position($width: $slider-thumb-width, $height: $slider-thumb-height) {
   position: absolute;
-  @include rtl-prop(left, right, (-$width / 2));
+  @include rtl-prop(left, right, (-$width / 2), auto);
   top: ($slider-size / 2) - ($height / 2);
   width: $width;
   height: $height;
@@ -133,7 +133,7 @@ md-slider {
    */
   .md-thumb-container {
     position: absolute;
-    @include rtl-prop(left, right, 0);
+    @include rtl-prop(left, right, 0, auto);
     top: 50%;
     transform: translate3d(-50%,-50%,0);
     transition: all .4s cubic-bezier(.25,.8,.25,1);
@@ -141,7 +141,7 @@ md-slider {
   }
   .md-thumb {
     z-index: 1;
-    
+
     @include slider-thumb-position($slider-thumb-width, $slider-thumb-height);
 
     // We render thumb in an :after selector to fix an obscure problem with the
@@ -184,7 +184,7 @@ md-slider {
     &:after {
       position: absolute;
       content: '';
-      @include rtl-prop(left, right, -($slider-sign-width / 2 - $slider-arrow-width / 2));
+      @include rtl-prop(left, right, -($slider-sign-width / 2 - $slider-arrow-width / 2), auto);
       border-radius: $slider-arrow-height;
       top: 19px;
       border-left: $slider-arrow-width / 2 solid transparent;
@@ -337,7 +337,7 @@ md-slider {
     flex-direction: column;
     min-height: $slider-min-size;
     min-width: 0;
-    
+
     .md-slider-wrapper {
       flex: 1;
       padding-top: 12px;
@@ -427,8 +427,8 @@ md-slider {
   }
   &[md-invert] {
     &:not([md-vertical]) .md-track-fill {
-      @include rtl-prop(left, right, auto);
-      @include rtl-prop(right, left, 0);
+      @include rtl-prop(left, right, auto, auto);
+      @include rtl-prop(right, left, 0, auto);
     }
     &[md-vertical] {
       .md-track-fill {
@@ -460,11 +460,11 @@ md-slider-container {
   }
 
   & > *:first-child:not(md-slider) {
-    @include rtl-prop(margin-right, margin-left, $items-margin);
+    @include rtl-prop(margin-right, margin-left, $items-margin, auto);
   }
 
   & > *:last-child:not(md-slider) {
-    @include rtl-prop(margin-left, margin-right, $items-margin);
+    @include rtl-prop(margin-left, margin-right, $items-margin, auto);
   }
 
   &[md-vertical] {
@@ -481,7 +481,7 @@ md-slider-container {
   md-input-container {
     input[type="number"] {
       text-align: center;
-      @include rtl-prop(padding-left, padding-right, 15px); // size of arrows
+      @include rtl-prop(padding-left, padding-right, 15px, 0); // size of arrows
       height: $items-height * 2;
       margin-top: -$items-height;
     }

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -29,7 +29,7 @@ md-switch {
     @include rtl(margin-left, inherit, 0);
     @include rtl(margin-right, 0, inherit);
   }
-  
+
   &[disabled] {
     cursor: default;
 
@@ -44,7 +44,7 @@ md-switch {
     height: $switch-height;
     position: relative;
     user-select: none;
-    @include rtl-prop(margin-right, margin-left, 8px);
+    @include rtl-prop(margin-right, margin-left, 8px, auto);
     float: left;
   }
 

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -107,11 +107,11 @@ md-tabs-wrapper {
     }
   }
   md-prev-button {
-    @include rtl-prop(left, right, 0);
+    @include rtl-prop(left, right, 0, auto);
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMjA4IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTUuNCw3LjQgMTQsNiA4LDEyIDE0LDE4IDE1LjQsMTYuNiAxMC44LDEyIAkJIiBzdHlsZT0iZmlsbDp3aGl0ZTsiLz4gPHJlY3QgZmlsbD0ibm9uZSIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ii8+IDwvZz4gPC9nPiA8ZyBpZD0iR3JpZCIgZGlzcGxheT0ibm9uZSI+IDxnIGRpc3BsYXk9ImlubGluZSI+IDwvZz4gPC9nPiA8L3N2Zz4NCg==');
   }
   md-next-button {
-    @include rtl-prop(right, left, 0);
+    @include rtl-prop(right, left, 0, auto);
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMzM2IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTAsNiA4LjYsNy40IDEzLjIsMTIgOC42LDE2LjYgMTAsMTggMTYsMTIgCQkiIHN0eWxlPSJmaWxsOndoaXRlOyIvPiA8cmVjdCBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz4gPC9nPiA8L2c+IDxnIGlkPSJHcmlkIiBkaXNwbGF5PSJub25lIj4gPGcgZGlzcGxheT0iaW5saW5lIj4gPC9nPiA8L2c+IDwvc3ZnPg0K');
     md-icon {
       transform: translate3d(-50%, -50%, 0) rotate(180deg);
@@ -138,7 +138,7 @@ md-tabs-canvas {
   .md-dummy-wrapper {
     position: absolute;
     top: 0;
-    @include rtl-prop(left, right, 0);
+    @include rtl-prop(left, right, 0, auto);
   }
   &.md-paginated {
     margin: 0 $tabs-paginator-width;
@@ -161,7 +161,7 @@ md-pagination-wrapper {
   transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
   position: absolute;
   width: 999999px;
-  @include rtl-prop(left, right, 0);
+  @include rtl-prop(left, right, 0, auto);
   transform: translate3d(0, 0, 0);
   &.md-center-tabs {
     position: relative;

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -187,11 +187,11 @@ md-toast {
 
     // Support for RTL alignment
     &._md-start {
-      @include rtl-prop(left, right, 0);
+      @include rtl-prop(left, right, 0, auto);
     }
 
     &._md-end {
-      @include rtl-prop(right, left, 0);
+      @include rtl-prop(right, left, 0, auto);
     }
 
     /*

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -70,7 +70,7 @@ md-toolbar {
   }
 
   > .md-indent {
-    @include rtl-prop(margin-left, margin-right, $md-toolbar-indent-margin);
+    @include rtl-prop(margin-left, margin-right, $md-toolbar-indent-margin, auto);
   }
 
   ~ md-content {
@@ -133,16 +133,16 @@ md-toolbar {
     }
   }
   &> .md-button:first-child {
-    @include rtl-prop(margin-left, margin-right, $icon-button-margin-offset);
+    @include rtl-prop(margin-left, margin-right, $icon-button-margin-offset, auto);
   }
   &> .md-button:last-child {
-    @include rtl-prop(margin-right, margin-left, $icon-button-margin-offset);
+    @include rtl-prop(margin-right, margin-left, $icon-button-margin-offset, auto);
   }
 
   &> md-menu:last-child {
-    @include rtl-prop(margin-right, margin-left, $icon-button-margin-offset);
+    @include rtl-prop(margin-right, margin-left, $icon-button-margin-offset, auto);
     & > .md-button {
-      @include rtl-prop(margin-right, margin-left, 0);
+      @include rtl-prop(margin-right, margin-left, 0, auto);
     }
   }
 

--- a/src/components/virtualRepeat/virtual-repeater.scss
+++ b/src/components/virtualRepeat/virtual-repeater.scss
@@ -51,7 +51,7 @@ $virtual-repeat-scrollbar-width: 16px !default;
     // Leave room for the scroll bar.
     // TODO: Will probably need to perform measurements at runtime.
     bottom: $virtual-repeat-scrollbar-width;
-    @include rtl-prop(right, left, auto);
+    @include rtl-prop(right, left, auto, auto);
     white-space: nowrap;
   }
 }

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -53,8 +53,8 @@
     }
 
     #{$offsets} {
-      @if $i != 0 { @include rtl-prop(margin-left, margin-right, #{$i * 5 + '%'}); }
-      @else { @include rtl-prop(margin-left, margin-right, 0); }
+      @if $i != 0 { @include rtl-prop(margin-left, margin-right, #{$i * 5 + '%'}, auto); }
+      @else { @include rtl-prop(margin-left, margin-right, 0, auto); }
     }
   }
 
@@ -86,7 +86,7 @@
     }
 
     #{$offsets} {
-      @include rtl-prop(margin-left, margin-right, calc(200% / 3));
+      @include rtl-prop(margin-left, margin-right, calc(200% / 3), auto);
     }
   }
 }
@@ -157,7 +157,7 @@
 	    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
 	    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
 	  }
-	  
+
 	  .layout-column {
 	    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
 	    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -125,15 +125,10 @@
   }
 }
 
-@mixin rtl-prop($ltr-prop, $rtl-prop, $value) {
+@mixin rtl-prop($ltr-prop, $rtl-prop, $value, $reset-value) {
   #{$ltr-prop}: $value;
   [dir=rtl] & {
-    // fallback for auto
-    #{$ltr-prop}: 0;
-    // fallback for IE
-    #{$ltr-prop}: auto;
-    #{$ltr-prop}: initial;
-
+    #{$ltr-prop}: $reset-value;
     #{$rtl-prop}: $value;
   }
 }


### PR DESCRIPTION
* Refactors the rtl-prop mixin to include less CSS.
* Changes all the instances where it was used to incorporate the new syntax.

**Note:** There are a few instances where the mixin seems used redundantly. These aren't the objective of this PR.

Fixes #9217.