### PR TITLE
fix(autocomplete): remove unnecessary execution

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -330,7 +330,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         $scope.searchText = val;
         handleSelectedItemChange(selectedItem, previousSelectedItem);
       });
-    } else if (previousSelectedItem) {
+    } else if (previousSelectedItem && $scope.searchText) {
       getDisplayValue(previousSelectedItem).then(function(displayValue) {
         // Clear the searchText, when the selectedItem is set to null.
         // Do not clear the searchText, when the searchText isn't matching with the previous


### PR DESCRIPTION
Currently when the `selectedItem` changes, we check for the `searchText` being changed as well.
This requires querying the `getDisplayValue` function with the current `searchText`.

When the `searchText` is empty, we could remove that unnecessary execution and just skip the comparison (Reduces queries)

Also this improves the compatibility with the `virtual repeater`, since the repeater changes the scope bindings during runtime.
e.g `searchText` will be set to `undefined` and a ignorable error will be thrown.

FYI: It is not possible to add a test for that.

References #9020