### PR TITLE
fix(select, input): asterisk should be always red.

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -14,10 +14,8 @@ md-input-container.md-THEME_NAME-theme {
     color: '{{foreground-3}}';
   }
 
-  &.md-input-invalid {
-    label.md-required:after {
-      color: '{{warn-A700}}'
-    }
+  label.md-required:after {
+    color: '{{warn-A700}}'
   }
 
   &:not(.md-input-focused):not(.md-input-invalid) label.md-required:after {

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -1,13 +1,27 @@
 md-input-container {
-  &.md-input-focused {
-    &:not(.md-input-has-value) {
-      md-select.md-THEME_NAME-theme {
-        .md-select-value {
-          color: '{{primary-color}}';
-          &.md-select-placeholder {
-            color: '{{primary-color}}';
-          }
-        }
+
+  // The asterisk of the select should always use the warn color.
+  md-select.md-THEME_NAME-theme .md-select-value {
+    span:first-child:after {
+      color: '{{warn-A700}}'
+    }
+  }
+
+  // When the select is blurred and not invalid then the asterisk should use the foreground color.
+  &:not(.md-input-focused):not(.md-input-invalid) {
+    md-select.md-THEME_NAME-theme .md-select-value {
+      span:first-child:after {
+        color: '{{foreground-3}}';
+      }
+    }
+  }
+
+  &.md-input-focused:not(.md-input-has-value) {
+    md-select.md-THEME_NAME-theme .md-select-value {
+      color: '{{primary-color}}';
+
+      &.md-select-placeholder {
+        color: '{{primary-color}}';
       }
     }
   }
@@ -22,6 +36,7 @@ md-input-container {
       border-bottom-color: transparent !important;
     }
   }
+
 }
 
 md-select.md-THEME_NAME-theme {
@@ -31,10 +46,15 @@ md-select.md-THEME_NAME-theme {
     background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
   }
   .md-select-value {
+    border-bottom-color: '{{foreground-4}}';
+
     &.md-select-placeholder {
       color: '{{foreground-3}}';
     }
-    border-bottom-color: '{{foreground-4}}';
+
+    span:first-child:after {
+      color: '{{warn-A700}}'
+    }
   }
   &.md-no-underline .md-select-value {
     border-bottom-color: transparent !important;


### PR DESCRIPTION
Commit 024e9798b9029ebf1f30df5bed4b2198f96172a6 added support for asterisks for the `md-select`, but also removed the red styling for the asterisk.
As per specs, the asterisk should be always red, except when the input is blurred and not invalid.

This commit makes the asterisk always red and makes the `md-select` asterisk consistent to the inputs.

![image](https://cloud.githubusercontent.com/assets/4987015/17383654/5aa1bc10-59d7-11e6-9e3d-3b788cc3aa5c.png)


![image](https://cloud.githubusercontent.com/assets/4987015/17383655/5ce29daa-59d7-11e6-8f2d-36737ee525db.png)
