### PR TITLE
updates MdPanelRef config to be public as opposed to private

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -84,7 +84,7 @@ angular
  * @param config {Object=} Specific configuration object that may contain
  * the following properties:
  *
- *   - `template` - `{string=}`: HTML template to show in the dialog. This
+ *   - `template` - `{string=}`: HTML template to show in the panel. This
  *     **must** be trusted HTML with respect to Angular’s
  *     [$sce service](https://docs.angularjs.org/api/ng/service/$sce).
  *   - `templateUrl` - `{string=}`: The URL that will be used as the content of
@@ -326,6 +326,8 @@ angular
  * Updates the position configuration of a panel. Use this to update the
  * position of a panel that is open, without having to close and re-open the
  * panel.
+ *
+ * @param {!MdPanelPosition} position
  */
 
 /**
@@ -580,7 +582,7 @@ angular
  * @ngdoc method
  * @name MdPanelAnimation#closeTo
  * @description
- * Specifies where to animate the dialog close. `closeTo` accepts a
+ * Specifies where to animate the panel close. `closeTo` accepts a
  * query selector, DOM element, or a Rect object that is used to determine
  * the bounds.
  *
@@ -822,6 +824,9 @@ function MdPanelRef(config, $injector) {
    */
   this.id = config.id;
 
+  /** @type {!Object} */
+  this.config = config;
+
   /**
    * Whether the panel is attached. This is synchronous. When attach is called,
    * isAttached is set to true. When detach is called, isAttached is set to
@@ -831,9 +836,6 @@ function MdPanelRef(config, $injector) {
   this.isAttached = false;
 
   // Private variables.
-  /** @private {!Object} */
-  this._config = config;
-
   /** @private {!angular.JQLite|undefined} */
   this._panelContainer;
 
@@ -861,7 +863,7 @@ function MdPanelRef(config, $injector) {
  * Opens an already created and configured panel. If the panel is already
  * visible, does nothing.
  *
- * @returns {!angular.$q.Promise<MdPanelRef>} A promise that is resolved when
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when
  * the panel is opened and animations finish.
  */
 MdPanelRef.prototype.open = function() {
@@ -881,7 +883,7 @@ MdPanelRef.prototype.open = function() {
 /**
  * Closes the panel.
  *
- * @returns {!angular.$q.Promise} A promise that is resolved when the panel is
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when the panel is
  * closed and animations finish.
  */
 MdPanelRef.prototype.close = function() {
@@ -902,7 +904,7 @@ MdPanelRef.prototype.close = function() {
 /**
  * Attaches the panel. The panel will be hidden afterwards.
  *
- * @returns {!angular.$q.Promise<MdPanelRef>} A promise that is resolved when
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when
  * the panel is attached.
  */
 MdPanelRef.prototype.attach = function() {
@@ -913,7 +915,7 @@ MdPanelRef.prototype.attach = function() {
   var self = this;
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
-    var onDomAdded = self._config['onDomAdded'] || angular.noop;
+    var onDomAdded = self.config['onDomAdded'] || angular.noop;
     var addListeners = function(response) {
         self.isAttached = true;
         self._addEventListeners();
@@ -935,7 +937,7 @@ MdPanelRef.prototype.attach = function() {
 /**
  * Only detaches the panel. Will NOT hide the panel first.
  *
- * @returns {!angular.$q.Promise<MdPanelRef>} A promise that is resolved when the panel is
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when the panel is
  * detached.
  */
 MdPanelRef.prototype.detach = function() {
@@ -944,7 +946,7 @@ MdPanelRef.prototype.detach = function() {
   }
 
   var self = this;
-  var onDomRemoved = self._config['onDomRemoved'] || angular.noop;
+  var onDomRemoved = self.config['onDomRemoved'] || angular.noop;
 
   var detachFn = function() {
     self._removeEventListeners();
@@ -986,15 +988,15 @@ MdPanelRef.prototype.detach = function() {
  * Destroys the panel. The Panel cannot be opened again after this.
  */
 MdPanelRef.prototype.destroy = function() {
-  this._config.scope.$destroy();
-  this._config.locals = null;
+  this.config.scope.$destroy();
+  this.config.locals = null;
 };
 
 
 /**
  * Shows the panel.
  *
- * @returns {!angular.$q.Promise} A promise that is resolved when the panel has
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when the panel has
  * shown and animations finish.
  */
 MdPanelRef.prototype.show = function() {
@@ -1016,7 +1018,7 @@ MdPanelRef.prototype.show = function() {
 
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
-    var onOpenComplete = self._config['onOpenComplete'] || angular.noop;
+    var onOpenComplete = self.config['onOpenComplete'] || angular.noop;
 
     self._$q.all([
       self._backdropRef ? self._backdropRef.show() : self,
@@ -1031,7 +1033,7 @@ MdPanelRef.prototype.show = function() {
 /**
  * Hides the panel.
  *
- * @returns {!angular.$q.Promise} A promise that is resolved when the panel has
+ * @returns {!angular.$q.Promise<!MdPanelRef>} A promise that is resolved when the panel has
  * hidden and animations finish.
  */
 MdPanelRef.prototype.hide = function() {
@@ -1049,10 +1051,10 @@ MdPanelRef.prototype.hide = function() {
 
   return this._$q(function(resolve, reject) {
     var done = self._done(resolve, self);
-    var onRemoving = self._config['onRemoving'] || angular.noop;
+    var onRemoving = self.config['onRemoving'] || angular.noop;
 
     var focusOnOrigin = function() {
-      var origin = self._config['origin'];
+      var origin = self.config['origin'];
       if (origin) {
         getElement(origin).focus();
       }
@@ -1145,17 +1147,17 @@ MdPanelRef.prototype._createPanel = function() {
   var self = this;
 
   return this._$q(function(resolve, reject) {
-    if (!self._config.locals) {
-      self._config.locals = {};
+    if (!self.config.locals) {
+      self.config.locals = {};
     }
 
-    self._config.locals.mdPanelRef = self;
-    self._$mdCompiler.compile(self._config)
+    self.config.locals.mdPanelRef = self;
+    self._$mdCompiler.compile(self.config)
         .then(function(compileData) {
-          self._panelContainer = compileData.link(self._config['scope']);
-          getElement(self._config['attachTo']).append(self._panelContainer);
+          self._panelContainer = compileData.link(self.config['scope']);
+          getElement(self.config['attachTo']).append(self._panelContainer);
 
-          if (self._config['disableParentScroll']) {
+          if (self.config['disableParentScroll']) {
             self._restoreScroll = self._$mdUtil.disableScrollAround(
               null,
               self._panelContainer,
@@ -1167,12 +1169,12 @@ MdPanelRef.prototype._createPanel = function() {
               self._panelContainer[0].querySelector('.md-panel'));
 
           // Add a custom CSS class to the panel element.
-          if (self._config['panelClass']) {
-            self._panelEl.addClass(self._config['panelClass']);
+          if (self.config['panelClass']) {
+            self._panelEl.addClass(self.config['panelClass']);
           }
 
           // Handle click and touch events for the panel container.
-          if (self._config['propagateContainerEvents']) {
+          if (self.config['propagateContainerEvents']) {
             self._panelContainer.css('pointer-events', 'none');
           }
 
@@ -1180,7 +1182,7 @@ MdPanelRef.prototype._createPanel = function() {
           // regardless.
           if (self._$animate.pin) {
             self._$animate.pin(self._panelContainer,
-                getElement(self._config['attachTo']));
+                getElement(self.config['attachTo']));
           }
 
           self._configureTrapFocus();
@@ -1200,8 +1202,8 @@ MdPanelRef.prototype._createPanel = function() {
 MdPanelRef.prototype._addStyles = function() {
   var self = this;
   return this._$q(function(resolve) {
-    self._panelContainer.css('z-index', self._config['zIndex']);
-    self._panelEl.css('z-index', self._config['zIndex'] + 1);
+    self._panelContainer.css('z-index', self.config['zIndex']);
+    self._panelEl.css('z-index', self.config['zIndex'] + 1);
 
     var hideAndResolve = function() {
       // Remove left: -9999px and add hidden class.
@@ -1210,13 +1212,13 @@ MdPanelRef.prototype._addStyles = function() {
       resolve(self);
     };
 
-    if (self._config['fullscreen']) {
+    if (self.config['fullscreen']) {
       self._panelEl.addClass('_md-panel-fullscreen');
       hideAndResolve();
       return; // Don't setup positioning.
     }
 
-    var positionConfig = self._config['position'];
+    var positionConfig = self.config['position'];
     if (!positionConfig) {
       hideAndResolve();
       return; // Don't setup positioning.
@@ -1235,14 +1237,14 @@ MdPanelRef.prototype._addStyles = function() {
 
 /**
  * Updates the position configuration of a panel
- * @param {MdPanelPosition} position
+ * @param {!MdPanelPosition} position
  */
 MdPanelRef.prototype.updatePosition = function(position) {
   if (!this._panelContainer) {
     throw new Error('Panel does not exist yet. Call open() or attach().');
   }
 
-  this._config['position'] = position;
+  this.config['position'] = position;
   this._updatePosition();
 };
 
@@ -1253,7 +1255,7 @@ MdPanelRef.prototype.updatePosition = function(position) {
  * @private
  */
 MdPanelRef.prototype._updatePosition = function(init) {
-  var positionConfig = this._config['position'];
+  var positionConfig = this.config['position'];
 
   if (positionConfig) {
     positionConfig._setPanelPosition(this._panelEl);
@@ -1280,7 +1282,7 @@ MdPanelRef.prototype._updatePosition = function(init) {
  * @private
  */
 MdPanelRef.prototype._focusOnOpen = function() {
-  if (this._config['focusOnOpen']) {
+  if (this.config['focusOnOpen']) {
     // Wait for the template to finish rendering to guarantee md-autofocus has
     // finished adding the class md-autofocus, otherwise the focusable element
     // isn't available to focus.
@@ -1301,20 +1303,20 @@ MdPanelRef.prototype._focusOnOpen = function() {
  * @private
  */
 MdPanelRef.prototype._createBackdrop = function() {
-  if (this._config.hasBackdrop) {
+  if (this.config.hasBackdrop) {
     if (!this._backdropRef) {
       var backdropAnimation = this._$mdPanel.newPanelAnimation()
-          .openFrom(this._config.attachTo)
+          .openFrom(this.config.attachTo)
           .withAnimation({
             open: '_md-opaque-enter',
             close: '_md-opaque-leave'
           });
       var backdropConfig = {
         animation: backdropAnimation,
-        attachTo: this._config.attachTo,
+        attachTo: this.config.attachTo,
         focusOnOpen: false,
         panelClass: '_md-panel-backdrop',
-        zIndex: this._config.zIndex - 1
+        zIndex: this.config.zIndex - 1
       };
       this._backdropRef = this._$mdPanel.create(backdropConfig);
     }
@@ -1353,8 +1355,8 @@ MdPanelRef.prototype._removeEventListeners = function() {
  * @private
  */
 MdPanelRef.prototype._configureEscapeToClose = function() {
-  if (this._config['escapeToClose']) {
-    var parentTarget = getElement(this._config['attachTo']);
+  if (this.config['escapeToClose']) {
+    var parentTarget = getElement(this.config['attachTo']);
     var self = this;
 
     var keyHandlerFn = function(ev) {
@@ -1384,7 +1386,7 @@ MdPanelRef.prototype._configureEscapeToClose = function() {
  * @private
  */
 MdPanelRef.prototype._configureClickOutsideToClose = function() {
-  if (this._config['clickOutsideToClose']) {
+  if (this.config['clickOutsideToClose']) {
     var target = this._panelContainer;
     var sourceElem;
 
@@ -1398,7 +1400,7 @@ MdPanelRef.prototype._configureClickOutsideToClose = function() {
 
     // We check if our original element and the target is the backdrop
     // because if the original was the backdrop and the target was inside the
-    // dialog we don't want to dialog to close.
+    // panel we don't want to panel to close.
     var self = this;
     var mouseupHandler = function(ev) {
       if (sourceElem === target[0] && ev.target === target[0]) {
@@ -1432,7 +1434,7 @@ MdPanelRef.prototype._configureScrollListener = function() {
   var self = this;
 
   var onScroll = function() {
-    if (!self._config['disableParentScroll']) {
+    if (!self.config['disableParentScroll']) {
       debouncedUpdatePosition();
     }
   };
@@ -1455,7 +1457,7 @@ MdPanelRef.prototype._configureScrollListener = function() {
 MdPanelRef.prototype._configureTrapFocus = function() {
   // Focus doesn't remain instead of the panel without this.
   this._panelEl.attr('tabIndex', '-1');
-  if (this._config['trapFocus']) {
+  if (this.config['trapFocus']) {
     var element = this._panelEl;
     // Set up elements before and after the panel to capture focus and
     // redirect back into the panel.
@@ -1492,7 +1494,7 @@ MdPanelRef.prototype._configureTrapFocus = function() {
  */
 MdPanelRef.prototype._animateOpen = function() {
   this.addClass('md-panel-is-showing');
-  var animationConfig = this._config['animation'];
+  var animationConfig = this.config['animation'];
   if (!animationConfig) {
     // Promise is in progress, return it.
     this.addClass('_md-panel-shown');
@@ -1520,7 +1522,7 @@ MdPanelRef.prototype._animateOpen = function() {
  * @private
  */
 MdPanelRef.prototype._animateClose = function() {
-  var animationConfig = this._config['animation'];
+  var animationConfig = this.config['animation'];
   if (!animationConfig) {
     this.removeClass('md-panel-is-showing');
     this.removeClass('_md-panel-shown');
@@ -2031,8 +2033,6 @@ MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
     return;
   }
 
-  // TODO(ErinCoughlan): Position panel intelligently to keep it on screen.
-
   if (this._actualPosition) {
     this._calculatePanelPosition(panelEl, this._actualPosition);
     return;
@@ -2218,7 +2218,7 @@ MdPanelAnimation.prototype.openFrom = function(openFrom) {
 
 
 /**
- * Specifies where to animate the dialog close. `closeTo` accepts a
+ * Specifies where to animate the panel close. `closeTo` accepts a
  * query selector, DOM element, or a Rect object that is used to determine
  * the bounds.
  *
@@ -2330,9 +2330,6 @@ MdPanelAnimation.prototype.animateOpen = function(panelEl) {
           transitionOutClass: this._animationClass['close'],
         };
       }
-
-      // TODO(ErinCoughlan): Combine the user's custom transforms with the
-      // panel transform.
   }
 
   return animator
@@ -2395,9 +2392,6 @@ MdPanelAnimation.prototype.animateClose = function(panelEl) {
           transitionOutClass: this._animationClass['open']
         };
       }
-
-      // TODO(ErinCoughlan): Combine the user's custom transforms with the
-      // panel transform.
   }
 
   return animator

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -134,21 +134,21 @@ describe('$mdPanel', function() {
   it('destroy should clear the config locals on the panelRef', function () {
     openPanel(DEFAULT_CONFIG);
 
-    expect(panelRef._config.locals).not.toEqual(null);
+    expect(panelRef.config.locals).not.toEqual(null);
 
     panelRef.destroy();
 
-    expect(panelRef._config.locals).toEqual(null);
+    expect(panelRef.config.locals).toEqual(null);
   });
 
   it('destroy should destroy the panel scope', function () {
     openPanel(DEFAULT_CONFIG);
 
-    expect(panelRef._config.scope.$$destroyed).toBe(false);
+    expect(panelRef.config.scope.$$destroyed).toBe(false);
 
     panelRef.destroy();
 
-    expect(panelRef._config.scope.$$destroyed).toBe(true);
+    expect(panelRef.config.scope.$$destroyed).toBe(true);
   });
 
   describe('promises logic:', function() {
@@ -218,7 +218,7 @@ describe('$mdPanel', function() {
     it('should resolve on animate failure when opening', function() {
       var openResolved = false;
 
-      panelRef._config.animation.animateOpen = function() {
+      panelRef.config.animation.animateOpen = function() {
         return panelRef._$q.reject();
       };
 
@@ -272,7 +272,7 @@ describe('$mdPanel', function() {
       expect(panelRef._panelContainer).not.toHaveClass(HIDDEN_CLASS);
       expect(panelRef.isAttached).toEqual(true);
 
-      panelRef._config.animation.animateClose = function() {
+      panelRef.config.animation.animateClose = function() {
         return panelRef._$q.reject();
       };
 


### PR DESCRIPTION
The initial design had it documented as public as we want to allow the user access to the config when the open/close/show/hide promises resolve.

Also, other smaller docs updates.