### PR TITLE
fix(toolbar): Title text should allow ellipsis.

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -872,10 +872,25 @@ table.attributes  tr  td:last-child {
   padding-left: 10px;
 }
 
-table.md-api-table  tr  td:first-child {
+table.md-api-table:not(.md-css-table)  tr  td:first-child {
   font-weight: bold;
 }
 
+table.md-css-table .md-css-selector {
+  display: block;
+  padding: 8px 16px;
+
+  /* Offset the padding of the <td> element */
+  margin: -12px -16px 12px -16px;
+
+  background-color: #0C2238;
+  color: #9ccc65;
+}
+
+/* Fix some odd bottom margin */
+table.md-css-table td p {
+  margin: 0.8em 0;
+}
 
 .layout_note {
   font-size: 0.9em;

--- a/docs/app/js/css-api-table.js
+++ b/docs/app/js/css-api-table.js
@@ -1,0 +1,51 @@
+(function() {
+  angular.module('docsApp')
+    .directive('docsCssApiTable', DocsCssApiTableDirective)
+    .directive('docsCssSelector', DocsCssSelectorDirective);
+
+  function DocsCssApiTableDirective() {
+    return {
+      restrict: 'E',
+      transclude: true,
+
+      bindToController: true,
+      controller: function() {},
+      controllerAs: '$ctrl',
+
+      scope: {},
+
+      template:
+      '<table class="md-api-table md-css-table">' +
+      '  <thead>' +
+      '    <tr><th>Available Selectors</th></tr>' +
+      '  </thead>' +
+      '  <tbody ng-transclude>' +
+      '  </tbody>' +
+      '</table>'
+    }
+  }
+
+  function DocsCssSelectorDirective() {
+    return {
+      restrict: 'E',
+      transclude: true,
+      replace: true,
+
+      bindToController: true,
+      controller: function() {},
+      controllerAs: '$ctrl',
+
+      scope: {
+        code: '@'
+      },
+
+      template:
+      '<tr>' +
+      '  <td>' +
+      '    <code class="md-css-selector">{{$ctrl.code}}</code>' +
+      '    <span ng-transclude></span>' +
+      '  </td>' +
+      '</tr>'
+    }
+  }
+})();

--- a/src/components/toolbar/demoBasicUsage/index.html
+++ b/src/components/toolbar/demoBasicUsage/index.html
@@ -10,13 +10,13 @@
         <md-button class="md-icon-button" aria-label="Settings" ng-disabled="true">
           <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
         </md-button>
-        <h2>
-          <span>Toolbar with Disabled/Enabled Icon Buttons</span>
-        </h2>
-        <span flex></span>
+
+        <h2 flex md-truncate>Toolbar with Disabled/Enabled Icon Buttons</h2>
+
         <md-button class="md-icon-button" aria-label="Favorite">
           <md-icon md-svg-icon="img/icons/favorite.svg" style="color: greenyellow;"></md-icon>
         </md-button>
+
         <md-button class="md-icon-button" aria-label="More">
           <md-icon md-svg-icon="img/icons/more_vert.svg"></md-icon>
         </md-button>
@@ -30,9 +30,9 @@
         <md-button aria-label="Go Back">
           Go Back
         </md-button>
-        <h2>
-          <span>Toolbar with Standard Buttons</span>
-        </h2>
+
+        <md-truncate style="position: absolute; left: 90px; right: 170px; top: 13px; bottom: 13px;">Toolbar with Standard Buttons</md-truncate>
+
         <span flex></span>
         <md-button class="md-raised" aria-label="Learn More">
           Learn More

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -28,10 +28,7 @@ angular.module('material.components.toolbar', [
  *   <md-toolbar>
  *
  *     <div class="md-toolbar-tools">
- *       <span>My App's Title</span>
- *
- *       <!-- fill up the space between left and right area -->
- *       <span flex></span>
+ *       <h2 md-truncate flex>My App's Title</h2>
  *
  *       <md-button>
  *         Right Bar Button
@@ -44,6 +41,30 @@ angular.module('material.components.toolbar', [
  *   </md-content>
  * </div>
  * </hljs>
+ *
+ * <i><b>Note:</b> The code above shows usage with the `md-truncate` component which provides an
+ * ellipsis if the title is longer than the width of the Toolbar.</i>
+ *
+ * ## CSS & Styles
+ *
+ * The `<md-toolbar>` provides a few custom CSS classes that you may use to enhance the
+ * functionality of your toolbar.
+ *
+ * <div>
+ * <docs-css-api-table>
+ *
+ *   <docs-css-selector code="md-toolbar .md-toolbar-tools">
+ *     The `md-toolbar-tools` class provides quite a bit of automatic styling for your toolbar
+ *     buttons and text. When applied, it will center the buttons and text vertically for you.
+ *   </docs-css-selector>
+ *
+ * </docs-css-api-table>
+ * </div>
+ *
+ * ### Private Classes
+ *
+ * Currently, the only private class is the `md-toolbar-transitions` class. All other classes are
+ * considered public.
  *
  * @param {boolean=} md-scroll-shrink Whether the header should shrink away as
  * the user scrolls down, and reveal itself as the user scrolls up.
@@ -58,6 +79,7 @@ angular.module('material.components.toolbar', [
  * @param {number=} md-shrink-speed-factor How much to change the speed of the toolbar's
  * shrinking by. For example, if 0.25 is given then the toolbar will shrink
  * at one fourth the rate at which the user scrolls down. Default 0.5.
+ *
  */
 
 function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {

--- a/src/components/truncate/demoBasicUsage/index.html
+++ b/src/components/truncate/demoBasicUsage/index.html
@@ -1,0 +1,70 @@
+<div>
+
+  <div layout-padding>
+    <p>
+      The <code>md-truncate</code> component can be used within a wide range of existing Material
+      components and supports multiple layout scenarios.
+    </p>
+
+    <div>
+      <md-toolbar class="md-accent">
+        <div class="md-toolbar-tools">
+          <md-truncate flex>
+            Here is an awesome title that will shrink and overflow.
+          </md-truncate>
+
+          <md-button class="md-icon-button md-fab-mini" aria-label="Favorite">
+            <md-icon md-svg-icon="img/icons/favorite.svg"></md-icon>
+          </md-button>
+        </div>
+      </md-toolbar>
+    </div>
+
+    <p>
+      Note the Toolbar above which uses flex to grow and shrink, or the fake app below which uses
+      absolute positioning.
+    </p>
+
+    <div id="fake-app">
+      <div class="sidebar">
+        <md-icon md-svg-icon="img/icons/menu.svg" aria-label="Menu"></md-icon>
+        <md-icon md-svg-icon="img/icons/favorite.svg" aria-label="Favorites"></md-icon>
+        <md-icon md-svg-icon="img/icons/more_vert.svg" aria-label="More Options"></md-icon>
+      </div>
+
+      <div class="app-body">
+        <h2 md-truncate>My Awesome Application - Page Title</h2>
+
+        <p>
+          Did you know?
+        </p>
+
+        <p>
+          Bacon ipsum dolor amet ground round landjaeger kielbasa fatback biltong hamburger shankle
+          shank tenderloin short loin pork. Chicken spare ribs meatball ball tip. Turducken pancetta
+          shank filet mignon ham boudin. Drumstick kevin pork chop ham meatloaf venison. Doner
+          turducken pastrami ham. Fatback beef meatball pork chop.
+        </p>
+
+        <p>
+          Pastrami turducken spare ribs short ribs. Leberkas pork loin ham hock landjaeger.
+          Porchetta pork chop ham hock turducken beef leberkas. Drumstick pork belly alcatra,
+          andouille meatball salami chuck hamburger ham hock t-bone ham swine cow cupim jerky.
+        </p>
+
+        <p>
+          Landjaeger pastrami pork chop hamburger swine jowl beef ribs. Alcatra ball tip short loin
+          flank picanha ground round tri-tip porchetta biltong fatback frankfurter swine. Shankle
+          flank short ribs capicola. Frankfurter tongue sausage meatball rump fatback strip steak
+          tenderloin swine venison. Tongue bacon cupim fatback ham.
+        </p>
+      </div>
+
+      <div class="rightbar">
+        <p>
+          Here is some fantastic information about your application!
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/components/truncate/demoBasicUsage/style.scss
+++ b/src/components/truncate/demoBasicUsage/style.scss
@@ -1,0 +1,48 @@
+#fake-app {
+  position: relative;
+  height: 400px;
+  width: 400px;
+  margin-left: auto;
+  margin-right: auto;
+
+  border: 1px solid #333;
+
+  .sidebar {
+    position: absolute;
+    width: 50px;
+    left: 0;
+    top: 0;
+    bottom: 0;
+
+    background-color: #333;
+
+    md-icon {
+      display: block;
+      color: #ddd;
+      margin-top: 15px;
+    }
+  }
+
+  .app-body {
+    position: absolute;
+    left: 50px;
+    right: 100px;
+    top: 0;
+    bottom: 0;
+
+    background-color: white;
+    padding: 10px;
+    overflow: auto;
+  }
+
+  .rightbar {
+    position: absolute;
+    width: 100px;
+    right: 0;
+    top: 0;
+    bottom: 0;
+
+    background: #ddd;
+    padding: 10px;
+  }
+}

--- a/src/components/truncate/truncate.js
+++ b/src/components/truncate/truncate.js
@@ -1,0 +1,86 @@
+/**
+ * @ngdoc module
+ * @name material.components.truncate
+ */
+angular.module('material.components.truncate', ['material.core'])
+  .directive('mdTruncate', MdTruncateDirective);
+
+/**
+ * @ngdoc directive
+ * @name mdTruncate
+ * @module material.components.truncate
+ * @restrict AE
+ * @description
+ *
+ * The `md-truncate` component displays a label that will automatically clip text which is wider
+ * than the component. By default, it displays an ellipsis, but you may apply the `md-clip` CSS
+ * class to override this default and use a standard "clipping" approach.
+ *
+ * <i><b>Note:</b> The `md-truncate` component does not automatically adjust it's width. You must
+ * provide the `flex` attribute, or some other CSS-based width management. See the
+ * <a ng-href="./demo/truncate">demos</a> for examples.</i>
+ *
+ * @usage
+ *
+ * ### As an Element
+ *
+ * <hljs lang="html">
+ *   <div layout="row">
+ *     <md-button>Back</md-button>
+ *
+ *     <md-truncate flex>Chapter 1 - The Way of the Old West</md-truncate>
+ *
+ *     <md-button>Forward</md-button>
+ *   </div>
+ * </hljs>
+ *
+ * ### As an Attribute
+ *
+ * <hljs lang="html">
+ *   <h2 md-truncate style="max-width: 100px;">Some Title With a Lot of Text</h2>
+ * </hljs>
+ *
+ * ## CSS & Styles
+ *
+ * `<md-truncate>` provides two CSS classes that you may use to control the type of clipping.
+ *
+ * <i><b>Note:</b> The `md-truncate` also applies a setting of `width: 0;` when used with the `flex`
+ * attribute to fix an issue with the flex element not shrinking properly.</i>
+ *
+ * <div>
+ * <docs-css-api-table>
+ *
+ *   <docs-css-selector code=".md-ellipsis">
+ *     Assigns the "ellipsis" behavior (default) which will cut off mid-word and append an ellipsis
+ *     (&hellip;) to the end of the text.
+ *   </docs-css-selector>
+ *
+ *   <docs-css-selector code=".md-clip">
+ *     Assigns the "clipping" behavior which will simply chop off the text. This may happen
+ *     mid-word or even mid-character.
+ *   </docs-css-selector>
+ *
+ * </docs-css-api-table>
+ * </div>
+ */
+function MdTruncateDirective() {
+  return {
+    restrict: 'AE',
+
+    controller: MdTruncateController,
+    controllerAs: '$ctrl',
+    bindToController: true
+  }
+}
+
+/**
+ * Controller for the <md-truncate> component.
+ *
+ * @param $element The md-truncate element.
+ *
+ * @constructor
+ * @ngInject
+ */
+function MdTruncateController($element) {
+  $element.addClass('md-truncate');
+}

--- a/src/components/truncate/truncate.scss
+++ b/src/components/truncate/truncate.scss
@@ -1,0 +1,17 @@
+.md-truncate {
+  overflow: hidden;
+  white-space: nowrap;
+
+  // Default overflow is ellipsis
+  text-overflow: ellipsis;
+
+  // Allow override to use clipping
+  &.md-clip {
+    text-overflow: clip;
+  }
+
+  // This is a flex-specific hack that forces the element to only take up available space.
+  &.flex {
+    width: 0;
+  }
+}

--- a/src/components/truncate/truncate.spec.js
+++ b/src/components/truncate/truncate.spec.js
@@ -1,0 +1,29 @@
+describe('<md-truncate>', function() {
+  var $compile, $rootScope;
+
+  beforeEach(module('material.components.truncate'));
+  beforeEach(inject(function(_$compile_, _$rootScope_) {
+    $compile = _$compile_;
+    $rootScope = _$rootScope_;
+  }));
+
+  it('works as an element', function() {
+    var el = setup('<md-truncate>Test</md-truncate>');
+
+    expect(el).toHaveClass('md-truncate');
+  });
+
+  it('works as an attribute', function() {
+    var el = setup('<h2 md-truncate>Test</h2>');
+
+    expect(el).toHaveClass('md-truncate');
+  });
+
+  function setup(template) {
+    var element = $compile(template)($rootScope);
+
+    $rootScope.$digest();
+
+    return element;
+  }
+});


### PR DESCRIPTION
Currently, the title text of a toolbar wraps around on small screens causing the toolbar to become larger than expected.
- Provide a new `md-truncate` component that applies the appropriate styles
  for using CSS-based text-overflow with an ellipsis.
  
  This component is designed to work nicely with the Toolbar component,
  but is also reusable and can be used in any other component.
- Add docs/demos for the new component.
- Update Toolbar demos to use new `md-truncate` component and show proper
  usage.

Additionally, add the appropriate CSS docs in a new CSS & Styles section which includes a new doc-only directive (`docs-css-api-table`) that creates a clean way to view documentation regarding available CSS classes.

Fixes #9026.

---

_**Edit:** Add screenshot of new docs section._

<img width="773" alt="screen shot 2016-08-03 at 6 56 33 pm" src="https://cloud.githubusercontent.com/assets/54370/17411559/69a4477a-5a3e-11e6-8d24-4590f3634f35.png">
