### PR TITLE
fix(select): Allow 0 as default value.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -816,7 +816,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         // the current option, which will be added, then we can be sure, that the validation
         // of the option has occurred before the option was added properly.
         // This means, that we have to manually trigger a new validation of the current option.
-        if (self.ngModel.$modelValue && self.hashGetter(self.ngModel.$modelValue) === hashKey) {
+        if (angular.isDefined(self.ngModel.$modelValue) && self.hashGetter(self.ngModel.$modelValue) === hashKey) {
           self.ngModel.$validate();
         }
 


### PR DESCRIPTION
A recent change introduced a bug which no longer allowed `0` as a valid `ng-value`.

Fix by surrounding associated `if` code with `angular.isDefined(...)` to ensure `0` is treated as a valid value.

Fixes #9232.

_**Note:** It looks like lots of changes to the `.spec.js` file because I moved some of the tests to a more relevant location. In reality, I only added 1 test and moved the others. See my line comment for the actual change._