### PR TITLE
fix(showHide): don't call getComputedStyle on comment node

### DIFF
--- a/src/components/showHide/showHide.js
+++ b/src/components/showHide/showHide.js
@@ -14,7 +14,7 @@ angular.module('material.components.showHide', [
 
 
 function createDirective(name, targetValue) {
-  return ['$mdUtil', function($mdUtil) {
+  return ['$mdUtil', '$window', function($mdUtil, $window) {
     return {
       restrict: 'A',
       multiElement: true,
@@ -22,7 +22,9 @@ function createDirective(name, targetValue) {
         var unregister = $scope.$on('$md-resize-enable', function() {
           unregister();
 
-          var cachedTransitionStyles = window.getComputedStyle($element[0]);
+          var node = $element[0];
+          var cachedTransitionStyles = node.nodeType === $window.Node.ELEMENT_NODE ?
+            $window.getComputedStyle(node) : {};
 
           $scope.$watch($attr[name], function(value) {
             if (!!value === targetValue) {

--- a/src/components/showHide/showHide.spec.js
+++ b/src/components/showHide/showHide.spec.js
@@ -122,3 +122,33 @@ describe('showHide', function() {
     });
   });
 });
+
+describe('showHide directive on a transcluded element', function() {
+  var $compile, scope;
+
+  beforeEach(function() {
+    module('material.components.showHide', function($compileProvider) {
+      // Declare a directive that will convert the element to a comment node.
+      $compileProvider.directive('convertToCommentNode', function(){
+        return { transclude: 'element' };
+      });
+    });
+
+    inject(function(_$compile_, $rootScope) {
+      $compile = _$compile_;
+      scope = $rootScope.$new();
+    });
+  });
+
+  it('does not try to get the computed style of a comment node', function() {
+    expect(function() {
+      $compile('<div ng-show convert-to-comment-node></div>')(scope);
+      scope.$broadcast('$md-resize-enable');
+      scope.$apply();
+    }).not.toThrowError(/getComputedStyle/);
+  });
+
+  afterEach(function() {
+    scope.$destroy();
+  });
+});


### PR DESCRIPTION
Fixes the ngShow and ngHide directive calling getComputedStyle on comment nodes.

Fixes #9243.