### PR TITLE
update(list): remove explicit background color reset.

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -145,9 +145,6 @@ md-list-item {
       padding: 0 16px;
       margin: 0;
 
-      // The button should not inherit the parents background color.
-      background-color: initial;
-
       font-weight: 400;
       @include rtl(text-align, left, right);
       border: medium none;


### PR DESCRIPTION
* The overlaying button explicitly set the `background-color`  to initial to avoid inheriting from the parent.
   Removing that background color property works anyway, since the `background-color` isn't inheriting by default.

* A developer reported an issue with this "reset", because the `initial` value isn't existing on IE11 and **can** cause unexpected results.

Closes #9222.