### PR TITLE
feat(dialog): allow developers to specify zIndex.

### DIFF
--- a/src/components/backdrop/backdrop.scss
+++ b/src/components/backdrop/backdrop.scss
@@ -18,10 +18,7 @@ md-backdrop {
   }
   &.md-select-backdrop {
     z-index: $z-index-dialog + 1;
-    transition-duration: 0;
-  }
-  &.md-dialog-backdrop {
-    z-index: $z-index-dialog - 1;
+    transition-duration: 0ms;
   }
   &.md-bottom-sheet-backdrop {
     z-index: $z-index-bottom-sheet - 1;

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -484,6 +484,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *     custom dialog directive.
  *   - `targetEvent` - `{DOMClickEvent=}`: A click's event object. When passed in as an option,
  *     the location of the click will be used as the starting point for the opening animation
+ *   - `zIndex` - `{number=}`: The z-index to place the dialog at. Defaults to 80.
  *     of the the dialog.
  *   - `openFrom` - `{string|Element|object}`: The query selector, DOM element or the Rect object
  *     that is used to determine the bounds (top, left, height, width) from which the Dialog will
@@ -560,8 +561,11 @@ function MdDialogProvider($$interimElementProvider) {
 
   return $$interimElementProvider('$mdDialog')
     .setDefaults({
-      methods: ['disableParentScroll', 'hasBackdrop', 'clickOutsideToClose', 'escapeToClose',
-          'targetEvent', 'closeTo', 'openFrom', 'parent', 'fullscreen', 'contentElement'],
+      methods: [
+        'disableParentScroll', 'hasBackdrop', 'clickOutsideToClose', 'escapeToClose',
+        'targetEvent', 'closeTo', 'openFrom', 'parent', 'fullscreen', 'contentElement',
+        'zIndex'
+      ],
       options: dialogDefaultOptions
     })
     .addPreset('alert', {
@@ -653,18 +657,25 @@ function MdDialogProvider($$interimElementProvider) {
       disableParentScroll: true,
       autoWrap: true,
       fullscreen: false,
+      zIndex: 80,
       transformTemplate: function(template, options) {
+
+        template = prepareTemplate(template);
+
         // Make the dialog container focusable, because otherwise the focus will be always redirected to
         // an element outside of the container, and the focus trap won't work probably..
         // Also the tabindex is needed for the `escapeToClose` functionality, because
         // the keyDown event can't be triggered when the focus is outside of the container.
-        return '<div class="md-dialog-container" tabindex="-1">' + validatedTemplate(template) + '</div>';
+        return '' +
+          '<div class="md-dialog-container" tabindex="-1" style="z-index: ' + options.zIndex +'">' +
+            template +
+          '</div>';
 
         /**
-         * The specified template should contain a <md-dialog> wrapper element....
+         * The specified template should contain a <md-dialog> wrapper element.
          */
-        function validatedTemplate(template) {
-          if (options.autoWrap && !/<\/md-dialog>/g.test(template)) {
+        function prepareTemplate(template) {
+          if (options.autoWrap && template.indexOf('</md-dialog>') === -1) {
             return '<md-dialog>' + (template || '') + '</md-dialog>';
           } else {
             return template || '';
@@ -846,6 +857,10 @@ function MdDialogProvider($$interimElementProvider) {
       }
     }
 
+    /**
+     * Detects the theme from the specified targetEvent option and applies
+     * it to the dialog options.
+     */
     function detectTheming(options) {
       // Only detect the theming, if the developer didn't specify the theme specifically.
       if (options.theme) return;
@@ -1021,11 +1036,15 @@ function MdDialogProvider($$interimElementProvider) {
       if (options.disableParentScroll) {
         // !! DO this before creating the backdrop; since disableScrollAround()
         //    configures the scroll offset; which is used by mdBackDrop postLink()
-        options.restoreScroll = $mdUtil.disableScrollAround(element, options.parent);
+        options.restoreScroll = $mdUtil.disableScrollAround(null, element, {
+          disableScrollMask: true
+        });
       }
 
       if (options.hasBackdrop) {
-        options.backdrop = $mdUtil.createBackdrop(scope, "md-dialog-backdrop md-opaque");
+        options.backdrop = $mdUtil.createBackdrop(scope, "md-opaque");
+        options.backdrop.css('z-index', options.zIndex - 1);
+
         $animate.enter(options.backdrop, options.parent);
       }
 

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -13,7 +13,6 @@ $dialog-padding: $baseline-grid * 3 !default;
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: $z-index-dialog;
   overflow: hidden;
 }
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1278,6 +1278,48 @@ describe('$mdDialog', function() {
       expect(parent[0].querySelectorAll('md-dialog.two').length).toBe(0);
     }));
 
+    describe('z-index', function() {
+
+      it('should have a default z-index', inject(function($mdDialog) {
+        var parent = angular.element('<div>');
+
+        $mdDialog.show({
+          template: '<md-dialog>Test</md-dialog>',
+          parent: parent
+        });
+
+        runAnimation();
+
+        var container = parent[0].querySelector('.md-dialog-container');
+        var backdrop = parent[0].querySelector('md-backdrop');
+
+        // Use toMatch here, because IE11 sometimes returns a number instead.
+        expect(container.style.zIndex).toMatch('80');
+        expect(backdrop.style.zIndex).toMatch('79');
+      }));
+
+      it('should have allow custom z-index', inject(function($mdDialog) {
+        var parent = angular.element('<div>');
+        var zIndex = 100;
+
+        $mdDialog.show({
+          template: '<md-dialog>Test</md-dialog>',
+          parent: parent,
+          zIndex: zIndex
+        });
+
+        runAnimation();
+
+        var container = parent[0].querySelector('.md-dialog-container');
+        var backdrop = parent[0].querySelector('md-backdrop');
+
+        // Use toMatch here, because IE11 sometimes returns a number instead.
+        expect(container.style.zIndex).toMatch(zIndex.toString());
+        expect(backdrop.style.zIndex).toMatch((zIndex - 1).toString());
+      }));
+
+    });
+
     describe('contentElement', function() {
       var $mdDialog, $rootScope, $compile, $timeout;
 

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -204,44 +204,56 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      *     use the passed parent element.
      */
     disableScrollAround: function(element, parent, options) {
-      $mdUtil.disableScrollAround._count = $mdUtil.disableScrollAround._count || 0;
-      ++$mdUtil.disableScrollAround._count;
-      if ($mdUtil.disableScrollAround._enableScrolling) return $mdUtil.disableScrollAround._enableScrolling;
-      var body = $document[0].body,
-        restoreBody = disableBodyScroll(),
-        restoreElement = disableElementScroll(parent);
+      options = options || {};
 
-      return $mdUtil.disableScrollAround._enableScrolling = function() {
+      $mdUtil.disableScrollAround._count = $mdUtil.disableScrollAround._count || 0;
+      $mdUtil.disableScrollAround._count++;
+
+      if ($mdUtil.disableScrollAround._restoreScroll) {
+        return $mdUtil.disableScrollAround._restoreScroll;
+      }
+
+      var body = $document[0].body;
+      var restoreBody = disableBodyScroll();
+      var restoreElement = disableElementScroll(parent);
+
+      return $mdUtil.disableScrollAround._restoreScroll = function() {
         if (!--$mdUtil.disableScrollAround._count) {
           restoreBody();
           restoreElement();
-          delete $mdUtil.disableScrollAround._enableScrolling;
+          delete $mdUtil.disableScrollAround._restoreScroll;
         }
       };
 
-      // Creates a virtual scrolling mask to absorb touchmove, keyboard, scrollbar clicking, and wheel events
+      /**
+       * Creates a virtual scrolling mask to prevent touchmove, keyboard, scrollbar clicking,
+       * and wheel events
+       */
       function disableElementScroll(element) {
         element = angular.element(element || body);
+
         var scrollMask;
-        if (options && options.disableScrollMask) {
+
+        if (options.disableScrollMask) {
           scrollMask = element;
         } else {
-          element = element[0];
           scrollMask = angular.element(
             '<div class="md-scroll-mask">' +
             '  <div class="md-scroll-mask-bar"></div>' +
             '</div>');
-          element.appendChild(scrollMask[0]);
+          element.append(scrollMask);
         }
 
         scrollMask.on('wheel', preventDefault);
         scrollMask.on('touchmove', preventDefault);
 
-        return function restoreScroll() {
+        return function restoreElementScroll() {
           scrollMask.off('wheel');
           scrollMask.off('touchmove');
-          scrollMask[0].parentNode.removeChild(scrollMask[0]);
-          delete $mdUtil.disableScrollAround._enableScrolling;
+
+          if (!options.disableScrollMask) {
+            scrollMask[0].parentNode.removeChild(scrollMask[0]);
+          }
         };
 
         function preventDefault(e) {
@@ -283,10 +295,12 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         }
       }
     },
+
     enableScrolling: function() {
-      var method = this.disableScrollAround._enableScrolling;
-      method && method();
+      var restoreFn = this.disableScrollAround._restoreScroll;
+      restoreFn && restoreFn();
     },
+
     floatingScrollbars: function() {
       if (this.floatingScrollbars.cached === undefined) {
         var tempNode = angular.element('<div><div></div></div>').css({


### PR DESCRIPTION
* Allows developers to specify a custom zIndex on the dialog.
* Cleans up the `disableScrollAround` utility function (possibly fix for $mdPanel)

> Developers are currently not able to specify the z-index of the dialog dynamically and need to change it per overwriting the SCSS variables or overwriting it per CSS selectors.

> For example in #7101 a developer had a custom element, which accidentally overlays the dialog, so he had to change the z-index of the **specific** dialog (not all) 

References #8475. Fixes #7101