### PR TITLE
chore(): remove final initial values

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -185,10 +185,6 @@ pre {
 pre > code.highlight {
   padding: 16px;
   font-weight: 400;
-  -webkit-user-select: initial;
-  -moz-user-select: initial;
-  -ms-user-select: initial;
-  user-select: initial;
 }
 
 pre, code {

--- a/src/components/sidenav/sidenav.js
+++ b/src/components/sidenav/sidenav.js
@@ -371,7 +371,7 @@ function SidenavDirective($mdMedia, $mdUtil, $mdConstant, $mdTheming, $animate, 
         // parent, to increase the performance. Using 100% as height, will impact the performance heavily.
         var positionStyle = {
           top: scrollTop + 'px',
-          bottom: 'initial',
+          bottom: 'auto',
           height: parent[0].clientHeight + 'px'
         };
 

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -165,7 +165,7 @@ md-pagination-wrapper {
   transform: translate3d(0, 0, 0);
   &.md-center-tabs {
     position: relative;
-    width: initial;
+    width: auto;
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
Removes the last few instances of the `initial` CSS value which isn't support on all browsers.

Fixes #9150.