### PR TITLE
md-autocomplete with  md-min-length="0" not working

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -66,7 +66,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    * Initialize the controller, setup watchers, gather elements
    */
   function init () {
-    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: '', selectedItem: null });
+    $mdUtil.initOptionalProperties($scope, $attrs, { searchText: null, selectedItem: null });
     $mdTheming($element);
     configureWatchers();
     $mdUtil.nextTick(function () {


### PR DESCRIPTION
initial handleSearchText() exits on line

```js
if (searchText === previousSearchText) return;
```
because it always ```'' === ''```

and handleQuery() (-> fetchResults()) dont execute until searchText change