### PR TITLE
autoComplete: fix for searchText bug

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -452,6 +452,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     hasFocus = true;
     //-- if searchText is null, let's force it to be a string
     if (!angular.isString($scope.searchText)) $scope.searchText = '';
+    if (getMinLength() === 0 && $scope.searchText === '') {
+      handleQuery();
+    }
     ctrl.hidden = shouldHide();
     if (!ctrl.hidden) handleQuery();
   }


### PR DESCRIPTION
Handling query when min-length is zero & no change in searchText is observed. This case happens when there is no change in searchText but matches are available for selection.