### PR TITLE
fix(select): Alter dropdown icon to conform to spec.

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -203,8 +203,8 @@ md-input-container.md-input-has-value .md-select-value {
     position: relative;
     top: 2px;
     speak: none;
-    font-size: 16px;
-    transform: scaleY(0.6) scaleX(1);
+    font-size: 13px;
+    transform: scaleY(0.5) scaleX(1);
   }
 
   &.md-select-placeholder {


### PR DESCRIPTION
Currently the dropdown icon used in the select is drastically larger than the spec suggests:

https://material.google.com/components/text-fields.html#text-fields-single-line-text-field

Alter the SCSS slightly to reduce the size and better match the spec.

**Before:**

<img width="284" alt="select-dropdown-before" src="https://cloud.githubusercontent.com/assets/54370/17599810/75d543e0-5fc6-11e6-8b80-03123b07f742.png">

**After:**
<img width="289" alt="select-dropdown-after" src="https://cloud.githubusercontent.com/assets/54370/17599816/7d06f79e-5fc6-11e6-81be-1bc1beff9b1a.png">

@ThomasBurleson _Note: This is definitely not super important, but if you think it's relevant, then I think it should go into 1.1.0 or 1.2.0 (i.e. not 1.1.1) since it is a spec/css change._