### PR TITLE
fix(dialog): remove transition classes after hide

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -525,7 +525,8 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *   - `onRemoving` - `function(element, removePromise)`: Callback function used to announce the
  *      close/hide() action is starting. This allows developers to run custom animations
  *      in parallel the close animations.
- *   - `fullscreen` `{boolean=}`: An option to apply `.md-dialog-fullscreen` class on open.
+ *   - `fullscreen` `{boolean=}`: An option to toggle whether the dialog should show in fullscreen
+ *      or not. Defaults to `false`.
  * @returns {promise} A promise that can be resolved with `$mdDialog.hide()` or
  * rejected with `$mdDialog.cancel()`.
  */
@@ -1188,13 +1189,12 @@ function MdDialogProvider($$interimElementProvider) {
       var from = animator.toTransformCss(buildTranslateToOrigin(dialogEl, options.openFrom || options.origin));
       var to = animator.toTransformCss("");  // defaults to center display (or parent or $rootElement)
 
-      if (options.fullscreen) {
-        dialogEl.addClass('md-dialog-fullscreen');
-      }
+      dialogEl.toggleClass('md-dialog-fullscreen', !!options.fullscreen);
 
       return animator
         .translate3d(dialogEl, from, to, translateOptions)
         .then(function(animateReversal) {
+
           // Build a reversal translate function synced to this translation...
           options.reverseAnimate = function() {
             delete options.reverseAnimate;
@@ -1219,13 +1219,20 @@ function MdDialogProvider($$interimElementProvider) {
 
           };
 
-          // Builds a function, which clears the animations / transforms of the dialog element.
-          // Required for contentElements, which should not have the the animation styling after
-          // the dialog is closed.
+          // Function to revert the generated animation styles on the dialog element.
+          // Useful when using a contentElement instead of a template.
           options.clearAnimate = function() {
             delete options.clearAnimate;
-            return animator
-              .translate3d(dialogEl, to, animator.toTransformCss(''), {});
+
+            // Remove the transition classes, added from $animateCSS, since those can't be removed
+            // by reversely running the animator.
+            dialogEl.removeClass([
+              translateOptions.transitionOutClass,
+              translateOptions.transitionInClass
+            ].join(' '));
+
+            // Run the animation reversely to remove the previous added animation styles.
+            return animator.translate3d(dialogEl, to, animator.toTransformCss(''), {});
           };
 
           return true;

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1294,6 +1294,7 @@ describe('$mdDialog', function() {
             '<md-dialog>Dialog</md-dialog>' +
           '</div>'
         )($rootScope);
+
         var parentEl = angular.element('<div>');
 
         // Add the contentElement to the DOM.
@@ -1324,6 +1325,7 @@ describe('$mdDialog', function() {
             '<md-dialog>Dialog</md-dialog>' +
           '</div>'
         )($rootScope);
+
         var parentEl = angular.element('<div>');
 
         // Add the contentElement to the DOM.
@@ -1354,6 +1356,7 @@ describe('$mdDialog', function() {
           '<md-dialog>Dialog</md-dialog>' +
           '</div>'
         )($rootScope);
+
         var parentEl = angular.element('<div>');
 
         $mdDialog.show({
@@ -1369,6 +1372,85 @@ describe('$mdDialog', function() {
 
         $mdDialog.hide();
         runAnimation();
+      });
+
+      it('should properly toggle the fullscreen class', function() {
+        var contentElement = $compile(
+          '<div class="md-dialog-container" id="myId">' +
+            '<md-dialog>Dialog</md-dialog>' +
+          '</div>'
+        )($rootScope);
+
+        var parentEl = angular.element('<div>');
+        var dialogEl = contentElement.find('md-dialog');
+
+        // Show the dialog with fullscreen enabled.
+        $mdDialog.show({
+          contentElement: contentElement,
+          parent: parentEl,
+          escapeToClose: true,
+          fullscreen: true
+        });
+
+        $rootScope.$apply();
+        runAnimation();
+
+        expect(contentElement[0].parentNode).toBe(parentEl[0]);
+        expect(dialogEl).toHaveClass('md-dialog-fullscreen');
+
+        // Hide the dialog to allow the second dialog to show up.
+        $mdDialog.hide();
+        runAnimation();
+
+        // Show the dialog with fullscreen disabled
+        $mdDialog.show({
+          contentElement: contentElement,
+          parent: parentEl,
+          escapeToClose: true,
+          fullscreen: false
+        });
+
+        $rootScope.$apply();
+        runAnimation();
+
+        expect(contentElement[0].parentNode).toBe(parentEl[0]);
+        expect(dialogEl).not.toHaveClass('md-dialog-fullscreen');
+
+        // Hide the dialog to avoid issues with other tests.
+        $mdDialog.hide();
+        runAnimation();
+      });
+
+      it('should remove the transition classes', function() {
+        var contentElement = $compile(
+          '<div class="md-dialog-container" id="myId">' +
+            '<md-dialog>Dialog</md-dialog>' +
+          '</div>'
+        )($rootScope);
+
+        var parentEl = angular.element('<div>');
+        var dialogEl = contentElement.find('md-dialog');
+
+        // Show the dialog with fullscreen enabled.
+        $mdDialog.show({
+          contentElement: contentElement,
+          parent: parentEl,
+          escapeToClose: true,
+          fullscreen: true
+        });
+
+        $rootScope.$apply();
+        runAnimation();
+
+        expect(contentElement[0].parentNode).toBe(parentEl[0]);
+        expect(dialogEl).toHaveClass('md-transition-in');
+
+        // Hide the dialog to allow the second dialog to show up.
+        $mdDialog.hide();
+        runAnimation();
+
+        expect(dialogEl).not.toHaveClass('md-transition-in');
+        expect(dialogEl).not.toHaveClass('md-transition-out');
       });
 
     });


### PR DESCRIPTION
* Properly remove the transition classes on the dialog element from the transition3d animator.
* Toggle the `fullscreen` class, instead of just adding it. Necessary for prerendered dialogs, because those could change from `fullscreen: true` to `fullscreen: false`

cc. @topherfangio @EladBezalel 

Fixes #9276.