### PR TITLE
fix(FAB/Toast): Properly reposition FABs when toasts open.

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -113,6 +113,23 @@ function MdAnchorDirective($mdTheming) {
  *    <md-icon md-svg-icon="path/to/your.svg"></md-icon>
  *  </md-button>
  * </hljs>
+ *
+ * You may also easily position the FABs by applying one one of the following classes to the
+ * `<md-button>` element:
+ *  - `md-fab-top-left`
+ *  - `md-fab-top-right`
+ *  - `md-fab-bottom-left`
+ *  - `md-fab-bottom-right`
+ *
+ *  Additionally, we now offer the following bi-direction classes which automatically change
+ *  position based on the current `dir` setting (i.e. `ltr` or `rtl`).
+ *  - `md-fab-top-start`
+ *  - `md-fab-top-end`
+ *  - `md-fab-bottom-start`
+ *  - `md-fab-bottom-end`
+ *
+ * These CSS classes use `position: absolute`, so you need to ensure that the container element
+ * also uses `position: absolute` or `position: relative` in order for them to work.
  */
 function MdButtonDirective($mdButtonInkRipple, $mdTheming, $mdAria, $timeout) {
 

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -187,33 +187,81 @@ button.md-button.md-fab {
   }
 }
 
-.md-toast-open-top {
-  .md-button.md-fab-top-left,
-  .md-button.md-fab-top-right {
-    transition: $swift-ease-out;
-    transform: translate3d(0, $button-fab-toast-offset, 0);
-    &:not([disabled]) {
-      &.md-focused,
-      &:hover {
-        transform: translate3d(0, $button-fab-toast-offset - 1, 0);
-      }
+/*
+ * When a toast is open that is on the same side as our FAB, move the FAB out of the way.
+ *
+ * Note: On mobile; the toast will always open with the `md-toast-open-bottom` class, regardless of
+ * requested positioning.
+ */
+.md-toast-open-top-left .md-button.md-fab-top-left,
+.md-toast-open-top-start .md-button.md-fab-top-start,
+.md-toast-open-top-left .md-button.md-fab-top-start,
+.md-toast-open-top-start .md-button.md-fab-top-left,
+[dir=rtl] .md-toast-open-top-end .md-button.md-fab-top-left,
+[dir=rtl] .md-toast-open-top-left .md-button.md-fab-top-end,
+
+.md-toast-open-top-right .md-button.md-fab-top-right,
+.md-toast-open-top-end .md-button.md-fab-top-end,
+.md-toast-open-top-right .md-button.md-fab-top-end,
+.md-toast-open-top-end .md-button.md-fab-top-right,
+[dir=rtl] .md-toast-open-top-start .md-button.md-fab-top-right,
+[dir=rtl] .md-toast-open-top-right .md-button.md-fab-top-start
+{
+  transition: $swift-ease-out;
+  transform: translate3d(0, $button-fab-toast-offset, 0);
+  &:not([disabled]) {
+    &.md-focused,
+    &:hover {
+      transform: translate3d(0, $button-fab-toast-offset - 1, 0);
     }
   }
 }
 
-.md-toast-open-bottom {
-  .md-button.md-fab-bottom-left,
-  .md-button.md-fab-bottom-right {
-    transition: $swift-ease-out;
-    transform: translate3d(0, -$button-fab-toast-offset, 0);
-    &:not([disabled]) {
-      &.md-focused,
-      &:hover {
-        transform: translate3d(0, -$button-fab-toast-offset - 1, 0);
-      }
+// Note: We do not currently allow `md-toast-open-top`, but we do allow `md-toast-open-bottom` for
+// mobile devices.
+.md-toast-open-bottom .md-button.md-fab-bottom-start,
+.md-toast-open-bottom .md-button.md-fab-bottom-end,
+.md-toast-open-bottom .md-button.md-fab-bottom-left,
+.md-toast-open-bottom .md-button.md-fab-bottom-right,
+
+.md-toast-open-bottom-left .md-button.md-fab-bottom-left,
+.md-toast-open-bottom-start .md-button.md-fab-bottom-start,
+.md-toast-open-bottom-left .md-button.md-fab-bottom-start,
+.md-toast-open-bottom-start .md-button.md-fab-bottom-left,
+[dir=rtl] .md-toast-open-bottom-end .md-button.md-fab-bottom-left,
+[dir=rtl] .md-toast-open-bottom-left .md-button.md-fab-bottom-end,
+
+.md-toast-open-bottom-right .md-button.md-fab-bottom-right,
+.md-toast-open-bottom-end .md-button.md-fab-bottom-end,
+.md-toast-open-bottom-right .md-button.md-fab-bottom-end,
+.md-toast-open-bottom-end .md-button.md-fab-bottom-right,
+[dir=rtl] .md-toast-open-bottom-start .md-button.md-fab-bottom-right,
+[dir=rtl] .md-toast-open-bottom-right .md-button.md-fab-bottom-start
+{
+  transition: $swift-ease-out;
+  transform: translate3d(0, -$button-fab-toast-offset, 0);
+  &:not([disabled]) {
+    &.md-focused,
+    &:hover {
+      transform: translate3d(0, -$button-fab-toast-offset - 1, 0);
     }
   }
 }
+
+// Add some RTL overrides for ones we know are ok and don't need to be transformed
+[dir=rtl] .md-toast-open-top-left .md-button.md-fab-top-start,
+[dir=rtl] .md-toast-open-top-start .md-button.md-fab-top-left,
+[dir=rtl] .md-toast-open-top-right .md-button.md-fab-top-end,
+[dir=rtl] .md-toast-open-top-end .md-button.md-fab-top-right,
+
+[dir=rtl] .md-toast-open-bottom-left .md-button.md-fab-bottom-start,
+[dir=rtl] .md-toast-open-bottom-start .md-button.md-fab-bottom-left,
+[dir=rtl] .md-toast-open-bottom-right .md-button.md-fab-bottom-end,
+[dir=rtl] .md-toast-open-bottom-end .md-button.md-fab-bottom-right
+{
+  transform: none;
+}
+
 
 .md-button-group {
   display: flex;

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -56,6 +56,13 @@
    *  - `md-fab-bottom-left`
    *  - `md-fab-bottom-right`
    *
+   *  Additionally, we now offer the following bi-direction classes which automatically change
+   *  position based on the current `dir` setting (i.e. `ltr` or `rtl`).
+   *  - `md-fab-top-start`
+   *  - `md-fab-top-end`
+   *  - `md-fab-bottom-start`
+   *  - `md-fab-bottom-end`
+   *
    * These CSS classes use `position: absolute`, so you need to ensure that the container element
    * also uses `position: absolute` or `position: relative` in order for them to work.
    *

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -42,6 +42,13 @@
    *  - `md-fab-bottom-left`
    *  - `md-fab-bottom-right`
    *
+   *  Additionally, we now offer the following bi-direction classes which automatically change
+   *  position based on the current `dir` setting (i.e. `ltr` or `rtl`).
+   *  - `md-fab-top-start`
+   *  - `md-fab-top-end`
+   *  - `md-fab-bottom-start`
+   *  - `md-fab-bottom-end`
+   *
    * These CSS classes use `position: absolute`, so you need to ensure that the container element
    * also uses `position: absolute` or `position: relative` in order for them to work.
    *

--- a/src/components/toast/demoBasicUsage/index.html
+++ b/src/components/toast/demoBasicUsage/index.html
@@ -1,37 +1,58 @@
-<div ng-controller="AppCtrl" layout-fill layout="column" class="inset" ng-cloak paddi>
+<div ng-controller="AppCtrl as $ctrl" layout-fill layout="column" class="inset" ng-cloak>
+  <p>
+    Toast can be dismissed with a swipe, a timer, or a button.
+  </p>
+
+  <div layout="row" layout-align="space-around">
+    <div style="width:50px"></div>
+
+    <md-button ng-click="$ctrl.showSimpleToast()">
+      Show Simple
+    </md-button>
+
+    <md-button class="md-raised" ng-click="$ctrl.showActionToast()">
+      Show With Action
+    </md-button>
+
+    <div style="width:50px"></div>
+  </div>
+
+  <div id="toastBounds">
     <p>
-    Toast can be dismissed with a swipe, a timer, or a button.<br/>
+      <label>Toast Position ('{{$ctrl.getToastPosition()}}')</label>
     </p>
 
-
-    <div layout="row" layout-align="space-around">
-      <div style="width:50px"></div>
-      <md-button ng-click="showSimpleToast()">
-        Show Simple
-      </md-button>
-      <md-button class="md-raised" ng-click="showActionToast()">
-        Show With Action
-      </md-button>
-      <div style="width:50px"></div>
+    <div class="md-inline-form">
+      <md-radio-group ng-model="$ctrl.topBottom">
+        <md-radio-button ng-repeat="option in $ctrl.topBottomOptions" value="{{option}}">
+          {{option}}
+        </md-radio-button>
+      </md-radio-group>
     </div>
 
-    <div layout="row" id="toastBounds">
-
-      <div>
-        <p><b>Toast Position: "{{getToastPosition()}}"</b></p>
-        <md-checkbox ng-repeat="(name, isSelected) in toastPosition"
-          ng-model="toastPosition[name]">
-          {{name}}
-        </md-checkbox>
-      </div>
+    <div class="md-inline-form">
+      <md-radio-group ng-model="$ctrl.position">
+        <md-radio-button ng-repeat="option in $ctrl.positionOptions" value="{{option}}">
+          {{option}}
+        </md-radio-button>
+      </md-radio-group>
     </div>
-    <div layout="row">
-      <md-button class="md-primary md-fab md-fab-bottom-right">
-        FAB
-      </md-button>
-      <md-button class="md-accent md-fab md-fab-top-right">
-        FAB
-      </md-button>
 
-    </div>
+    <p>
+      <md-input-container>
+        <label>Hide Delay (ms)</label>
+        <input ng-model="$ctrl.delay" name="delay" />
+      </md-input-container>
+    </p>
+  </div>
+
+  <div layout="row">
+    <md-button class="md-primary md-fab md-fab-bottom-end">
+      FAB
+    </md-button>
+
+    <md-button class="md-accent md-fab md-fab-top-end">
+      FAB
+    </md-button>
+  </div>
 </div>

--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -1,48 +1,33 @@
 
 angular.module('toastDemo1', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdToast) {
-  var last = {
-      bottom: false,
-      top: true,
-      left: false,
-      right: true
-    };
+.controller('AppCtrl', function($mdToast) {
+  var $ctrl = this;
 
-  $scope.toastPosition = angular.extend({},last);
+  this.delay = 3000;
+  this.topBottomOptions = ['top', 'bottom'];
+  this.positionOptions = ['left', 'right', 'start', 'end'];
 
-  $scope.getToastPosition = function() {
-    sanitizePosition();
+  this.topBottom = 'top';
+  this.position = 'left';
 
-    return Object.keys($scope.toastPosition)
-      .filter(function(pos) { return $scope.toastPosition[pos]; })
-      .join(' ');
+  this.getToastPosition = function() {
+    return this.topBottom + ' ' + this.position;
   };
 
-  function sanitizePosition() {
-    var current = $scope.toastPosition;
-
-    if ( current.bottom && last.top ) current.top = false;
-    if ( current.top && last.bottom ) current.bottom = false;
-    if ( current.right && last.left ) current.left = false;
-    if ( current.left && last.right ) current.right = false;
-
-    last = angular.extend({},current);
-  }
-
-  $scope.showSimpleToast = function() {
-    var pinTo = $scope.getToastPosition();
+  this.showSimpleToast = function() {
+    var pinTo = $ctrl.getToastPosition();
 
     $mdToast.show(
       $mdToast.simple()
         .textContent('Simple Toast!')
-        .position(pinTo )
-        .hideDelay(3000)
+        .position(pinTo)
+        .hideDelay($ctrl.delay)
     );
   };
 
-  $scope.showActionToast = function() {
-    var pinTo = $scope.getToastPosition();
+  this.showActionToast = function() {
+    var pinTo = $ctrl.getToastPosition();
     var toast = $mdToast.simple()
       .textContent('Marked as read')
       .action('UNDO')

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -154,6 +154,10 @@ md-toast {
     bottom: 0;
     padding: 0;
 
+    .md-toast-content {
+      border-radius: 0;
+    }
+
     &.ng-leave.ng-leave-active {
       &.md-swipeup {
         .md-toast-content {
@@ -186,11 +190,11 @@ md-toast {
     }
 
     // Support for RTL alignment
-    &._md-start {
+    &.md-start {
       @include rtl-prop(left, right, 0, auto);
     }
 
-    &._md-end {
+    &.md-end {
       @include rtl-prop(right, left, 0, auto);
     }
 

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -236,17 +236,6 @@ describe('$mdToast service', function() {
         expect(toast[0].querySelector('.md-toast-content').textContent).toBe('Message');
       }));
 
-      it('should add position class to toast', inject(function($rootElement, $timeout) {
-        setup({
-          template: '<md-toast>',
-          position: 'top left'
-        });
-        var toast = $rootElement.find('md-toast');
-        $timeout.flush();
-        expect(toast.hasClass('md-top')).toBe(true);
-        expect(toast.hasClass('md-left')).toBe(true);
-      }));
-
       it('should wrap toast content with .md-toast-content', inject(function($rootElement, $timeout) {
         setup({
           template: '<md-toast><p>Charmander</p></md-toast>',
@@ -263,7 +252,38 @@ describe('$mdToast service', function() {
         expect(contentSpan).not.toHaveClass('md-toast-text');
       }));
 
+      it('should add position class to toast', inject(function($rootElement, $timeout) {
+        setup({
+          template: '<md-toast>',
+          position: 'top left'
+        });
+        var toast = $rootElement.find('md-toast');
+        $timeout.flush();
+        expect(toast.hasClass('md-top')).toBe(true);
+        expect(toast.hasClass('md-left')).toBe(true);
+      }));
 
+      describe('when user supplies "top" position', function() {
+        it('should add "top left" class to toast parent', inject(function($rootElement) {
+          setup({
+            template: '<md-toast>',
+            position: 'top',
+            parent: $rootElement
+          });
+          expect($rootElement.hasClass('md-toast-open-top-left')).toBe(true);
+        }));
+      });
+
+      ['top left', 'top right', 'bottom left', 'bottom right'].forEach(function(position) {
+        it('should add "' + position + '" class to toast parent', inject(function($rootElement) {
+          setup({
+            template: '<md-toast>',
+            position: position,
+            parent: $rootElement
+          });
+          expect($rootElement.hasClass('md-toast-open-' + position.replace(' ', '-'))).toBe(true);
+        }));
+      });
 
       describe('sm screen', function () {
         beforeEach(function () {
@@ -438,15 +458,17 @@ describe('$mdToast service', function() {
       setup({
         template: '<md-toast>'
       });
-      expect($rootElement.hasClass('md-toast-open-bottom')).toBe(true);
-
+      expect($rootElement.hasClass('md-toast-open-bottom-left')).toBe(true);
       $material.flushInterimElement();
 
+      // If we only provide `top`, the toast will reset the position to `top left` so that the
+      // CSS will work properly
       setup({
         template: '<md-toast>',
         position: 'top'
       });
-      expect($rootElement.hasClass('md-toast-open-top')).toBe(true);
+      expect($rootElement.hasClass('md-toast-open-top-left')).toBe(true);
+      $material.flushInterimElement();
     }));
   });
 

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -147,19 +147,45 @@
 // Position a FAB button.
 @mixin fab-position($spot, $top: auto, $right: auto, $bottom: auto, $left: auto) {
   &.md-fab-#{$spot} {
+    position: absolute;
     top: $top;
     right: $right;
     bottom: $bottom;
     left: $left;
-    position: absolute;
   }
 }
 
 @mixin fab-all-positions() {
-  @include fab-position(bottom-right, auto, ($button-fab-width - $button-fab-padding)/2, ($button-fab-height - $button-fab-padding)/2, auto);
-  @include fab-position(bottom-left, auto, auto, ($button-fab-height - $button-fab-padding)/2, ($button-fab-width - $button-fab-padding)/2);
-  @include fab-position(top-right, ($button-fab-height - $button-fab-padding)/2, ($button-fab-width - $button-fab-padding)/2, auto, auto);
-  @include fab-position(top-left, ($button-fab-height - $button-fab-padding)/2, auto, auto, ($button-fab-width - $button-fab-padding)/2);
+  $widthOffset: ($button-fab-width - $button-fab-padding)/2;
+  $heightOffset: ($button-fab-height - $button-fab-padding)/2;
+
+  @include fab-position(bottom-right, auto, $widthOffset, $heightOffset, auto);
+  @include fab-position(bottom-left, auto, auto, $heightOffset, $widthOffset);
+  @include fab-position(top-right, $heightOffset, $widthOffset, auto, auto);
+  @include fab-position(top-left, $heightOffset, auto, auto, $widthOffset);
+
+  // Add bi-directional/RTL support
+  &.md-fab-top-start, &.md-fab-top-end {
+    position:absolute;
+    top: $heightOffset;
+    bottom: auto;
+  }
+
+  &.md-fab-bottom-start, &.md-fab-bottom-end {
+    position:absolute;
+    bottom: $heightOffset;
+    top: auto;
+  }
+
+  &.md-fab-top-start, &.md-fab-bottom-start {
+    @include rtl(left, $widthOffset, auto);
+    @include rtl(right, auto, $widthOffset);
+  }
+
+  &.md-fab-top-end, &.md-fab-bottom-end {
+    @include rtl(right, $widthOffset, auto);
+    @include rtl(left, auto, $widthOffset);
+  }
 }
 
 // This mixin allows a user to use the md-checkbox css outside of the


### PR DESCRIPTION
Previously, there were many cases where a FAB would erroneously reposition itself when a Toast was opened somewhere else in the parent container (i.e. the top-right FAB would open when a top-left Toast opened).
- Add `start`/`end` classes to FAB (i.e. `md-fab-bottom.end`) which
- Fix `top` position to default to `top left` since our CSS does
  not support a full-width `top` Toast.
- Fix Toast positioning CSS to include left/right information.
- Fix CSS privatization issue with Toast `start`/`end` positioning.
  automatically update based on current LTR/RTL settings.
- Refactor Toast to use JS for mobile positioning to reduce CSS
  complexity.
- Refactor FAB SCSS to use variables for better readability.
- Update FAB/Toast docs accordingly.

Additionally, update the Toast Demo with the following related changes:
- Include `start`/`end` options.
- More clearly separate `top`/`bottom` from other positions, and
  use radio button groups instead of checkboxes.
- Refactor to use `$ctrl` instead of `$scope`.
- Add new `Delay` option to control how long the Toast remains open.
- Update FABs to use new `end` option instead of just `right` to
  work better with RTL.

BREAKING CHANGE (minor)

We used to apply a CSS class of `md-toast-open-top` or `md-toast-open-bottom` to the parent container of the toast. If you used one of these two classes, please update your code to use one of the following, more specific, classes instead:
- `md-toast-open-top-left`, `md-toast-open-top-start`
- `md-toast-open-top-right`, `md-toast-open-top-end`
- `md-toast-open-bottom-left`, `md-toast-open-bottom-start`
- `md-toast-open-bottom-right`, `md-toast-open-bottom-end`

Fixes #9298.
