### PR TITLE
fix(tabs): Add proper RTL support.

### DIFF
--- a/src/components/tabs/demoDynamicTabs/script.js
+++ b/src/components/tabs/demoDynamicTabs/script.js
@@ -6,21 +6,32 @@
 
   function AppCtrl ($scope, $log) {
     var tabs = [
-          { title: 'One', content: "Tabs will become paginated if there isn't enough room for them."},
-          { title: 'Two', content: "You can swipe left and right on a mobile device to change tabs."},
-          { title: 'Three', content: "You can bind the selected tab via the selected attribute on the md-tabs element."},
-          { title: 'Four', content: "If you set the selected tab binding to -1, it will leave no tab selected."},
-          { title: 'Five', content: "If you remove a tab, it will try to select a new one."},
-          { title: 'Six', content: "There's an ink bar that follows the selected tab, you can turn it off if you want."},
-          { title: 'Seven', content: "If you set ng-disabled on a tab, it becomes unselectable. If the currently selected tab becomes disabled, it will try to select the next tab."},
-          { title: 'Eight', content: "If you look at the source, you're using tabs to look at a demo for tabs. Recursion!"},
-          { title: 'Nine', content: "If you set md-theme=\"green\" on the md-tabs element, you'll get green tabs."},
-          { title: 'Ten', content: "If you're still reading this, you should just go check out the API docs for tabs!"}
-        ],
-        selected = null,
-        previous = null;
+        { title: 'Zero (AKA 0, Cero, One - One, -Nineteen + 19, and so forth and so on and continuing into what seems like infinity.)', content: 'Woah...that is a really long title!' },
+        { title: 'One', content: "Tabs will become paginated if there isn't enough room for them."},
+        { title: 'Two', content: "You can swipe left and right on a mobile device to change tabs."},
+        { title: 'Three', content: "You can bind the selected tab via the selected attribute on the md-tabs element."},
+        { title: 'Four', content: "If you set the selected tab binding to -1, it will leave no tab selected."},
+        { title: 'Five', content: "If you remove a tab, it will try to select a new one."},
+        { title: 'Six', content: "There's an ink bar that follows the selected tab, you can turn it off if you want."},
+        { title: 'Seven', content: "If you set ng-disabled on a tab, it becomes unselectable. If the currently selected tab becomes disabled, it will try to select the next tab."},
+        { title: 'Eight', content: "If you look at the source, you're using tabs to look at a demo for tabs. Recursion!"},
+        { title: 'Nine', content: "If you set md-theme=\"green\" on the md-tabs element, you'll get green tabs."},
+        { title: 'Ten', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Eleven', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Twelve', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Thirteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Fourteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Fifteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Sixteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Seventeen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Eighteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Nineteen', content: "If you're still reading this, you should just go check out the API docs for tabs!"},
+        { title: 'Twenty', content: "If you're still reading this, you should just go check out the API docs for tabs!"}
+      ],
+      selected = null,
+      previous = null;
     $scope.tabs = tabs;
-    $scope.selectedIndex = 2;
+    $scope.selectedIndex = 0;
     $scope.$watch('selectedIndex', function(current, old){
       previous = selected;
       selected = tabs[current];

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -6,7 +6,8 @@ angular
  * @ngInject
  */
 function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple, $mdUtil,
-                           $animateCss, $attrs, $compile, $mdTheming, $mdInteraction) {
+                           $animateCss, $attrs, $compile, $mdTheming, $mdInteraction,
+                           MdTabsPaginationService) {
   // define private properties
   var ctrl      = this,
       locked    = false,
@@ -189,9 +190,16 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (newWidth !== oldWidth) {
       var elements = getElements();
 
+      // Set the max width for the real tabs
       angular.forEach(elements.tabs, function(tab) {
         tab.style.maxWidth = newWidth + 'px';
       });
+
+      // Set the max width for the dummy tabs too
+      angular.forEach(elements.dummies, function(tab) {
+        tab.style.maxWidth = newWidth + 'px';
+      });
+
       $mdUtil.nextTick(ctrl.updateInkBarStyles);
     }
   }
@@ -221,7 +229,10 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function handleOffsetChange (left) {
     var elements = getElements();
-    var newValue = ctrl.shouldCenterTabs ? '' : '-' + left + 'px';
+    var newValue = ((ctrl.shouldCenterTabs || isRtl() ? '' : '-') + left + 'px');
+
+    // Fix double-negative which can happen with RTL support
+    newValue = newValue.replace('--', '');
 
     angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate3d(' + newValue + ', 0, 0)');
     $scope.$broadcast('$mdTabsPaginationChanged');
@@ -340,48 +351,23 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * Slides the tabs over approximately one page forward.
    */
   function nextPage () {
-    var elements = getElements();
-    var viewportWidth = elements.canvas.clientWidth,
-        totalWidth    = viewportWidth + ctrl.offsetLeft,
-        i, tab;
-    for (i = 0; i < elements.tabs.length; i++) {
-      tab = elements.tabs[ i ];
-      if (tab.offsetLeft + tab.offsetWidth > totalWidth) break;
-    }
+    if (!ctrl.canPageForward()) { return }
 
-    if (viewportWidth > tab.offsetWidth) {
-      //Canvas width *greater* than tab width: usual positioning
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft);
-    } else {
-      /**
-       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let
-       * pagination "for loop" to proceed correctly on next tab when nextPage() is called again
-       */
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
-    }
+    var newOffset = MdTabsPaginationService.increasePageOffset(getElements(), ctrl.offsetLeft);
+
+    ctrl.offsetLeft = fixOffset(newOffset);
   }
 
   /**
    * Slides the tabs over approximately one page backward.
    */
   function previousPage () {
-    var i, tab, elements = getElements();
+    if (!ctrl.canPageBack()) { return }
 
-    for (i = 0; i < elements.tabs.length; i++) {
-      tab = elements.tabs[ i ];
-      if (tab.offsetLeft + tab.offsetWidth >= ctrl.offsetLeft) break;
-    }
+    var newOffset = MdTabsPaginationService.decreasePageOffset(getElements(), ctrl.offsetLeft);
 
-    if (elements.canvas.clientWidth > tab.offsetWidth) {
-      //Canvas width *greater* than tab width: usual positioning
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
-    } else {
-      /**
-       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let
-       * pagination "for loop" to break correctly on previous tab when previousPage() is called again
-       */
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft);
-    }
+    // Set the new offset
+    ctrl.offsetLeft = fixOffset(newOffset);
   }
 
   /**
@@ -390,6 +376,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function handleWindowResize () {
     ctrl.lastSelectedIndex = ctrl.selectedIndex;
     ctrl.offsetLeft        = fixOffset(ctrl.offsetLeft);
+
     $mdUtil.nextTick(function () {
       ctrl.updateInkBarStyles();
       updatePagination();
@@ -486,6 +473,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     elements.canvas  = elements.wrapper.querySelector('md-tabs-canvas');
     elements.paging  = elements.canvas.querySelector('md-pagination-wrapper');
     elements.inkBar  = elements.paging.querySelector('md-ink-bar');
+    elements.nextButton = node.querySelector('md-next-button');
+    elements.prevButton = node.querySelector('md-prev-button');
 
     elements.contents = node.querySelectorAll('md-tabs-content-wrapper > md-tab-content');
     elements.tabs    = elements.paging.querySelectorAll('md-tab-item');
@@ -499,6 +488,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @returns {boolean}
    */
   function canPageBack () {
+    // This works for both LTR and RTL
     return ctrl.offsetLeft > 0;
   }
 
@@ -509,6 +499,11 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function canPageForward () {
     var elements = getElements();
     var lastTab = elements.tabs[ elements.tabs.length - 1 ];
+
+    if (isRtl()) {
+      return ctrl.offsetLeft < elements.paging.offsetWidth - elements.canvas.offsetWidth;
+    }
+
     return lastTab && lastTab.offsetLeft + lastTab.offsetWidth > elements.canvas.clientWidth +
         ctrl.offsetLeft;
   }
@@ -556,7 +551,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (ctrl.noPagination || !loaded) return false;
     var canvasWidth = $element.prop('clientWidth');
 
-    angular.forEach(getElements().dummies, function (tab) {
+    angular.forEach(getElements().tabs, function (tab) {
       canvasWidth -= tab.offsetWidth;
     });
 
@@ -615,7 +610,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @returns {number}
    */
   function calcPagingWidth () {
-    return calcTabsWidth(getElements().dummies);
+    return calcTabsWidth(getElements().tabs);
   }
 
   function calcTabsWidth(tabs) {
@@ -633,7 +628,28 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   function getMaxTabWidth () {
-    return $element.prop('clientWidth');
+    var elements = getElements(),
+        containerWidth = elements.canvas.clientWidth,
+
+        // See https://material.google.com/components/tabs.html#tabs-specs
+        specMax = 264;
+
+    // Do the spec maximum, or the canvas width; whichever is *smaller* (tabs larger than the canvas
+    // width can break the pagination) but not less than 0
+    return Math.max(0, Math.min(containerWidth - 1, specMax));
+  }
+
+  function getMinTabWidth() {
+    var elements = getElements(),
+        containerWidth = elements.canvas.clientWidth,
+        xsBreakpoint = 600,
+
+        // See https://material.google.com/components/tabs.html#tabs-specs
+        specMin = containerWidth > xsBreakpoint ? 160 : 72;
+
+    // Do the spec minimum, or the canvas width; whichever is *smaller* (tabs larger than the canvas
+    // width can break the pagination) but not less than 0
+    return Math.max(0, Math.min(containerWidth - 1, specMin));
   }
 
   /**
@@ -686,9 +702,25 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (ctrl.shouldCenterTabs) return;
     var tab         = elements.tabs[ index ],
         left        = tab.offsetLeft,
-        right       = tab.offsetWidth + left;
-    ctrl.offsetLeft = Math.max(ctrl.offsetLeft, fixOffset(right - elements.canvas.clientWidth + 32 * 2));
-    ctrl.offsetLeft = Math.min(ctrl.offsetLeft, fixOffset(left));
+        right       = tab.offsetWidth + left,
+        extraOffset = 32;
+
+    // If we are selecting the first tab (in LTR and RTL), always set the offset to 0
+    if (index == 0) {
+      ctrl.offsetLeft = 0;
+      return;
+    }
+
+    if (isRtl()) {
+      var tabWidthsBefore = calcTabsWidth(Array.prototype.slice.call(elements.tabs, 0, index));
+      var tabWidthsIncluding = calcTabsWidth(Array.prototype.slice.call(elements.tabs, 0, index + 1));
+
+      ctrl.offsetLeft = Math.min(ctrl.offsetLeft, fixOffset(tabWidthsBefore));
+      ctrl.offsetLeft = Math.max(ctrl.offsetLeft, fixOffset(tabWidthsIncluding - elements.canvas.clientWidth));
+    } else {
+      ctrl.offsetLeft = Math.max(ctrl.offsetLeft, fixOffset(right - elements.canvas.clientWidth + extraOffset));
+      ctrl.offsetLeft = Math.min(ctrl.offsetLeft, fixOffset(left));
+    }
   }
 
   /**
@@ -845,10 +877,18 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     var elements = getElements();
 
     if (!elements.tabs.length || !ctrl.shouldPaginate) return 0;
+
     var lastTab    = elements.tabs[ elements.tabs.length - 1 ],
         totalWidth = lastTab.offsetLeft + lastTab.offsetWidth;
-    value          = Math.max(0, value);
-    value          = Math.min(totalWidth - elements.canvas.clientWidth, value);
+
+    if (isRtl()) {
+      value = Math.min(elements.paging.offsetWidth - elements.canvas.clientWidth, value);
+      value = Math.max(0, value);
+    } else {
+      value = Math.max(0, value);
+      value = Math.min(totalWidth - elements.canvas.clientWidth, value);
+    }
+
     return value;
   }
 
@@ -873,5 +913,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       var nodes = $element[0].querySelectorAll('[md-tab-id="' + tab.id + '"]');
       angular.element(nodes).attr('aria-controls', ctrl.tabContentPrefix + tab.id);
     }
+  }
+
+  function isRtl() {
+    return ($mdUtil.bidi() == 'rtl');
   }
 }

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -105,6 +105,11 @@ md-tabs-wrapper {
       left: 50%;
       transform: translate3d(-50%, -50%, 0);
     }
+
+    // For RTL tabs, rotate the buttons
+    [dir="rtl"] & {
+      transform: rotateY(180deg) translateY(-50%);
+    }
   }
   md-prev-button {
     @include rtl-prop(left, right, 0, auto);
@@ -113,6 +118,8 @@ md-tabs-wrapper {
   md-next-button {
     @include rtl-prop(right, left, 0, auto);
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4gPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDE3LjEuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPiA8IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPiA8c3ZnIHZlcnNpb249IjEuMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSIyNHB4IiBoZWlnaHQ9IjI0cHgiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgMjQgMjQiIHhtbDpzcGFjZT0icHJlc2VydmUiPiA8ZyBpZD0iSGVhZGVyIj4gPGc+IDxyZWN0IHg9Ii02MTgiIHk9Ii0xMzM2IiBmaWxsPSJub25lIiB3aWR0aD0iMTQwMCIgaGVpZ2h0PSIzNjAwIi8+IDwvZz4gPC9nPiA8ZyBpZD0iTGFiZWwiPiA8L2c+IDxnIGlkPSJJY29uIj4gPGc+IDxwb2x5Z29uIHBvaW50cz0iMTAsNiA4LjYsNy40IDEzLjIsMTIgOC42LDE2LjYgMTAsMTggMTYsMTIgCQkiIHN0eWxlPSJmaWxsOndoaXRlOyIvPiA8cmVjdCBmaWxsPSJub25lIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiLz4gPC9nPiA8L2c+IDxnIGlkPSJHcmlkIiBkaXNwbGF5PSJub25lIj4gPGcgZGlzcGxheT0iaW5saW5lIj4gPC9nPiA8L2c+IDwvc3ZnPg0K');
+
+    // In regular mode, we need to flip the chevron icon to point the other way
     md-icon {
       transform: translate3d(-50%, -50%, 0) rotate(180deg);
     }
@@ -283,7 +290,7 @@ md-tab {
   }
 }
 
-md-toolbar + md-tabs {
+md-toolbar + md-tabs, md-toolbar + md-dialog-content md-tabs {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }

--- a/src/components/tabs/tabsPaginationService.js
+++ b/src/components/tabs/tabsPaginationService.js
@@ -1,0 +1,112 @@
+angular
+.module('material.components.tabs')
+.service('MdTabsPaginationService', MdTabsPaginationService);
+
+/**
+ * @private
+ * @module material.components.tabs
+ * @name MdTabsPaginationService
+ * @description Provides many standalone functions to ease in pagination calculations.
+ *
+ * Most functions accept the elements and the current offset.
+ *
+ * The `elements` parameter is typically the value returned from the `getElements()` function of the
+ * tabsController.
+ *
+ * The `offset` parameter is always positive regardless of LTR or RTL (we simply make the LTR one
+ * negative when we apply our transform). This is typically the `ctrl.leftOffset` variable in the
+ * tabsController.
+ *
+ * @returns MdTabsPaginationService
+ * @constructor
+ */
+function MdTabsPaginationService() {
+  return {
+    decreasePageOffset: decreasePageOffset,
+    increasePageOffset: increasePageOffset,
+    getTabOffsets: getTabOffsets,
+    getTotalTabsWidth: getTotalTabsWidth
+  };
+
+  /**
+   * Returns the offset for the next decreasing page.
+   *
+   * @param elements
+   * @param currentOffset
+   * @returns {number}
+   */
+  function decreasePageOffset(elements, currentOffset) {
+    var canvas       = elements.canvas,
+        tabOffsets   = getTabOffsets(elements),
+        i, firstVisibleTabOffset;
+
+    // Find the first fully visible tab in offset range
+    for (i = 0; i < tabOffsets.length; i++) {
+      if (tabOffsets[i] >= currentOffset) {
+        firstVisibleTabOffset = tabOffsets[i];
+        break;
+      }
+    }
+
+    // Return (the first visible tab offset - the tabs container width) without going negative
+    return Math.max(0, firstVisibleTabOffset - canvas.clientWidth);
+  }
+
+  /**
+   * Returns the offset for the next increasing page.
+   *
+   * @param elements
+   * @param currentOffset
+   * @returns {number}
+   */
+  function increasePageOffset(elements, currentOffset) {
+    var canvas       = elements.canvas,
+        maxOffset    = getTotalTabsWidth(elements) - canvas.clientWidth,
+        tabOffsets   = getTabOffsets(elements),
+        i, firstHiddenTabOffset;
+
+    // Find the first partially (or fully) invisible tab
+    for (i = 0; i < tabOffsets.length, tabOffsets[i] <= currentOffset + canvas.clientWidth; i++) {
+      firstHiddenTabOffset = tabOffsets[i];
+    }
+
+    // Return the offset of the first hidden tab, or the maximum offset (whichever is smaller)
+    return Math.min(maxOffset, firstHiddenTabOffset);
+  }
+
+  /**
+   * Returns the offsets of all of the tabs based on their widths.
+   *
+   * @param elements
+   * @returns {number[]}
+   */
+  function getTabOffsets(elements) {
+    var i, tab, currentOffset = 0, offsets = [];
+
+    for (i = 0; i < elements.tabs.length; i++) {
+      tab = elements.tabs[i];
+      offsets.push(currentOffset);
+      currentOffset += tab.offsetWidth;
+    }
+
+    return offsets;
+  }
+
+  /**
+   * Sum the width of all tabs.
+   *
+   * @param elements
+   * @returns {number}
+   */
+  function getTotalTabsWidth(elements) {
+    var sum = 0, i, tab;
+
+    for (i = 0; i < elements.tabs.length; i++) {
+      tab = elements.tabs[i];
+      sum += tab.offsetWidth;
+    }
+
+    return sum;
+  }
+
+}

--- a/src/components/tabs/tabsPaginationService.spec.js
+++ b/src/components/tabs/tabsPaginationService.spec.js
@@ -1,0 +1,231 @@
+describe('MdTabsPaginationService', function() {
+
+  const TAB_WIDTH = 100;
+
+  var MdTabsPaginationService;
+
+  beforeEach(module('material.components.tabs'));
+  beforeEach(injectGlobals);
+
+  var customMatchers = {
+    toEqualPageOffset: function(util, customEqualityTesters) {
+      return {
+        compare: function(actual, expected) {
+          var config = decode(expected),
+            result = {};
+
+          result.pass = util.equals(actual, config.offsetStart, customEqualityTesters);
+
+          if (!result.pass) {
+            result.message = "Expected " + actual + " to equal " + config.offsetStart +
+              " for pagination description '" + expected + "'.";
+          }
+
+          return result;
+        }
+      }
+    }
+  };
+
+  beforeEach(function() {
+    jasmine.addMatchers(customMatchers);
+  });
+
+  describe('#decreasePageOffset', function() {
+    it('with a current offset of 0 returns 0', function() {
+      var start = '[-----]----------';
+      var end   = '[-----]----------';
+      var config = decode(start);
+
+      var decreasedOffset = MdTabsPaginationService.decreasePageOffset(config.elements, 0);
+      expect(decreasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a current offset smaller than the offset range returns 0', function() {
+      var start = '---[-----]-------';
+      var end   = '[-----]----------';
+      var config = decode(start);
+
+      var decreasedOffset =
+            MdTabsPaginationService.decreasePageOffset(config.elements, config.offsetStart);
+
+      expect(decreasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a current offset larger than the offset range shows next lowest page', function() {
+      var start = '---------[-----]-';
+      var end   = '----[-----]------';
+      var config = decode(start);
+
+      var decreasedOffset =
+            MdTabsPaginationService.decreasePageOffset(config.elements, config.offsetStart);
+
+      expect(decreasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a max offset and partially visible tab it fully shows the tab', function() {
+      var start = '---------.[.-----]'; // Tab 9 (0-based index) is partially visible
+      var end   = '----.[.-----]-----'; // Tab 9 (0-based index) is the last fully visible tab
+      var config = decode(start);
+
+      var decreasedOffset =
+            MdTabsPaginationService.decreasePageOffset(config.elements, config.offsetStart);
+
+      expect(decreasedOffset).toEqualPageOffset(end);
+    });
+  });
+
+  describe('#increasePageOffset', function() {
+    it('with a current offset at 0 and no partial tabs shows the next page up', function() {
+      var start = '[-----]----------';
+      var end   = '-----[-----]-----';
+      var config = decode(start);
+
+      var increasedOffset =
+            MdTabsPaginationService.increasePageOffset(config.elements, config.offsetStart);
+      expect(increasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a current offset at 0 and partial tabs shows the partially hidden tab', function() {
+      var start = '[-----.].---------';
+      var end   = '-----[-----.].----';
+      var config = decode(start);
+
+      var increasedOffset =
+            MdTabsPaginationService.increasePageOffset(config.elements, config.offsetStart);
+      expect(increasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a current offset close to the max returns max', function() {
+      var start   = '-----[-----.].----';
+      var end     = '---------.[.-----]';
+      var config = decode(start);
+
+      var increasedOffset =
+            MdTabsPaginationService.increasePageOffset(config.elements, config.offsetStart);
+      expect(increasedOffset).toEqualPageOffset(end);
+    });
+
+    it('with a current offset at max returns max', function() {
+      var start = '----------[-----]';
+      var end   = '----------[-----]';
+      var config = decode(start);
+
+      var increasedOffset =
+            MdTabsPaginationService.increasePageOffset(config.elements, config.offsetStart);
+      expect(increasedOffset).toEqualPageOffset(end);
+    });
+  });
+
+  describe('#getTabOffsets', function() {
+    it('returns an array of tab offsets', function() {
+      var descriptor = '[----]------';
+      var config = decode(descriptor);
+
+      var expected = new Array(10).fill(0).map(function(item, index) { return TAB_WIDTH * index});
+
+      expect(MdTabsPaginationService.getTabOffsets(config.elements)).toEqual(expected);
+    });
+  });
+
+  describe('#getTotalTabsWidth', function() {
+    it('adds the width of ideal tabs', function() {
+      var descriptor = '[-----]----------';
+      var config = decode(descriptor);
+
+      expect(MdTabsPaginationService.getTotalTabsWidth(config.elements)).toEqual(TAB_WIDTH * 15);
+    });
+
+    it('adds the width of partially visible tabs', function() {
+      var descriptor = '[-----.].---------';
+      var config = decode(descriptor);
+
+      expect(MdTabsPaginationService.getTotalTabsWidth(config.elements)).toEqual(TAB_WIDTH * 15);
+    });
+  });
+
+  /**
+   * Decode the requested pagination description and return a config object containing the canvas
+   * and tab elements, along with the start/end offset.
+   *
+   * The width of every tab is defined by the TAB_WIDTH constant at the top of this file.
+   *
+   * @param description {string} A string representing the pagination object. Each character
+   * represents a portion of the tabs as follows:
+   *
+   *     `-` - The dash, or hyphen, represents a single tab of length TAB_WIDTH.
+   *     `.` - A period represents a tab that is half-visible. It is partially hidden by the
+   *           pagination wrapping. If used, you MUST have an even number of periods, and you MUST
+   *           only separate them with pagination characters (i.e. don't put a tab inside a half
+   *           tab).
+   *     `[` - The beginning of the pagination.
+   *     `]` - The end of the pagination.
+   *
+   * All descriptions MUST contain a series of dashes and/or dots representing tabs, as well as a
+   * single beginning and ending tag for the pagination.
+   *
+   * Examples:
+   *
+   *     '[-----.].----'
+   *
+   * This example has 5 visible tabs; 1 tab that is half-visible, half-hidden; and 4 visible tabs.
+   * The pagination starts at 0 and ends at 5.5 * TAB_WIDTH.
+   *
+   *     '---[---]---'
+   *
+   * This example has 3 hidden tabs; 3 visible tabs; and then 3 more hidden tabs. The pagination
+   * starts at 3 * TAB_WIDTH and ends at 6 * TAB_WIDTH.
+   *
+   * @returns {{elements: {canvas: {}, tabs: Array}, offsetStart: number, offsetEnd: number}}
+   */
+  function decode(description) {
+    var pagination = {
+      elements: { canvas: {}, tabs: [] },
+      offsetStart: 0,
+      offsetEnd: 0
+    };
+
+    var i, char, currentWidth = 0, midTab = false;
+
+    // Initialize our tabs and offsets
+    for (i = 0; i < description.length; i++) {
+      char = description.charAt(i);
+
+      switch (char) {
+        case '-':
+          currentWidth += TAB_WIDTH;
+          pagination.elements.tabs.push({ offsetWidth: TAB_WIDTH });
+          break;
+        case '.':
+          currentWidth += (TAB_WIDTH / 2);
+
+          // If we're in the middle of a tab and we see another half; go ahead and add a full tab.
+          if (midTab) {
+            pagination.elements.tabs.push({ offsetWidth: TAB_WIDTH });
+            midTab = false;
+          } else {
+            midTab = true;
+          }
+          break;
+        case '[': pagination.offsetStart = currentWidth;
+          break;
+        case ']': pagination.offsetEnd = currentWidth;
+          break;
+        default:
+          throw new Error("Unrecognized char for decode(): '" + char + "'");
+      }
+    }
+
+    // Initialize our canvas element
+    pagination.elements.canvas.clientWidth = pagination.offsetEnd - pagination.offsetStart;
+
+    return pagination;
+  }
+
+  function injectGlobals() {
+    inject(function(_MdTabsPaginationService_) {
+      MdTabsPaginationService = _MdTabsPaginationService_;
+    });
+  }
+
+});


### PR DESCRIPTION
Tabs currently attempts no RTL support for scrolling and pagination.

Update component to properly support RTL.

 - Add new MdTabsPaginationService to handle some calculations in
   a more testable way.
 - Add many instances of RTL checks/math.
 - Add minimum tab width based on spec (or tabs width if smaller).
 - Update SCSS to account for RTL mode with pagination icons.
 - Also add check to ensure pagination buttons ignore clicks when
   disabled.

Fixes #9292.
