### PR TITLE
fix(datepicker): keyboard navigation not working if the user scrolls too much

### DIFF
--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -181,7 +181,15 @@
       $element.attr('tabindex', '-1');
     }
 
-    $element.on('keydown', angular.bind(this, this.handleKeyEvent));
+    var boundKeyHandler = angular.bind(this, this.handleKeyEvent);
+
+    // Bind the keydown handler to the body, in order to handle cases where the focused
+    // element gets removed from the DOM and stops propagating click events.
+    angular.element(document.body).on('keydown', boundKeyHandler);
+
+    $scope.$on('$destroy', function() {
+      angular.element(document.body).off('keydown', boundKeyHandler);
+    });
   }
 
   /**

--- a/src/components/datepicker/js/calendar.spec.js
+++ b/src/components/datepicker/js/calendar.spec.js
@@ -113,7 +113,7 @@ describe('md-calendar', function() {
   function dispatchKeyEvent(keyCode, opt_modifiers) {
     var mod = opt_modifiers || {};
 
-    angular.element(calendarController.$element).triggerHandler({
+    angular.element(document.body).triggerHandler({
       type: 'keydown',
       keyCode: keyCode,
       which: keyCode,


### PR DESCRIPTION
Fixes the datepicker's keyboard navigation not working if the user scrolls too much. This is due to the fact that after a month is destroyed, the browser automatically shifts focus to the body which prevents the calendar from picking up keyboard events. This change switches to listening for keyboard events on the body.

Fixes #9294.