### PR TITLE
fix(checkbox, progressLinear): removed forgotten privatization in mixins, fixed accent colors

### DIFF
--- a/src/components/progressLinear/progress-linear-theme.scss
+++ b/src/components/progressLinear/progress-linear-theme.scss
@@ -19,7 +19,7 @@ md-progress-linear.md-THEME_NAME-theme {
 
   &.md-accent {
     .md-container {
-      background-color: '{{accent-A100}}';
+      background-color: '{{accent-100}}';
     }
 
     .md-bar {
@@ -38,10 +38,10 @@ md-progress-linear.md-THEME_NAME-theme {
     }
     &.md-accent {
       .md-bar1 {
-        background-color: '{{accent-A100}}';
+        background-color: '{{accent-100}}';
       }
       .md-dashed:before {
-        background: radial-gradient('{{accent-A100}}' 0%, '{{accent-A100}}' 16%, transparent 42%);
+        background: radial-gradient('{{accent-100}}' 0%, '{{accent-100}}' 16%, transparent 42%);
       }
     }
   }

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -299,24 +299,24 @@
     color: '{{primary-color-0.87}}';
   }
 
-  &:not(.md-checked) ._md-icon {
+  &:not(.md-checked) .md-icon {
     border-color: '{{foreground-2}}';
   }
 
-  &#{$checkedSelector} ._md-icon {
+  &#{$checkedSelector} .md-icon {
     background-color: '{{primary-color-0.87}}';
   }
 
-  &#{$checkedSelector}.md-focused ._md-container:before {
+  &#{$checkedSelector}.md-focused .md-container:before {
     background-color: '{{primary-color-0.26}}';
   }
 
-  &#{$checkedSelector} ._md-icon:after {
+  &#{$checkedSelector} .md-icon:after {
     border-color: '{{primary-contrast-0.87}}';
   }
 
   & .md-indeterminate[disabled] {
-    ._md-container {
+    .md-container {
       color: '{{foreground-3}}';
     }
   }


### PR DESCRIPTION
- privatization prefix (`_`) was left on the mixin of checkbox which caused other colors than accent to not be applied
- accent progress-linear was using A100 instead of 100