### PR TITLE
docs(contributing): fix invalid links and typo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -111,9 +111,9 @@ before investing significant effort in a planned Pull Request submission; it's l
 working on a related PR.
 
 * All contributions must be consistent with the Angular Material coding conventions. See the
-  [Coding Guidelines](docs/guides/CODING.md)
+  [Coding Guidelines](../docs/guides/CODING.md)
 * Submit proposed changes or additions as GitHub pull requests. See the
-  [Pull Request Guidelines](docs/guides/PULL_REQUESTS.md)
+  [Pull Request Guidelines](../docs/guides/PULL_REQUESTS.md)
 
 <br/>
 ## <a name="commit"></a> Git Commit Guidelines
@@ -200,7 +200,11 @@ refactor(content): prefix mdContent scroll- attributes
 <br/>
 ## <a name="pr_forks"></a> Guidelines for Developer Commit Authorizations
 
-Please review the [Commit Level and Authorization Guidelines](https://github.com/angular/material/blob/master/docs/guides/COMMIT_LEVELS.md) for details on how to implement and submit your fixes, changes, or enchancements to Angular Material. This guideline provides details on creating a repository Fork of the Angular Material repository and how to submit Pull Requests.
+Please review the [Commit Level and Authorization Guidelines](../docs/guides/COMMIT_LEVELS.md) for
+details on how to implement and submit your fixes, changes, or enhancements to Angular Material.
+
+This guideline provides details on creating a repository Fork of the Angular Material repository
+and how to submit Pull Requests.
 
 
 

--- a/docs/guides/COMMIT_LEVELS.md
+++ b/docs/guides/COMMIT_LEVELS.md
@@ -35,7 +35,7 @@ The development team has defined three (3) Github levels of **commit authorizati
   * Should ensure their issues are tested with latest HEAD versions of Angular Material
   * Should ensure their issues are tested with latest releases of Angular (1.3.x, 1.4.x, 1.5.x)
 * Core: 
-  * Includes: [Ryan Schmukler](https://github.com/rschmukler), [Robert Messerlee](https://github.com/robertmesserle), [Topher Fangio](https://github.com/topherfangio)
+  * Includes: [Topher Fangio](https://github.com/topherfangio)
   * Should not merge PRs (unless explicitly requested)
   * Should use Angular Material branches for major, non-trivial changes. 
   * For minor changes, developers in this group may elect to commit direct to master.


### PR DESCRIPTION
* An typo for `enhancements` was fixed
* Fixed invalid links to the `docs/guides` directory.
* Fix wrong spelling of @robertmesserle's name

Closes #9328.