### PR TITLE
fix(datepicker, menu, slider): remove duplicate properties

### DIFF
--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -15,10 +15,9 @@ $md-calendar-height:
     ($md-calendar-weeks-to-show * $md-calendar-cell-size) + $md-calendar-header-height !default;
 
 // Styles for date cells, including day-of-the-week header cells.
-@mixin md-calendar-cell() {
-  height: $md-calendar-cell-size;
+@mixin md-calendar-cell($height: $md-calendar-cell-size) {
+  height: $height;
   width: $md-calendar-cell-size;
-
   text-align: center;
 
   // Remove all padding and borders so we can completely
@@ -146,9 +145,8 @@ md-calendar {
   @include md-calendar-table();
 
   th {
-    @include md-calendar-cell();
+    @include md-calendar-cell($md-calendar-header-height);
     font-weight: normal;
-    height: $md-calendar-header-height;
   }
 }
 

--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -66,7 +66,6 @@ md-menu-content.md-menu-bar-menu.md-dense {
 
   md-menu-item > .md-button, .md-menu > .md-button {
     @include rtl(text-align, left, right);
-    text-align: start;
   }
 
   .md-menu {

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -427,8 +427,8 @@ md-slider {
   }
   &[md-invert] {
     &:not([md-vertical]) .md-track-fill {
-      @include rtl-prop(left, right, auto, auto);
-      @include rtl-prop(right, left, 0, auto);
+      @include rtl(left, auto, 0);
+      @include rtl(right, 0, auto);
     }
     &[md-vertical] {
       .md-track-fill {


### PR DESCRIPTION
* Reworks the `md-calendar-cell` mixin to allow for the height to be specified, avoiding the need for a duplicate property when overriding.
* Removes the `text-align: start` from the menu bar since, at least according to MDN, it's not supported by IE. Also the rtl mixin right before it does exactly the same.
* Reworks the rtl setup for the inverted slider so it doesn't result in duplicate properties.