### PR TITLE
fix(prefixer): do not throw an exception if element is undefined

### DIFF
--- a/src/core/util/prefixer.js
+++ b/src/core/util/prefixer.js
@@ -49,7 +49,11 @@ function MdPrefixer(initialAttributes, buildSelector) {
   }
 
   function _hasAttribute(element, attribute) {
-    element = element[0] || element;
+    element = _getNativeElement(element);
+
+    if (!element) {
+      return false;
+    }
 
     var prefixedAttrs = _buildList(attribute);
 
@@ -63,10 +67,30 @@ function MdPrefixer(initialAttributes, buildSelector) {
   }
 
   function _removeAttribute(element, attribute) {
-    element = element[0] || element;
+    element = _getNativeElement(element);
+
+    if (!element) {
+      return;
+    }
 
     _buildList(attribute).forEach(function(prefixedAttribute) {
       element.removeAttribute(prefixedAttribute);
     });
   }
+
+  /**
+   * Transforms a jqLite or DOM element into a HTML element.
+   * This is useful when supporting jqLite elements and DOM elements at
+   * same time.
+   * @param element {JQLite|Element} Element to be parsed
+   * @returns {HTMLElement} Parsed HTMLElement
+   */
+  function _getNativeElement(element) {
+    element =  element[0] || element;
+
+    if (element.nodeType) {
+      return element;
+    }
+  }
+
 }

--- a/src/core/util/prefixer.spec.js
+++ b/src/core/util/prefixer.spec.js
@@ -74,6 +74,15 @@ describe('prefixer', function() {
         expect(prefixer.hasAttribute(element, 'ng-click')).toBe(true);
       });
 
+      it('should not throw an error if element is undefined', function() {
+        // Create an empty jqLite element to test if it does throw an error.
+        var emptyElement = angular.element();
+
+        expect(function() {
+          prefixer.hasAttribute(emptyElement, 'ng-click')
+        }).not.toThrow();
+      });
+
     });
 
     describe('and removing an attribute', function() {
@@ -100,6 +109,15 @@ describe('prefixer', function() {
         prefixer.removeAttribute(element, 'ng-click');
 
         expect(prefixer.hasAttribute(element, 'ng-click')).toBeFalsy();
+      });
+
+      it('should not throw an error if element is undefined', function() {
+        // Create an empty jqLite element to test if it does throw an error.
+        var emptyElement = angular.element();
+
+        expect(function() {
+          prefixer.removeAttribute(emptyElement, 'ng-click');
+        }).not.toThrow();
       });
 
     });


### PR DESCRIPTION
* The prefixer currently throws an error, when the jqLite element / native element is empty / undefined.
  This was noticeable when having a `md-fab-actions` element without any child elements.

**FYI**: Checking the `nodeType` is more elegant, than comparing the prototype. It's the same way jQuery uses as well.

cc. @ErinCoughlan 