### PR TITLE
fix(virtual-repeat): not re-rendering when switching to a smaller list

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -696,13 +696,12 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
   var itemsLength = items && items.length || 0;
   var lengthChanged = false;
 
-  // If the number of items shrank
+  // If the number of items shrank, keep the scroll position.
   if (this.items && itemsLength < this.items.length && this.container.getScrollOffset() !== 0) {
     this.items = items;
     var previousScrollOffset = this.container.getScrollOffset();
     this.container.resetScroll();
     this.container.scrollTo(previousScrollOffset);
-    return;
   }
 
   if (itemsLength !== this.itemsLength) {

--- a/src/components/virtualRepeat/virtual-repeater.spec.js
+++ b/src/components/virtualRepeat/virtual-repeater.spec.js
@@ -59,11 +59,11 @@ describe('<md-virtual-repeat>', function() {
     return component;
   }
 
-  function createItems(num) {
+  function createItems(num, label) {
     var items = [];
 
     for (var i = 0; i < num; i++) {
-      items.push('s' + (i * 2) + 's');
+      items.push(label || 's' + (i * 2) + 's');
     }
 
     return items;
@@ -661,6 +661,22 @@ describe('<md-virtual-repeat>', function() {
     scroller.triggerHandler('scroll');
 
     expect(getTransform(offsetter)).toBe('translateY(880px)');
+  });
+
+  it('should re-render the list when switching to a smaller array', function() {
+    scope.items = createItems(50, 'list one');
+
+    createRepeater();
+    scroller[0].scrollTop = 5;
+    scroller.triggerHandler('scroll');
+
+    expect(offsetter.children().eq(0).text()).toContain('list one');
+
+    scope.$apply(function() {
+      scope.items = createItems(25, 'list two');
+    });
+
+    expect(offsetter.children().eq(0).text()).toContain('list two');
   });
 
   describe('md-on-demand', function() {


### PR DESCRIPTION
Fixes the virtual repeater not re-rendering, if the list is scrolled slightly and the user switches to a shorter array of items.

Fixes #9315.