### PR TITLE
fix(datepicker): arrow direction in rtl

### DIFF
--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -132,7 +132,7 @@ md-calendar {
   }
 
   md-icon {
-    transform: rotate(180deg);
+    @include rtl(transform, rotate(180deg), none);
   }
 
   span {


### PR DESCRIPTION
Fixes the arrow on the month header pointing in the wrong direction on RTL.

Referencing #9214.