### PR TITLE
fix(docs): Fix dangling links.

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -35,10 +35,10 @@ angular
  * There is an example below of how this should look.
  *
  * ### Notes
- * The `md-autocomplete` uses the the [VirtualRepeat](api/directive/mdVirtualRepeatContainer)
+ * The `md-autocomplete` uses the the <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeat</a>
  * directive for displaying the results inside of the dropdown.<br/>
  * > When encountering issues regarding the item template please take a look at the
- *   [VirtualRepeatContainer](api/directive/mdVirtualRepeatContainer) documentation.
+ *   <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeatContainer</a> documentation.
  *
  *
  * @param {expression} md-items An expression in the format of `item in items` to iterate over

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -40,8 +40,8 @@ angular
  * </hljs>
  *
  * ### Notes
- * - The `md-subheader` directive uses the [$mdSticky](api/service/$mdSticky) service to make the
- * subheader sticky.
+ * - The `md-subheader` directive uses the <a ng-href="api/service/$mdSticky">$mdSticky</a> service
+ * to make the subheader sticky.
  *
  * > Whenever the current browser doesn't support stickiness natively, the subheader
  * will be compiled twice to create a sticky clone of the subheader.

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -36,8 +36,8 @@ angular.module('material.components.virtualRepeat', [
  *
  * <!-- This comment forces a break between blockquotes //-->
  *
- * > Please also review the [VirtualRepeat](api/directive/mdVirtualRepeat) documentation for more
- * information.
+ * > Please also review the <a ng-href="api/directive/mdVirtualRepeat">VirtualRepeat</a>
+ * documentation for more information.
  *
  *
  * @usage
@@ -429,8 +429,8 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
  * Track by, as alias, and (key, value) syntax are not supported.
  *
  * > <b>Note:</b> Please also review the
- *   [VirtualRepeatContainer](api/directive/mdVirtualRepeatContainer) documentation for more
- *   information.
+ *   <a ng-href="api/directive/mdVirtualRepeatContainer">VirtualRepeatContainer</a> documentation
+ *   for more information.
  *
  * @usage
  * <hljs lang="html">


### PR DESCRIPTION
Dgeni shows a warning when it cannot find the correct link files. Since we are using an Angular app, the only way I have found around it is to use the `ng-href` attribute so Dgeni ignores them.

Ping @ThomasBurleson for review.