### PR TITLE
fix(theming): fix read-only $mdThemingProvider.configuration()

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -328,10 +328,15 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
     extendPalette: extendPalette,
     theme: registerTheme,
 
+    /**
+     * return a read-only clone of the current theme configuration
+     */
     configuration : function() {
-      // return a read-only clone of the current configuration
-      var locals = { defaultTheme : defaultTheme, alwaysWatchTheme : alwaysWatchTheme };
-      return angular.extend( { }, config, locals );
+      return angular.extend( { }, themeConfig, {
+        defaultTheme : defaultTheme,
+        alwaysWatchTheme : alwaysWatchTheme,
+        registeredStyles : [].concat(themeConfig.registeredStyles)
+      });
     },
 
     /**

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -402,6 +402,44 @@ describe('$mdThemingProvider', function() {
       expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
     });
   })
+
+  describe('configuration', function () {
+    beforeEach(function () {
+      module('material.core', function($mdThemingProvider) {
+            themingProvider = $mdThemingProvider;
+      });
+      startAngular();
+    });
+
+    it('should have access to read-only configuration', function () {
+      var config = themingProvider.configuration();
+
+      expect(config.disableTheming).toBe(false);
+      expect(config.generateOnDemand).toBe(false);
+      expect(config.registeredStyles.length).toBe(0);
+      expect(config.nonce).toBe(null);
+      expect(config.alwaysWatchTheme).toBe(false);
+
+      // Change local copies
+      config.disableTheming = true;
+      config.generateOnDemand = true;
+      config.registeredStyles.push("Something");
+      config.nonce = 'myNonce';
+      config.alwaysWatchTheme = true;
+
+      var config2 = themingProvider.configuration();
+
+      // Confirm master versions are not altered
+      expect(config2.disableTheming).toBe(false);
+      expect(config2.generateOnDemand).toBe(false);
+      expect(config2.registeredStyles.length).toBe(0);
+      expect(config2.nonce).toBe(null);
+      expect(config2.alwaysWatchTheme).toBe(false);
+
+    });
+
+
+  })
 });
 
 describe('$mdThemeProvider with custom styles', function() {


### PR DESCRIPTION
*  insure we clone properly the a configuration map object.
*  implement unit test to verify.