### PR TITLE
docs(select): Add note about value/ng-value differences.

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -66,6 +66,9 @@ angular.module('material.components.select', [
  * **Note:** A value of `undefined` ***is considered a valid value*** (and does not auto-apply this
  * attribute) since you may wish this to be your "Not Available" or "None" option.
  *
+ * **Note:** Using the `value` attribute (as opposed to `ng-value`) always evaluates to a string, so
+ * `value="null"` will require the test `ng-if="myValue != 'null'"` rather than `ng-if="!myValue"`.
+ *
  * @param {expression} ng-model The model!
  * @param {boolean=} multiple Whether it's multiple.
  * @param {expression=} md-on-close Expression to be evaluated when the select is closed.


### PR DESCRIPTION
Some users expressed confusion about the fact that the `value` attribute always evaluates to a string as opposed to the `ng-value` attribute which allows any value.

Add a note to the docs to describe the differences and give an example of how to properly use `ng-if` with the `value` attribute.

Fixes #9373.