### PR TITLE
fix: undo change to unknown symbol for prod build

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -130,7 +130,7 @@ function buildModule(module, opts) {
 
   function buildMin() {
     return lazypipe()
-        .pipe(gulpif, /.css$/, cleanCSS(),
+        .pipe(gulpif, /.css$/, minifyCss(),
         uglify({ preserveComments: 'some' })
             .on('error', function(e) {
               console.log('\x07',e.message);


### PR DESCRIPTION
PR #8850 made this change, but it seems unintentional because the symbol `cleanCSS` doesn't exist anywhere.