### PR TITLE
fix(build): properly filter core module files with updated gulp-filter

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -122,9 +122,12 @@ function buildModule(module, opts) {
 
   function splitStream (stream) {
     var js = series(stream, themeBuildStream())
-        .pipe(filter('*.js'))
+        .pipe(filter('**/*.js'))
         .pipe(concat('core.js'));
-    var css = stream.pipe(filter('*.css'));
+
+    var css = stream
+      .pipe(filter(['**/*.css', '!**/ie_fixes.css']))
+
     return series(js, css);
   }
 


### PR DESCRIPTION
* After an update to the new `gulp-filter` major version (without any changelog) 
  it seems that `gulp-filter` can no longer match files (which aren't at the root level)

  This new behavior makes completely sense, and the old one was not valid.

  > Previous Version: `*.css` matches `src/core/core.css | src/core/core-default-theme.css`
  > New Version: `*.css` matches no files, because at the project root are no CSS files.

* Now using multi level globs to match the core module files properly, because those are not at the root level (but `src/core/`).