### PR TITLE
feat(datepicker): add timezone support

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -122,6 +122,10 @@ describe('md-datepicker', function() {
     }).not.toThrow();
   });
 
+  it('should set the element type as "date"', function() {
+    expect(ngElement.attr('type')).toBe('date');
+  });
+
   describe('ngMessages support', function() {
     it('should set the `required` $error flag', function() {
       pageScope.isRequired = true;


### PR DESCRIPTION
Adds the ability to specify the datepicker's timezone via the `ng-model-options` attribute, e.g. for UTC, the element would look like this:

```
<md-datepicker ng-model="date" ng-model-options="{ timezone: 'utc' }"></md-datepicker>
```

This works by re-using the logic from Angular's `input[type="date"]` directive.

Fixes #8448.
Fixes #8936.