### PR TITLE
fix(menu-bar): unable to close menu when clicking on toolbar

### DIFF
--- a/src/components/menuBar/menu-bar.scss
+++ b/src/components/menuBar/menu-bar.scss
@@ -1,9 +1,18 @@
-md-toolbar.md-menu-toolbar {
-  h2.md-toolbar-tools {
-    line-height: 1rem;
-    height: auto;
-    padding: 3.5 * $baseline-grid;
-    padding-bottom: 1.5 * $baseline-grid;
+md-toolbar {
+  &.md-menu-toolbar {
+    h2.md-toolbar-tools {
+      line-height: 1rem;
+      height: auto;
+      padding: 3.5 * $baseline-grid;
+      padding-bottom: 1.5 * $baseline-grid;
+    }
+  }
+
+  // Used to allow hovering from one menu to the
+  // next when inside of a toolbar.
+  &.md-has-open-menu {
+    position: relative;
+    z-index: $z-index-menu;
   }
 }
 

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -25,6 +25,32 @@ describe('material.components.menuBar', function() {
         expect(nestedMenu.getAttribute('md-position-mode')).toBe('left bottom');
       });
 
+      it('should close when clicking on the wrapping toolbar', inject(function($compile, $rootScope, $timeout) {
+        var ctrl = null;
+        var toolbar = $compile(
+          '<md-toolbar>' +
+            '<md-menu-bar>' +
+              '<md-menu ng-repeat="i in [1, 2, 3]">' +
+                '<button ng-click></button>' +
+                '<md-menu-content></md-menu-content>' +
+              '</md-menu>' +
+            '</md-menu-bar>' +
+          '</md-toolbar>'
+        )($rootScope);
+
+        $rootScope.$digest();
+        ctrl = toolbar.find('md-menu-bar').controller('mdMenuBar');
+
+        toolbar.find('md-menu').eq(0).controller('mdMenu').open();
+        $timeout.flush();
+
+        expect(toolbar).toHaveClass('md-has-open-menu');
+        toolbar.triggerHandler('click');
+
+        expect(toolbar).not.toHaveClass('md-has-open-menu');
+        expect(ctrl.getOpenMenuIndex()).toBe(-1);
+      }));
+
       describe('ARIA', function() {
 
         it('sets role="menubar" on the menubar', function() {


### PR DESCRIPTION
fix(menu-bar): unable to close menu when clicking on toolbar

* Fixes not being able to close a toolbar menu by clicking on the wrapping toolbar. Works by adding an extra click handler on the toolbar that closes the menu. Note that the same effect could be achieved by removing the `z-index` altogether, but that could break the functionality that allows users to jump from one menu to the next without clicking.
* Moves the menu bar's z-index to CSS so it's easier to manage.
* Adds call to `disableOpenOnHover` when the scope is destroyed, in order to clean up leftover event handlers.

Fixes #8965.

Cheers to @topherfangio for catching a potentially breaking error.