### PR TITLE
fix(datepicker): improved overlay positioning

### DIFF
--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -60,12 +60,18 @@
     }
   }
 
-  .md-datepicker-open .md-datepicker-input-container,
-  .md-datepicker-input-mask-opaque {
-    background: '{{background-hue-1}}';
-  }
-
   .md-datepicker-calendar {
     background: '{{background-A100}}';
+  }
+
+  $mask-color: '{{background-hue-1}}';
+
+  // The box-shadow acts as the background for the overlay.
+  .md-datepicker-input-mask-opaque {
+    box-shadow: 0 0 0 9999px $mask-color;
+  }
+
+  .md-datepicker-open .md-datepicker-input-container {
+    background: $mask-color;
   }
 }

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -53,6 +53,7 @@ md-datepicker {
   @include md-flat-input();
   min-width: 120px;
   max-width: $md-calendar-width - $md-datepicker-button-gap;
+  padding: 0 0 $md-datepicker-border-bottom-gap;
 }
 
 // If the datepicker is inside of a md-input-container
@@ -94,7 +95,6 @@ md-datepicker {
   // Position relative in order to absolutely position the down-triangle button within.
   position: relative;
 
-  padding-bottom: $md-datepicker-border-bottom-gap;
   border-bottom-width: 1px;
   border-bottom-style: solid;
 
@@ -139,27 +139,14 @@ md-datepicker {
 
 // Portion of the floating panel that sits, invisibly, on top of the input.
 .md-datepicker-input-mask {
-  // It needs to be 1px shorter because of the datepicker-input-container's bottom border,
-  // which can cause a slight hole in the mask when it's inside a md-input-container.
-  height: $md-datepicker-input-mask-height - 1px;
+  height: $md-datepicker-input-mask-height;
   width: $md-calendar-width;
   position: relative;
+  overflow: hidden;
 
   background: transparent;
   pointer-events: none;
   cursor: text;
-}
-
-.md-datepicker-input-mask-opaque {
-  position: absolute;
-  right: 0;
-  left: 120px;
-  height: 100%;
-
-  // The margin pulls it an extra pixel to the left, which gives it a slight overlap
-  // with the input container. This ensures that there are no gaps between the two
-  // elements.
-  margin-left: -1px;
 }
 
 // The calendar portion of the floating pane (vs. the input mask).
@@ -231,26 +218,8 @@ md-datepicker[disabled] {
 .md-datepicker-open {
   overflow: hidden;
 
-  .md-datepicker-input-container {
-    // The negative bottom margin prevents the content around the datepicker
-    // from jumping when it gets opened.
-    margin-bottom: -$md-datepicker-border-bottom-gap;
-  }
-
-  .md-icon-button + .md-datepicker-input-container {
-    @include rtl-prop(margin-left, margin-right, -$md-datepicker-button-gap, auto);
-  }
-
-  .md-datepicker-input,
-  label:not(.md-no-float):not(.md-container-ignore) {
-    margin-bottom: -$md-datepicker-border-bottom-gap;
-  }
-
-  // This needs some extra specificity in order to override
-  // the focused/invalid border colors.
-  input.md-datepicker-input {
-    @include rtl-prop(margin-left, margin-right, 24px, auto);
-    height: $md-datepicker-input-mask-height;
+  .md-datepicker-input-container,
+  input.md-input {
     border-bottom-color: transparent;
   }
 

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -382,7 +382,7 @@ describe('md-datepicker', function() {
       $timeout.flush();
 
       expect(controller.calendarPane.offsetHeight).toBeGreaterThan(0);
-      expect(controller.inputMask.style.left).toBe(controller.inputContainer.clientWidth + 'px');
+      expect(controller.inputMask[0].style.left).toBeTruthy();
 
       // Click off of the calendar.
       document.body.click();
@@ -499,7 +499,8 @@ describe('md-datepicker', function() {
       var triggerRect = controller.inputContainer.getBoundingClientRect();
 
       // We expect the offset to be close to the exact height, because on IE there are some deviations.
-      expect(paneRect.top).toBeCloseTo(triggerRect.top, 0.5);
+      expect(controller.topMargin).toBeGreaterThan(0);
+      expect(paneRect.top).toBeCloseTo(triggerRect.top - controller.topMargin, 0.5);
 
       // Restore body to pre-test state.
       body.removeChild(superLongElement);


### PR DESCRIPTION
The current approach for positioning the datepicker's calendar works by expanding the input container in order to fill a gap in the floating calendar pane and using negative margins to prevent the UI from jumping around. This comes with some drawbacks:
* It causes the input element to shift down slightly when the calendar gets opened.
* It can shift all of the elements surrounding the datepicker, despite the negative margins.
* It makes it hard to refactor the positioning.

This new approach solves all of the above-mentioned issues by using an element with a box-shadow to create the overlay, avoiding the need for expanding the container.

Referencing #9342.

### Comprasion:
#### Current approach:
![current](https://cloud.githubusercontent.com/assets/4450522/18028666/3b3a2072-6c85-11e6-8098-f114dc87a1f2.gif)

#### New approach:
![new](https://cloud.githubusercontent.com/assets/4450522/18028670/431f4b6e-6c85-11e6-8bef-1e8e98136d4a.gif)

