### PR TITLE
feat(sticky): new sticky polyfill

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -41,7 +41,7 @@ md-list {
   display: block;
   padding: $list-padding-top $list-padding-right $list-padding-bottom $list-padding-left;
 
-  .md-subheader {
+  md-subheader {
     font-size: $body-font-size-base;
     font-weight: 500;
     letter-spacing: 0.010em;

--- a/src/components/subheader/demoBasicUsage/index.html
+++ b/src/components/subheader/demoBasicUsage/index.html
@@ -1,9 +1,5 @@
 <div ng-controller="SubheaderAppCtrl" layout="column" flex layout-fill ng-cloak>
 
-  <md-toolbar md-scroll-shrink>
-    <div class="md-toolbar-tools">My Messages</div>
-  </md-toolbar>
-
   <md-content style="height: 600px;" md-theme="altTheme">
 
     <section>

--- a/src/components/subheader/subheader-theme.scss
+++ b/src/components/subheader/subheader-theme.scss
@@ -1,13 +1,16 @@
-.md-subheader.md-THEME_NAME-theme {
+md-subheader.md-THEME_NAME-theme {
+
   color: '{{ foreground-2-0.23 }}';
   background-color: '{{background-default}}';
 
   &.md-primary {
     color: '{{primary-color}}'
   }
+
   &.md-accent {
     color: '{{accent-color}}'
   }
+
   &.md-warn {
     color: '{{warn-color}}'
   }

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -52,63 +52,31 @@ angular
  * </hljs>
  */
 
-function MdSubheaderDirective($mdSticky, $compile, $mdTheming, $mdUtil) {
+function MdSubheaderDirective($mdSticky, $mdTheming, $$rAF) {
   return {
     restrict: 'E',
-    replace: true,
     transclude: true,
-    template: (
-    '<div class="md-subheader _md">' +
-    '  <div class="md-subheader-inner">' +
-    '    <div class="md-subheader-content"></div>' +
-    '  </div>' +
-    '</div>'
-    ),
-    link: function postLink(scope, element, attr, controllers, transclude) {
+    template: '<div ng-transclude></div>',
+    link: function postLink(scope, element) {
       $mdTheming(element);
       element.addClass('_md');
 
-      // Remove the ngRepeat attribute from the root element, because we don't want to compile
-      // the ngRepeat for the sticky clone again.
-      $mdUtil.prefixer().removeAttribute(element, 'ng-repeat');
-
-      var outerHTML = element[0].outerHTML;
-
-      function getContent(el) {
-        return angular.element(el[0].querySelector('.md-subheader-content'));
-      }
-
-      // Transclude the user-given contents of the subheader
-      // the conventional way.
-      transclude(scope, function(clone) {
-        getContent(element).append(clone);
-      });
-
-      // Create another clone, that uses the outer and inner contents
-      // of the element, that will be 'stickied' as the user scrolls.
       if (!element.hasClass('md-no-sticky')) {
-        transclude(scope, function(clone) {
-          // If the user adds an ng-if or ng-repeat directly to the md-subheader element, the
-          // compiled clone below will only be a comment tag (since they replace their elements with
-          // a comment) which cannot be properly passed to the $mdSticky; so we wrap it in our own
-          // DIV to ensure we have something $mdSticky can use
-          var wrapper = $compile('<div class="md-subheader-wrapper">' + outerHTML + '</div>')(scope);
-
-          // Delay initialization until after any `ng-if`/`ng-repeat`/etc has finished before
-          // attempting to create the clone
-          $mdUtil.nextTick(function() {
-            // Append our transcluded clone into the wrapper.
-            // We don't have to recompile the element again, because the clone is already
-            // compiled in it's transclusion scope. If we recompile the outerHTML of the new clone, we would lose
-            // our ngIf's and other previous registered bindings / properties.
-            getContent(wrapper).append(clone);
-          });
-
-          // Make the element sticky and provide the stickyClone our self, to avoid recompilation of the subheader
-          // element.
-          $mdSticky(scope, element, wrapper);
-        });
+        $$rAF(onElementReady);
       }
+
+      /**
+       * Wait for the element to be visible in the DOM.
+       * The element may be invisible due to the router or ng-cloak.
+       */
+      function onElementReady() {
+        if (!element[0].offsetParent) {
+          $$rAF(onElementReady);
+        } else {
+          $mdSticky(element);
+        }
+      }
+
     }
   };
 }

--- a/src/components/subheader/subheader.scss
+++ b/src/components/subheader/subheader.scss
@@ -1,67 +1,23 @@
-$subheader-line-height: 1em !default;
-$subheader-font-size: rem(1.4) !default;
-$subheader-padding: ($baseline-grid * 2) !default;
-$subheader-font-weight: 500 !default;
-$subheader-margin: 0 0 0 0 !default;
-$subheader-sticky-shadow: 0px 2px 4px 0 rgba(0,0,0,0.16) !default;
+$md-subheader-line-height: 1em !default;
+$md-subheader-font-size: rem(1.4) !default;
+$md-subheader-padding: ($baseline-grid * 2) !default;
+$md-subheader-font-weight: 500 !default;
+$md-subheader-margin: 0 0 0 0 !default;
 
-@keyframes subheaderStickyHoverIn {
-  0% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-  100% {
-    box-shadow: $subheader-sticky-shadow;
-  }
-}
-@keyframes subheaderStickyHoverOut {
-  0% {
-    box-shadow: $subheader-sticky-shadow;
-  }
-  100% {
-    box-shadow: 0 0 0 0 transparent;
-  }
-}
-
-.md-subheader-wrapper {
-
-  &:not(.md-sticky-no-effect) {
-    .md-subheader {
-      margin: 0;
-    }
-
-    transition: 0.2s ease-out margin;
-
-    &.md-sticky-clone {
-      z-index: 2;
-    }
-
-    &[sticky-state="active"] {
-      margin-top: -2px;
-    }
-
-    &:not(.md-sticky-clone)[sticky-prev-state="active"] .md-subheader-inner:after {
-      animation: subheaderStickyHoverOut 0.3s ease-out both;
-    }
-  }
-
-}
-
-.md-subheader {
-  display: block;
-  font-size: $subheader-font-size;
-  font-weight: $subheader-font-weight;
-  line-height: $subheader-line-height;
-  margin: $subheader-margin;
+md-subheader {
   position: relative;
+  display: block;
 
-  .md-subheader-inner {
-    display: block;
-    padding: $subheader-padding;
-  }
+  box-sizing: border-box;
+  width: 100%;
 
-  .md-subheader-content {
-    display: block;
-    z-index: 1;
-    position: relative;
-  }
+  z-index: 2;
+  top: 0;
+
+  font-size: $md-subheader-font-size;
+  font-weight: $md-subheader-font-weight;
+  line-height: $md-subheader-line-height;
+
+  margin: $md-subheader-margin;
+  padding: $md-subheader-padding;
 }


### PR DESCRIPTION
* New sticky polyfill which follows the w3c specification draft
* High performance due to reduced scroll listeners and DOM recalculations
* Fixed position polyfill, takes care of smooth scrolling and no shaking.
* Advanced API for developers (manually trigger update / recalculation)
* New directive for making elements sticky
* No clone elements anymore (fixes all ng-repeat, ng-if and scope issues)
* Means that there is no recompilation anymore (no 2x initialized directives)

---

**This is still in progress and not ready for review**
**FYI**: Tests for the subheader will fail (no extra efforts while having open points)

There are two issues with the position fixed
- [ ] Sticky elements can leave Parent Boundary (extra coordinate system?)
- [ ] Calculations are incorrect if the sticky element is already in an extra coordinate system?