### PR TITLE
fix(autocomplete): properly run animation for dialog in demo.

### DIFF
--- a/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
+++ b/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
@@ -1,4 +1,5 @@
-<md-dialog aria-label="Autocomplete Dialog Example" ng-cloak>
+<md-dialog aria-label="Autocomplete Dialog Example">
+
   <md-toolbar>
     <div class="md-toolbar-tools">
       <h2>Autocomplete Dialog Example</h2>
@@ -9,7 +10,7 @@
     </div>
   </md-toolbar>
 
-  <md-dialog-content>
+  <md-dialog-content ng-cloak>
     <div class="md-dialog-content">
       <form ng-submit="$event.preventDefault()">
         <p>Use <code>md-autocomplete</code> to search for matches from local or remote data sources.</p>

--- a/src/core/services/layout/layout.js
+++ b/src/core/services/layout/layout.js
@@ -210,7 +210,7 @@
 
   /**
    * Tail-hook ngCloak to delay the uncloaking while Layout transformers
-   * finish processing. Eliminates flicker with Material.Layoouts
+   * finish processing. Eliminates flicker with Material.Layouts
    */
   function buildCloakInterceptor(className) {
     return [ '$timeout', function($timeout){


### PR DESCRIPTION
The autocomplete demo with the dialog currently logs a warning for the `ng-cloak` being present on the dialog template.

  Removing `ng-cloak` removes that warning and also fixes the warning in the console.