### PR TITLE
fix(card): limit img size when using md-card-title-media

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -60,7 +60,8 @@ md-card {
   }
 
   > img,
-  > md-card-header img {
+  > md-card-header img,
+  md-card-title-media img {
     box-sizing: border-box;
     display: flex;
     flex: 0 0 auto;


### PR DESCRIPTION
Use flexbox for img elements when child of md-card-title-media

Fixes #9355