### PR TITLE
chore(build): minify theme template for ng constant

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -229,6 +229,7 @@ function themeBuildStream() {
       .pipe(utils.hoistScssVariables())
       .pipe(sass())
       .pipe(dedupeCss())
+      .pipe(minifyCss())
       .pipe(utils.cssToNgConstant('material.core', '$MD_THEME_CSS'));
 }
 


### PR DESCRIPTION
Now minifies the theme css for the Angular constant.

As discussed:
>- Now minifying the SCSS for the $MD_THEME_CSS constant. (new)
> - Not minifying the SCSS, when exporting a release build for bower-material. (currently)

R: @EladBezalel 

Fixes #9066.