### PR TITLE
fix(tabs): scroll blocks in pagination (related to #5439)

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -333,8 +333,12 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth > totalWidth) break;
     }
-    if (viewportWidth > tab.offsetWidth) ctrl.offsetLeft = fixOffset(tab.offsetLeft);
-    else ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
+    
+    if (viewportWidth > tab.offsetWidth) {
+        ctrl.offsetLeft = fixOffset(tab.offsetLeft);
+    } else {
+        ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
+    }
   }
 
   /**
@@ -347,8 +351,12 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth >= ctrl.offsetLeft) break;
     }
-    if (elements.canvas.clientWidth > tab.offsetWidth) ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
-    else ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
+    
+    if (elements.canvas.clientWidth > tab.offsetWidth) {
+        ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
+    } else {
+        ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
+    }
   }
 
   /**

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -333,7 +333,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth > totalWidth) break;
     }
-    ctrl.offsetLeft = fixOffset(tab.offsetLeft);
+    if (viewportWidth > tab.offsetWidth) ctrl.offsetLeft = fixOffset(tab.offsetLeft);
+    else ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
   }
 
   /**
@@ -346,7 +347,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       tab = elements.tabs[ i ];
       if (tab.offsetLeft + tab.offsetWidth >= ctrl.offsetLeft) break;
     }
-    ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
+    if (elements.canvas.clientWidth > tab.offsetWidth) ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
+    else ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
   }
 
   /**

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -335,9 +335,14 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     }
     
     if (viewportWidth > tab.offsetWidth) {
-        ctrl.offsetLeft = fixOffset(tab.offsetLeft);
+      //Canvas width *greater* than tab width: usual positioning
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft);
     } else {
-        ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
+      /**
+       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let 
+       * pagination "for loop" to proceed correctly on next tab when nextPage() is called again
+       */
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
     }
   }
 
@@ -353,9 +358,14 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     }
     
     if (elements.canvas.clientWidth > tab.offsetWidth) {
-        ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
+      //Canvas width *greater* than tab width: usual positioning
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
     } else {
-        ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
+      /**
+       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let 
+       * pagination "for loop" to break correctly on previous tab when previousPage() is called again
+       */
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
     }
   }
 


### PR DESCRIPTION
Fixes md-tabs scroll blocking happening when single tab is larger than containing canvas (e.g. tabs containing long text elements).