### PR TITLE
fix(util): properly determine viewport top offset

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -122,9 +122,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       styles.bottom    = bot + 'px';
       styles.maxHeight = Math.min(dropdownHeight, hrect.top - root.top - MENU_PADDING) + 'px';
     } else {
+      var bottomSpace = root.bottom - hrect.bottom - MENU_PADDING + $mdUtil.getViewportTop();
+
       styles.top       = (top - offset) + 'px';
       styles.bottom    = 'auto';
-      styles.maxHeight = Math.min(dropdownHeight, root.bottom + $mdUtil.scrollTop() - hrect.bottom - MENU_PADDING) + 'px';
+      styles.maxHeight = Math.min(dropdownHeight, bottomSpace) + 'px';
     }
 
     elements.$.scrollContainer.css(styles);

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1176,8 +1176,11 @@ function MdDialogProvider($$interimElementProvider) {
         height: container.css('height')
       };
 
+      // If the body is fixed, determine the distance to the viewport in relative from the parent.
+      var parentTop = Math.abs(options.parent[0].getBoundingClientRect().top);
+
       container.css({
-        top: (isFixed ? $mdUtil.scrollTop(options.parent) : 0) + 'px',
+        top: (isFixed ? parentTop : 0) + 'px',
         height: height ? height + 'px' : '100%'
       });
 

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -572,7 +572,8 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
 
         function onDrag(ev) {
           if (!isDragging) return;
-          element.css('height', startHeight + (ev.pointer.y - dragStart) - $mdUtil.scrollTop() + 'px');
+
+          element.css('height', (startHeight + ev.pointer.distanceY) + 'px');
         }
 
         function onDragEnd(ev) {

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -223,8 +223,40 @@ describe('util', function() {
         // Restore the scrolling.
         enableScrolling();
         window.scrollTo(0, 0);
-        document.body.removeChild(element[0]);
+
+        element.remove();
       }));
+    });
+
+    describe('getViewportTop', function() {
+
+      it('should properly determine the top offset', inject(function($mdUtil) {
+        var viewportHeight = Math.round(window.innerHeight);
+        var element = angular.element('<div style="height: ' + (viewportHeight * 2) + 'px">');
+
+        document.body.appendChild(element[0]);
+
+        // Scroll down the viewport height.
+        window.scrollTo(0, viewportHeight);
+
+        expect(getViewportTop()).toBe(viewportHeight);
+
+        // Restore the scrolling.
+        window.scrollTo(0, 0);
+
+        expect(getViewportTop()).toBe(0);
+
+        element.remove();
+
+        /*
+         * Round the viewport top offset because the test browser might be resized and
+         * could cause deviations for the test.
+         */
+        function getViewportTop() {
+          return Math.round($mdUtil.getViewportTop());
+        }
+      }));
+
     });
 
     describe('nextTick', function() {


### PR DESCRIPTION
* Properly determines the viewport top offset, without any consistency issues for the `scrollTop`.
* The `scrollTop` method had a wrong name when passing an element, because it resolved the client rects in relative to the viewport.
* Now it determines the viewport top offset from the window (instead of using the body element - this is deprecated)
* Also makes sure that the calculations in the source are not too long (extra variables)

**FYI**: Mostly some cleanup in the `disableBodyScroll` function.

Fixes #9370.