### PR TITLE
fix(input): Ensure animated messages disappear.

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -936,11 +936,15 @@ function ngMessageAnimation($$AnimateRunner, $animateCss, $mdUtil) {
 
   return {
     enter: function(element, done) {
-      return showMessage(element);
+      var animator = showMessage(element);
+
+      animator.start().done(done);
     },
 
     leave: function(element, done) {
-      return hideMessage(element);
+      var animator = hideMessage(element);
+
+      animator.start().done(done);
     }
   }
 }
@@ -998,7 +1002,6 @@ function showMessage(element) {
 function hideMessage(element) {
   var height = element[0].offsetHeight;
   var styles = window.getComputedStyle(element[0]);
-  //var styles = { opacity: element.css('opacity') };
 
   // If we are already hidden, just return an empty animation
   if (styles.opacity == 0) {


### PR DESCRIPTION
After some recent changes to the input animations, the input could get into a state where animated messages were still being shown even if they were invalid.

The underlying issue was that the animation was not calling the `done` function and Angular's animation framework was thus not actually removing the element from the DOM, so any further message animations found the old message in the DOM and attempted to show it.

 - Ensure all input animations properly call the `.done()` method
   which is returned by `$animateCss()`.
 - Update tests to check for `.done()` calls and use a better
   method for flushing the animations.
 - Remove some old/commented code.

Fixes #9454.