### PR TITLE
docs(navbar): Add mdNavBar note to tab docs.

### DIFF
--- a/src/components/tabs/demoDynamicHeight/readme.html
+++ b/src/components/tabs/demoDynamicHeight/readme.html
@@ -1,1 +1,11 @@
-<p>The Dynamic Height demo shows how tabs can be used to display content with varying heights.</p>
+<p>
+  The Dynamic Height demo shows how tabs can be used to display content with varying heights.
+</p>
+
+<p>
+  <i>
+    <b>Note:</b> If you are using the Tabs component for page-level navigation, please take a look
+    at the <a href="./demo/navBar">NavBar component</a> instead as it can handle this case a bit
+    more natively.
+  </i>
+</p>

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -6,9 +6,10 @@
  * @restrict E
  *
  * @description
- * The `<md-tabs>` directive serves as the container for 1..n `<md-tab>` child directives to produces a Tabs components.
- * In turn, the nested `<md-tab>` directive is used to specify a tab label for the **header button** and a [optional] tab view
- * content that will be associated with each tab button.
+ * The `<md-tabs>` directive serves as the container for 1..n `<md-tab>` child directives to
+ * produces a Tabs components. In turn, the nested `<md-tab>` directive is used to specify a tab
+ * label for the **header button** and a [optional] tab view content that will be associated with
+ * each tab button.
  *
  * Below is the markup for its simplest usage:
  *
@@ -26,9 +27,18 @@
  *  2. Tabs with internal view content
  *  3. Tabs with external view content
  *
- * **Tab-only** support is useful when tab buttons are used for custom navigation regardless of any other components, content, or views.
- * **Tabs with internal views** are the traditional usages where each tab has associated view content and the view switching is managed internally by the Tabs component.
- * **Tabs with external view content** is often useful when content associated with each tab is independently managed and data-binding notifications announce tab selection changes.
+ * **Tab-only** support is useful when tab buttons are used for custom navigation regardless of any
+ * other components, content, or views.
+ *
+ * <i><b>Note:</b> If you are using the Tabs component for page-level navigation, please take a look
+ * at the <a ng-href="./api/directive/mdNavBar">NavBar component</a> instead as it can handle this
+ * case a bit more natively.</i>
+ *
+ * **Tabs with internal views** are the traditional usages where each tab has associated view
+ * content and the view switching is managed internally by the Tabs component.
+ *
+ * **Tabs with external view content** is often useful when content associated with each tab is
+ * independently managed and data-binding notifications announce tab selection changes.
  *
  * Additional features also include:
  *


### PR DESCRIPTION
Some users are unaware of the new `<md-nav-bar>` component which can provide a better option for page-level navigation.

 - Update tabs demo and docs to include a note about, and link to,
   the `<md-nav-bar>` component demo & docs.
 - Update some tab docs with proper line wrapping to follow our
   standards.

Fixes #6676