### PR TITLE
docs(): viewport should be not scalable

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -7,7 +7,7 @@
   Angular Material
 </title>
 <link rel="icon" type="image/x-icon" href="favicon.ico" />
-<meta name="viewport" content="initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic">
 <link rel="stylesheet" href="angular-material.min.css">
 <link rel="stylesheet" href="docs.css">


### PR DESCRIPTION
* Normally modern webapp do not allow the developer to zoom into the page on mobile.
  This applies the most common meta tag to the docs page and makes the demos look way better on mobile.

* Components, which have a text input (like datepicker, autocomplete or normal input) no longer zoom in, when clicking on them.

I had a quick chat with @topherfangio about it, and we were not 100% sure, why we didn't apply that meta tag before. 
