### PR TITLE
Bypass click/mouse handlers for any contenteditable elements

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -545,7 +545,7 @@ function attachToDocument( $mdGesture, $$MdGestureHandler ) {
 
   function mouseInputHijacker(ev) {
     var isKeyClick = !ev.clientX && !ev.clientY;
-    if (!isKeyClick && !ev.$material && !ev.isIonicTap
+    if (!isKeyClick && !ev.$material && !ev.isIonicTap && !ev.target.isContentEditable
       && !isInputEventFromLabelClick(ev)) {
       ev.preventDefault();
       ev.stopPropagation();
@@ -554,7 +554,7 @@ function attachToDocument( $mdGesture, $$MdGestureHandler ) {
 
   function clickHijacker(ev) {
     var isKeyClick = ev.clientX === 0 && ev.clientY === 0;
-    if (!isKeyClick && !ev.$material && !ev.isIonicTap
+    if (!isKeyClick && !ev.$material && !ev.isIonicTap && !ev.target.isContentEditable
       && !isInputEventFromLabelClick(ev)) {
       ev.preventDefault();
       ev.stopPropagation();

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -715,6 +715,10 @@ describe('$mdGesture', function() {
         target: el[0]
       });
 
+      expect(spyClick).not.toHaveBeenCalled();
+
+      el.trigger('click');
+
       expect(spyClick).toHaveBeenCalled();
     }));
 
@@ -726,12 +730,20 @@ describe('$mdGesture', function() {
         target: el[0]
       });
 
+      expect(spyMouseDown).not.toHaveBeenCalled();
+
+      el.trigger('mousedown');
+
       expect(spyMouseDown).toHaveBeenCalled();
 
       $document.triggerHandler({
         type: 'mouseup',
         target: el[0]
       });
+
+      expect(spyMouseUp).not.toHaveBeenCalled();
+
+      el.trigger('mouseup');
 
       expect(spyMouseUp).toHaveBeenCalled();
     }));

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -717,7 +717,7 @@ describe('$mdGesture', function() {
 
       expect(spyClick).not.toHaveBeenCalled();
 
-      el.trigger('click');
+      el.triggerHandler('click');
 
       expect(spyClick).toHaveBeenCalled();
     }));
@@ -732,7 +732,7 @@ describe('$mdGesture', function() {
 
       expect(spyMouseDown).not.toHaveBeenCalled();
 
-      el.trigger('mousedown');
+      el.triggerHandler('mousedown');
 
       expect(spyMouseDown).toHaveBeenCalled();
 
@@ -743,7 +743,7 @@ describe('$mdGesture', function() {
 
       expect(spyMouseUp).not.toHaveBeenCalled();
 
-      el.trigger('mouseup');
+      el.triggerHandler('mouseup');
 
       expect(spyMouseUp).toHaveBeenCalled();
     }));

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -690,13 +690,16 @@ describe('$mdGesture', function() {
 
   describe('contenteditable', function() {
 
-    // Click tests should only be enabled when `$$hijackClicks == true` (for mobile)
-
     it('should not hijack click on contenteditable element', inject(function($document, $mdGesture) {
       var spy = jasmine.createSpy('click');
       var el = angular.element('<div contenteditable>');
 
       el.on('click', spy);
+
+      $document.triggerHandler({
+        type: 'click',
+        target: el[0]
+      });
 
       expect(spy).toHaveBeenCalled();
     }));
@@ -707,9 +710,20 @@ describe('$mdGesture', function() {
       var el = angular.element('<div contenteditable>');
 
       el.on('mousedown', spy1);
+      el.on('mouseup', spy2);
+
+      $document.triggerHandler({
+        type: 'mousedown',
+        target: el[0]
+      });
+
       expect(spy1).toHaveBeenCalled();
 
-      el.on('mouseup', spy2);
+      $document.triggerHandler({
+        type: 'mouseup',
+        target: el[0]
+      });
+
       expect(spy2).toHaveBeenCalled();
     }));
 

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -704,10 +704,6 @@ describe('$mdGesture', function() {
         el.on('click', spyClick);
         el.on('mousedown', spyMouseDown);
         el.on('mouseup', spyMouseUp);
-
-        $mdGesture.register(el, 'click');
-        $mdGesture.register(el, 'mousedown');
-        $mdGesture.register(el, 'mouseup');
       });
     });
 

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -690,45 +690,54 @@ describe('$mdGesture', function() {
 
   describe('contenteditable', function() {
 
+    var spyClick, spyMouseDown, spyMouseUp;
+    var el;
+
+    beforeEach(function() {
+      inject(function($mdGesture) {
+        spyClick = jasmine.createSpy('click');
+        spyMouseDown = jasmine.createSpy('mousedown');
+        spyMouseUp = jasmine.createSpy('mouseup');
+
+        el = angular.element('<div contenteditable="true">');
+
+        el.on('click', spyClick);
+        el.on('mousedown', spyMouseDown);
+        el.on('mouseup', spyMouseUp);
+
+        $mdGesture.register(el, 'click');
+        $mdGesture.register(el, 'mousedown');
+        $mdGesture.register(el, 'mouseup');
+      });
+    });
+
     it('should not hijack click on contenteditable element', inject(function($document, $mdGesture) {
       $document.triggerHandler('$$mdGestureReset');
-
-      var spy = jasmine.createSpy('click');
-      var el = angular.element('<div contenteditable="true">');
-
-      el.on('click', spy);
 
       $document.triggerHandler({
         type: 'click',
         target: el[0]
       });
 
-      expect(spy).toHaveBeenCalled();
+      expect(spyClick).toHaveBeenCalled();
     }));
 
     it('should not hijack mousedown/mouseup on contenteditable element', inject(function($document, $mdGesture) {
       $document.triggerHandler('$$mdGestureReset');
-
-      var spy1 = jasmine.createSpy('mousedown');
-      var spy2 = jasmine.createSpy('mouseup');
-      var el = angular.element('<div contenteditable="true">');
-
-      el.on('mousedown', spy1);
-      el.on('mouseup', spy2);
 
       $document.triggerHandler({
         type: 'mousedown',
         target: el[0]
       });
 
-      expect(spy1).toHaveBeenCalled();
+      expect(spyMouseDown).toHaveBeenCalled();
 
       $document.triggerHandler({
         type: 'mouseup',
         target: el[0]
       });
 
-      expect(spy2).toHaveBeenCalled();
+      expect(spyMouseUp).toHaveBeenCalled();
     }));
 
   });

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -688,4 +688,36 @@ describe('$mdGesture', function() {
 
   });
 
+  describe('contenteditable', function() {
+
+    // Click tests should only be enabled when `$$hijackClicks == true` (for mobile)
+
+    it('should not hijack click on contenteditable element', inject(function($document, $mdGesture) {
+      if ( $mdGesture.$$hijackClicks ) {
+        var spy = jasmine.createSpy('click');
+        var el = angular.element('<div contenteditable>');
+
+        el.on('click', spy);
+
+        expect(spy).toHaveBeenCalled();
+      }
+
+    }));
+
+    it('should not hijack mousedown/mouseup on contenteditable element', inject(function($document, $mdGesture) {
+      if ( $mdGesture.$$hijackClicks ) {
+        var spy1 = jasmine.createSpy('mousedown');
+        var spy2 = jasmine.createSpy('mouseup');
+        var el = angular.element('<div contenteditable>');
+
+        el.on('mousedown', spy1);
+        expect(spy1).toHaveBeenCalled();
+
+        el.on('mouseup', spy2);
+        expect(spy2).toHaveBeenCalled();
+      }
+
+    }));
+
+  });
 });

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -693,30 +693,24 @@ describe('$mdGesture', function() {
     // Click tests should only be enabled when `$$hijackClicks == true` (for mobile)
 
     it('should not hijack click on contenteditable element', inject(function($document, $mdGesture) {
-      if ( $mdGesture.$$hijackClicks ) {
-        var spy = jasmine.createSpy('click');
-        var el = angular.element('<div contenteditable>');
+      var spy = jasmine.createSpy('click');
+      var el = angular.element('<div contenteditable>');
 
-        el.on('click', spy);
+      el.on('click', spy);
 
-        expect(spy).toHaveBeenCalled();
-      }
-
+      expect(spy).toHaveBeenCalled();
     }));
 
     it('should not hijack mousedown/mouseup on contenteditable element', inject(function($document, $mdGesture) {
-      if ( $mdGesture.$$hijackClicks ) {
-        var spy1 = jasmine.createSpy('mousedown');
-        var spy2 = jasmine.createSpy('mouseup');
-        var el = angular.element('<div contenteditable>');
+      var spy1 = jasmine.createSpy('mousedown');
+      var spy2 = jasmine.createSpy('mouseup');
+      var el = angular.element('<div contenteditable>');
 
-        el.on('mousedown', spy1);
-        expect(spy1).toHaveBeenCalled();
+      el.on('mousedown', spy1);
+      expect(spy1).toHaveBeenCalled();
 
-        el.on('mouseup', spy2);
-        expect(spy2).toHaveBeenCalled();
-      }
-
+      el.on('mouseup', spy2);
+      expect(spy2).toHaveBeenCalled();
     }));
 
   });

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -747,6 +747,5 @@ describe('$mdGesture', function() {
 
       expect(spyMouseUp).toHaveBeenCalled();
     }));
-
   });
 });

--- a/src/core/services/gesture/gesture.spec.js
+++ b/src/core/services/gesture/gesture.spec.js
@@ -691,8 +691,10 @@ describe('$mdGesture', function() {
   describe('contenteditable', function() {
 
     it('should not hijack click on contenteditable element', inject(function($document, $mdGesture) {
+      $document.triggerHandler('$$mdGestureReset');
+
       var spy = jasmine.createSpy('click');
-      var el = angular.element('<div contenteditable>');
+      var el = angular.element('<div contenteditable="true">');
 
       el.on('click', spy);
 
@@ -705,9 +707,11 @@ describe('$mdGesture', function() {
     }));
 
     it('should not hijack mousedown/mouseup on contenteditable element', inject(function($document, $mdGesture) {
+      $document.triggerHandler('$$mdGestureReset');
+
       var spy1 = jasmine.createSpy('mousedown');
       var spy2 = jasmine.createSpy('mouseup');
-      var el = angular.element('<div contenteditable>');
+      var el = angular.element('<div contenteditable="true">');
 
       el.on('mousedown', spy1);
       el.on('mouseup', spy2);


### PR DESCRIPTION
Fixes issues #9414 and #5937.  I can't see any reason why ngMaterial would need to hijack clicks for elements that have contenteditable attribute set.