### PR TITLE
fix(util): getClosest not working on elements with lowercase nodeName

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -510,7 +510,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       if ( angular.isString(validateWith) ) {
         var tagName = validateWith.toUpperCase();
         validateWith = function(el) {
-          return el.nodeName === tagName;
+          return el.nodeName.toUpperCase() === tagName;
         };
       }
 
@@ -776,18 +776,18 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
       function scrollChunk() {
         var newPosition = calculateNewPosition();
-        
+
         element.scrollTop = newPosition;
-        
+
         if (scrollingDown ? newPosition < scrollEnd : newPosition > scrollEnd) {
           $$rAF(scrollChunk);
         }
       }
-      
+
       function calculateNewPosition() {
         var duration = 1000;
         var currentTime = $mdUtil.now() - startTime;
-        
+
         return ease(currentTime, scrollStart, scrollChange, duration);
       }
 
@@ -797,7 +797,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         if (currentTime > duration) {
           return start + change;
         }
-        
+
         var ts = (currentTime /= duration) * currentTime;
         var tc = ts * currentTime;
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -503,7 +503,7 @@ describe('util', function() {
       })
     );
   });
-  
+
   describe('isParentFormSubmitted', function() {
     var formTemplate =
       '<form>' +
@@ -514,26 +514,26 @@ describe('util', function() {
     it('returns false if you pass no element', inject(function($mdUtil) {
       expect($mdUtil.isParentFormSubmitted()).toBe(false);
     }));
-    
+
     it('returns false if there is no form', inject(function($mdUtil) {
       var element = angular.element('<input />');
-      
+
       expect($mdUtil.isParentFormSubmitted(element)).toBe(false);
     }));
-    
-    it('returns false if the parent form is NOT submitted', inject(function($compile, $rootScope, $mdUtil) { 
+
+    it('returns false if the parent form is NOT submitted', inject(function($compile, $rootScope, $mdUtil) {
       var scope = $rootScope.$new();
       var form = $compile(formTemplate)(scope);
-      
+
       expect($mdUtil.isParentFormSubmitted(form.find('input'))).toBe(false);
     }));
-    
+
     it('returns true if the parent form is submitted', inject(function($compile, $rootScope, $mdUtil) {
       var scope = $rootScope.$new();
       var form = $compile(formTemplate)(scope);
 
       var formController = form.controller('form');
-      
+
       formController.$setSubmitted();
 
       expect(formController.$submitted).toBe(true);
@@ -615,6 +615,15 @@ describe('util', function() {
       expect(result).toBe(grandparent[0]);
 
       grandparent.remove();
+    });
+
+    it('should be able to handle nodes whose nodeName is lowercase', function() {
+      var parent = angular.element('<svg version="1.1"></svg>');
+      var element = angular.element('<circle/>');
+
+      parent.append(element);
+      expect($mdUtil.getClosest(element, 'svg')).toBeTruthy();
+      parent.remove();
     });
   });
 });


### PR DESCRIPTION
Fixes the `$mdUtil.getClosest` method not working properly when looking for elements with a lowercase `nodeName` (e.g. SVG).

Fixes #9509.