### PR TITLE
feat(compiler): pass $element to controller instantiation

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -61,7 +61,7 @@ function mdCompilerService($q, $templateRequest, $injector, $compile, $controlle
     *   - `link` - `{function(scope)}`: A link function, which, when called, will compile
     *     the element and instantiate the provided controller (if given).
     *   - `locals` - `{object}`: The locals which will be passed into the controller once `link` is
-    *     called. If `bindToController` is true, they will be coppied to the ctrl instead
+    *     called. If `bindToController` is true, they will be copied to the ctrl instead
     *   - `bindToController` - `bool`: bind the locals to the controller, instead of passing them in.
     */
   this.compile = function(options) {
@@ -112,12 +112,19 @@ function mdCompilerService($q, $templateRequest, $injector, $compile, $controlle
         link: function link(scope) {
           locals.$scope = scope;
 
-          //Instantiate controller if it exists, because we have scope
+          // Instantiate controller if it exists, because we have scope
           if (controller) {
-            var invokeCtrl = $controller(controller, locals, true, controllerAs);
+
+            var ctrlLocals = angular.extend(locals, {
+              $element: element
+            });
+
+            var invokeCtrl = $controller(controller, ctrlLocals, true, controllerAs);
+
             if (bindToController) {
               angular.extend(invokeCtrl.instance, locals);
             }
+
             var ctrl = invokeCtrl();
             //See angular-route source for this logic
             element.data('$ngControllerController', ctrl);

--- a/src/core/services/compiler/compiler.spec.js
+++ b/src/core/services/compiler/compiler.spec.js
@@ -132,6 +132,22 @@ describe('$mdCompiler service', function() {
         expect(data.element.controller().injectedOne).toBe(1);
       }));
 
+      it('should instantiate the controller with $element as local', inject(function($rootScope) {
+        var ctrlElement = null;
+
+        var data = compile({
+          template: '<span>hello</span>',
+          controller: function Ctrl($scope, $element) {
+            ctrlElement = $element;
+          }
+        });
+
+        var scope = $rootScope.$new();
+        data.link(scope);
+
+        expect(ctrlElement).toBe(data.element);
+      }));
+
       it('should compile with controllerAs', inject(function($rootScope) {
         var data = compile({
           template: '<span>hello</span>',


### PR DESCRIPTION
* Pass the `$element` local to the instantiated controller, as same as a normal Angular 1.x DDO.

Closes #9507.