### PR TITLE
perf(chips,navbar,tooltip): avoid extra DOM lookups

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -193,7 +193,7 @@ MdChipsCtrl.prototype.updateChipContents = function(chipIndex, chipContents){
  * @return {boolean}
  */
 MdChipsCtrl.prototype.isEditingChip = function() {
-  return !!this.$element[0].getElementsByClassName('_md-chip-editing').length;
+  return !!this.$element[0].querySelector('._md-chip-editing');
 };
 
 
@@ -215,7 +215,7 @@ MdChipsCtrl.prototype.isRemovable = function() {
 MdChipsCtrl.prototype.chipKeydown = function (event) {
   if (this.getChipBuffer()) return;
   if (this.isEditingChip()) return;
-  
+
   switch (event.keyCode) {
     case this.$mdConstant.KEY_CODE.BACKSPACE:
     case this.$mdConstant.KEY_CODE.DELETE:

--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -185,7 +185,7 @@ function MdNavBarController($element, $scope, $timeout, $mdConstant) {
  * @private
  */
 MdNavBarController.prototype._initTabs = function() {
-  this._inkbar = angular.element(this._navBarEl.getElementsByTagName('md-nav-ink-bar')[0]);
+  this._inkbar = angular.element(this._navBarEl.querySelector('md-nav-ink-bar'));
 
   var self = this;
   this._$timeout(function() {

--- a/src/components/sticky/sticky.spec.js
+++ b/src/components/sticky/sticky.spec.js
@@ -26,7 +26,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].querySelector('.md-sticky-clone');
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(scope);
@@ -68,7 +68,7 @@ describe('$mdSticky service', function() {
       } else {
         expect(contentEl.children().length).toBe(2);
 
-        var stickyClone = contentEl[0].getElementsByClassName('md-sticky-clone')[0];
+        var stickyClone = contentEl[0].querySelector('.md-sticky-clone');
         expect(stickyClone).toBeTruthy();
 
         expect(angular.element(stickyClone).scope()).toBe(cloneScope);

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -67,7 +67,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $mdUtil, $mdThe
     $mdTheming(element);
 
     var parent        = $mdUtil.getParentWithPointerEvents(element),
-        content       = angular.element(element[0].getElementsByClassName('md-content')[0]),
+        content       = angular.element(element[0].querySelector('.md-content')),
         tooltipParent = angular.element(document.body),
         showTimeout   = null,
         debouncedOnResize = $$rAF.throttle(function () { updatePosition(); });

--- a/src/core/services/layout/layout.spec.js
+++ b/src/core/services/layout/layout.spec.js
@@ -3,14 +3,14 @@ describe("Layout API ", function() {
   describe("can be globally disabled with 'md-layouts-disabled' ", function() {
     var disableLayouts = angular.noop,
         activateLayouts = function() {
-          var el = document.getElementsByTagName('body')[0];
+          var el = document.body;
               el.removeAttribute('md-layouts-disabled');
 
           disableLayouts(false);
         };
 
     beforeEach(function() {
-      var el = document.getElementsByTagName('body')[0];
+      var el = document.body;
           el.setAttribute('md-layouts-disabled', '');
 
       // Load the core module

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -582,12 +582,12 @@ describe('$mdThemeProvider with disabled themes', function() {
   describe('can disable themes declaratively', function() {
     beforeEach(function() {
       // Set the body attribute BEFORE the theming module is loaded
-      var el = document.getElementsByTagName('body')[0];
+      var el = document.body;
           el.setAttribute('md-themes-disabled', '');
     });
 
     afterEach(function() {
-      var el = document.getElementsByTagName('body')[0];
+      var el = document.body;
           el.removeAttribute('md-themes-disabled');
     });
 


### PR DESCRIPTION
The chips, navbar and tooltip had a few cases where they look up all the elements of a certain class or node name, but they only use the first one. This change switches to using `querySelector` which will stop looking after the first match.