### PR TITLE
fix(chips): no longer throw an error when returning focus to input.

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1139,6 +1139,43 @@ describe('<md-chips>', function() {
           expect(scope.items[4]).toBe('Acai Berry');
           expect(element.find('input').val()).toBe('');
         }));
+
+        it('should remove a chip on click and return focus to the input', function() {
+
+          var template =
+            '<md-chips ng-model="items" md-max-chips="1">' +
+              '<md-autocomplete ' +
+                  'md-selected-item="selectedItem" ' +
+                  'md-search-text="searchText" ' +
+                  'md-items="item in querySearch(searchText)" ' +
+                  'md-item-text="item">' +
+                '<span md-highlight-text="searchText">{{itemtype}}</span>' +
+              '</md-autocomplete>' +
+            '</md-chips>';
+
+          setupScopeForAutocomplete();
+
+          var element = buildChips(template);
+
+          document.body.appendChild(element[0]);
+
+          // Flush the autocomplete's init timeout.
+          $timeout.flush();
+
+          var input = element.find('input');
+          var removeButton = element[0].querySelector('.md-chip-remove');
+
+          expect(scope.items.length).toBe(3);
+
+          angular.element(removeButton).triggerHandler('click');
+
+          $timeout.flush();
+
+          expect(scope.items.length).toBe(2);
+          expect(document.activeElement).toBe(input[0]);
+
+          element.remove();
+        });
       });
 
       describe('user input templates', function() {

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -29,6 +29,9 @@ function MdChipsCtrl ($scope, $attrs, $mdConstant, $log, $element, $timeout, $md
   /** @type {angular.$scope} */
   this.parent = $scope.$parent;
 
+  /** @type {$mdUtil} */
+  this.$mdUtil = $mdUtil;
+
   /** @type {$log} */
   this.$log = $log;
 


### PR DESCRIPTION
* An error will be thrown if the chips component is used in combination with an autocomplete.
  It did not make the chips unuseable, the chips just didn't return the focus to the input element.

Fixes #9520.