### PR TITLE
update(css): components should use rem font-sizes

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,5 +1,7 @@
 // The default item height is also specified in the JavaScript.
 $md-autocomplete-item-height: 48px !default;
+$md-autocomplete-button-font-size: rem(1.2) !default;
+$md-autocomplete-dropdown-font-size: rem(1.4) !default;
 
 @keyframes md-autocomplete-list-out {
   0% {
@@ -140,7 +142,7 @@ md-autocomplete {
     border: none;
     border-radius: 50%;
     padding: 0;
-    font-size: 12px;
+    font-size: $md-autocomplete-button-font-size;
     background: transparent;
     margin: auto 5px;
     &:after {
@@ -215,7 +217,7 @@ md-autocomplete {
   padding: 0;
 
   li {
-    font-size: 14px;
+    font-size: $md-autocomplete-dropdown-font-size;
     overflow: hidden;
     padding: 0 15px;
     line-height: $md-autocomplete-item-height;

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -1,5 +1,7 @@
 $card-padding: 16px !default;
 $card-box-shadow: $whiteframe-shadow-1dp !default;
+$card-title-font-size: rem(1.4) !default;
+$card-subhead-font-size: rem(1.4) !default;
 
 md-card {
   box-sizing: border-box;
@@ -43,7 +45,7 @@ md-card {
         max-height: 40px;
 
         .md-title {
-          font-size: 14px;
+          font-size: $card-title-font-size;
         }
       }
     }
@@ -54,7 +56,7 @@ md-card {
       flex-direction: column;
 
       .md-subhead {
-        font-size: 14px;
+        font-size: $card-subhead-font-size;
       }
     }
   }
@@ -86,7 +88,7 @@ md-card {
 
       .md-subhead {
         padding-top: 0;
-        font-size: 14px;
+        font-size: $card-subhead-font-size;
       }
 
       &:only-child {

--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -1,4 +1,5 @@
 /** Styles for mdCalendar. */
+$md-calendar-font-size: rem(1.3) !default;
 $md-calendar-cell-size: 44px !default;
 $md-calendar-header-height: 40px !default;
 $md-calendar-cell-emphasis-size: 40px !default;
@@ -6,7 +7,7 @@ $md-calendar-side-padding: 16px !default;
 $md-calendar-weeks-to-show: 7 !default;
 
 $md-calendar-month-label-padding: 8px !default;
-$md-calendar-month-label-font-size: 14px !default;
+$md-calendar-month-label-font-size: rem(1.4) !default;
 
 $md-calendar-scroll-cue-shadow-radius: 6px !default;
 
@@ -50,7 +51,7 @@ $md-calendar-height:
 }
 
 md-calendar {
-  font-size: 13px;
+  font-size: $md-calendar-font-size;
   user-select: none;
 }
 

--- a/src/components/gridList/grid-list.scss
+++ b/src/components/gridList/grid-list.scss
@@ -1,3 +1,6 @@
+$md-gridlist-title-font-size: rem(1.4) !default;
+$md-gridlist-subtitle-font-size: rem(1.2) !default;
+
 md-grid-list {
   box-sizing: border-box;
   display: block;
@@ -51,11 +54,11 @@ md-grid-list {
       }
 
       h3 {
-        font-size: 14px;
+        font-size: $md-gridlist-title-font-size;
       }
 
       h4 {
-        font-size: 12px;
+        font-size: $md-gridlist-subtitle-font-size;
       }
     }
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -5,6 +5,7 @@ $input-label-default-scale: 1.0 !default;
 $input-label-float-offset: 6px !default;
 $input-label-float-scale: 0.75 !default;
 $input-label-float-width: $input-container-padding + 16px !default;
+$input-label-asterisk-font-size: rem(1.3) !default;
 
 $input-placeholder-offset: $input-label-default-offset !default;
 
@@ -13,7 +14,7 @@ $input-border-width-focused: 2px !default;
 $input-line-height: 26px !default;
 $input-padding-top: 2px !default;
 
-$input-error-font-size: 12px !default;
+$input-error-font-size: rem(1.2) !default;
 $input-error-height: 24px !default;
 $input-error-line-height: $input-error-font-size + 2px !default;
 $error-padding-top: ($input-error-height - $input-error-line-height) / 2 !default;
@@ -105,7 +106,7 @@ md-input-container {
 
     &.md-required:after {
       content: ' *';
-      font-size: 13px;
+      font-size: $input-label-asterisk-font-size;
       vertical-align: top;
     }
   }

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -1,4 +1,5 @@
 $menu-border-radius: 2px !default;
+$menu-item-button-font-size: rem(1.5) !default;
 $max-visible-items: 6 !default;
 $menu-item-height: 6 * $baseline-grid !default;
 $dense-menu-item-height: 4 * $baseline-grid !default;
@@ -102,7 +103,7 @@ md-menu-item {
     display: inline-block;
     border-radius: 0;
     margin: auto 0;
-    font-size: (2*$baseline-grid) - 1;
+    font-size: $menu-item-button-font-size;
     text-transform: none;
     font-weight: 400;
     height: 100%;

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -6,6 +6,10 @@ $select-option-padding: 16px !default;
 $select-container-padding: 16px !default;
 $select-container-transition-duration: 350ms !default;
 
+$select-optgroup-font-size: rem(1.4) !default;
+$select-value-font-size: rem(1.3) !default;
+$select-arrow-icon-font-size: rem(1.2) !default;
+
 $select-max-visible-options: 5 !default;
 
 // Fixes the animations with the floating label when select is inside an input container
@@ -85,7 +89,7 @@ md-input-container:not(.md-input-has-value) {
   md-select[required]:not(.md-no-asterisk), md-select.ng-required:not(.md-no-asterisk) {
     .md-select-value span:first-child:after {
       content: ' *';
-      font-size: 13px;
+      font-size: $select-value-font-size;
       vertical-align: top;
     }
   }
@@ -108,7 +112,7 @@ md-select {
     &.ng-invalid:not(.md-no-asterisk) {
       .md-select-value span:first-child:after {
         content: ' *';
-        font-size: 13px;
+        font-size: $select-value-font-size;
         vertical-align: top;
       }
     }
@@ -194,7 +198,7 @@ md-input-container.md-input-has-value .md-select-value {
     width: 3 * $baseline-grid;
     margin: 0 .5 * $baseline-grid;
     transform: translate3d(0, -2px, 0);
-    font-size: 1.2rem;
+    font-size: $select-arrow-icon-font-size;
   }
 
   .md-select-icon:after {
@@ -203,7 +207,7 @@ md-input-container.md-input-has-value .md-select-value {
     position: relative;
     top: 2px;
     speak: none;
-    font-size: 13px;
+    font-size: $select-value-font-size;
     transform: scaleY(0.5) scaleX(1);
   }
 
@@ -282,7 +286,7 @@ md-optgroup {
   display: block;
   label {
     display: block;
-    font-size: rem(1.4);
+    font-size: $select-optgroup-font-size;
     text-transform: uppercase;
     padding: $baseline-grid * 2;
     font-weight: 500;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -12,6 +12,7 @@ $slider-thumb-focus-scale: 1 !default;
 $slider-thumb-disabled-scale: 0.5 !default;
 $slider-thumb-disabled-border: 4px !default;
 $slider-thumb-focus-duration: .7s !default;
+$slider-thumb-label-font-size: rem(1.2) !default;
 
 $slider-focus-thumb-width:  34px !default;
 $slider-focus-thumb-height: $slider-focus-thumb-width !default;
@@ -199,7 +200,7 @@ md-slider {
 
     .md-thumb-text {
       z-index: 1;
-      font-size: 12px;
+      font-size: $slider-thumb-label-font-size;
       font-weight: bold;
     }
   }
@@ -400,7 +401,7 @@ md-slider {
 
         .md-thumb-text {
           z-index: 1;
-          font-size: 12px;
+          font-size: $slider-thumb-label-font-size;
           font-weight: bold;
         }
       }

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -2,6 +2,9 @@ $tabs-paginator-width: $baseline-grid * 4 !default;
 $tabs-tab-width: $baseline-grid * 12 !default;
 $tabs-header-height: 48px !default;
 
+$tabs-arrow-button-font-size: rem(1.6) !default;
+$tabs-label-font-size: rem(1.4) !default;
+
 @keyframes md-tab-content-hide {
   0% { opacity: 1; }
   50% { opacity: 1; }
@@ -86,7 +89,7 @@ md-tabs-wrapper {
     line-height: 1em;
     z-index: 2;
     cursor: pointer;
-    font-size: 16px;
+    font-size: $tabs-arrow-button-font-size;
     background: transparent no-repeat center center;
     transition: $swift-ease-in-out;
     &:focus {
@@ -248,7 +251,7 @@ md-tab {
 }
 
 .md-tab {
-  font-size: 14px;
+  font-size: $tabs-label-font-size;
   text-align: center;
   line-height: $tabs-header-height - 24;
   padding: 12px 24px;

--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -1,9 +1,10 @@
 // See height set globally, depended on by buttons
 
 $md-toast-content-padding: 3 * $baseline-grid - $button-left-right-padding !default;
+$md-toast-content-font-size: rem(1.4) !default;
+
 $md-toast-button-left-margin: 3 * $baseline-grid - 2 * $button-left-right-padding !default;
 $md-toast-text-padding: $button-left-right-padding !default;
-
 
 .md-toast-text {
   padding: 0 $md-toast-text-padding;
@@ -26,7 +27,7 @@ md-toast {
 
   .md-toast-content {
     display: flex;
-    direction: row;
+    flex-direction: row;
     align-items: center;
 
     max-height: 7 * $toast-height;
@@ -41,7 +42,7 @@ md-toast {
 
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
     border-radius: 2px;
-    font-size: 14px;
+    font-size: $md-toast-content-font-size;
 
     overflow: hidden;
 

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -46,7 +46,7 @@
 // Mixin for a "flat" input that can be used for components that contain an input
 // (datepicker, autocomplete).
 @mixin md-flat-input() {
-  font-size: 14px;
+  font-size: rem(1.4);
 
   box-sizing: border-box;
   border: none;


### PR DESCRIPTION
- The components should use our internal `rem` function to allow developers to globally overwrite the font of all components with a native-like `rem` behavior.
- Also includes extra variables for the font-size instead of hard-coded values, so developer can overwrite a _specific_ font of a component / part.

**FYI**: Ignore the prefixes of the variables. Right now those are just made consistent to the previous ones, but it is planned to prefix everything with `md-`

Closes #9498.
