### PR TITLE
feat(panel): Panel grouping

### DIFF
--- a/src/components/panel/demoBasicUsage/index.html
+++ b/src/components/panel/demoBasicUsage/index.html
@@ -1,4 +1,4 @@
-<div class="demo-md-panel md-padding" ng-controller="BasicDemoCtrl as ctrl">
+<div class="md-padding" ng-controller="BasicDemoCtrl as ctrl">
   <p>
     A panel can be used to create dialogs, menus, and other overlays.
   </p>

--- a/src/components/panel/demoGroups/index.html
+++ b/src/components/panel/demoGroups/index.html
@@ -1,0 +1,46 @@
+<div ng-controller="PanelGroupsCtrl as ctrl" ng-cloak>
+
+  <md-toolbar class="md-accent">
+    <div class="md-toolbar-tools">
+      <md-button
+        class="md-icon-button"
+        aria-label="Settings"
+        ng-click="ctrl.showToolbarMenu($event, ctrl.settings)">
+        <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
+      </md-button>
+      <h2>Toolbar with grouped panels (Maximum open: 2)</h2>
+      <span flex></span>
+      <md-button
+        class="md-icon-button"
+        aria-label="Favorite"
+        ng-click="ctrl.showToolbarMenu($event, ctrl.favorite)">
+        <md-icon md-svg-icon="img/icons/favorite.svg"></md-icon>
+      </md-button>
+      <md-button
+        class="md-icon-button"
+        aria-label="More"
+        ng-click="ctrl.showToolbarMenu($event, ctrl.more)">
+        <md-icon md-svg-icon="img/icons/more_vert.svg"></md-icon>
+      </md-button>
+    </div>
+  </md-toolbar>
+
+  <md-content layout-padding>
+    <p>
+      Panels can be added to a group. Groups are used to configure specific
+      behaviors on multiple panels. To add a panel to a group, use the
+      <code>$mdPanel.newPanelGroup</code> method, or simply add a group name
+      to the configuration object passed into the <code>$mdPanel.create</code>
+      method.
+    </p>
+    <p>
+      Grouping allows for methods to be applied to several panels at once, i.e.
+      closing all panels within the toolbar group, or destroying all panels
+      within a dialog group. With the <code>maxOpen</code> property, you can
+      also limit the number of panels allowed open within a specific group. This
+      can be useful in limiting the number of menu panels allowed open at a
+      time, etc.
+    </p>
+  </md-content>
+
+</div>

--- a/src/components/panel/demoGroups/script.js
+++ b/src/components/panel/demoGroups/script.js
@@ -1,0 +1,88 @@
+(function() {
+  'use strict';
+
+  angular
+    .module('panelGroupsDemo', ['ngMaterial'])
+    .controller('PanelGroupsCtrl', PanelGroupsCtrl)
+    .controller('PanelMenuCtrl', PanelMenuCtrl);
+
+  function PanelGroupsCtrl($mdPanel) {
+    this.settings = {
+      name: 'settings',
+      items: [
+        'Home',
+        'About',
+        'Contact'
+      ]
+    };
+    this.favorite = {
+      name: 'favorite',
+      items: [
+        'Add to Favorites'
+      ]
+    };
+    this.more = {
+      name: 'more',
+      items: [
+        'Account',
+        'Sign Out'
+      ]
+    };
+
+    this.showToolbarMenu = function($event, menu) {
+      var template = '' +
+          '<div class="menu-panel" md-whiteframe="4">' +
+          '  <div class="menu-content">' +
+          '    <div class="menu-item" ng-repeat="item in ctrl.items">' +
+          '      <button class="md-button">' +
+          '        <span>{{item}}</span>' +
+          '      </button>' +
+          '    </div>' +
+          '    <md-divider></md-divider>' +
+          '    <div class="menu-item">' +
+          '      <button class="md-button" ng-click="ctrl.closeMenu()">' +
+          '        <span>Close Menu</span>' +
+          '      </button>' +
+          '    </div>' +
+          '  </div>' +
+          '</div>';
+
+      var position = $mdPanel.newPanelPosition()
+          .relativeTo($event.srcElement)
+          .addPanelPosition(
+            $mdPanel.xPosition.ALIGN_START,
+            $mdPanel.yPosition.BELOW
+          );
+
+      $mdPanel.newPanelGroup('toolbar', {
+        maxOpen: 2
+      });
+
+      var config = {
+        id: 'toolbar_' + menu.name,
+        attachTo: angular.element(document.body),
+        controller: PanelMenuCtrl,
+        controllerAs: 'ctrl',
+        template: template,
+        position: position,
+        panelClass: 'menu-panel-container',
+        locals: {
+          items: menu.items
+        },
+        openFrom: $event,
+        focusOnOpen: false,
+        zIndex: 100,
+        propagateContainerEvents: true,
+        groupName: 'toolbar'
+      };
+
+      $mdPanel.open(config);
+    }
+  }
+
+  function PanelMenuCtrl(mdPanelRef) {
+    this.closeMenu = function() {
+      mdPanelRef && mdPanelRef.close();
+    }
+  }
+})();

--- a/src/components/panel/demoGroups/style.global.css
+++ b/src/components/panel/demoGroups/style.global.css
@@ -1,0 +1,77 @@
+.menu-panel-container {
+  pointer-events: auto;
+}
+
+.menu-panel {
+  width: 256px;
+  background-color: #fff;
+  border-radius: 4px;
+}
+
+.menu-panel .menu-divider {
+  width: 100%;
+  height: 1px;
+  min-height: 1px;
+  max-height: 1px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.menu-panel .menu-content {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+  max-height: 305px;
+  overflow-y: auto;
+  min-width: 256px;
+}
+
+.menu-panel .menu-item {
+  display: flex;
+  flex-direction: row;
+  min-height: 48px;
+  height: 48px;
+  align-content: center;
+  justify-content: flex-start;
+}
+.menu-panel .menu-item > * {
+  width: 100%;
+  margin: auto 0;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.menu-panel .menu-item > a.md-button {
+  padding-top: 5px;
+}
+.menu-panel .menu-item > .md-button {
+  display: inline-block;
+  border-radius: 0;
+  margin: auto 0;
+  font-size: 15px;
+  text-transform: none;
+  font-weight: 400;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+  text-align: left;
+}
+.menu-panel .menu-item > .md-button::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+.menu-panel .menu-item > .md-button md-icon {
+  margin: auto 16px auto 0;
+}
+.menu-panel .menu-item > .md-button p {
+  display: inline-block;
+  margin: auto;
+}
+.menu-panel .menu-item > .md-button span {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+.menu-panel .menu-item > .md-button .md-ripple-container {
+  border-radius: inherit;
+}

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -1059,6 +1059,169 @@ describe('$mdPanel', function() {
     });
   });
 
+  describe('grouping logic:', function() {
+    it('should create a group using the newPanelGroup method', function() {
+      $mdPanel.newPanelGroup('test');
+
+      expect($mdPanel._groups['test']).toExist();
+    });
+
+    it('should create a group using the config option groupName when the ' +
+        'group hasn\'t been created yet', function() {
+          var config = {
+            groupName: 'test'
+          };
+          var panel = $mdPanel.create(config);
+
+          expect($mdPanel._groups['test']).toExist();
+        });
+
+    it('should only create a group once', function() {
+      var config = {
+        groupName: 'test'
+      };
+      var panel = $mdPanel.create(config);
+
+      expect(getNumberOfGroups()).toEqual(1);
+
+      $mdPanel.newPanelGroup('test');
+
+      expect(getNumberOfGroups()).toEqual(1);
+    });
+
+    it('should not create a group using the config option when the group is ' +
+        'already defined', function() {
+          $mdPanel.newPanelGroup('test');
+
+          expect(getNumberOfGroups()).toEqual(1);
+
+          var config = {
+            groupName: 'test'
+          };
+          var panel = $mdPanel.create(config);
+
+          expect(getNumberOfGroups()).toEqual(1);
+        });
+
+    it('should add a panel to a group using the addToGroup method', function() {
+      $mdPanel.newPanelGroup('test');
+      var panel = $mdPanel.create(DEFAULT_CONFIG);
+
+      panel.addToGroup('test');
+      expect(getGroupPanels('test')).toContain(panel);
+    });
+
+    it('should add a panel to a group using the config option groupName',
+        function() {
+          $mdPanel.newPanelGroup('test');
+
+          var config = {
+            groupName: 'test'
+          };
+
+          var panel = $mdPanel.create(config);
+          expect(getGroupPanels('test')).toContain(panel);
+        });
+
+    it('should remove a panel from a group using the removeFromGroup method',
+        function() {
+          $mdPanel.newPanelGroup('test');
+
+          var config = {
+            groupName: 'test'
+          };
+
+          var panel = $mdPanel.create(config);
+
+          panel.removeFromGroup('test');
+          expect(getGroupPanels('test')).not.toContain(panel);
+        });
+
+    it('should remove a panel from a group on panel destroy', function() {
+      $mdPanel.newPanelGroup('test');
+
+      var config = {
+        groupName: 'test'
+      };
+
+      var panel = $mdPanel.create(config);
+
+      panel.destroy();
+      expect(getGroupPanels('test')).not.toContain(panel);
+    });
+
+    it('should set the maximum number of panels allowed open within a group ' +
+        'using the newPanelGroup option', function() {
+          $mdPanel.newPanelGroup('test', {
+            maxOpen: 1
+          });
+
+          expect(getGroupMaxOpen('test')).toEqual(1);
+        });
+
+    it('should set the maximum number of panels allowed open within a group ' +
+        'using the setGroupMaxOpen method', function() {
+          $mdPanel.newPanelGroup('test');
+          $mdPanel.setGroupMaxOpen('test', 1);
+
+          expect(getGroupMaxOpen('test')).toEqual(1);
+        });
+
+    it('should throw if trying to set maxOpen on a group that doesn\'t exist',
+        function() {
+          var expression = function() {
+            $mdPanel.setGroupMaxOpen('test', 1);
+          };
+
+          expect(expression).toThrow();
+        });
+
+    it('should update open panels when a panel is closed', function() {
+      $mdPanel.newPanelGroup('test');
+
+      var config = {
+        groupName: 'test'
+      };
+
+      openPanel(config);
+      flushPanel();
+      expect(getGroupOpenPanels('test')).toContain(panelRef);
+
+      closePanel();
+      flushPanel();
+      expect(getGroupOpenPanels('test')).not.toContain(panelRef);
+    });
+
+    it('should close the first open panel when more than the maximum number ' +
+        'of panels is opened', function() {
+          $mdPanel.newPanelGroup('test', {
+            maxOpen: 2
+          });
+
+          var config = {
+            groupName: 'test'
+          };
+
+          var panel1 = $mdPanel.create(config);
+          var panel2 = $mdPanel.create(config);
+          var panel3 = $mdPanel.create(config);
+
+          panel1.open();
+          flushPanel();
+          expect(panel1.isAttached).toEqual(true);
+
+          panel2.open();
+          panel3.open();
+          flushPanel();
+          expect(panel1.isAttached).toEqual(false);
+          expect(panel2.isAttached).toEqual(true);
+          expect(panel3.isAttached).toEqual(true);
+
+          panel2.close();
+          panel3.close();
+        });
+  });
+
   describe('component logic: ', function() {
     it('should allow templateUrl to specify content', function() {
       var htmlContent = 'Puppies and Unicorns';
@@ -2239,8 +2402,7 @@ describe('$mdPanel', function() {
       spyOn(obj, 'callback');
 
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      flushPanel();
+      callInterceptors('CLOSE');
 
       expect(obj.callback).toHaveBeenCalledWith(panelRef);
     });
@@ -2254,9 +2416,8 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(1));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
-
-      panelRef._callInterceptors(interceptorTypes.CLOSE).then(obj.callback);
-      flushPanel();
+      callInterceptors('CLOSE').then(obj.callback);
+      $rootScope.$apply();
 
       expect(results).toEqual([3, 2, 1]);
       expect(obj.callback).toHaveBeenCalled();
@@ -2280,8 +2441,8 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
 
-      panelRef._callInterceptors(interceptorTypes.CLOSE).catch(obj.callback);
-      flushPanel();
+      callInterceptors('CLOSE').catch(obj.callback);
+      $rootScope.$apply();
 
       expect(results).toEqual([3, 2]);
       expect(obj.callback).toHaveBeenCalled();
@@ -2308,8 +2469,8 @@ describe('$mdPanel', function() {
         return $q.resolve();
       });
 
-      panelRef._callInterceptors(interceptorTypes.CLOSE).catch(obj.callback);
-      flushPanel();
+      callInterceptors('CLOSE').catch(obj.callback);
+      $rootScope.$apply();
 
       expect(obj.callback).toHaveBeenCalled();
     });
@@ -2319,8 +2480,8 @@ describe('$mdPanel', function() {
 
       spyOn(obj, 'callback');
 
-      panelRef._callInterceptors(interceptorTypes.CLOSE).then(obj.callback);
-      flushPanel();
+      callInterceptors('CLOSE').then(obj.callback);
+      $rootScope.$apply();
 
       expect(obj.callback).toHaveBeenCalled();
     });
@@ -2331,8 +2492,8 @@ describe('$mdPanel', function() {
       spyOn(obj, 'callback');
 
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      flushPanel();
+
+      callInterceptors('CLOSE');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
 
@@ -2355,17 +2516,16 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
       panelRef.registerInterceptor('onOpen', obj.otherCallback);
 
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      panelRef._callInterceptors('onOpen');
-      flushPanel();
+      callInterceptors('CLOSE');
+      callInterceptors('onOpen');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
 
       panelRef.removeAllInterceptors();
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      panelRef._callInterceptors('onOpen');
-      flushPanel();
+
+      callInterceptors('CLOSE');
+      callInterceptors('onOpen');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
@@ -2383,17 +2543,16 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
       panelRef.registerInterceptor('onOpen', obj.otherCallback);
 
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      panelRef._callInterceptors('onOpen');
-      flushPanel();
+      callInterceptors('CLOSE');
+      callInterceptors('onOpen');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
 
       panelRef.removeAllInterceptors(interceptorTypes.CLOSE);
-      panelRef._callInterceptors(interceptorTypes.CLOSE);
-      panelRef._callInterceptors('onOpen');
-      flushPanel();
+
+      callInterceptors('CLOSE');
+      callInterceptors('onOpen');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(2);
@@ -2519,5 +2678,32 @@ describe('$mdPanel', function() {
   function flushPanel() {
     $rootScope.$apply();
     $material.flushOutstandingAnimations();
+  }
+
+  function callInterceptors(type) {
+    if (panelRef) {
+      var promise = panelRef._callInterceptors(
+        $mdPanel.interceptorTypes[type] || type
+      );
+
+      flushPanel();
+      return promise;
+    }
+  }
+
+  function getNumberOfGroups() {
+    return Object.keys($mdPanel._groups).length;
+  }
+
+  function getGroupPanels(groupName) {
+    return $mdPanel._groups[groupName].panels;
+  }
+
+  function getGroupOpenPanels(groupName) {
+    return $mdPanel._groups[groupName].openPanels;
+  }
+
+  function getGroupMaxOpen(groupName) {
+    return $mdPanel._groups[groupName].maxOpen;
   }
 });


### PR DESCRIPTION
Panels are now capable of being grouped together by any designation the user sees fit. Grouping allows the user to specify logic for a collection of panels. For instance, all popups in the header can be considered one group with a maximum of one popup open at a time. Dialogs within dialogs are another example of groups. This implementation prevents the panel from storing a ridiculous amount of data in memory or polluting the DOM with several panels. This helps performance and gives the user more flexibility about how to use panels.

Fixes #8971

Ping @ErinCoughlan