### PR TITLE
fix(util): disableScrollAround should not remove disabled scroll mask

### DIFF
--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -210,6 +210,7 @@ describe('util', function() {
     });
 
     describe('disableScrollAround', function() {
+
       it('should prevent scrolling of the passed element', inject(function($mdUtil) {
         var element = angular.element('<div style="height: 2000px">');
         document.body.appendChild(element[0]);
@@ -226,6 +227,24 @@ describe('util', function() {
 
         element.remove();
       }));
+
+      it('should not remove the element when being use as scorll mask', inject(function($mdUtil) {
+        var element = angular.element('<div>');
+
+        document.body.appendChild(element[0]);
+
+        var enableScrolling = $mdUtil.disableScrollAround(element, null, {
+          disableScrollMask: true
+        });
+
+        // Restore the scrolling.
+        enableScrolling();
+
+        expect(element[0].parentNode).toBeTruthy();
+
+        element.remove();
+      }));
+
     });
 
     describe('getViewportTop', function() {


### PR DESCRIPTION
* When the scroll mask is disabled per the new options which were recently added, the specified element will be used as scroll mask (under the hood)
  If restoring scroll, the scroll mask will be removed from the DOM (even the disabled one) - This is invalid.

This causes an issue when restoring the scroll, while the element is still showing up (e.g dialog with z-index)

@ThomasBurleson Also I need to correct my self, the issue within the `$mdPanel` is not reproducable (**but present**), because the element will be anyways detached by the panel.

Part of #9256 