### PR TITLE
docs(mdPanel): fix formatting

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -26,7 +26,7 @@ angular
  * @usage
  * <hljs lang="js">
  * (function(angular, undefined) {
- *   ‘use strict’;
+ *   'use strict';
  *
  *   angular
  *       .module('demoApp', ['ngMaterial'])
@@ -64,11 +64,9 @@ angular
  *         });
  *   }
  *
- *   function DialogController(MdPanelRef, toppings) {
- *     var toppings;
- *
+ *   function DialogController(MdPanelRef) {
  *     function closeDialog() {
- *       MdPanelRef && MdPanelRef.close();
+ *       if (MdPanelRef) MdPanelRef.close();
  *     }
  *   }
  * })(angular);
@@ -528,8 +526,10 @@ angular
  * xPosition must be one of the following values available on
  * $mdPanel.xPosition:
  *
+ *
  * CENTER | ALIGN_START | ALIGN_END | OFFSET_START | OFFSET_END
  *
+ * <pre>
  *    *************
  *    *           *
  *    *   PANEL   *
@@ -542,12 +542,14 @@ angular
  * C: CENTER
  * D: ALIGN_END (for LTR displays)
  * E: OFFSET_END (for LTR displays)
+ * </pre>
  *
  * yPosition must be one of the following values available on
  * $mdPanel.yPosition:
  *
  * CENTER | ALIGN_TOPS | ALIGN_BOTTOMS | ABOVE | BELOW
  *
+ * <pre>
  *   F
  *   G *************
  *     *           *
@@ -561,6 +563,7 @@ angular
  * H: CENTER
  * I: ALIGN_BOTTOMS
  * J: ABOVE
+ * </pre>
  *
  * @param {string} xPosition
  * @param {string} yPosition


### PR DESCRIPTION
70c146f:
* Use constant-width formatting for the position guides:
![image](https://cloud.githubusercontent.com/assets/469365/18399115/6422d7f0-7684-11e6-92b8-9b8c132e480f.png)
(compare with https://material.angularjs.org/latest/api/type/MdPanelPosition#addPanelPosition)

f8c0b31:
* Fix the smart quotes around `use strict`.
* Remove unused `toppings` variable/parameter.
* Avoid escaping problem (`&amp;`) by slightly changing syntax.

Note: this file is checked in to github with CRLF line endings. I did not fix that.