### PR TITLE
chore(panel): fix failing unit test

### DIFF
--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -675,14 +675,10 @@ describe('$mdPanel', function() {
       spyOn($mdUtil, 'disableScrollAround').and.callThrough();
 
       openPanel(config);
-
       expect(PANEL_EL).toExist();
-      expect(SCROLL_MASK_CLASS).toExist();
-
+      expect(SCROLL_MASK_CLASS).not.toExist();
       closePanel();
 
-      var scrollMaskEl = $rootEl[0].querySelector(SCROLL_MASK_CLASS);
-      expect(scrollMaskEl).not.toExist();
       expect($mdUtil.disableScrollAround).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
When running the panel tests separately from all the others, the one about disabling scrolling was failing. This wasn't happening when running it together with all the other components, because some other component (not sure exactly which one, but it seemed like either dialog or autocomplete) wasn't cleaning up the DOM properly and was leaving a scroll mask lying around.

This change removes the DOM lookup for the scroll mask, because it looks like it got disabled in PR #8901, however the test didn't get updated.

@bradrich can you confirm that this is desired behaviour? 