### PR TITLE
fix(autocomplete): two specs leak the scroll mask element

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -914,7 +914,7 @@ describe('<md-autocomplete>', function() {
     }));
 
     it('removes the md-scroll-mask on cleanup', inject(function($mdUtil, $timeout, $material) {
-      spyOn($mdUtil, 'enableScrolling');
+      spyOn($mdUtil, 'enableScrolling').and.callThrough();
 
       var scope = createScope();
       var template =
@@ -957,7 +957,7 @@ describe('<md-autocomplete>', function() {
     }));
 
     it('removes the md-scroll-mask when md-autocomplete removed on change', inject(function($mdUtil, $timeout, $material) {
-      spyOn($mdUtil, 'enableScrolling');
+      spyOn($mdUtil, 'enableScrolling').and.callThrough();
 
       var scope = createScope();
       var template =

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -675,14 +675,10 @@ describe('$mdPanel', function() {
       spyOn($mdUtil, 'disableScrollAround').and.callThrough();
 
       openPanel(config);
-
       expect(PANEL_EL).toExist();
-      expect(SCROLL_MASK_CLASS).toExist();
-
+      expect(SCROLL_MASK_CLASS).not.toExist();
       closePanel();
 
-      var scrollMaskEl = $rootEl[0].querySelector(SCROLL_MASK_CLASS);
-      expect(scrollMaskEl).not.toExist();
       expect($mdUtil.disableScrollAround).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
* The scroll mask was not removed by two specs of the autocomplete and could cause unexpected issues in other suites, when setting focus on those.