### PR TITLE
feat(panel): add interceptors API and onClose hook

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -355,6 +355,47 @@ angular
  * @param {!MdPanelPosition} position
  */
 
+/**
+ * @ngdoc method
+ * @name MdPanelRef#registerInterceptor
+ * @description
+ *
+ * Registers an interceptor with the panel. The callback should return a promise,
+ * which will allow the action to continue when it gets resolved, or will
+ * prevent an action if it is rejected. The interceptors are called sequentially
+ * and it reverse order. `type` must be one of the following
+ * values available on `$mdPanel.interceptorTypes`:
+ * * `CLOSE` - Gets called before the panel begins closing.
+ *
+ * @param {string} type Type of interceptor.
+ * @param {!angular.$q.Promise<any>} callback Callback to be registered.
+ * @returns {!MdPanelRef}
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#removeInterceptor
+ * @description
+ *
+ * Removes a registered interceptor.
+ *
+ * @param {string} type Type of interceptor to be removed.
+ * @param {function(): !angular.$q.Promise<any>} callback Interceptor to be removed.
+ * @returns {!MdPanelRef}
+ */
+
+/**
+ * @ngdoc method
+ * @name MdPanelRef#removeAllInterceptors
+ * @description
+ *
+ * Removes all interceptors. If a type is supplied, only the
+ * interceptors of that type will be cleared.
+ *
+ * @param {string=} type Type of interceptors to be removed.
+ * @returns {!MdPanelRef}
+ */
+
 
 /*****************************************************************************
  *                               MdPanelPosition                            *
@@ -740,6 +781,12 @@ function MdPanelService($rootElement, $rootScope, $injector, $window) {
    * @type {enum}
    */
   this.yPosition = MdPanelPosition.yPosition;
+
+  /**
+   * Possible values for the interceptors that can be registered on a panel.
+   * @type {enum}
+   */
+  this.interceptorTypes = MdPanelRef.interceptorTypes;
 }
 
 
@@ -909,7 +956,18 @@ function MdPanelRef(config, $injector) {
 
   /** @private {Function?} */
   this._restoreScroll = null;
+
+  /**
+   * Keeps track of all the panel interceptors.
+   * @private {!Object}
+   */
+  this._interceptors = Object.create(null);
 }
+
+
+MdPanelRef.interceptorTypes = {
+  CLOSE: 'onClose'
+};
 
 
 /**
@@ -941,13 +999,15 @@ MdPanelRef.prototype.close = function() {
   var self = this;
 
   return this._$q(function(resolve, reject) {
-    var done = self._done(resolve, self);
-    var detach = self._simpleBind(self.detach, self);
+    self._callInterceptors(MdPanelRef.interceptorTypes.CLOSE).then(function() {
+      var done = self._done(resolve, self);
+      var detach = self._simpleBind(self.detach, self);
 
-    self.hide()
-        .then(detach)
-        .then(done)
-        .catch(reject);
+      self.hide()
+          .then(detach)
+          .then(done)
+          .catch(reject);
+    }, reject);
   });
 };
 
@@ -1039,6 +1099,7 @@ MdPanelRef.prototype.detach = function() {
 MdPanelRef.prototype.destroy = function() {
   this.config.scope.$destroy();
   this.config.locals = null;
+  this._interceptors = null;
 };
 
 
@@ -1634,6 +1695,106 @@ MdPanelRef.prototype._animateClose = function() {
     animationConfig.animateClose(self.panelEl)
         .then(done, warnAndClose);
   });
+};
+
+/**
+ * Registers a interceptor with the panel. The callback should return a promise,
+ * which will allow the action to continue when it gets resolved, or will
+ * prevent an action if it is rejected.
+ * @param {string} type Type of interceptor.
+ * @param {!angular.$q.Promise<!any>} callback Callback to be registered.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.registerInterceptor = function(type, callback) {
+  var error = null;
+
+  if (!angular.isString(type)) {
+    error = 'Interceptor type must be a string, instead got ' + typeof type;
+  } else if (!angular.isFunction(callback)) {
+    error = 'Interceptor callback must be a function, instead got ' + typeof callback;
+  }
+
+  if (error) {
+    throw new Error('MdPanel: ' + error);
+  }
+
+  var interceptors = this._interceptors[type] = this._interceptors[type] || [];
+
+  if (interceptors.indexOf(callback) === -1) {
+    interceptors.push(callback);
+  }
+
+  return this;
+};
+
+/**
+ * Removes a registered interceptor.
+ * @param {string} type Type of interceptor to be removed.
+ * @param {Function} callback Interceptor to be removed.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.removeInterceptor = function(type, callback) {
+  var index = this._interceptors[type] ?
+    this._interceptors[type].indexOf(callback) : -1;
+
+  if (index > -1) {
+    this._interceptors[type].splice(index, 1);
+  }
+
+  return this;
+};
+
+
+/**
+ * Removes all interceptors.
+ * @param {string=} type Type of interceptors to be removed.
+ *     If ommited, all interceptors types will be removed.
+ * @returns {!MdPanelRef}
+ */
+MdPanelRef.prototype.removeAllInterceptors = function(type) {
+  if (type) {
+    this._interceptors[type] = [];
+  } else {
+    this._interceptors = Object.create(null);
+  }
+
+  return this;
+};
+
+
+/**
+ * Invokes all the interceptors of a certain type sequantially in
+ *     reverse order. Works in a similar way to `$q.all`, except it
+ *     respects the order of the functions.
+ * @param {string} type Type of interceptors to be invoked.
+ * @returns {!angular.$q.Promise<!MdPanelRef>}
+ * @private
+ */
+MdPanelRef.prototype._callInterceptors = function(type) {
+  var self = this;
+  var $q = self._$q;
+  var interceptors = self._interceptors && self._interceptors[type] || [];
+
+  return interceptors.reduceRight(function(promise, interceptor) {
+    var isPromiseLike = interceptor && angular.isFunction(interceptor.then);
+    var response = isPromiseLike ? interceptor : null;
+
+    /**
+    * For interceptors to reject/cancel subsequent portions of the chain, simply
+    * return a `$q.reject(<value>)`
+    */
+    return promise.then(function() {
+      if (!response) {
+        try {
+          response = interceptor(self);
+        } catch(e) {
+          response = $q.reject(e);
+        }
+      }
+
+     return response;
+    });
+  }, $q.resolve(self));
 };
 
 

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2147,6 +2147,213 @@ describe('$mdPanel', function() {
     });
   });
 
+  describe('interceptor logic: ', function() {
+    var interceptorTypes;
+
+    beforeEach(function() {
+      interceptorTypes = $mdPanel.interceptorTypes;
+      openPanel();
+    });
+
+    it('should throw when registering an interceptor without a type', function() {
+      expect(function() {
+        panelRef.registerInterceptor();
+      }).toThrowError('MdPanel: Interceptor type must be a string, instead got undefined');
+    });
+
+    it('should throw when registering an interceptor without a callback', function() {
+      expect(function() {
+        panelRef.registerInterceptor(interceptorTypes.CLOSE);
+      }).toThrowError('MdPanel: Interceptor callback must be a function, instead got undefined');
+    });
+
+    it('should execute the registered interceptors', function() {
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
+      callInteceptors('CLOSE');
+
+      expect(obj.callback).toHaveBeenCalledWith(panelRef);
+    });
+
+    it('should execute the interceptors in reverse order', function() {
+      var results = [];
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(1));
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
+
+      callInteceptors('CLOSE').then(obj.callback);
+      $rootScope.$apply();
+
+      expect(results).toEqual([3, 2, 1]);
+      expect(obj.callback).toHaveBeenCalled();
+
+      function makePromise(value) {
+        return function() {
+          return $q.resolve().then(function() {
+            results.push(value);
+          });
+        };
+      }
+    });
+
+    it('should reject and break the chain if one of the promises is rejected', function() {
+      var results = [];
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(1, true));
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
+
+      callInteceptors('CLOSE').catch(obj.callback);
+      $rootScope.$apply();
+
+      expect(results).toEqual([3, 2]);
+      expect(obj.callback).toHaveBeenCalled();
+
+      function makePromise(value, shouldFail) {
+        return function() {
+          return shouldFail ? $q.reject() : $q.resolve().then(function() {
+            results.push(value);
+          });
+        };
+      }
+    });
+
+    it('should reject if one of the interceptors throws', function() {
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, function() {
+        throw new Error('Something went wrong.');
+      });
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, function() {
+        return $q.resolve();
+      });
+
+      callInteceptors('CLOSE').catch(obj.callback);
+      $rootScope.$apply();
+
+      expect(obj.callback).toHaveBeenCalled();
+    });
+
+    it('should resolve if the interceptor queue is empty', function() {
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      callInteceptors('CLOSE').then(obj.callback);
+      $rootScope.$apply();
+
+      expect(obj.callback).toHaveBeenCalled();
+    });
+
+    it('should remove individual interceptors', function() {
+      var obj = { callback: function() {} };
+
+      spyOn(obj, 'callback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
+      callInteceptors('CLOSE');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+
+      panelRef.removeInterceptor(interceptorTypes.CLOSE, obj.callback);
+      panelRef._callInterceptors('CLOSE');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove all interceptors', function() {
+      var obj = {
+        callback: function() {},
+        otherCallback: function() {}
+      };
+
+      spyOn(obj, 'callback');
+      spyOn(obj, 'otherCallback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
+      panelRef.registerInterceptor('onOpen', obj.otherCallback);
+
+      callInteceptors('CLOSE');
+      callInteceptors('onOpen');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+      expect(obj.otherCallback).toHaveBeenCalledTimes(1);
+
+      panelRef.removeAllInterceptors();
+      callInteceptors('CLOSE');
+      callInteceptors('onOpen');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+      expect(obj.otherCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should remove all interceptors of a certain type', function() {
+      var obj = {
+        callback: function() {},
+        otherCallback: function() {}
+      };
+
+      spyOn(obj, 'callback');
+      spyOn(obj, 'otherCallback');
+
+      panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
+      panelRef.registerInterceptor('onOpen', obj.otherCallback);
+
+      callInteceptors('CLOSE');
+      callInteceptors('onOpen');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+      expect(obj.otherCallback).toHaveBeenCalledTimes(1);
+
+      panelRef.removeAllInterceptors(interceptorTypes.CLOSE);
+      callInteceptors('CLOSE');
+      callInteceptors('onOpen');
+
+      expect(obj.callback).toHaveBeenCalledTimes(1);
+      expect(obj.otherCallback).toHaveBeenCalledTimes(2);
+    });
+
+    describe('CLOSE interceptor', function() {
+      it('should prevent the panel from closing when the handler is rejected',
+        function() {
+          panelRef.registerInterceptor(interceptorTypes.CLOSE, function() {
+            return $q.reject();
+          });
+
+          expect(panelRef.isAttached).toBe(true);
+
+          closePanel();
+
+          expect(panelRef.isAttached).toBe(true);
+        });
+
+      it('should allow the panel to close when the handler resolves', function() {
+        panelRef.registerInterceptor(interceptorTypes.CLOSE, function() {
+          return $q.when();
+        });
+
+        expect(panelRef.isAttached).toBe(true);
+
+        closePanel();
+
+        expect(panelRef.isAttached).toBe(false);
+      });
+    });
+  });
+
   /**
    * Attached an element to document.body. Keeps track of attached elements
    * so that they can be removed in an afterEach.
@@ -2238,5 +2445,16 @@ describe('$mdPanel', function() {
   function flushPanel() {
     $rootScope.$apply();
     $material.flushOutstandingAnimations();
+  }
+
+  function callInteceptors(type) {
+    if (panelRef) {
+      var promise = panelRef._callInterceptors(
+        $mdPanel.interceptorTypes[type] || type
+      );
+
+      flushPanel();
+      return promise;
+    }
   }
 });


### PR DESCRIPTION
* Adds an API that can be used for registering interceptors on the panel.
* Adds support for an `onClose` interceptor that allows the user to prevent a panel from closing.

Fixes #9557.