### PR TITLE
fix(switch): invalid container margin in RTL

### DIFF
--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -44,7 +44,7 @@ md-switch {
     height: $switch-height;
     position: relative;
     user-select: none;
-    @include rtl-prop(margin-right, margin-left, 8px, auto);
+    @include rtl-prop(margin-right, margin-left, 8px, 0px);
     float: left;
   }
 


### PR DESCRIPTION
* The switch does not properly display in RTL mode - this is due to the recent changes to the RTL mixin, which introduced a reset value.
* Inside of the switch the container should have a 0px reset value

| Before | After |
| ------ | ------ |
|
![image](https://cloud.githubusercontent.com/assets/4987015/18448692/5247af9c-792c-11e6-96f6-26cf73a7153f.png) | ![image](https://cloud.githubusercontent.com/assets/4987015/18448693/5561a962-792c-11e6-8b09-c8ac5db087d0.png) | 

