### PR TITLE
fix(menu-bar): nested menus not closing when clicking on the toolbar

### DIFF
--- a/src/components/menuBar/js/menuBarController.js
+++ b/src/components/menuBar/js/menuBarController.js
@@ -249,12 +249,8 @@ MenuBarController.prototype.handleParentClick = function(event) {
   var openMenu = this.querySelector('md-menu.md-open');
 
   if (openMenu && !openMenu.contains(event.target)) {
-    angular.element(openMenu).controller('mdMenu').close();
+    angular.element(openMenu).controller('mdMenu').close(true, {
+      closeAll: true
+    });
   }
 };
-
-
-
-
-
-

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -27,6 +27,7 @@ describe('material.components.menuBar', function() {
 
       it('should close when clicking on the wrapping toolbar', inject(function($compile, $rootScope, $timeout, $material) {
         var ctrl = null;
+        var menuCtrl = null;
         var toolbar = $compile(
           '<md-toolbar>' +
             '<md-menu-bar>' +
@@ -42,16 +43,22 @@ describe('material.components.menuBar', function() {
         attachedMenuElements.push(toolbar); // ensure it gets cleaned up
 
         ctrl = toolbar.find('md-menu-bar').controller('mdMenuBar');
+        menuCtrl = toolbar.find('md-menu').eq(0).controller('mdMenu');
 
-        toolbar.find('md-menu').eq(0).controller('mdMenu').open();
+        menuCtrl.open();
         $timeout.flush();
 
         expect(toolbar).toHaveClass('md-has-open-menu');
+        spyOn(menuCtrl, 'close').and.callThrough();
+
         toolbar.triggerHandler('click');
         $material.flushInterimElement(); // flush out the scroll mask
 
         expect(toolbar).not.toHaveClass('md-has-open-menu');
         expect(ctrl.getOpenMenuIndex()).toBe(-1);
+        expect(menuCtrl.close).toHaveBeenCalledWith(true, {
+          closeAll: true
+        });
       }));
 
       describe('ARIA', function() {


### PR DESCRIPTION
Fixes nested menus not getting closed properly when the user clicks on the toolbar.

Fixes #9599.