### PR TITLE
chore(): remove old git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "material-icons"]
-	path = material-icons
-	url = https://github.com/angular/material-icons.git


### PR DESCRIPTION
Removes the old Git submodule for Material Icons, which is not used anywhere.