### PR TITLE
fix(chips): Add basic accessibility support.

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html ng-app="docsApp" ng-controller="DocsCtrl" lang="en" ng-strict-di >
+<html ng-app="docsApp" ng-controller="DocsCtrl" lang="en" ng-strict-di>
 <head>
 <base href="/">
 <title ng-bind="'Angular Material - ' + menu.currentSection.name +
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="angular-material.min.css">
 <link rel="stylesheet" href="docs.css">
 </head>
-<body class="docs-body" layout="row" ng-cloak>
+<body class="docs-body" layout="row" ng-cloak aria-label="Angular Material Docs">
 
   <md-sidenav class="site-sidenav md-sidenav-left md-whiteframe-z2"
               md-component-id="left" hide-print

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -9,6 +9,7 @@ describe('<md-contact-chips>', function() {
           md-contact-email="email"\
           md-highlight-flags="i"\
           md-min-length="1"\
+          md-chip-append-delay="2000"\
           placeholder="To">\
       </md-contact-chips>';
 
@@ -62,6 +63,13 @@ describe('<md-contact-chips>', function() {
       var ctrl = element.controller('mdContactChips');
 
       expect(ctrl.highlightFlags).toEqual('i');
+    });
+
+    it('forwards the md-chips-append-delay attribute to the md-chips', function() {
+      var element = buildChips(CONTACT_CHIPS_TEMPLATE);
+      var chipsCtrl = element.find('md-chips').controller('mdChips');
+
+      expect(chipsCtrl.chipAppendDelay).toEqual(2000);
     });
 
     it('renders an image element for contacts with an image property', function() {

--- a/src/components/chips/demoBasicUsage/index.html
+++ b/src/components/chips/demoBasicUsage/index.html
@@ -5,7 +5,7 @@
 
     <form name="fruitForm">
       <md-chips ng-model="ctrl.roFruitNames" name="fruitName" readonly="ctrl.readonly"
-                md-removable="ctrl.removable" md-max-chips="5">
+                md-removable="ctrl.removable" md-max-chips="5" placeholder="Enter a fruit...">
         <md-chip-template>
           <strong>{{$chip}}</strong>
           <em>(fruit)</em>

--- a/src/components/chips/demoBasicUsage/readme.html
+++ b/src/components/chips/demoBasicUsage/readme.html
@@ -1,0 +1,10 @@
+<p>
+  <b>Note:</b> Version 1.1.2 drastically improves keyboard and screen reader accessibility for the
+  <code>md-chips</code> component. In order to achieve this, the behavior has changed to also select
+  and highlight the newly appended chip for <code>300ms</code> before re-focusing the text input.
+</p>
+
+<p>
+  Please see the <a href="api/directive/mdChips">documentation</a> for more information and for
+  the new <code>md-chip-append-delay</code> option which allows you to customize this delay.
+</p>

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -1,5 +1,14 @@
 (function () {
   'use strict';
+
+  // If we do not have CryptoJS defined; import it
+  if (typeof CryptoJS == 'undefined') {
+    var cryptoSrc = '//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/md5.js';
+    var scriptTag = document.createElement('script');
+    scriptTag.setAttribute('src', cryptoSrc);
+    document.body.appendChild(scriptTag);
+  }
+
   angular
       .module('contactChipsDemo', ['ngMaterial'])
       .controller('ContactChipDemoCtrl', DemoCtrl);
@@ -7,7 +16,7 @@
   function DemoCtrl ($q, $timeout) {
     var self = this;
     var pendingSearch, cancelSearch = angular.noop;
-    var cachedQuery, lastSearch;
+    var lastSearch;
 
     self.allContacts = loadContacts();
     self.contacts = [self.allContacts[0]];
@@ -21,8 +30,7 @@
      * Search for contacts; use a random delay to simulate a remote call
      */
     function querySearch (criteria) {
-      cachedQuery = cachedQuery || criteria;
-      return cachedQuery ? self.allContacts.filter(createFilterFor(cachedQuery)) : [];
+      return criteria ? self.allContacts.filter(createFilterFor(criteria)) : [];
     }
 
     /**
@@ -30,7 +38,6 @@
      * Also debounce the queries; since the md-contact-chips does not support this
      */
     function delayedQuerySearch(criteria) {
-      cachedQuery = criteria;
       if ( !pendingSearch || !debounceSearch() )  {
         cancelSearch();
 
@@ -39,7 +46,7 @@
           cancelSearch = reject;
           $timeout(function() {
 
-            resolve( self.querySearch() );
+            resolve( self.querySearch(criteria) );
 
             refreshDebounce();
           }, Math.random() * 500, true)
@@ -72,7 +79,7 @@
       var lowercaseQuery = angular.lowercase(query);
 
       return function filterFn(contact) {
-        return (contact._lowername.indexOf(lowercaseQuery) != -1);;
+        return (contact._lowername.indexOf(lowercaseQuery) != -1);
       };
 
     }
@@ -92,10 +99,13 @@
 
       return contacts.map(function (c, index) {
         var cParts = c.split(' ');
+        var email = cParts[0][0].toLowerCase() + '.' + cParts[1].toLowerCase() + '@example.com';
+        var hash = CryptoJS.MD5(email);
+
         var contact = {
           name: c,
-          email: cParts[0][0].toLowerCase() + '.' + cParts[1].toLowerCase() + '@example.com',
-          image: 'http://lorempixel.com/50/50/people?' + index
+          email: email,
+          image: '//www.gravatar.com/avatar/' + hash + '?s=50&d=retro'
         };
         contact._lowername = contact.name.toLowerCase();
         return contact;

--- a/src/components/chips/js/contactChipsController.js
+++ b/src/components/chips/js/contactChipsController.js
@@ -18,17 +18,10 @@ function MdContactChipsCtrl () {
 
 
 MdContactChipsCtrl.prototype.queryContact = function(searchText) {
-  var results = this.contactQuery({'$query': searchText});
-  return this.filterSelected ?
-      results.filter(angular.bind(this, this.filterSelectedContacts)) : results;
+  return this.contactQuery({'$query': searchText});
 };
 
 
 MdContactChipsCtrl.prototype.itemName = function(item) {
   return item[this.contactName];
-};
-
-
-MdContactChipsCtrl.prototype.filterSelectedContacts = function(contact) {
-  return this.contacts.indexOf(contact) == -1;
 };

--- a/src/components/chips/js/contactChipsDirective.js
+++ b/src/components/chips/js/contactChipsDirective.js
@@ -32,9 +32,10 @@ angular
  * @param {number=} md-min-length Specifies the minimum length of text before autocomplete will
  *    make suggestions
  *
- *
  * @param {expression=} filter-selected Whether to filter selected contacts from the list of
- *    suggestions shown in the autocomplete. This attribute has been removed but may come back.
+ *    suggestions shown in the autocomplete.
+ *
+ *    ***Note:** This attribute has been removed but may come back.*
  *
  *
  *
@@ -57,6 +58,7 @@ var MD_CONTACT_CHIPS_TEMPLATE = '\
       <md-chips class="md-contact-chips"\
           ng-model="$mdContactChipsCtrl.contacts"\
           md-require-match="$mdContactChipsCtrl.requireMatch"\
+          md-chip-append-delay="{{$mdContactChipsCtrl.chipAppendDelay}}" \
           md-autocomplete-snap>\
           <md-autocomplete\
               md-menu-class="md-contact-chips-suggestions"\
@@ -122,17 +124,23 @@ function MdContactChips($mdTheming, $mdUtil) {
       contacts: '=ngModel',
       requireMatch: '=?mdRequireMatch',
       minLength: '=?mdMinLength',
-      highlightFlags: '@?mdHighlightFlags'
+      highlightFlags: '@?mdHighlightFlags',
+      chipAppendDelay: '@?mdChipAppendDelay'
     }
   };
 
   function compile(element, attr) {
     return function postLink(scope, element, attrs, controllers) {
+      var contactChipsController = controllers;
 
       $mdUtil.initOptionalProperties(scope, attr);
       $mdTheming(element);
 
       element.attr('tabindex', '-1');
+
+      attrs.$observe('mdChipAppendDelay', function(newValue) {
+        contactChipsController.chipAppendDelay = newValue;
+      });
     };
   }
 }


### PR DESCRIPTION
Previously, chips had no, or very broken, support for accessibility.

Make many updates to fix broken functionality and add required features.
- Remove existing `aria-hidden` attributes.
- Dynamically apply required `role` and `aria-owns` attributes.
- Ensure `tabindex` is set properly on all elements. Particularly,
  you can now tab to, and navigate through, a set of chips in
  readonly mode.
- Provide new `input-aria-label` option to identify the inputs.
- Provide new `container-hint` option used when the element is in
  readonly mode.
- Provide new `md-chip-append-delay` option which controls the delay
  (in ms) before a user can add a new chip (fixes screen readers).
- Fix issue with `delete-hint` never being read by screen readers
  because it was outside of the chip.
- Fix keyboard navigation to properly wrap when moving both left
  or right.
- Fix keyboard navigation when in readonly mode.
- Fix issue where the wrong chip may be focused because the old
  chip was still in the DOM.
- Fix issue where `onAdd` callback passed incorrect `$index` (it
  was 1-based instead of 0-based).

Additionally update the Chips docs with new Accessibility info and
a few other minor changes to the docs/demos.
- Remove the "WORK IN PROGRESS" notice.
- Fix mispelling of "maximum" on first chips demo.
- Fix Contact Chips demo filtering.
- Fix Contact Chips demo images to use new/faster service.

BREAKING CHANGES

**MAJOR**

In order to make the chips fully accessible and work properly across
a wide variety of screen readers, we have added a 300ms delay after
appending a chip before we re-focus the input.

This is necessary because some screen readers change operational modes
when the enter key is pressed inside of an input and this causes the
screen reader to move into "navigation" mode and no longer apply
keystrokes to the input.

Additionally, this ensures that the newly added chip is properly
announced to the screen readers.

You **may** alter this value with the new `md-chip-append-delay`
attribute, however using a value less than `300` can cause issues
on JAWS and NVDA and will make your application inaccessible to those
users.

Note 1: This issue only seems to affect chips appended when using the
`enter` key. If you override the `md-separator-keys` and disable the
`enter` key (and enable something like `,` or `;`), you may be able
to reduce this delay to `0` and achieve past functionality.

Note 2: This issue does not appear to affect VoiceOver or ChromeVox,
so if you are only targeting those users, you may be able to reduce
the delay to `0`.

**MINOR**

We consider the following to be minor breaking changes since we never
expected these attributes/elements to be utilized by developers.

Nonetheless, we want to ensure that they are documented.
- The `role` of the `.md-chip-content` has been modified from `button`
  to `option` so that it works with the new `listbox` role of it's
  parent.
  
  If you rely on this role being `button`, you should update your code
  accordingly.
- The delete hint on removable chips now resides inside of the
  `div.md-chip-content` rather than the parent `md-chip` element where
  it could not be read by screen readers.
  
  If you interact with this element (in CSS or JS) please update your
  selectors/code to account for the new DOM hierarchy.

Fixes #9391. Fixes #9556. Fixes #8897. Fixes #8867. Fixes #9649.
