### PR TITLE
fix(build): fix errors on angular 1.3

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -982,7 +982,7 @@ describe('<md-autocomplete>', function() {
       ctrl.focus();
 
       // Set our search text to a value to make md-scroll-mask added to DOM
-      scope.searchText = 'searchText';
+      scope.$apply('searchText = "searchText"');
 
       $timeout.flush();
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -34,7 +34,8 @@ function DetectNgTouch($log, $injector) {
  */
 function MdCoreConfigure($provide, $mdThemingProvider) {
 
-  $provide.decorator('$$rAF', ["$delegate", rAFDecorator]);
+  $provide.decorator('$$rAF', ['$delegate', rAFDecorator]);
+  $provide.decorator('$q', ['$delegate', qDecorator]);
 
   $mdThemingProvider.theme('default')
     .primaryPalette('indigo')
@@ -74,5 +75,23 @@ function rAFDecorator($delegate) {
       }
     };
   };
+  return $delegate;
+}
+
+/**
+ * @ngInject
+ */
+function qDecorator($delegate) {
+  /**
+   * Adds a shim for $q.resolve for Angular version that don't have it,
+   * so we don't have to think about it.
+   *
+   * via https://github.com/angular/angular.js/pull/11987
+   */
+
+  // TODO(crisbeto): this won't be necessary once we drop Angular 1.3
+  if (!$delegate.resolve) {
+    $delegate.resolve = $delegate.when;
+  }
   return $delegate;
 }

--- a/src/core/core.spec.js
+++ b/src/core/core.spec.js
@@ -20,6 +20,9 @@ describe('material.core', function() {
 
   });
 
-
+  it('should shim $q.resolve', inject(function($q) {
+    expect(angular.isFunction($q.resolve)).toBe(true);
+    expect($q.resolve).toBe($q.when);
+  }));
 });
 


### PR DESCRIPTION
* Fixes a test in the autocomplete that was failing, because it wasn't triggering a digest.
* Adds a shim for `$q.resolve`, which was first introduced in Angular 1.4.1, in order to prevent similar errors in the future.