### PR TITLE
fix(util): check for definition of window.performance.now before using in mdUtil

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -59,7 +59,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
   var $mdUtil = {
     dom: {},
-    now: window.performance ?
+    now: window.performance && window.performance.now ?
       angular.bind(window.performance, window.performance.now) : Date.now || function() {
       return new Date().getTime();
     },


### PR DESCRIPTION
The previous behavior assumes the existence of the now() function in browsers that provide the 
window.performance API. This change verifies it is available and if not, uses existing fallbacks.

According to the [Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/API/Performance#Browser_compatibility) reference page, the following browsers have the `window.performance` API, but not support for `now()`:
* Chrome 6-23
* Firefox 7-14
* IE 9