### PR TITLE
feat(tabs): add stretchHeight to fill parent element

### DIFF
--- a/src/components/tabs/demoStretchHeight/index.html
+++ b/src/components/tabs/demoStretchHeight/index.html
@@ -1,0 +1,35 @@
+<div ng-controller="DemoStretchHeightCtrl" ng-cloak>
+  <md-block style="height: 460px" layout="column">
+    <p class="md-padding">The content in this <code>&lt;p&gt;</code> tag and the <code>md-tab</code> element below are in a 460 pixel tall container. <code>md-stretch-height</code> will automatically account for sibling elements.</p>
+    <md-tabs md-stretch-height>
+      <md-tab label="one">
+        <md-content class="md-padding" layout-fill layout="column">
+          <h1 class="md-display-2">Tab One</h1>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla venenatis ante augue. Phasellus volutpat neque ac dui mattis vulputate. Etiam consequat aliquam cursus. In sodales pretium ultrices. Maecenas lectus est, sollicitudin consectetur felis nec, feugiat ultricies mi.</p>
+        </md-content>
+      </md-tab>
+      <md-tab label="two">
+        <div layout-fill layout="column">
+          <h1 class="md-display-2 md-padding">Tab Two</h1>
+          <md-divider></md-divider>
+          <md-content class="md-padding" flex>
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla venenatis ante augue. Phasellus volutpat neque ac dui mattis vulputate. Etiam consequat aliquam cursus. In sodales pretium ultrices. Maecenas lectus est, sollicitudin consectetur felis nec, feugiat ultricies mi. Aliquam erat volutpat. Nam placerat, tortor in ultrices porttitor, orci enim rutrum enim, vel tempor sapien arcu a tellus. Vivamus convallis sodales ante varius gravida. Curabitur a purus vel augue ultrices ultricies id a nisl. Nullam malesuada consequat diam, a facilisis tortor volutpat et. Sed urna dolor, aliquet vitae posuere vulputate, euismod ac lorem. Sed felis risus, pulvinar at interdum quis, vehicula sed odio. Phasellus in enim venenatis, iaculis tortor eu, bibendum ante. Donec ac tellus dictum neque volutpat blandit. Praesent efficitur faucibus risus, ac auctor purus porttitor vitae. Phasellus ornare dui nec orci posuere, nec luctus mauris semper.</p>
+            <p>Morbi viverra, ante vel aliquet tincidunt, leo dolor pharetra quam, at semper massa orci nec magna. Donec posuere nec sapien sed laoreet. Etiam cursus nunc in condimentum facilisis. Etiam in tempor tortor. Vivamus faucibus egestas enim, at convallis diam pulvinar vel. Cras ac orci eget nisi maximus cursus. Nunc urna libero, viverra sit amet nisl at, hendrerit tempor turpis. Maecenas facilisis convallis mi vel tempor. Nullam vitae nunc leo. Cras sed nisl consectetur, rhoncus sapien sit amet, tempus sapien.</p>
+            <p>Integer turpis erat, porttitor vitae mi faucibus, laoreet interdum tellus. Curabitur posuere molestie dictum. Morbi eget congue risus, quis rhoncus quam. Suspendisse vitae hendrerit erat, at posuere mi. Cras eu fermentum nunc. Sed id ante eu orci commodo volutpat non ac est. Praesent ligula diam, congue eu enim scelerisque, finibus commodo lectus.</p>
+          </md-content>
+        </div>
+      </md-tab>
+      <md-tab label="three">
+        <div class="md-padding" layout-fill layout="column">
+          <h1 class="md-display-2">Tab Three</h1>
+          <md-content flex>
+            <p>Integer turpis erat, porttitor vitae mi faucibus, laoreet interdum tellus. Curabitur posuere molestie dictum.</p>
+          </md-content>
+          <div layout="row" layout-align="center center">
+            <md-button class="md-primary md-raised" ng-click="sampleAction($event)">Holy Smokes!</md-button>
+          </div>
+        </div>
+      </md-tab>
+    </md-tabs>
+  </md-block>
+</div>

--- a/src/components/tabs/demoStretchHeight/readme.html
+++ b/src/components/tabs/demoStretchHeight/readme.html
@@ -1,0 +1,3 @@
+<p>
+  The Stretch Height demo shows how tabs can be made to fill the available height of their parent container.
+</p>

--- a/src/components/tabs/demoStretchHeight/script.js
+++ b/src/components/tabs/demoStretchHeight/script.js
@@ -1,0 +1,12 @@
+angular
+  .module('tabsDemoStretchHeight', ['ngMaterial'])
+  .controller('DemoStretchHeightCtrl', function ($scope, $mdDialog) {
+    $scope.sampleAction = function (ev) {
+      $mdDialog.show($mdDialog.alert()
+        .title('Button clicked')
+        .textContent('You were thoroughly impressed.')
+        .ok('Great')
+        .targetEvent(ev)
+      );
+    };
+  });

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -7,7 +7,7 @@ angular
  */
 function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple, $mdUtil,
                            $animateCss, $attrs, $compile, $mdTheming, $mdInteraction,
-                           MdTabsPaginationService) {
+                           MdTabsPaginationService, $timeout) {
   // define private properties
   var ctrl      = this,
       locked    = false,
@@ -15,7 +15,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       queue     = [],
       destroyed = false,
       loaded    = false;
-
 
   // Define public methods
   ctrl.$onInit            = $onInit;
@@ -62,6 +61,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     // Define boolean attributes
     defineBooleanAttribute('noInkBar', handleInkBar);
     defineBooleanAttribute('dynamicHeight', handleDynamicHeight);
+    defineBooleanAttribute('stretchHeight');
     defineBooleanAttribute('noPagination');
     defineBooleanAttribute('swipeContent');
     defineBooleanAttribute('noDisconnect');
@@ -261,7 +261,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     ctrl.selectedIndex     = getNearestSafeIndex(newValue);
     ctrl.lastSelectedIndex = oldValue;
     ctrl.updateInkBarStyles();
-    updateHeightFromContent();
+    if(!ctrl.stretchHeight) updateHeightFromContent();
     adjustOffset(newValue);
     $scope.$broadcast('$mdTabsChanged');
     ctrl.tabs[ oldValue ] && ctrl.tabs[ oldValue ].scope.deselect();
@@ -387,6 +387,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     $mdUtil.nextTick(function () {
       ctrl.updateInkBarStyles();
       updatePagination();
+      if(ctrl.stretchHeight) updateHeightFromParent();
     });
   }
 
@@ -764,6 +765,48 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function refreshIndex () {
     ctrl.selectedIndex = getNearestSafeIndex(ctrl.selectedIndex);
     ctrl.focusIndex    = getNearestSafeIndex(ctrl.focusIndex);
+  } 
+
+  /**
+   * Rapid fires function to compensate for rendering lag for post-render functions.
+   * Note: Only use on inexpensive functions to avoid performace issues.
+   * @returns {*}
+   */
+  function cascadeTimeouts (func) {
+    var timeouts = [],
+        offsets = [50, 100, 300, 1000];
+
+    for (var i = 0; i < offsets.length; i++) {
+      timeouts.push($timeout(func, offsets[i]));
+    }
+
+    ctrl.scope.$on('$destroy', function () {
+      for (var i = 0; i < timeouts.length; i++) {
+        $timeout.cancel(timeouts[i]);
+      }
+    });   
+  }
+
+  /**
+   * Updates element's height of fill available space of parent element.
+   * @returns {*}
+   */
+  function updateHeightFromParent () {
+    var parent = $element[0].parentNode,
+        parentHeight = parent.clientHeight,
+        siblingsHeight = 0;
+
+    angular.forEach(parent.children, function(child){
+      if(child != $element[0]){
+        var childStyle = $window.getComputedStyle(child);
+
+        siblingsHeight += child.offsetHeight;
+        siblingsHeight += parseInt(childStyle.marginTop);
+        siblingsHeight += parseInt(childStyle.marginBottom);
+      }
+    });
+  
+    $element.css('height', parentHeight - siblingsHeight + 'px');
   }
 
   /**
@@ -771,8 +814,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * @returns {*}
    */
   function updateHeightFromContent () {
-    if (!ctrl.dynamicHeight) return $element.css('height', '');
+    if (!ctrl.dynamicHeight && !ctrl.stretchHeight) return $element.css('height', '');
     if (!ctrl.tabs.length) return queue.push(updateHeightFromContent);
+    if (ctrl.stretchHeight) return cascadeTimeouts(updateHeightFromParent);
 
     var elements = getElements();
 


### PR DESCRIPTION
Use `md-stretch-height` to fill available space in parent element.

Closes won't fix issue #2254 abandoned by core team for material 2 surge.
