### PR TITLE
fix(interim): do not immediately splice interim.

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -349,7 +349,7 @@ function InterimElementProvider() {
         }
 
         // Hide the latest showing interim element.
-        return closeElement(showingInterims.pop());
+        return closeElement(showingInterims[showingInterims.length - 1]);
 
         function closeElement(interim) {
 

--- a/src/core/services/interimElement/interimElement.spec.js
+++ b/src/core/services/interimElement/interimElement.spec.js
@@ -365,6 +365,35 @@ describe('$$interimElement service', function() {
         }
       });
 
+      it('should hide multiple elements', function() {
+        var showCount = 0;
+
+        showInterim();
+        expect(showCount).toBe(1);
+
+        showInterim();
+        expect(showCount).toBe(2);
+
+        Service.hide();
+        expect(showCount).toBe(1);
+
+        Service.hide();
+        expect(showCount).toBe(0);
+
+        function showInterim() {
+          Service.show({
+            template: '<div>Interim Element</div>',
+            onShow: function() {
+              showCount++;
+            },
+            onRemove: function() {
+              showCount--;
+            },
+            multiple: true
+          });
+        }
+
+      });
 
       it('should not show multiple interim elements by default', function() {
         var showCount = 0;


### PR DESCRIPTION
* SHA 421fed4 introduced multiple interim elements support (internal right now)

* If multiple interim elements are showing up, the last one can't be closed in some situations (because we accidentally splice it too early)

Not considered as a breakingbug for now, because the `multiple` option is not public yet