### PR TITLE
fix(ngModelCtrl) compatibility with snapshot breaking changes

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -422,7 +422,7 @@
     // Forwards any events from the input to the root element. This is necessary to get `updateOn`
     // working for events that don't bubble (e.g. 'blur') since Angular binds the handlers to
     // the `<md-datepicker>`.
-    var updateOn = ngModelCtrl.$options && ngModelCtrl.$options.updateOn;
+    var updateOn = self.$mdUtil.getModelOption(ngModelCtrl, 'updateOn');
 
     if (updateOn) {
       this.ngInputElement.on(

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -734,9 +734,11 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
 
       // Allow users to provide `ng-model="foo" ng-model-options="{trackBy: 'foo.id'}"` so
       // that we can properly compare objects set on the model to the available options
-      if (ngModel.$options && ngModel.$options.trackBy) {
+      var trackByOption = $mdUtil.getModelOption(ngModel, 'trackBy');
+
+      if (trackByOption) {
         var trackByLocals = {};
-        var trackByParsed = $parse(ngModel.$options.trackBy);
+        var trackByParsed = $parse(trackByOption);
         self.hashGetter = function(value, valueScope) {
           trackByLocals.$value = value;
           return trackByParsed(valueScope || $scope, trackByLocals);
@@ -852,7 +854,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
           values.push(self.selected[hashKey]);
         }
       }
-      var usingTrackBy = self.ngModel.$options && self.ngModel.$options.trackBy;
+      var usingTrackBy = $mdUtil.getModelOption(self.ngModel, 'trackBy');
 
       var newVal = self.isMultiple ? values : values[0];
       var prevVal = self.ngModel.$modelValue;

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -65,6 +65,25 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     /**
+     * Cross-version compatibility method to retrieve an option of a ngModel controller,
+     * which supports the breaking changes in the AngularJS snapshot (SHA 87a2ff76af5d0a9268d8eb84db5755077d27c84c).
+     * @param {!angular.ngModelCtrl} ngModelCtrl
+     * @param {!string} optionName
+     * @returns {Object|undefined}
+     */
+    getModelOption: function (ngModelCtrl, optionName) {
+      if (!ngModelCtrl.$options) {
+        return;
+      }
+
+      var $options = ngModelCtrl.$options;
+
+      // The newer versions of Angular introduced a `getOption function and made the option values no longer
+      // visible on the $options object.
+      return $options.getOption ? $options.getOption(optionName) : $options[optionName]
+    },
+
+    /**
      * Bi-directional accessor/mutator used to easily update an element's
      * property based on the current 'dir'ectional value.
      */

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -64,6 +64,46 @@ describe('util', function() {
 
     });
 
+    describe('getModelOption', function() {
+
+      it('should support the old ngModelCtrl options', inject(function($mdUtil) {
+        var ngModelCtrl = {
+          $options: {
+            trackBy: 'Test'
+          }
+        };
+
+        expect($mdUtil.getModelOption(ngModelCtrl, 'trackBy')).toBe('Test');
+      }));
+
+      it('should support the newer ngModelCtrl options', inject(function($mdUtil) {
+        var ngModelCtrl = {
+          $options: {
+            getOption: function() {
+              return 'Test';
+            }
+          }
+        };
+
+        expect($mdUtil.getModelOption(ngModelCtrl, 'trackBy')).toBe('Test');
+      }));
+
+      it('should return nothing if $options is not set', inject(function($mdUtil) {
+        expect($mdUtil.getModelOption({}, 'trackBy')).toBeFalsy();
+      }));
+
+      it('should not throw if an option is not available', inject(function($mdUtil) {
+        var ngModelCtrl = {
+          $options: {}
+        };
+
+        expect(function() {
+          $mdUtil.getModelOption(ngModelCtrl, 'Unknown')
+        }).not.toThrow();
+      }));
+
+    });
+
     describe('findFocusTarget', function() {
 
       it('should not find valid focus target', inject(function($rootScope, $compile, $mdUtil) {


### PR DESCRIPTION
* AngularJS recently made a breaking API change which is is currently in Snapshot (https://github.com/angular/angular.js/commit/87a2ff76af5d0a9268d8eb84db5755077d27c84c)

* This commit introduces a cross-version compatibility method to support the older and newer API.