### PR TITLE
chore(chips, datepicker, select): clean up test leaks in angular < 1.5

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -23,6 +23,9 @@ describe('<md-chips>', function() {
 
   afterEach(function() {
     attachedElements.forEach(function(element) {
+      var scope = element.scope();
+
+      scope && scope.$destroy();
       element.remove();
     });
     attachedElements = [];
@@ -308,7 +311,7 @@ describe('<md-chips>', function() {
         });
 
       });
-      
+
       describe('when removable', function() {
 
         it('should not append the input div when not removable and readonly is enabled', function() {
@@ -1173,8 +1176,6 @@ describe('<md-chips>', function() {
 
           expect(scope.items.length).toBe(2);
           expect(document.activeElement).toBe(input[0]);
-
-          element.remove();
         });
       });
 

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -39,6 +39,9 @@ describe('<md-contact-chips>', function() {
   var attachedElements = [];
   afterEach(function() {
     attachedElements.forEach(function(element) {
+      var scope = element.scope();
+
+      scope && scope.$destroy();
       element.remove();
     });
     attachedElements = [];

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -43,6 +43,13 @@ describe('md-datepicker', function() {
     createDatepickerInstance(DATEPICKER_TEMPLATE);
     controller.closeCalendarPane();
   }));
+
+  afterEach(function() {
+    controller.isAttached && controller.closeCalendarPane();
+    pageScope.$destroy();
+    ngElement.remove();
+  });
+
   /**
    * Compile and link the given template and store values for element, scope, and controller.
    * @param {string} template

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -19,6 +19,9 @@ describe('<md-select>', function() {
 
   afterEach(inject(function($document) {
     attachedElements.forEach(function(element) {
+      var scope = element.scope();
+
+      scope && scope.$destroy();
       element.remove();
     });
     attachedElements = [];
@@ -510,7 +513,10 @@ describe('<md-select>', function() {
     });
 
     it('does not allow keydown events to propagate from inside the md-select-menu', inject(function($rootScope, $compile) {
-      $rootScope.val = [1];
+      var scope = $rootScope.$new();
+
+      scope.val = [1];
+
       var select = $compile(
           '<md-input-container>' +
           '  <label>Label</label>' +
@@ -519,15 +525,15 @@ describe('<md-select>', function() {
           '    <md-option value="2">Two</md-option>' +
           '    <md-option value="3">Three</md-option>' +
           '  </md-select>' +
-          '</md-input-container>')($rootScope);
+          '</md-input-container>')(scope);
 
       var mdOption = select.find('md-option');
       var selectMenu = select.find('md-select-menu');
       var keydownEvent = {
-	type: 'keydown',
-	target: mdOption[0],
-	preventDefault: jasmine.createSpy(),
-	stopPropagation: jasmine.createSpy()
+        type: 'keydown',
+        target: mdOption[0],
+        preventDefault: jasmine.createSpy(),
+        stopPropagation: jasmine.createSpy()
       };
 
       openSelect(select);
@@ -535,6 +541,9 @@ describe('<md-select>', function() {
 
       expect(keydownEvent.preventDefault).toHaveBeenCalled();
       expect(keydownEvent.stopPropagation).toHaveBeenCalled();
+
+      scope.$destroy();
+      select.remove();
     }));
 
     it('supports raw html', inject(function($rootScope, $compile, $sce) {


### PR DESCRIPTION
Fixes unit tests in the chips, contact chips, datepicker and select components that were leaking elements in older Angular version. This was causing other tests to fail.