### PR TITLE
fix(panel): invoke offset callbacks later

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1399,13 +1399,15 @@ MdPanelRef.prototype._updatePosition = function(init) {
   var positionConfig = this.config['position'];
 
   if (positionConfig) {
+    positionConfig._setPanelPosition(this.panelEl);
+
     // Use the vendor prefixed version of transform.
-    // Note that the offset should be assigned before the position, in
-    // order to avoid tiny jumps in the panel's position, on slower browsers.
+    // Note that the offset should be assigned before the CSS positions, in
+    // order to avoid tiny jumps in the panel's position, on slower browsers,
+    // however it should be after _setPanelPosition so _actualPosition is
+    // available in the callback.
     var prefixedTransform = this._$mdConstant.CSS.TRANSFORM;
     this.panelEl.css(prefixedTransform, positionConfig.getTransform());
-
-    positionConfig._setPanelPosition(this.panelEl);
 
     // Hide the panel now that position is known.
     if (init) {

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -1880,6 +1880,60 @@ describe('$mdPanel', function() {
         });
       });
 
+      it('should have assigned the actual position by the time the offset' +
+        'methods have been called', function() {
+          var positionSnapshot = null;
+          var obj = {
+            getOffsetX: function(mdPanelPosition) {
+              positionSnapshot = angular.copy(mdPanelPosition.getActualPosition());
+            }
+          };
+          var position = mdPanelPosition
+              .relativeTo(myButton[0])
+              .addPanelPosition(xPosition.ALIGN_START, yPosition.ALIGN_TOPS)
+              .withOffsetX(obj.getOffsetX);
+
+          config['position'] = position;
+
+          openPanel(config);
+
+          expect(positionSnapshot).toEqual({
+            x: xPosition.ALIGN_START,
+            y: yPosition.ALIGN_TOPS
+          });
+      });
+
+      it('should have assigned the actual position when using ' +
+        'multiple positions', function() {
+          var positionSnapshot = [];
+          var obj = {
+            getOffsetX: function(mdPanelPosition) {
+              positionSnapshot = angular.copy(mdPanelPosition.getActualPosition());
+              return 0;
+            }
+          };
+          var position = mdPanelPosition
+              .relativeTo(myButton[0])
+              .addPanelPosition(xPosition.ALIGN_END, yPosition.BELOW)
+              .addPanelPosition(xPosition.ALIGN_START, yPosition.ABOVE)
+              .withOffsetX(obj.getOffsetX);
+
+          myButton.css({
+            position: 'absolute',
+            right: '0px',
+            bottom: '0px'
+          });
+
+          config['position'] = position;
+
+          openPanel(config);
+
+          expect(positionSnapshot).toEqual({
+            x: xPosition.ALIGN_START,
+            y: yPosition.ABOVE
+          });
+      });
+
       describe('vertically', function() {
         it('above an element', function() {
           var position = mdPanelPosition


### PR DESCRIPTION
Invokes the panel's offset functions slightly later, in order to allow for the _actualPosition to be assigned.
This lets the user make better decisions regarding the offset.