### PR TITLE
fix(select): Fix command+keypress being intercepted during focus

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -539,6 +539,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
           e.preventDefault();
           openSelect(e);
         } else {
+          if (e.metaKey) return;
           if ($mdConstant.isInputKey(e) || $mdConstant.isNumPadKey(e)) {
             e.preventDefault();
 

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1244,6 +1244,18 @@ describe('<md-select>', function() {
         expect($rootScope.someModel).toBe(2);
       }));
 
+      it('ignores key combinations involving command/windows keys', inject(function($document, $rootScope) {
+        var el = setupSelect('ng-model="someModel"', [1, 2, 3]).find('md-select');
+        var keydownEvent = {
+          type: 'keydown',
+          keyCode: 82, // 'r' key
+          metaKey: true,
+          preventDefault: jasmine.createSpy()
+        };
+        el.triggerHandler(keydownEvent);
+        expect(keydownEvent.preventDefault.calls.count()).toEqual(0);
+      }));
+
       it('disallows selection of disabled options', inject(function($rootScope) {
         var optsTemplate =
           '<md-option value="1">1</md-option>' +


### PR DESCRIPTION
While an md-select is focused, a keypress listener intercepts all keypress
events. The listener was not accounting for the `metaKey` (command/windows key)
being pressed, and as a result would capture and prevent certain keyboard
shortcuts, such as command+R and command+L, from executing properly.

Fixes #9717.
