### PR TITLE
fix(panel): use prefixed transform property

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -2087,6 +2087,9 @@ function MdPanelPosition($injector) {
   /** @private {boolean} */
   this._isRTL = $injector.get('$mdUtil').bidi() === 'rtl';
 
+  /** @private @const {!angular.$mdConstant} */
+  this._$mdConstant = $injector.get('$mdConstant');
+
   /** @private {boolean} */
   this._absolute = false;
 
@@ -2475,7 +2478,8 @@ MdPanelPosition.prototype._isOnscreen = function(panelEl) {
   var top = parseInt(this.getTop());
 
   if (this._translateX.length || this._translateY.length) {
-    var offsets = getComputedTranslations(panelEl);
+    var prefixedTransform = this._$mdConstant.CSS.TRANSFORM;
+    var offsets = getComputedTranslations(panelEl, prefixedTransform);
     left += offsets.x;
     top += offsets.y;
   }
@@ -2990,13 +2994,14 @@ function getElement(el) {
 /**
  * Gets the computed values for an element's translateX and translateY in px.
  * @param {!angular.JQLite|!Element} el
+ * @param {string} property
  * @return {{x: number, y: number}}
  */
-function getComputedTranslations(el) {
+function getComputedTranslations(el, property) {
   // The transform being returned by `getComputedStyle` is in the format:
   // `matrix(a, b, c, d, translateX, translateY)` if defined and `none`
   // if the element doesn't have a transform.
-  var transform = getComputedStyle(el[0] || el).transform;
+  var transform = getComputedStyle(el[0] || el)[property];
   var openIndex = transform.indexOf('(');
   var closeIndex = transform.lastIndexOf(')');
   var output = { x: 0, y: 0 };


### PR DESCRIPTION
Fixes a JS error in the panel, if the user's browser uses the prefixed `transform` property.