### PR TITLE
fix(panel): make the actual position available in the offset methods

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -3,11 +3,11 @@
  * @name material.components.panel
  */
 angular
-    .module('material.components.panel', [
-      'material.core',
-      'material.components.backdrop'
-    ])
-    .service('$mdPanel', MdPanelService);
+  .module('material.components.panel', [
+    'material.core',
+    'material.components.backdrop'
+  ])
+  .service('$mdPanel', MdPanelService);
 
 
 /*****************************************************************************
@@ -1578,12 +1578,6 @@ MdPanelRef.prototype._updatePosition = function(init) {
   var positionConfig = this.config['position'];
 
   if (positionConfig) {
-    // Use the vendor prefixed version of transform.
-    // Note that the offset should be assigned before the position, in
-    // order to avoid tiny jumps in the panel's position, on slower browsers.
-    var prefixedTransform = this._$mdConstant.CSS.TRANSFORM;
-    this.panelEl.css(prefixedTransform, positionConfig.getTransform());
-
     positionConfig._setPanelPosition(this.panelEl);
 
     // Hide the panel now that position is known.
@@ -2087,6 +2081,9 @@ function MdPanelPosition($injector) {
   /** @private {boolean} */
   this._isRTL = $injector.get('$mdUtil').bidi() === 'rtl';
 
+  /** @private @const {!angular.$mdConstant} */
+  this._$mdConstant = $injector.get('$mdConstant');
+
   /** @private {boolean} */
   this._absolute = false;
 
@@ -2462,11 +2459,24 @@ MdPanelPosition.prototype.getTransform = function() {
   return (translateX + ' ' + translateY).trim();
 };
 
+
+/**
+ * Sets the `transform` value for a panel element.
+ * @param {!angular.JQLite} panelEl
+ * @returns {!angular.JQLite}
+ * @private
+ */
+MdPanelPosition.prototype._setTransform = function(panelEl) {
+  return panelEl.css(this._$mdConstant.CSS.TRANSFORM, this.getTransform());
+};
+
+
 /**
  * True if the panel is completely on-screen with this positioning; false
  * otherwise.
  * @param {!angular.JQLite} panelEl
  * @return {boolean}
+ * @private
  */
 MdPanelPosition.prototype._isOnscreen = function(panelEl) {
   // this works because we always use fixed positioning for the panel,
@@ -2527,17 +2537,21 @@ MdPanelPosition.prototype._reduceTranslateValues =
 MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
   // Only calculate the position if necessary.
   if (this._absolute) {
+    this._setTransform(panelEl);
     return;
   }
 
   if (this._actualPosition) {
     this._calculatePanelPosition(panelEl, this._actualPosition);
+    this._setTransform(panelEl);
     return;
   }
 
   for (var i = 0; i < this._positions.length; i++) {
     this._actualPosition = this._positions[i];
     this._calculatePanelPosition(panelEl, this._actualPosition);
+    this._setTransform(panelEl);
+
     if (this._isOnscreen(panelEl)) {
       break;
     }

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2077,6 +2077,61 @@ describe('$mdPanel', function() {
         });
       });
 
+      it('should have assigned the actual position by the time the offset' +
+        'methods have been called', function() {
+        var positionSnapshot = null;
+        var getOffsetX = function(mdPanelPosition) {
+          positionSnapshot = angular.copy(mdPanelPosition.getActualPosition());
+        };
+
+        var position = mdPanelPosition
+            .relativeTo(myButton[0])
+            .withOffsetX(getOffsetX)
+            .addPanelPosition(xPosition.ALIGN_START, yPosition.ALIGN_TOPS);
+
+        config.position = position;
+
+        openPanel(config);
+        expect(positionSnapshot).toEqual({
+          x: xPosition.ALIGN_START,
+          y: yPosition.ALIGN_TOPS
+        });
+      });
+
+      it('should have assigned the actual position when using ' +
+        'multiple positions', function() {
+          var positionSnapshots = [];
+          var getOffsetX = function(mdPanelPosition) {
+            positionSnapshots.push(
+              angular.copy(mdPanelPosition.getActualPosition())
+            );
+          };
+          var position = mdPanelPosition
+              .relativeTo(myButton[0])
+              .addPanelPosition(xPosition.ALIGN_END, yPosition.BELOW)
+              .addPanelPosition(xPosition.ALIGN_START, yPosition.ABOVE)
+              .withOffsetX(getOffsetX);
+
+          myButton.css({
+            position: 'absolute',
+            right: 0,
+            bottom: 0
+          });
+
+          config.position = position;
+          openPanel(config);
+
+          expect(positionSnapshots[0]).toEqual({
+            x: xPosition.ALIGN_END,
+            y: yPosition.BELOW
+          });
+
+          expect(positionSnapshots[1]).toEqual({
+            x: xPosition.ALIGN_START,
+            y: yPosition.ABOVE
+          });
+      });
+
       describe('vertically', function() {
         it('above an element', function() {
           var position = mdPanelPosition


### PR DESCRIPTION
* Makes the panel's current actual position available, when passing in a function to the `withOffsetX` and `withOffsetY` methods. This allows users to make better decisions when determining the offset.
* Fixes some extra indentation that was throwing off IDEs when determining the file's indentation level.
* Fixes the `_isOnScreen` method not being marked as private.

This PR is a followup to #9697.