### PR TITLE
﻿fix(autocomplete): dropdown shrink restore

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -184,6 +184,10 @@ md-autocomplete {
   position: absolute;
   box-shadow: 0 2px 5px rgba(black, 0.25);
   z-index: $z-index-tooltip;
+
+  // Expand the virtualRepeatContainer as much as the max-height from the JavaScript allows.
+  // This is necessary for the virtualRepeatContainer to be able to grow back.
+  height: 100%;
 }
 
 .md-virtual-repeat-container.md-not-found {

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -21,8 +21,8 @@ describe('<md-autocomplete>', function() {
   function createScope(items, scopeData, matchLowercase) {
 
     items = items || ['foo', 'bar', 'baz'].map(function(item) {
-      return { display: item };
-    });
+        return { display: item };
+      });
 
     inject(function($rootScope, $timeout) {
       scope = $rootScope.$new();
@@ -126,12 +126,12 @@ describe('<md-autocomplete>', function() {
 
         var template =
           '<md-autocomplete ' +
-              'md-selected-item="selectedItem" ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'placeholder="placeholder"> ' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
+          'md-selected-item="selectedItem" ' +
+          'md-search-text="searchText" ' +
+          'md-items="item in match(searchText)" ' +
+          'md-item-text="item.display" ' +
+          'placeholder="placeholder"> ' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
           '</md-autocomplete>';
 
         var element = compile(template, scope);
@@ -183,12 +183,12 @@ describe('<md-autocomplete>', function() {
 
         var template =
           '<md-autocomplete ' +
-              'md-selected-item="selectedItem" ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'placeholder="placeholder"> ' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
+          'md-selected-item="selectedItem" ' +
+          'md-search-text="searchText" ' +
+          'md-items="item in match(searchText)" ' +
+          'md-item-text="item.display" ' +
+          'placeholder="placeholder"> ' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
           '</md-autocomplete>';
 
         var element = compile(template, scope);
@@ -355,15 +355,15 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<md-autocomplete ' +
-            'md-input-id="{{inputId}}" ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'md-select-on-focus="" ' +
-            'tabindex="3"' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-input-id="{{inputId}}" ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-select-on-focus="" ' +
+        'tabindex="3"' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -378,13 +378,13 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'ng-trim="false" ' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'ng-trim="false" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -403,16 +403,16 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<form name="testForm">' +
-          '<md-autocomplete ' +
-              'md-input-name="autocomplete" ' +
-              'md-selected-item="selectedItem" ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'ng-pattern="/^[0-9]$/" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-input-name="autocomplete" ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'ng-pattern="/^[0-9]$/" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</form>';
 
       var element = compile(template, scope);
@@ -435,14 +435,14 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<md-autocomplete ' +
-            'md-input-id="{{inputId}}" ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'tabindex="3"' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-input-id="{{inputId}}" ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'tabindex="3"' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -457,14 +457,14 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<md-autocomplete ' +
-            'md-input-id="{{inputId}}" ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'tabindex="3"' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-input-id="{{inputId}}" ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'tabindex="3"' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -481,13 +481,13 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'ng-blur="onBlur($event)" ' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'ng-blur="onBlur($event)" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -511,13 +511,13 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'ng-focus="onFocus($event)" ' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'ng-focus="onFocus($event)" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -600,18 +600,18 @@ describe('<md-autocomplete>', function() {
         var scope = createScope(null, {inputId: 'custom-input-id'});
         var template =
           '<form name="testForm">' +
-            '<md-autocomplete ' +
-                'md-input-id="{{inputId}}" ' +
-                'md-input-maxlength="2" ' +
-                'md-input-name="testAutocomplete" ' +
-                'md-selected-item="selectedItem" ' +
-                'md-search-text="searchText" ' +
-                'md-items="item in match(searchText)" ' +
-                'md-item-text="item.display" ' +
-                'tabindex="3"' +
-                'md-floating-label="Favorite state">' +
-              '<span md-highlight-text="searchText">{{item.display}}</span>' +
-            '</md-autocomplete>' +
+          '<md-autocomplete ' +
+          'md-input-id="{{inputId}}" ' +
+          'md-input-maxlength="2" ' +
+          'md-input-name="testAutocomplete" ' +
+          'md-selected-item="selectedItem" ' +
+          'md-search-text="searchText" ' +
+          'md-items="item in match(searchText)" ' +
+          'md-item-text="item.display" ' +
+          'tabindex="3"' +
+          'md-floating-label="Favorite state">' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+          '</md-autocomplete>' +
           '</form>';
 
         var element = compile(template, scope);
@@ -631,18 +631,18 @@ describe('<md-autocomplete>', function() {
         var scope = createScope(null, {inputId: 'custom-input-id'});
         var template =
           '<form name="testForm">' +
-            '<md-autocomplete ' +
-                'md-input-id="{{inputId}}" ' +
-                'md-input-maxlength="2" ' +
-                'md-input-name="testAutocomplete" ' +
-                'md-selected-item="selectedItem" ' +
-                'md-search-text="searchText" ' +
-                'md-items="item in match(searchText)" ' +
-                'md-item-text="item.display" ' +
-                'tabindex="3"' +
-                'md-floating-label="Favorite state">' +
-              '<span md-highlight-text="searchText">{{item.display}}</span>' +
-            '</md-autocomplete>' +
+          '<md-autocomplete ' +
+          'md-input-id="{{inputId}}" ' +
+          'md-input-maxlength="2" ' +
+          'md-input-name="testAutocomplete" ' +
+          'md-selected-item="selectedItem" ' +
+          'md-search-text="searchText" ' +
+          'md-items="item in match(searchText)" ' +
+          'md-item-text="item.display" ' +
+          'tabindex="3"' +
+          'md-floating-label="Favorite state">' +
+          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+          '</md-autocomplete>' +
           '</form>';
 
         var element = compile(template, scope);
@@ -950,15 +950,15 @@ describe('<md-autocomplete>', function() {
 
       var scope = createScope();
       var template =
-          '<md-autocomplete' +
-          '   md-selected-item="selectedItem"' +
-          '   md-search-text="searchText"' +
-          '   md-items="item in match(searchText)"' +
-          '   md-item-text="item.display"' +
-          '   placeholder="placeholder">' +
-          '  <md-item-template>{{item.display}}</md-item-template>' +
-          '  <md-not-found>Sorry, not found...</md-not-found>' +
-          '</md-autocomplete>';
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <md-item-template>{{item.display}}</md-item-template>' +
+        '  <md-not-found>Sorry, not found...</md-not-found>' +
+        '</md-autocomplete>';
       var element = compile(template, scope);
       var ctrl = element.controller('mdAutocomplete');
 
@@ -1185,16 +1185,16 @@ describe('<md-autocomplete>', function() {
       var scope = createScope();
       var template1 =
         '<div>' +
-          '<md-autocomplete ' +
-              'md-selected-item="selectedItem" ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'placeholder="placeholder" ' +
-              'ng-if="showAutocomplete">' +
-            '<md-item-template>{{item.display}}</md-item-template>' +
-            '<md-not-found>Sorry, not found...</md-not-found>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'placeholder="placeholder" ' +
+        'ng-if="showAutocomplete">' +
+        '<md-item-template>{{item.display}}</md-item-template>' +
+        '<md-not-found>Sorry, not found...</md-not-found>' +
+        '</md-autocomplete>' +
         '</div>';
       var element = compile(template1, scope);
       var ctrl = element.children().controller('mdAutocomplete');
@@ -1317,9 +1317,9 @@ describe('<md-autocomplete>', function() {
 
         var template =
           '<md-autocomplete ' +
-              'md-selected-item="selectedItem" ' +
-              'md-search-text="searchText"' +
-              'md-items="item in match(searchText)"> ' +
+          'md-selected-item="selectedItem" ' +
+          'md-search-text="searchText"' +
+          'md-items="item in match(searchText)"> ' +
           '</md-autocomplete>';
 
         var element = compile(template, scope);
@@ -1344,12 +1344,12 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'placeholder="placeholder"> ' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'placeholder="placeholder"> ' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -1365,12 +1365,12 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'md-floating-label="Label"> ' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-floating-label="Label"> ' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -1387,13 +1387,13 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<md-autocomplete ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'md-floating-label="Label" ' +
-            'md-clear-button="showButton">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-floating-label="Label" ' +
+        'md-clear-button="showButton">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
 
       var element = compile(template, scope);
@@ -1794,14 +1794,14 @@ describe('<md-autocomplete>', function() {
       var scope = createScope(null, null, true);
       var template =
         '<md-autocomplete ' +
-            'md-select-on-match ' +
-            'md-selected-item="selectedItem" ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item.display" ' +
-            'placeholder="placeholder" ' +
-            'md-match-case-insensitive="true">' +
-          '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        'md-select-on-match ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'placeholder="placeholder" ' +
+        'md-match-case-insensitive="true">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
         '</md-autocomplete>';
       var element = compile(template, scope);
 
@@ -2013,7 +2013,7 @@ describe('<md-autocomplete>', function() {
      * @returns {Array} Fake matches.
      */
     function fakeItemMatch() {
-       var matches = [];
+      var matches = [];
 
       for (var i = 0; i < dropdownItems; i++) {
         matches.push('Item ' + i);
@@ -2027,14 +2027,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div style="width: 400px">' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'md-min-length="0" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2081,14 +2081,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div style="width: 400px">' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'md-min-length="0" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2139,14 +2139,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div style="width: 400px">' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'md-min-length="0" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2181,14 +2181,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div style="width: 400px">' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'md-min-length="1" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="1" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2230,14 +2230,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div>' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item" ' +
-              'md-min-length="0" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2280,14 +2280,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div>' +
-            '<md-autocomplete ' +
-            'md-search-text="searchText" ' +
-            'md-items="item in match(searchText)" ' +
-            'md-item-text="item" ' +
-            'md-min-length="0" ' +
-            'md-dropdown-items="' + maxDropdownItems +'"' +
-            'placeholder="placeholder">' +
-          '<span md-highlight-text="searchText">{{item}}</span>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item" ' +
+        'md-min-length="0" ' +
+        'md-dropdown-items="' + maxDropdownItems +'"' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item}}</span>' +
         '</md-autocomplete>' +
         '</div>';
 
@@ -2328,16 +2328,16 @@ describe('<md-autocomplete>', function() {
       scope.position = 'top';
 
       var template = '<div>' +
-          '<md-autocomplete ' +
-          'md-search-text="searchText" ' +
-          'md-items="item in match(searchText)" ' +
-          'md-item-text="item" ' +
-          'md-min-length="0" ' +
-          'md-dropdown-position="{{position}}" ' +
-          'placeholder="placeholder">' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item" ' +
+        'md-min-length="0" ' +
+        'md-dropdown-position="{{position}}" ' +
+        'placeholder="placeholder">' +
         '<span md-highlight-text="searchText">{{item}}</span>' +
-      '</md-autocomplete>' +
-      '</div>';
+        '</md-autocomplete>' +
+        '</div>';
 
       var parent = compile(template, scope);
       var element = parent.find('md-autocomplete');
@@ -2376,14 +2376,14 @@ describe('<md-autocomplete>', function() {
 
       var template =
         '<div style="width: 400px">' +
-          '<md-autocomplete ' +
-              'md-search-text="searchText" ' +
-              'md-items="item in match(searchText)" ' +
-              'md-item-text="item.display" ' +
-              'md-min-length="0" ' +
-              'placeholder="placeholder">' +
-            '<span md-highlight-text="searchText">{{item.display}}</span>' +
-          '</md-autocomplete>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
         '</div>';
 
       var parent = compile(template, scope);
@@ -2415,6 +2415,54 @@ describe('<md-autocomplete>', function() {
 
       // The scroll container should still have no minWidth, because there was no positioning called yet.
       expect(scrollContainer.style.minWidth).toBe('');
+
+      document.body.removeChild(parent[0]);
+    }));
+
+    it('should grow and shrink depending on the amount of items', inject(function($timeout) {
+      var scope = createScope();
+
+      dropdownItems = 2;
+      scope.match = fakeItemMatch;
+
+      var template =
+        '<div>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item" ' +
+        'md-min-length="0" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item}}</span>' +
+        '</md-autocomplete>' +
+        '</div>';
+
+      var parent = compile(template, scope);
+      var element = parent.find('md-autocomplete');
+      var ctrl = element.controller('mdAutocomplete');
+
+      // Add container to the DOM to be able to test the rect calculations.
+      document.body.appendChild(parent[0]);
+
+      $timeout.flush();
+
+      // Focus the autocomplete and trigger a query to be able to open the dropdown.
+      ctrl.focus();
+
+      scope.$apply('searchText = "A"');
+      waitForVirtualRepeat(element);
+
+      var scrollContainer = document.body.querySelector('.md-virtual-repeat-container');
+
+      expect(scrollContainer).toBeTruthy();
+      expect(scrollContainer.style.height).toBe(dropdownItems * DEFAULT_ITEM_HEIGHT + 'px');
+
+      dropdownItems = DEFAULT_MAX_ITEMS;
+
+      // Trigger a new query to request an update of the items and dropdown.
+      scope.$apply('searchText = "B"');
+
+      expect(scrollContainer.style.height).toBe(dropdownItems * DEFAULT_ITEM_HEIGHT + 'px');
 
       document.body.removeChild(parent[0]);
     }));


### PR DESCRIPTION
The `VirtualRepeat` determines the original size (when shrank) of the dropdown from the computed style.

Commit b114302717341638bb627792c197ec3c43e069ff removed the fixed height from the SCSS, because of the dynamic dropdown height.

Setting the height to `100%` allows the `VirtualRepeat` to properly determine the dimension of the dropdown.

Fixes #9726.
