### PR TITLE
feat(datepicker): add the ability to restrict users to a calendar view

### DIFF
--- a/src/components/datepicker/calendar.scss
+++ b/src/components/datepicker/calendar.scss
@@ -127,7 +127,7 @@ md-calendar {
   font-weight: 500; // Roboto Medium
   @include rtl(padding, 0 0 0 $md-calendar-side-padding + $md-calendar-month-label-padding, rtl-value( 0 0 0 $md-calendar-side-padding + $md-calendar-month-label-padding));
 
-  md-calendar-month &:not(.md-calendar-month-label-disabled) {
+  &.md-calendar-label-clickable {
     cursor: pointer;
   }
 

--- a/src/components/datepicker/demoBasicUsage/index.html
+++ b/src/components/datepicker/demoBasicUsage/index.html
@@ -29,5 +29,10 @@
       <md-datepicker ng-model="ctrl.myDate" md-placeholder="Enter date" md-is-open="ctrl.isOpen"></md-datepicker>
       <md-button class="md-primary md-raised" ng-click="ctrl.isOpen = true">Open</md-button>
     </div>
+
+    <div flex-gt-xs>
+      <h4>Date-picker that only allows for the month to be selected</h4>
+      <md-datepicker ng-model="ctrl.myDate" md-placeholder="Enter date" md-mode="month"></md-datepicker>
+    </div>
   </div>
 </md-content>

--- a/src/components/datepicker/js/calendar.spec.js
+++ b/src/components/datepicker/js/calendar.spec.js
@@ -17,7 +17,6 @@ describe('md-calendar', function() {
    */
   function applyDateChange() {
     $timeout.flush();
-    pageScope.$apply();
     $material.flushOutstandingAnimations();
 
     // Internally, the calendar sets scrollTop to scroll to the month for a change.
@@ -57,7 +56,7 @@ describe('md-calendar', function() {
   /**
    * Finds a month `tbody` in the calendar element given a date.
    */
-  function findMonthElement(date) {
+  function findMonthElement(element, date) {
     var months = element.querySelectorAll('[md-calendar-month-body]');
     var monthHeader = dateLocale.monthHeaderFormatter(date);
     var month;
@@ -72,8 +71,8 @@ describe('md-calendar', function() {
   }
 
   /** Find the `tbody` for a year in the calendar. */
-  function findYearElement(year) {
-    var node = element[0] || element;
+  function findYearElement(parent, year) {
+    var node = parent[0] || parent;
     var years = node.querySelectorAll('[md-calendar-year-body]');
     var yearHeader = year.toString();
     var target;
@@ -415,9 +414,9 @@ describe('md-calendar', function() {
         newScope.$apply();
         element = createElement(newScope)[0];
 
-        expect(findMonthElement(new Date(2014, JUL, 1))).not.toBeNull();
-        expect(findMonthElement(new Date(2014, JUN, 1))).not.toBeNull();
-        expect(findMonthElement(new Date(2014, MAY, 1))).toBeNull();
+        expect(findMonthElement(element, new Date(2014, JUL, 1))).not.toBeNull();
+        expect(findMonthElement(element, new Date(2014, JUN, 1))).not.toBeNull();
+        expect(findMonthElement(element, new Date(2014, MAY, 1))).toBeNull();
       });
     });
 
@@ -514,8 +513,27 @@ describe('md-calendar', function() {
         element.controller('mdCalendar').setCurrentView('year');
         applyDateChange();
 
-        expect(findYearElement(2014)).not.toBeNull();
-        expect(findYearElement(2013)).toBeNull();
+        expect(findYearElement(element, 2014)).not.toBeNull();
+        expect(findYearElement(element, 2013)).toBeNull();
+      });
+
+      it('should highlight the proper cell, even when the date is not the ' +
+        'first day of the month', function() {
+        var newScope = $rootScope.$new();
+
+        newScope.myDate = new Date(2015, MAY, 1);
+        element = createElement(newScope)[0];
+        angular.element(element).controller('mdCalendar').setCurrentView('year');
+        applyDateChange();
+
+        var yearElement = findYearElement(element, 2015);
+
+        expect(findCellByLabel(yearElement, 'May')).toHaveClass('md-calendar-selected-date');
+
+        newScope.myDate = new Date(2015, JUL, 15);
+        applyDateChange();
+
+        expect(findCellByLabel(yearElement, 'Jul')).toHaveClass('md-calendar-selected-date');
       });
 
       it('should ensure that all year elements have a height when the ' +
@@ -737,6 +755,106 @@ describe('md-calendar', function() {
     });
   });
 
+  describe('md-mode support', function() {
+    var element, controller;
+
+    function compileElement(attrs) {
+      ngElement.remove();
+      element = createElement(pageScope, '<md-calendar ng-model="myDate" ' + (attrs || '') + '></md-calendar>');
+      controller = element.controller('mdCalendar');
+    }
+
+    it('should go to the corresponding view', function() {
+      compileElement('md-mode="month"');
+
+      expect(element.find('md-calendar-month').length).toBe(0);
+      expect(element.find('md-calendar-year').length).toBe(1);
+      expect(controller.currentView).toBe('year');
+    });
+
+    it('should override md-current-view', function() {
+      compileElement('md-mode="day" md-current-view="year"');
+
+      expect(element.find('md-calendar-year').length).toBe(0);
+      expect(element.find('md-calendar-month').length).toBe(1);
+      expect(controller.currentView).toBe('month');
+    });
+
+    it('should not allow users to go to a different view', function() {
+      compileElement('md-mode="day"');
+
+      expect(controller.currentView).toBe('month');
+
+      element[0].querySelector('.md-calendar-month-label').click();
+      applyDateChange();
+
+      expect(controller.currentView).toBe('month');
+    });
+
+    it('should allow users to navigate to a different view if the md-mode is not supported', function() {
+      compileElement('md-mode="invalid-mode"');
+
+      expect(controller.currentView).toBe('month');
+      expect(controller.mode).toBeFalsy();
+
+      element[0].querySelector('.md-calendar-month-label').click();
+      applyDateChange();
+
+      expect(controller.currentView).toBe('year');
+    });
+
+    it('should update the model when clicking on a cell in the year view', function() {
+      pageScope.myDate = new Date(2015, MAY, 15);
+
+      compileElement('md-mode="month"');
+
+      expect(controller.currentView).toBe('year');
+
+      var yearElement = findYearElement(element[0], 2015);
+      var monthCell = findCellByLabel(yearElement, 'Sep');
+      var expectedDate = new Date(2015, SEP, 1);
+
+      monthCell.click();
+      applyDateChange();
+
+      expect(pageScope.myDate).toBeSameDayAs(expectedDate);
+      expect(controller.currentView).toBe('year');
+    });
+
+    it('should update the model when clicking on a cell in the day view', function() {
+      pageScope.myDate = new Date(2015, MAY, 15);
+
+      compileElement('md-mode="day"');
+
+      var monthElement = findMonthElement(element[0], pageScope.myDate);
+      var monthCell = findCellByLabel(monthElement, '28');
+      var expectedDate = new Date(2015, MAY, 28);
+
+      monthCell.click();
+      applyDateChange();
+
+      expect(pageScope.myDate).toBeSameDayAs(expectedDate);
+    });
+  });
+
+  describe('md-current-view support', function() {
+    beforeEach(function() {
+      ngElement && ngElement.remove();
+    });
+
+    it('should have a configurable default view', function() {
+      var calendar = createElement(null, '<md-calendar ng-model="myDate" md-current-view="year"></md-calendar>')[0];
+
+      expect(calendar.querySelector('md-calendar-month')).toBeFalsy();
+      expect(calendar.querySelector('md-calendar-year')).toBeTruthy();
+    });
+
+    it('should default to the month view if no view is supploied', function() {
+      var calendar = createElement(null, '<md-calendar ng-model="myDate"></md-calendar>');
+      expect(calendar.controller('mdCalendar').currentView).toBe('month');
+    });
+  });
+
   it('should render one single-row month of disabled cells after the max date', function() {
     ngElement.remove();
     var newScope = $rootScope.$new();
@@ -745,11 +863,11 @@ describe('md-calendar', function() {
     newScope.$apply();
     element = createElement(newScope)[0];
 
-    expect(findMonthElement(new Date(2014, MAR, 1))).not.toBeNull();
-    expect(findMonthElement(new Date(2014, APR, 1))).not.toBeNull();
+    expect(findMonthElement(element, new Date(2014, MAR, 1))).not.toBeNull();
+    expect(findMonthElement(element, new Date(2014, APR, 1))).not.toBeNull();
 
     // First date of May 2014 on Thursday (i.e. has 3 dates on the first row).
-    var nextMonth = findMonthElement(new Date(2014, MAY, 1));
+    var nextMonth = findMonthElement(element, new Date(2014, MAY, 1));
     expect(nextMonth).not.toBeNull();
     expect(nextMonth.querySelector('.md-calendar-month-label')).toHaveClass(
         'md-calendar-month-label-disabled');
@@ -762,13 +880,5 @@ describe('md-calendar', function() {
         expect(date).toHaveClass('md-calendar-date-disabled');
       }
     }
-  });
-
-  it('should have a configurable default view', function() {
-    ngElement.remove();
-    var calendar = createElement(null, '<md-calendar ng-model="myDate" md-current-view="year"></md-calendar>')[0];
-
-    expect(calendar.querySelector('md-calendar-month')).toBeFalsy();
-    expect(calendar.querySelector('md-calendar-year')).toBeTruthy();
   });
 });

--- a/src/components/datepicker/js/calendarMonth.js
+++ b/src/components/datepicker/js/calendarMonth.js
@@ -157,40 +157,6 @@
   };
 
   /**
-   * Change the selected date in the calendar (ngModel value has already been changed).
-   * @param {Date} date
-   */
-  CalendarMonthCtrl.prototype.changeSelectedDate = function(date) {
-    var self = this;
-    var calendarCtrl = self.calendarCtrl;
-    var previousSelectedDate = calendarCtrl.selectedDate;
-    calendarCtrl.selectedDate = date;
-
-    this.changeDisplayDate(date).then(function() {
-      var selectedDateClass = calendarCtrl.SELECTED_DATE_CLASS;
-      var namespace = 'month';
-
-      // Remove the selected class from the previously selected date, if any.
-      if (previousSelectedDate) {
-        var prevDateCell = document.getElementById(calendarCtrl.getDateId(previousSelectedDate, namespace));
-        if (prevDateCell) {
-          prevDateCell.classList.remove(selectedDateClass);
-          prevDateCell.setAttribute('aria-selected', 'false');
-        }
-      }
-
-      // Apply the select class to the new selected date if it is set.
-      if (date) {
-        var dateCell = document.getElementById(calendarCtrl.getDateId(date, namespace));
-        if (dateCell) {
-          dateCell.classList.add(selectedDateClass);
-          dateCell.setAttribute('aria-selected', 'true');
-        }
-      }
-    });
-  };
-
-  /**
    * Change the date that is being shown in the calendar. If the given date is in a different
    * month, the displayed month will be transitioned.
    * @param {Date} date
@@ -262,7 +228,8 @@
     var self = this;
 
     self.$scope.$on('md-calendar-parent-changed', function(event, value) {
-      self.changeSelectedDate(value);
+      self.calendarCtrl.changeSelectedDate(value);
+      self.changeDisplayDate(value);
     });
 
     self.$scope.$on('md-calendar-parent-action', angular.bind(this, this.handleKeyEvent));

--- a/src/components/datepicker/js/calendarMonthBody.js
+++ b/src/components/datepicker/js/calendarMonthBody.js
@@ -209,17 +209,21 @@
     var blankCellOffset = 0;
     var monthLabelCell = document.createElement('td');
     var monthLabelCellContent = document.createElement('span');
+    var calendarCtrl = this.calendarCtrl;
 
     monthLabelCellContent.textContent = this.dateLocale.monthHeaderFormatter(date);
     monthLabelCell.appendChild(monthLabelCellContent);
     monthLabelCell.classList.add('md-calendar-month-label');
     // If the entire month is after the max date, render the label as a disabled state.
-    if (this.calendarCtrl.maxDate && firstDayOfMonth > this.calendarCtrl.maxDate) {
+    if (calendarCtrl.maxDate && firstDayOfMonth > calendarCtrl.maxDate) {
       monthLabelCell.classList.add('md-calendar-month-label-disabled');
-    } else {
+    // If the user isn't supposed to be able to change views, render the
+    // label as usual, but disable the clicking functionality.
+    } else if (!calendarCtrl.mode) {
       monthLabelCell.addEventListener('click', this.monthCtrl.headerClickHandler);
       monthLabelCell.setAttribute('data-timestamp', firstDayOfMonth.getTime());
       monthLabelCell.setAttribute('aria-label', this.dateLocale.monthFormatter(date));
+      monthLabelCell.classList.add('md-calendar-label-clickable');
       monthLabelCell.appendChild(this.arrowIcon.cloneNode(true));
     }
 

--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -33,6 +33,10 @@
    * @param {String=} md-open-on-focus When present, the calendar will be opened when the input is focused.
    * @param {Boolean=} md-is-open Expression that can be used to open the datepicker's calendar on-demand.
    * @param {String=} md-current-view Default open view of the calendar pane. Can be either "month" or "year".
+   * @param {String=} md-mode Restricts the user to only selecting a value from a particular view. This option can
+   * be used if the user is only supposed to choose from a certain date type (e.g. only selecting the month).
+   * Can be either "month" or "day". **Note** that this will ovewrite the `md-current-view` value.
+   *
    * @param {String=} md-hide-icons Determines which datepicker icons should be hidden. Note that this may cause the
    * datepicker to not align properly with other components. **Use at your own risk.** Possible values are:
    * * `"all"` - Hides all icons.
@@ -112,6 +116,7 @@
           '<div class="md-datepicker-calendar">' +
             '<md-calendar role="dialog" aria-label="{{::ctrl.locale.msgCalendar}}" ' +
                 'md-current-view="{{::ctrl.currentView}}"' +
+                'md-mode="{{::ctrl.mode}}"' +
                 'md-min-date="ctrl.minDate"' +
                 'md-max-date="ctrl.maxDate"' +
                 'md-date-filter="ctrl.dateFilter"' +
@@ -126,6 +131,7 @@
         maxDate: '=mdMaxDate',
         placeholder: '@mdPlaceholder',
         currentView: '@mdCurrentView',
+        mode: '@mdMode',
         dateFilter: '=mdDateFilter',
         isOpen: '=?mdIsOpen',
         debounceInterval: '=mdDebounceInterval',


### PR DESCRIPTION
- Adds the ability to restrict users to a calendar view. For example, it's now possible to let users only select a month, instead of having to pick out a date within the month. This can be useful for cases like a credit card form, where the day of the month doesn't necessarily make sense.
- Fixes an issue where the year view wouldn't highlight the proper cell, if the model was changed externally and the date was different from the first day of the month.

Fixes #9260.
