### PR TITLE
fix(md-calendar): boundKeyHandler preventDefault on other input elements

### DIFF
--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -198,15 +198,17 @@
     var boundKeyHandler = angular.bind(this, this.handleKeyEvent);
 
 
-    var handleKeyElement = this.$element;
 
     // If use the md-calendar directly in the body without datepicker,
     // handleKeyEvent will disable other inputs on the page.
     // So only apply the handleKeyEvent on the body when the md-calendar inside datepicker,
     // otherwise apply on the calendar element only.
 
+    var handleKeyElement;
     if (this.$element.parent().hasClass('md-datepicker-calendar')) {
       handleKeyElement = angular.element(document.body);
+    } else {
+      handleKeyElement = this.$element;
     }
 
     // Bind the keydown handler to the body, in order to handle cases where the focused

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -13,8 +13,7 @@
    *
    * @description
    * `<md-calendar>` is a component that renders a calendar that can be used to select a date.
-   * It is a part of the `<
-   * ` pane, however it can also be used on it's own.
+   * It is a part of the `<md-datepicker` pane, however it can also be used on it's own.
    *
    * @usage
    *

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -201,10 +201,11 @@
 
     var handleKeyElement = this.$element;
 
-    // If use the md-calendar directly in body without datepicker,
+    // If use the md-calendar directly in the body without datepicker,
     // handleKeyEvent will disable other inputs on the page.
-    // On apply the handleKeyEvent on body when the md-calendar inside datepicker,
-    // Otherwise apply on the calendar element only.
+    // So only apply the handleKeyEvent on the body when the md-calendar inside datepicker,
+    // otherwise apply on the calendar element only.
+
     if (this.$element.parent().hasClass('md-datepicker-calendar')) {
       handleKeyElement = angular.element(document.body);
     }

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -205,10 +205,10 @@
     // otherwise apply on the calendar element only.
 
     var handleKeyElement;
-    if (this.$element.parent().hasClass('md-datepicker-calendar')) {
+    if ($element.parent().hasClass('md-datepicker-calendar')) {
       handleKeyElement = angular.element(document.body);
     } else {
-      handleKeyElement = this.$element;
+      handleKeyElement = $element;
     }
 
     // Bind the keydown handler to the body, in order to handle cases where the focused

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -13,7 +13,8 @@
    *
    * @description
    * `<md-calendar>` is a component that renders a calendar that can be used to select a date.
-   * It is a part of the `<md-datepicker` pane, however it can also be used on it's own.
+   * It is a part of the `<
+   * ` pane, however it can also be used on it's own.
    *
    * @usage
    *
@@ -197,12 +198,23 @@
 
     var boundKeyHandler = angular.bind(this, this.handleKeyEvent);
 
+
+    var handleKeyElement = this.$element;
+
+    // If use the md-calendar directly in body without datepicker,
+    // handleKeyEvent will disable other inputs on the page.
+    // On apply the handleKeyEvent on body when the md-calendar inside datepicker,
+    // Otherwise apply on the calendar element only.
+    if (this.$element.parent().hasClass('md-datepicker-calendar')) {
+      handleKeyElement = angular.element(document.body);
+    }
+
     // Bind the keydown handler to the body, in order to handle cases where the focused
     // element gets removed from the DOM and stops propagating click events.
-    angular.element(document.body).on('keydown', boundKeyHandler);
+    handleKeyElement.on('keydown', boundKeyHandler);
 
     $scope.$on('$destroy', function() {
-      angular.element(document.body).off('keydown', boundKeyHandler);
+      handleKeyElement.off('keydown', boundKeyHandler);
     });
 
     if (this.minDate && this.minDate > $mdDateLocale.firstRenderableDate) {

--- a/src/components/datepicker/js/calendar.spec.js
+++ b/src/components/datepicker/js/calendar.spec.js
@@ -113,14 +113,8 @@ describe('md-calendar', function() {
   function dispatchKeyEvent(keyCode, opt_modifiers) {
     var mod = opt_modifiers || {};
 
-    var dispatchElement;
-      if (angular.element(element).parent().hasClass('md-datepicker-calendar')) {
-        dispatchElement = document.body;
-      } else {
-        dispatchElement = element;
-    }
 
-    angular.element(dispatchElement).triggerHandler({
+    angular.element(element).triggerHandler({
       type: 'keydown',
       keyCode: keyCode,
       which: keyCode,

--- a/src/components/datepicker/js/calendar.spec.js
+++ b/src/components/datepicker/js/calendar.spec.js
@@ -113,7 +113,14 @@ describe('md-calendar', function() {
   function dispatchKeyEvent(keyCode, opt_modifiers) {
     var mod = opt_modifiers || {};
 
-    angular.element(document.body).triggerHandler({
+    var dispatchElement;
+      if (angular.element(element).parent().hasClass('md-datepicker-calendar')) {
+        dispatchElement = document.body;
+      } else {
+        dispatchElement = element;
+    }
+
+    angular.element(dispatchElement).triggerHandler({
       type: 'keydown',
       keyCode: keyCode,
       which: keyCode,


### PR DESCRIPTION
If use the md-calendar directly in the body without datepicker, boundKeyHandler will disable some keyEvent on other input elements in the page. So only apply the handleKeyEvent on the document.body when the md-calendar is inside datepicker. Otherwise, apply on the calendar element only.
