### PR TITLE
﻿fix(autocomplete): margin consistency with input

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,5 +1,6 @@
 // The default item height is also specified in the JavaScript.
-$md-autocomplete-item-height: 48px !default;
+$md-autocomplete-item-height: 48px !default
+$md-autocomplete-input-container-margin: 18px 0;
 
 @keyframes md-autocomplete-list-out {
   0% {
@@ -39,19 +40,25 @@ md-autocomplete {
   position: relative;
   overflow: visible;
   min-width: 190px;
+
   &[disabled] {
     input {
       cursor: default;
     }
   }
+
   &[md-floating-label] {
     border-radius: 0;
     background: transparent;
     height: auto;
 
+    margin: $md-autocomplete-input-container-margin;
+
     md-input-container {
-      padding-bottom: 0px;
+      margin: 0;
+      padding-bottom: 0;
     }
+
     md-autocomplete-wrap {
       height: auto;
     }


### PR DESCRIPTION
* Curently the autocomplete integrates as expected with the input container, because the underlaying input container handles all the margin.

* But when using `layout-margin`, then there will be some inconsistency, because the attribute changes the following margins
  - `md-input-container` (Normal Input - 18px -> 8px)
  - `md-autocomplete` (Autocomplete  - 0px -> 8px)

The issue is, that the `md-autocomplete` still uses the deault input container margin, because it's *inside*  of the autocomplete.

This means that the autocomplete is now higher than the input container.

| Default Input (no extra margin) | Default autocomplete (no extra margin) |
| ---------------------------------- | -------------------------------------------- |
| ![](https://i.gyazo.com/56b10bee24b73d40ddd91b0394965797.png) | ![](https://i.gyazo.com/4d16d992995a4ef73d5f9fedeeba0f93.png) |

> Basically you see that the margin is outside on the input-container.

---
@ThomasBurleson Not sure it's worth making this change, because this means we need to take care of the input container margin in the autocomplete SCSS.

> The solution before, was completely in sync with the `md-input-container` 
> I personally would go with the previous approach and not fix the issue (possible approach PR )



Fixes #9692.