### PR TITLE
feat(datepicker): allow the date locale to be overwritten on a per element basis

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -129,12 +129,31 @@ describe('md-datepicker', function() {
   });
 
   it('should pass the timezone to the formatting function', function() {
-    spyOn(dateLocale, 'formatDate');
+    spyOn(controller.locale, 'formatDate');
 
     createDatepickerInstance('<md-datepicker ng-model="myDate" ' +
       'ng-model-options="{ timezone: \'utc\' }"></md-datepicker>');
 
-    expect(dateLocale.formatDate).toHaveBeenCalledWith(pageScope.myDate, 'utc');
+    expect(controller.locale.formatDate).toHaveBeenCalledWith(pageScope.myDate, 'utc');
+  });
+
+  it('should allow for the locale to be overwritten on a specific element', function() {
+    pageScope.myDate = new Date(2015, SEP, 1);
+
+    pageScope.customLocale = {
+      formatDate: function() {
+        return 'September First';
+      }
+    };
+
+    spyOn(pageScope.customLocale, 'formatDate').and.callThrough();
+
+    createDatepickerInstance(
+      '<md-datepicker ng-model="myDate" md-date-locale="customLocale"></md-datepicker>'
+    );
+
+    expect(pageScope.customLocale.formatDate).toHaveBeenCalled();
+    expect(ngElement.find('input').val()).toBe('September First');
   });
 
   describe('ngMessages support', function() {


### PR DESCRIPTION
Adds the `md-date-locale` attribute which can be used to overwrite the locale formatting on a per-element basis.
This wasn't possible before, because the locale was global and it was being applied during the `config` phase.
These changes relate to PR #9736, because the specific datepicker modes might require special formatting (e.g. only showing the MM/YY on a credit card form).

Fixes #9270.