### PR TITLE
﻿feat(autocomplete): support ng-pattern attribute

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -399,6 +399,38 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should support ng-pattern for the search input', inject(function() {
+      var scope = createScope(null, {inputId: 'custom-input-id'});
+      var template =
+        '<form name="testForm">' +
+          '<md-autocomplete ' +
+              'md-input-name="autocomplete" ' +
+              'md-selected-item="selectedItem" ' +
+              'md-search-text="searchText" ' +
+              'md-items="item in match(searchText)" ' +
+              'md-item-text="item.display" ' +
+              'ng-pattern="/^[0-9]$/" ' +
+              'placeholder="placeholder">' +
+            '<span md-highlight-text="searchText">{{item.display}}</span>' +
+          '</md-autocomplete>' +
+        '</form>';
+
+      var element = compile(template, scope);
+      var input = element.find('input');
+
+      expect(input.attr('ng-pattern')).toBeTruthy();
+
+      scope.$apply('searchText = "Test"');
+
+      expect(scope.testForm.autocomplete.$error['pattern']).toBeTruthy();
+
+      scope.$apply('searchText = "3"');
+
+      expect(scope.testForm.autocomplete.$error['pattern']).toBeFalsy();
+
+      element.remove();
+    }));
+
     it('forwards the tabindex to the input', inject(function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -88,6 +88,10 @@ angular
  *     the dropdown.<br/><br/>
  *     When the dropdown doesn't fit into the viewport, the dropdown will shrink
  *     as less as possible.
+ * @param {string=} ng-trim If set to false, the search text will be not trimmed automatically.
+ *     Defaults to true.
+ * @param {string=} ng-pattern Adds the pattern validator to the ngModel of the search text.
+ *     [ngPattern Directive](https://docs.angularjs.org/api/ng/directive/ngPattern)
  *
  * @usage
  * ### Basic Example
@@ -203,7 +207,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
       dropdownItems:    '=?mdDropdownItems'
     },
     compile: function(tElement, tAttrs) {
-      var attributes = ['md-select-on-focus', 'md-no-asterisk', 'ng-trim'];
+      var attributes = ['md-select-on-focus', 'md-no-asterisk', 'ng-trim', 'ng-pattern'];
       var input = tElement.find('input');
 
       attributes.forEach(function(attribute) {


### PR DESCRIPTION
* Added support for ng-pattern attribute on the autocomplete
* Added ng-trim to supported attribute docs as well.

Fixes #9755. References #4492.