### PR TITLE
feat(dialog themes): extended theme inheritance of dialogs

### DIFF
--- a/src/components/dialog/demoThemeInheritance/dialog1.tmpl.html
+++ b/src/components/dialog/demoThemeInheritance/dialog1.tmpl.html
@@ -1,0 +1,44 @@
+<md-dialog aria-label="Mango (Fruit)">
+  <form ng-cloak>
+    <md-toolbar>
+      <div class="md-toolbar-tools">
+        <h2>Mango (Fruit)</h2>
+        <span flex></span>
+        <md-button class="md-icon-button" ng-click="cancel()">
+          <md-icon md-svg-src="img/icons/ic_close_24px.svg" aria-label="Close dialog"></md-icon>
+        </md-button>
+      </div>
+    </md-toolbar>
+
+    <md-dialog-content>
+      <div class="md-dialog-content">
+        <h2>Using .md-dialog-content class that sets the padding as the spec</h2>
+        <p>
+          The mango is a juicy stone fruit belonging to the genus Mangifera, consisting of numerous tropical fruiting trees, cultivated mostly for edible fruit. The majority of these species are found in nature as wild mangoes. They all belong to the flowering plant family Anacardiaceae. The mango is native to South and Southeast Asia, from where it has been distributed worldwide to become one of the most cultivated fruits in the tropics.
+        </p>
+
+        <img style="margin: auto; max-width: 100%;" alt="Lush mango tree" src="img/mangues.jpg">
+
+        <p>
+          The highest concentration of Mangifera genus is in the western part of Malesia (Sumatra, Java and Borneo) and in Burma and India. While other Mangifera species (e.g. horse mango, M. foetida) are also grown on a more localized basis, Mangifera indica&mdash;the "common mango" or "Indian mango"&mdash;is the only mango tree commonly cultivated in many tropical and subtropical regions.
+        </p>
+        <p>
+          It originated in Indian subcontinent (present day India and Pakistan) and Burma. It is the national fruit of India, Pakistan, and the Philippines, and the national tree of Bangladesh. In several cultures, its fruit and leaves are ritually used as floral decorations at weddings, public celebrations, and religious ceremonies.
+        </p>
+      </div>
+    </md-dialog-content>
+
+    <md-dialog-actions layout="row">
+      <md-button href="http://en.wikipedia.org/wiki/Mango" target="_blank" md-autofocus>
+        More on Wikipedia
+      </md-button>
+      <span flex></span>
+      <md-button ng-click="answer('not useful')">
+       Not Useful
+      </md-button>
+      <md-button ng-click="answer('useful')" class="md-primary">
+        Useful
+      </md-button>
+    </md-dialog-actions>
+  </form>
+</md-dialog>

--- a/src/components/dialog/demoThemeInheritance/index.html
+++ b/src/components/dialog/demoThemeInheritance/index.html
@@ -1,0 +1,7 @@
+<div ng-controller="AppCtrl" ng-cloak md-theme="{{theme}}" class="container">
+  <p class="inset">
+    We have an interval that changes the color of the button from <code>red</code> to <code>blue</code> themes,
+    Open the dialog to see the theme being inherited to the dialog and any component inside
+  </p>
+  <md-button class="md-primary md-raised" ng-click="showAdvanced($event)">Open Dialog</md-button>
+</div>

--- a/src/components/dialog/demoThemeInheritance/script.js
+++ b/src/components/dialog/demoThemeInheritance/script.js
@@ -1,0 +1,49 @@
+angular.module('dialogDemo1', ['ngMaterial'])
+  .config(function ($mdThemingProvider) {
+    $mdThemingProvider.theme('red')
+      .primaryPalette('red');
+
+    $mdThemingProvider.theme('blue')
+      .primaryPalette('blue');
+
+  })
+.controller('AppCtrl', function($scope, $mdDialog, $interval) {
+  $scope.theme = 'red';
+
+  var isThemeRed = true;
+
+  $interval(function () {
+    $scope.theme = isThemeRed ? 'blue' : 'red';
+
+    isThemeRed = !isThemeRed;
+  }, 2000);
+
+  $scope.showAdvanced = function(ev) {
+    $mdDialog.show({
+      controller: DialogController,
+      templateUrl: 'dialog1.tmpl.html',
+      parent: angular.element(document.body),
+      targetEvent: ev,
+      clickOutsideToClose:true
+    })
+    .then(function(answer) {
+      $scope.status = 'You said the information was "' + answer + '".';
+    }, function() {
+      $scope.status = 'You cancelled the dialog.';
+    });
+  };
+
+  function DialogController($scope, $mdDialog) {
+    $scope.hide = function() {
+      $mdDialog.hide();
+    };
+
+    $scope.cancel = function() {
+      $mdDialog.cancel();
+    };
+
+    $scope.answer = function(answer) {
+      $mdDialog.hide(answer);
+    };
+  }
+});

--- a/src/components/dialog/demoThemeInheritance/style.css
+++ b/src/components/dialog/demoThemeInheritance/style.css
@@ -1,0 +1,3 @@
+.container {
+  text-align: center;
+}

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1657,6 +1657,85 @@ describe('$mdDialog', function() {
       // Clean up our modifications to the DOM.
       document.body.removeChild(parent);
     });
+
+    describe('theming', function () {
+      it('should inherit targetElement theme', inject(function($mdDialog, $mdTheming, $rootScope, $compile) {
+        var template = '<div id="rawContent">Hello</div>';
+        var parent = angular.element('<div>');
+
+        var button = $compile('<button ng-click="showDialog($event)" md-theme="myTheme">test</button>')($rootScope);
+
+        $mdTheming(button);
+
+        $rootScope.showDialog = function (ev) {
+          $mdDialog.show({
+            template: template,
+            parent: parent,
+            targetEvent: ev
+          });
+        };
+
+        button[0].click();
+
+        var container = parent[0].querySelector('.md-dialog-container');
+        var dialog = angular.element(container).find('md-dialog');
+        expect(dialog.hasClass('md-myTheme-theme')).toBeTruthy();
+      }));
+
+      it('should watch targetElement theme if it has interpolation', inject(function($mdDialog, $mdTheming, $rootScope, $compile) {
+        var template = '<div id="rawContent">Hello</div>';
+        var parent = angular.element('<div>');
+
+        $rootScope.theme = 'myTheme';
+
+        var button = $compile('<button ng-click="showDialog($event)" md-theme="{{theme}}">test</button>')($rootScope);
+
+        $mdTheming(button);
+
+        $rootScope.showDialog = function (ev) {
+          $mdDialog.show({
+            template: template,
+            parent: parent,
+            targetEvent: ev
+          });
+        };
+
+        button[0].click();
+
+        var container = parent[0].querySelector('.md-dialog-container');
+        var dialog = angular.element(container).find('md-dialog');
+        expect(dialog.hasClass('md-myTheme-theme')).toBeTruthy();
+        $rootScope.$apply('theme = "anotherTheme"');
+        expect(dialog.hasClass('md-anotherTheme-theme')).toBeTruthy();
+      }));
+
+      it('should resolve targetElement theme if it\'s a function', inject(function($mdDialog, $mdTheming, $rootScope, $compile) {
+        var template = '<div id="rawContent">Hello</div>';
+        var parent = angular.element('<div>');
+
+        $rootScope.theme = function () {
+          return 'myTheme';
+        };
+
+        var button = $compile('<button ng-click="showDialog($event)" md-theme="theme">test</button>')($rootScope);
+
+        $mdTheming(button);
+
+        $rootScope.showDialog = function (ev) {
+          $mdDialog.show({
+            template: template,
+            parent: parent,
+            targetEvent: ev
+          });
+        };
+
+        button[0].click();
+
+        var container = parent[0].querySelector('.md-dialog-container');
+        var dialog = angular.element(container).find('md-dialog');
+        expect(dialog.hasClass('md-myTheme-theme')).toBeTruthy();
+      }));
+    });
   });
 
   function hasConfigurationMethods(preset, methods) {

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -769,15 +769,17 @@ describe('$mdTheming service', function() {
 describe('md-theme directive', function() {
   beforeEach(module('material.core'));
 
-  it('should watch and set mdTheme controller', inject(function($compile, $rootScope) {
-    $rootScope.themey = 'red';
-    var el = $compile('<div md-theme="{{themey}}">')($rootScope);
-    $rootScope.$apply();
-    var ctrl = el.data('$mdThemeController');
-    expect(ctrl.$mdTheme).toBe('red');
-    $rootScope.$apply('themey = "blue"');
-    expect(ctrl.$mdTheme).toBe('blue');
-  }));
+  it('should watch and set mdTheme controller',
+    inject(function ($compile, $rootScope) {
+      $rootScope.themey = 'red';
+      var el = $compile('<div md-theme="{{themey}}">')($rootScope);
+      $rootScope.$apply();
+      var ctrl = el.data('$mdThemeController');
+      expect(ctrl.$mdTheme).toBe('red');
+      $rootScope.$apply('themey = "blue"');
+      expect(ctrl.$mdTheme).toBe('blue');
+    })
+  );
 
   it('warns when an unregistered theme is used', inject(function ($log, $compile, $rootScope) {
     spyOn($log, 'warn');
@@ -801,6 +803,31 @@ describe('md-theme directive', function() {
     expect(el.hasClass('md-red-theme')).toBeTruthy();
   }));
 
+  it('should accept interpolation string as a theme and automatically watch changes',
+    inject(function ($compile, $rootScope, $mdTheming) {
+      $rootScope.themey = 'red';
+      var el = $compile('<div md-theme="{{themey}}">')($rootScope);
+      $mdTheming(el);
+      $rootScope.$apply();
+      expect(el.hasClass('md-red-theme')).toBeTruthy();
+      $rootScope.$apply('themey = "blue"');
+      expect(el.hasClass('md-blue-theme')).toBeTruthy();
+    })
+  );
+
+  it('should accept onetime bind interpolation string as a theme and not watch changes',
+    inject(function ($compile, $rootScope, $mdTheming) {
+      $rootScope.themey = 'red';
+      var el = $compile('<div md-theme="{{::themey}}">')($rootScope);
+      $mdTheming(el);
+      $rootScope.$apply();
+      expect(el.hasClass('md-red-theme')).toBeTruthy();
+      $rootScope.$apply('themey = "blue"');
+      expect(el.hasClass('md-blue-theme')).toBeFalsy();
+      expect(el.hasClass('md-red-theme')).toBeTruthy();
+    })
+  );
+
   it('should accept $q promise as a theme', inject(function($compile, $rootScope, $q, $mdTheming) {
     $rootScope.promise = $mdTheming.defineTheme('red', { primary: 'red' });
     var el = $compile('<div md-theme="promise"></div>')($rootScope);
@@ -821,6 +848,40 @@ describe('md-theme directive', function() {
       expect(el.hasClass('md-default-theme')).toBeFalsy();
       expect(el.hasClass('md-red-theme')).toBeTruthy();
     }));
+
+  describe('$shouldWatch controller property', function () {
+    it('should set to true if there\'s a md-theme-watch attribute',
+      inject(function ($mdTheming, $compile, $rootScope) {
+        var el = $compile('<div md-theme="default" md-theme-watch></div>')($rootScope);
+        $mdTheming(el);
+        $rootScope.$apply();
+
+        expect(el.controller('mdTheme').$shouldWatch).toBeTruthy();
+      })
+    );
+
+    it('should set to true if there\'s an interpolation',
+      inject(function ($mdTheming, $compile, $rootScope) {
+        $rootScope.theme = 'default';
+        var el = $compile('<div md-theme="{{theme}}"></div>')($rootScope);
+        $mdTheming(el);
+        $rootScope.$apply();
+
+        expect(el.controller('mdTheme').$shouldWatch).toBeTruthy();
+      })
+    );
+
+    it('should set to false if there\'s an interpolation with one way binding',
+      inject(function ($mdTheming, $compile, $rootScope) {
+        $rootScope.theme = 'default';
+        var el = $compile('<div md-theme="{{::theme}}"></div>')($rootScope);
+        $mdTheming(el);
+        $rootScope.$apply();
+
+        expect(el.controller('mdTheme').$shouldWatch).toBeFalsy();
+      })
+    );
+  });
 });
 
 describe('md-themable directive', function() {
@@ -846,29 +907,16 @@ describe('md-themable directive', function() {
     expect(el.children().hasClass('md-red-theme')).toBe(false);
   }));
 
-  it('should not watch parent theme by default', inject(function($compile, $rootScope) {
+  it('should watch parent theme by default', inject(function($compile, $rootScope) {
     $rootScope.themey = 'red';
     var el = $compile('<div md-theme="{{themey}}"><span md-themable></span></div>')($rootScope);
     $rootScope.$apply();
 
     expect(el.children().hasClass('md-red-theme')).toBe(true);
     $rootScope.$apply('themey = "blue"');
-    expect(el.children().hasClass('md-blue-theme')).toBe(false);
-    expect(el.children().hasClass('md-red-theme')).toBe(true);
+    expect(el.children().hasClass('md-blue-theme')).toBe(true);
+    expect(el.children().hasClass('md-red-theme')).toBe(false);
   }));
-
-  it('should support watching parent theme by default', function() {
-    $mdThemingProvider.alwaysWatchTheme(true);
-    inject(function($rootScope, $compile) {
-      $rootScope.themey = 'red';
-      var el = $compile('<div md-theme="{{themey}}"><span md-themable></span></div>')($rootScope);
-      $rootScope.$apply();
-      expect(el.children().hasClass('md-red-theme')).toBe(true);
-      $rootScope.$apply('themey = "blue"');
-      expect(el.children().hasClass('md-blue-theme')).toBe(false);
-      expect(el.children().hasClass('md-red-theme')).toBe(true);
-    });
-  });
 
   it('should not apply a class for an unnested default theme', inject(function($rootScope, $compile) {
     var el = $compile('<div md-themable></div>')($rootScope);


### PR DESCRIPTION
- Dialogs now can also inherit promise/function defined themes and listen to the targetElement theme changes
- Removed wrong tests, we now assume that if an interpolation is being used in `md-theme` it was meant to be watched,
unless one-way binding (::) was applied.

Related to #9475

> Note: rebased on #9475 until it would be merged in.

cc @ErinCoughlan, @ThomasBurleson, @topherfangio 