### PR TITLE
fix(build): prevent closure from stripping $inject annotations

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -161,6 +161,13 @@ function buildModule(module, opts) {
       {
         pattern: /\@ngInject/g,
         replacement: 'ngInject'
+      },
+      {
+        // Turns `thing.$inject` into `thing['$inject']` in order to prevent
+        // Closure from stripping it from objects with an @constructor
+        // annotation.
+        pattern: /\.\$inject\b/g,
+        replacement: "['$inject']"
       }
     ];
     return lazypipe()


### PR DESCRIPTION
Adds a config that will turn instances of `something.$inject` into `something['$inject']`.
This helps in cases where Closure strips the injector due to the object annotation having a `@constructor` directive.
Note that the regular JS builds have the same output as before.

Fixes #9758.

CC @jelbourn 