### PR TITLE
fix(docs): prevent tabbing over hidden content; better animation handling

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -355,8 +355,7 @@ body[dir=rtl] .menu-heading {
   overflow: hidden;
   position: relative;
   z-index: 1;
-  transition: 0.75s cubic-bezier(0.35, 0, 0.25, 1);
-  transition-property: height;
+  height: 0;
 }
 .docs-menu .menu-toggle-list a.md-button {
   display: block;

--- a/docs/app/partials/menu-toggle.tmpl.html
+++ b/docs/app/partials/menu-toggle.tmpl.html
@@ -15,7 +15,11 @@
   </span>
 </md-button>
 
-<ul id="docs-menu-{{section.name | nospace}}" class="menu-toggle-list">
+<ul id="docs-menu-{{section.name | nospace}}"
+  class="menu-toggle-list"
+  aria-hidden="{{!renderContent}}"
+  ng-style="{ visibility: renderContent ? 'visible' : 'hidden' }">
+
   <li ng-repeat="page in section.pages">
     <menu-link section="page"></menu-link>
   </li>


### PR DESCRIPTION
* Fixes users being able to tab through the hidden content on the docs site.
* Switches the docs site's menu accordions to use `$animateCss` for their transitions. This allows us to reliably know when an animation has started and finished.

Fixes #8896.