### PR TITLE
feat(md-nav-item): Support for `ui-sref-opts` on `md-nav-item`

### DIFF
--- a/src/components/navBar/demoBasicUsage/index.html
+++ b/src/components/navBar/demoBasicUsage/index.html
@@ -1,15 +1,25 @@
 <div ng-controller="AppCtrl" ng-cloak>
   <md-content class="md-padding">
-    <md-nav-bar md-selected-nav-item="currentNavItem"
-                md-no-ink-bar="disableInkBar"
-                nav-bar-aria-label="navigation links">
-
-      <md-nav-item md-nav-click="goto('page1')" name="page1">Page One</md-nav-item>
-      <md-nav-item md-nav-click="goto('page2')" name="page2">Page Two</md-nav-item>
-      <md-nav-item md-nav-click="goto('page3')" name="page3">Page Three</md-nav-item>
-      <!-- these require actual routing with ui-router or ng-route, so they won't work in the demo
-      <md-nav-item md-nav-sref="app.page4" name="page4">Page Four</md-nav-item>
-      <md-nav-item md-nav-href="#page5" name="page5">Page Five</md-nav-item>
+    <md-nav-bar
+      md-selected-nav-item="currentNavItem"
+      nav-bar-aria-label="navigation links">
+      <md-nav-item md-nav-click="goto('page1')" name="page1">
+        Page One
+      </md-nav-item>
+      <md-nav-item md-nav-click="goto('page2')" name="page2">
+        Page Two
+      </md-nav-item>
+      <md-nav-item md-nav-click="goto('page3')" name="page3">
+        Page Three
+      </md-nav-item>
+      <!-- these require actual routing with ui-router or ng-route, so they
+      won't work in the demo
+      <md-nav-item md-nav-href="#page4" name="page5">Page Four</md-nav-item>
+      <md-nav-item md-nav-sref="app.page5" name="page4">Page Five</md-nav-item>
+      You can also add options for the <code>ui-sref-opts</code> attribute.
+      <md-nav-item md-nav-sref="page6" sref-opts="{reload:true, notify:true}">
+        Page Six
+      </md-nav-item>
       -->
     </md-nav-bar>
     <div class="ext-content">

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -158,6 +158,23 @@ describe('mdNavBar', function() {
 
       expect($scope.selectedTabRoute).toBe('tab2');
     });
+
+    it('adds ui-sref-opts attribute to nav item when sref-opts attribute is ' +
+        'defined', function() {
+          create(
+            '<md-nav-bar md-selected-nav-item="selected" nav-bar-aria-label="nav">' +
+              '<md-nav-item md-nav-sref="page1">' +
+                'tab1' +
+              '</md-nav-item>' +
+              '<md-nav-item md-nav-sref="page2" sref-opts="{reload:true,notify:true}">' +
+                'tab2' +
+              '</md-nav-item>' +
+            '</md-nav-bar>'
+          );
+
+          expect(getTab('tab2').attr('ui-sref-opts'))
+              .toBe('{"reload":true,"notify":true}');
+        });
   });
 
   describe('inkbar', function() {


### PR DESCRIPTION
Options can now be passed through the `sref-opts` attribute on the `md-nav-item` element to the `ui-sref-opts` attribute that will be added to the rendered DOM element. All known options from the [`ui-router-opts` wiki](https://ui-router.github.io/docs/latest/interfaces/transition.transitionoptions.html) are supported.

Fixes #9481