### PR TITLE
fix(docs, dialog, interim, panel): compatibility with latest angular snapshot

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -338,7 +338,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
   $rootScope.$on('$locationChangeSuccess', onLocationChange);
 
   $http.get("/docs.json")
-      .success(function(response) {
+      .then(function(response) {
         var versionId = getVersionIdFromPath();
         var head = { type: 'version', url: '/HEAD', id: 'head', name: 'HEAD (master)', github: '' };
         var commonVersions = versionId === 'head' ? [] : [ head ];

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -686,17 +686,21 @@ function MdDialogProvider($$interimElementProvider) {
     function beforeShow(scope, element, options, controller) {
 
       if (controller) {
-        controller.mdHtmlContent = controller.htmlContent || options.htmlContent || '';
-        controller.mdTextContent = controller.textContent || options.textContent ||
+        var mdHtmlContent = controller.htmlContent || options.htmlContent || '';
+        var mdTextContent = controller.textContent || options.textContent ||
             controller.content || options.content || '';
 
-        if (controller.mdHtmlContent && !$injector.has('$sanitize')) {
+        if (mdHtmlContent && !$injector.has('$sanitize')) {
           throw Error('The ngSanitize module must be loaded in order to use htmlContent.');
         }
 
-        if (controller.mdHtmlContent && controller.mdTextContent) {
+        if (mdHtmlContent && mdTextContent) {
           throw Error('md-dialog cannot have both `htmlContent` and `textContent`');
         }
+
+        // Only assign the content if nothing throws, otherwise it'll still be compiled.
+        controller.mdHtmlContent = mdHtmlContent;
+        controller.mdTextContent = mdTextContent;
       }
     }
 
@@ -709,7 +713,7 @@ function MdDialogProvider($$interimElementProvider) {
       // Once a dialog has `ng-cloak` applied on his template the dialog animation will not work properly.
       // This is a very common problem, so we have to notify the developer about this.
       if (dialogElement.hasClass('ng-cloak')) {
-        var message = '$mdDialog: using `<md-dialog ng-cloak >` will affect the dialog opening animations.';
+        var message = '$mdDialog: using `<md-dialog ng-cloak>` will affect the dialog opening animations.';
         $log.warn( message, element[0] );
       }
 
@@ -1004,7 +1008,7 @@ function MdDialogProvider($$interimElementProvider) {
 
 
         if (options.disableParentScroll) {
-          options.restoreScroll();
+          options.restoreScroll && options.restoreScroll();
           delete options.restoreScroll;
         }
 

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2468,7 +2468,8 @@ describe('$mdPanel', function() {
       spyOn(obj, 'callback');
 
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
-      callInterceptors('CLOSE');
+      panelRef._callInterceptors(interceptorTypes.CLOSE);
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalledWith(panelRef);
     });
@@ -2482,8 +2483,9 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(1));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
-      callInterceptors('CLOSE').then(obj.callback);
-      $rootScope.$apply();
+
+      panelRef._callInterceptors(interceptorTypes.CLOSE).then(obj.callback);
+      flushPanel();
 
       expect(results).toEqual([3, 2, 1]);
       expect(obj.callback).toHaveBeenCalled();
@@ -2507,8 +2509,8 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(2));
       panelRef.registerInterceptor(interceptorTypes.CLOSE, makePromise(3));
 
-      callInterceptors('CLOSE').catch(obj.callback);
-      $rootScope.$apply();
+      panelRef._callInterceptors(interceptorTypes.CLOSE).catch(obj.callback);
+      flushPanel();
 
       expect(results).toEqual([3, 2]);
       expect(obj.callback).toHaveBeenCalled();
@@ -2535,8 +2537,8 @@ describe('$mdPanel', function() {
         return $q.resolve();
       });
 
-      callInterceptors('CLOSE').catch(obj.callback);
-      $rootScope.$apply();
+      panelRef._callInterceptors(interceptorTypes.CLOSE).catch(obj.callback);
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalled();
     });
@@ -2546,8 +2548,8 @@ describe('$mdPanel', function() {
 
       spyOn(obj, 'callback');
 
-      callInterceptors('CLOSE').then(obj.callback);
-      $rootScope.$apply();
+      panelRef._callInterceptors(interceptorTypes.CLOSE).then(obj.callback);
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalled();
     });
@@ -2558,8 +2560,8 @@ describe('$mdPanel', function() {
       spyOn(obj, 'callback');
 
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
-
-      callInterceptors('CLOSE');
+      panelRef._callInterceptors(interceptorTypes.CLOSE)
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
 
@@ -2582,16 +2584,17 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
       panelRef.registerInterceptor('onOpen', obj.otherCallback);
 
-      callInterceptors('CLOSE');
-      callInterceptors('onOpen');
+      panelRef._callInterceptors(interceptorTypes.CLOSE);
+      panelRef._callInterceptors('onOpen');
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
 
       panelRef.removeAllInterceptors();
 
-      callInterceptors('CLOSE');
-      callInterceptors('onOpen');
+      panelRef._callInterceptors(interceptorTypes.CLOSE);
+      panelRef._callInterceptors('onOpen');
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
@@ -2609,16 +2612,18 @@ describe('$mdPanel', function() {
       panelRef.registerInterceptor(interceptorTypes.CLOSE, obj.callback);
       panelRef.registerInterceptor('onOpen', obj.otherCallback);
 
-      callInterceptors('CLOSE');
-      callInterceptors('onOpen');
+      panelRef._callInterceptors(interceptorTypes.CLOSE);
+      panelRef._callInterceptors('onOpen');
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(1);
 
       panelRef.removeAllInterceptors(interceptorTypes.CLOSE);
 
-      callInterceptors('CLOSE');
-      callInterceptors('onOpen');
+      panelRef._callInterceptors(interceptorTypes.CLOSE);
+      panelRef._callInterceptors('onOpen');
+      flushPanel();
 
       expect(obj.callback).toHaveBeenCalledTimes(1);
       expect(obj.otherCallback).toHaveBeenCalledTimes(2);
@@ -2744,17 +2749,6 @@ describe('$mdPanel', function() {
   function flushPanel() {
     $rootScope.$apply();
     $material.flushOutstandingAnimations();
-  }
-
-  function callInterceptors(type) {
-    if (panelRef) {
-      var promise = panelRef._callInterceptors(
-        $mdPanel.interceptorTypes[type] || type
-      );
-
-      flushPanel();
-      return promise;
-    }
   }
 
   function getNumberOfGroups() {

--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -244,8 +244,8 @@ function InterimElementProvider() {
   }
 
   /* @ngInject */
-  function InterimElementFactory($document, $q, $$q, $rootScope, $timeout, $rootElement, $animate,
-                                 $mdUtil, $mdCompiler, $mdTheming, $injector ) {
+  function InterimElementFactory($document, $q, $rootScope, $timeout, $rootElement, $animate,
+                                 $mdUtil, $mdCompiler, $mdTheming, $injector, $exceptionHandler) {
     return function createInterimElementService() {
       var SHOW_CANCELLED = false;
 
@@ -320,9 +320,18 @@ function InterimElementProvider() {
 
         showPromises.push(showAction);
 
+        // In Angular 1.6+, exceptions inside promises will cause a rejection. We need to handle
+        // the rejection and only log it if it's an error.
+        interimElement.deferred.promise.catch(function(fault) {
+          if (fault instanceof Error) {
+            $exceptionHandler(fault);
+          }
+
+          return fault;
+        });
+
         // Return a promise that will be resolved when the interim
         // element is hidden or cancelled...
-
         return interimElement.deferred.promise;
       }
 
@@ -488,8 +497,7 @@ function InterimElementProvider() {
 
                 showAction = showElement(element, options, compiledData.controller)
                   .then(resolve, rejectAll);
-
-              }, rejectAll);
+              }).catch(rejectAll);
 
             function rejectAll(fault) {
               // Force the '$md<xxx>.show()' promise to reject
@@ -523,15 +531,11 @@ function InterimElementProvider() {
             });
 
           } else {
-
-            $q.when(showAction)
-                .finally(function() {
-                  hideElement(options.element, options).then(function() {
-
-                    (isCancelled && rejectAll(response)) || resolveAll(response);
-
-                  }, rejectAll);
-                });
+            $q.when(showAction).finally(function() {
+              hideElement(options.element, options).then(function() {
+                isCancelled ? rejectAll(response) : resolveAll(response);
+              }, rejectAll);
+            });
 
             return self.deferred.promise;
           }
@@ -682,7 +686,12 @@ function InterimElementProvider() {
           // Trigger onComplete callback when the `show()` finishes
           var notifyComplete = options.onComplete || angular.noop;
 
-          notifyShowing(options.scope, element, options, controller);
+          // Necessary for consistency between Angular 1.5 and 1.6.
+          try {
+            notifyShowing(options.scope, element, options, controller);
+          } catch (e) {
+            return $q.reject(e);
+          }
 
           return $q(function (resolve, reject) {
             try {
@@ -693,10 +702,9 @@ function InterimElementProvider() {
                   startAutoHide();
 
                   resolve(element);
+                }, reject);
 
-                }, reject );
-
-            } catch(e) {
+            } catch (e) {
               reject(e.message);
             }
           });
@@ -705,35 +713,29 @@ function InterimElementProvider() {
         function hideElement(element, options) {
           var announceRemoving = options.onRemoving || angular.noop;
 
-          return $$q(function (resolve, reject) {
+          return $q(function (resolve, reject) {
             try {
               // Start transitionIn
-              var action = $$q.when( options.onRemove(options.scope, element, options) || true );
+              var action = $q.when( options.onRemove(options.scope, element, options) || true );
 
               // Trigger callback *before* the remove operation starts
               announceRemoving(element, action);
 
-              if ( options.$destroy ) {
-
+              if (options.$destroy) {
                 // For $destroy, onRemove should be synchronous
                 resolve(element);
-
               } else {
-
                 // Wait until transition-out is done
                 action.then(function () {
-
                   if (!options.preserveScope && options.scope ) {
                     options.scope.$destroy();
                   }
 
                   resolve(element);
-
-                }, reject );
+                }, reject);
               }
-
-            } catch(e) {
-              reject(e);
+            } catch (e) {
+              reject(e.message);
             }
           });
         }


### PR DESCRIPTION
* Fixes the docs site not working against the latest snapshot.
* Fixes the `dialog` throwing an error about `ngSanitize` not being present and then compiling the contents anyway.
* Makes the `interimElement` compatible both with the latest changes to promises from Angular PR #15213 and the current promise handling in Angular <= 1.5.
* Reintroduces the panel changes from #9688 which were overwritten accidentally.
* Fixes an error that was being swallowed during unit tests, but was still showing up in the `$exceptionHandler`.