### PR TITLE
feat(toolbar): add CSS rules for checkbox support

### DIFF
--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -115,6 +115,9 @@ md-toolbar {
     display: flex;
     align-items: center;
   }
+  md-checkbox {
+    margin: inherit;
+  }
   .md-button {
     margin-top: 0;
     margin-bottom: 0;


### PR DESCRIPTION
Checkboxes should center vertically when inside a toolbar

* Inherit margins from parent as in h1, h2, and h3

Fixes #9500