### PR TITLE
fix(card): fix alignment with avatar icons in Safari

### DIFF
--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -37,6 +37,11 @@ md-card {
 
       md-icon {
         padding: 8px;
+        > svg {
+          // Safari workaround for any SVG with padded parent
+          height: inherit;
+          width: inherit;
+        }
       }
 
       & + md-card-header-text {


### PR DESCRIPTION
Safari has an alignment issue with SVG icons when its parent has
any padding, causing its content to shift placement

* Force SVG elements to inherit height and width properties.

Fixes #9147