### PR TITLE
fix(input): increase placeholder contrast on focus

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -29,6 +29,12 @@ md-input-container.md-THEME_NAME-theme {
     }
   }
 
+  &.md-input-focused {
+    .md-input {
+      @include input-placeholder-color('\'{{foreground-2}}\'');
+    }
+  }
+
   &:not(.md-input-invalid) {
     &.md-input-has-value {
       label {


### PR DESCRIPTION
According to Material Design spec and a11y accessibility, a focused
text field should have a secondary text opacity

* Change input placeholder color from foreground-3 to foreground-2 on focus

Fixes #8903