### PR TITLE
fix(datepicker,select): arrow button consistency

### DIFF
--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -194,10 +194,10 @@ md-datepicker {
 .md-datepicker-triangle-button {
   position: absolute;
   @include rtl-prop(right, left, 0, auto);
-  top: $md-date-arrow-size;
+  bottom: -$md-date-arrow-size / 2;
 
   // TODO(jelbourn): This position isn't great on all platforms.
-  @include rtl(transform, translateY(-25%) translateX(45%), translateY(-25%) translateX(-45%));
+  @include rtl(transform, translateX(45%), translateX(-45%));
 }
 
 // Need crazy specificity to override .md-button.md-icon-button.

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -94,6 +94,14 @@ md-select.md-THEME_NAME-theme {
       }
     }
   }
+
+  .md-select-icon {
+    color: '{{foreground-3}}';
+
+    &:hover {
+      color: '{{foreground-2}}';
+    }
+  }
 }
 
 md-select-menu.md-THEME_NAME-theme {


### PR DESCRIPTION
- Fixes the datepicker's arrow being off a few pixels inside `md-input-container`, as well as being too close to the bottom when not in a `md-input-container`.
- Fixes the select's arrow icon being too dark, because it inherits from the closest `color` rule.

Relates to #9798.

For reference, here's what it looked like before:
![before](https://cloud.githubusercontent.com/assets/4450522/19249517/4dbdd80a-8f36-11e6-9519-0fa122243e9a.png)

And here's what it looks like after:
![after](https://cloud.githubusercontent.com/assets/4450522/19249523/5658f3f0-8f36-11e6-97c8-7f6736bf5935.png)
