### PR TITLE
fix(docs): re-add accidentally removed css

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -518,6 +518,7 @@ md-tabs.demo-source-tabs .active md-tab-label {
 .demo-content {
   position: relative;
   display: flex;
+  overflow: hidden;
 }
 .small-demo .demo-source-tabs:not(.ng-hide) {
   height: 224px;


### PR DESCRIPTION
* In 8b4d2f98f5112ba0b83109af00dbbed3f93f7a5f the overflow property has been accidentally removed.