### PR TITLE
feat(panel): add contentElement option

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -93,6 +93,8 @@ angular
  *     [$sce service](https://docs.angularjs.org/api/ng/service/$sce).
  *   - `templateUrl` - `{string=}`: The URL that will be used as the content of
  *     the panel.
+ *   - `contentElement` - `{(string|!angular.JQLite|!Element)=}`: Pre-compiled
+ *     element to be used as the panel's content.
  *   - `controller` - `{(function|string)=}`: The controller to associate with
  *     the panel. The controller can inject a reference to the returned
  *     panelRef, which allows the panel to be closed, hidden, and shown. Any
@@ -1028,6 +1030,24 @@ MdPanelService.prototype._wrapTemplate = function(origTemplate) {
 };
 
 
+/**
+ * Wraps a content element in a md-panel-outer wrapper and
+ * positions it off-screen. Allows for proper control over positoning
+ * and animations.
+ * @param {!angular.JQLite} contentElement Element to be wrapped.
+ * @return {!angular.JQLite} Wrapper element.
+ * @private
+ */
+MdPanelService.prototype._wrapContentElement = function(contentElement) {
+  var wrapper = angular.element('<div class="md-panel-outer-wrapper">');
+
+  contentElement.addClass('md-panel').css('left', '-9999px');
+  wrapper.append(contentElement);
+
+  return wrapper;
+};
+
+
 /*****************************************************************************
  *                                 MdPanelRef                                *
  *****************************************************************************/
@@ -1117,6 +1137,23 @@ function MdPanelRef(config, $injector) {
    * @private {!Object}
    */
   this._interceptors = Object.create(null);
+
+  /**
+   * Cleanup function, provided by `$mdCompiler` and assigned after the element
+   * has been compiled. When `contentElement` is used, the function is used to
+   * restore the element to it's proper place in the DOM.
+   * @private {!Function}
+   */
+  this._compilerCleanup = null;
+
+  /**
+   * Cache for saving and restoring element inline styles, CSS classes etc.
+   * @type {{styles: string, classes: string}}
+   */
+  this._restoreCache = {
+    styles: '',
+    classes: ''
+  };
 }
 
 
@@ -1231,6 +1268,14 @@ MdPanelRef.prototype.detach = function() {
       self._bottomFocusTrap.parentNode.removeChild(self._bottomFocusTrap);
     }
 
+    if (self._restoreCache.classes) {
+      self.panelEl[0].className = self._restoreCache.classes;
+    }
+
+    // Either restore the saved styles or clear the ones set by mdPanel.
+    self.panelEl[0].style.cssText = self._restoreCache.styles || '';
+
+    self._compilerCleanup();
     self.panelContainer.remove();
     self.isAttached = false;
     return self._$q.when(self);
@@ -1457,6 +1502,51 @@ MdPanelRef.prototype.toggleClass = function(toggleClass, onElement) {
 
 
 /**
+ * Compiles the panel, according to the passed in config and appends it to
+ * the DOM. Helps normalize differences in the compilation process between
+ * using a string template and a content element.
+ * @returns {!angular.$q.Promise<!MdPanelRef>} Promise that is resolved when
+ *     the element has been compiled and added to the DOM.
+ * @private
+ */
+MdPanelRef.prototype._compile = function() {
+  var self = this;
+
+  // Compile the element via $mdCompiler. Note that when using a
+  // contentElement, the element isn't actually being compiled, rather the
+  // compiler saves it's place in the DOM and provides a way of restoring it.
+  return self._$mdCompiler.compile(self.config).then(function(compileData) {
+    var config = self.config;
+
+    if (config.contentElement) {
+      var panelEl = compileData.element;
+
+      // Since mdPanel modifies the inline styles and CSS classes, we need
+      // to save them in order to be able to restore on close.
+      self._restoreCache.styles = panelEl[0].style.cssText;
+      self._restoreCache.classes = panelEl[0].className;
+
+      self.panelContainer = self._$mdPanel._wrapContentElement(panelEl);
+      self.panelEl = panelEl;
+    } else {
+      self.panelContainer = compileData.link(config['scope']);
+      self.panelEl = angular.element(
+        self.panelContainer[0].querySelector('.md-panel')
+      );
+    }
+
+    // Save a reference to the cleanup function from the compiler.
+    self._compilerCleanup = compileData.cleanup;
+
+    // Attach the panel to the proper place in the DOM.
+    getElement(self.config['attachTo']).append(self.panelContainer);
+
+    return self;
+  });
+};
+
+
+/**
  * Creates a panel and adds it to the dom.
  * @returns {!angular.$q.Promise} A promise that is resolved when the panel is
  *     created.
@@ -1471,44 +1561,41 @@ MdPanelRef.prototype._createPanel = function() {
     }
 
     self.config.locals.mdPanelRef = self;
-    self._$mdCompiler.compile(self.config)
-        .then(function(compileData) {
-          self.panelContainer = compileData.link(self.config['scope']);
-          getElement(self.config['attachTo']).append(self.panelContainer);
 
-          if (self.config['disableParentScroll']) {
-            self._restoreScroll = self._$mdUtil.disableScrollAround(
-              null,
-              self.panelContainer,
-              { disableScrollMask: true }
-            );
-          }
+    self._compile().then(function() {
+      if (self.config['disableParentScroll']) {
+        self._restoreScroll = self._$mdUtil.disableScrollAround(
+          null,
+          self.panelContainer,
+          { disableScrollMask: true }
+        );
+      }
 
-          self.panelEl = angular.element(
-              self.panelContainer[0].querySelector('.md-panel'));
+      // Add a custom CSS class to the panel element.
+      if (self.config['panelClass']) {
+        self.panelEl.addClass(self.config['panelClass']);
+      }
 
-          // Add a custom CSS class to the panel element.
-          if (self.config['panelClass']) {
-            self.panelEl.addClass(self.config['panelClass']);
-          }
+      // Handle click and touch events for the panel container.
+      if (self.config['propagateContainerEvents']) {
+        self.panelContainer.css('pointer-events', 'none');
+      }
 
-          // Handle click and touch events for the panel container.
-          if (self.config['propagateContainerEvents']) {
-            self.panelContainer.css('pointer-events', 'none');
-          }
+      // Panel may be outside the $rootElement, tell ngAnimate to animate
+      // regardless.
+      if (self._$animate.pin) {
+        self._$animate.pin(
+          self.panelContainer,
+          getElement(self.config['attachTo'])
+        );
+      }
 
-          // Panel may be outside the $rootElement, tell ngAnimate to animate
-          // regardless.
-          if (self._$animate.pin) {
-            self._$animate.pin(self.panelContainer,
-                getElement(self.config['attachTo']));
-          }
+      self._configureTrapFocus();
+      self._addStyles().then(function() {
+        resolve(self);
+      }, reject);
+    }, reject);
 
-          self._configureTrapFocus();
-          self._addStyles().then(function() {
-            resolve(self);
-          }, reject);
-        }, reject);
   });
 };
 

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -3,8 +3,10 @@ describe('$mdPanel', function() {
       $mdUtil, $animate, $$rAF, $window;
   var panelRef;
   var attachedElements = [];
-  var PANEL_WRAPPER_CLASS = '.md-panel-outer-wrapper';
+  var PANEL_WRAPPER = '.md-panel-outer-wrapper';
+  var PANEL_WRAPPER_CLASS = 'md-panel-outer-wrapper';
   var PANEL_EL = '.md-panel';
+  var PANEL_EL_CLASS = 'md-panel';
   var HIDDEN_CLASS = '_md-panel-hidden';
   var FOCUS_TRAPS_CLASS = '._md-panel-focus-trap';
   var FULLSCREEN_CLASS = '_md-panel-fullscreen';
@@ -128,17 +130,17 @@ describe('$mdPanel', function() {
     openPanel(DEFAULT_CONFIG);
 
     expect(PANEL_EL).toExist();
-    expect(PANEL_WRAPPER_CLASS).not.toHaveClass(HIDDEN_CLASS);
+    expect(PANEL_WRAPPER).not.toHaveClass(HIDDEN_CLASS);
 
     hidePanel();
 
     expect(PANEL_EL).toExist();
-    expect(PANEL_WRAPPER_CLASS).toHaveClass(HIDDEN_CLASS);
+    expect(PANEL_WRAPPER).toHaveClass(HIDDEN_CLASS);
 
     showPanel();
 
     expect(PANEL_EL).toExist();
-    expect(PANEL_WRAPPER_CLASS).not.toHaveClass(HIDDEN_CLASS);
+    expect(PANEL_WRAPPER).not.toHaveClass(HIDDEN_CLASS);
   });
 
   it('destroy should clear the config locals on the panelRef', function () {
@@ -185,7 +187,7 @@ describe('$mdPanel', function() {
       flushPanel();
 
       expect(openResolved).toBe(true);
-      expect(PANEL_WRAPPER_CLASS).toExist();
+      expect(PANEL_WRAPPER).toExist();
       expect(panelRef.panelContainer).not.toHaveClass(HIDDEN_CLASS);
       expect(panelRef.isAttached).toEqual(true);
 
@@ -194,7 +196,7 @@ describe('$mdPanel', function() {
 
       expect(closeResolved).toBe(true);
       expect(panelRef.isAttached).toEqual(false);
-      expect(PANEL_WRAPPER_CLASS).not.toExist();
+      expect(PANEL_WRAPPER).not.toExist();
     });
 
     it('should reject on create when opening', function() {
@@ -403,7 +405,7 @@ describe('$mdPanel', function() {
 
         openPanel(config);
 
-        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER);
         expect(panelWrapperEl.parentElement).toBe(parentEl);
 
         closePanel();
@@ -419,7 +421,7 @@ describe('$mdPanel', function() {
 
         openPanel(config);
 
-        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER);
         expect(panelWrapperEl.parentElement).toBe(parentEl);
 
         closePanel();
@@ -435,7 +437,7 @@ describe('$mdPanel', function() {
 
         openPanel(config);
 
-        var panelWrapperEl = document.querySelector(PANEL_WRAPPER_CLASS);
+        var panelWrapperEl = document.querySelector(PANEL_WRAPPER);
         expect(panelWrapperEl.parentElement).toBe(parentEl);
 
         closePanel();
@@ -455,7 +457,7 @@ describe('$mdPanel', function() {
 
         openPanel(config);
 
-        wrapper = angular.element(document.querySelector(PANEL_WRAPPER_CLASS));
+        wrapper = angular.element(document.querySelector(PANEL_WRAPPER));
         expect(wrapper.css('pointer-events')).not.toEqual('none');
       });
 
@@ -467,7 +469,7 @@ describe('$mdPanel', function() {
 
         openPanel(config);
 
-        wrapper = angular.element(document.querySelector(PANEL_WRAPPER_CLASS));
+        wrapper = angular.element(document.querySelector(PANEL_WRAPPER));
         expect(wrapper.css('pointer-events')).toEqual('none');
       });
     });
@@ -498,7 +500,7 @@ describe('$mdPanel', function() {
 
       // We have to use `toMatch` here, because IE11 is sometimes returning an integer instead of
       // an string.
-      expect(document.querySelector(PANEL_WRAPPER_CLASS).style.zIndex)
+      expect(document.querySelector(PANEL_WRAPPER).style.zIndex)
           .toMatch(zIndex);
     });
 
@@ -514,7 +516,7 @@ describe('$mdPanel', function() {
 
       // We have to use `toMatch` here, because IE11 is sometimes returning an integer instead of
       // an string.
-      expect(document.querySelector(PANEL_WRAPPER_CLASS).style.zIndex)
+      expect(document.querySelector(PANEL_WRAPPER).style.zIndex)
           .toMatch(zIndex);
     });
 
@@ -709,7 +711,7 @@ describe('$mdPanel', function() {
 
             expect(onDomAddedCalled).toBe(true);
             expect(PANEL_EL).toExist();
-            expect(PANEL_WRAPPER_CLASS).toHaveClass(HIDDEN_CLASS);
+            expect(PANEL_WRAPPER).toHaveClass(HIDDEN_CLASS);
           });
 
       it('should continue resolving when onDomAdded resolves', function() {
@@ -773,7 +775,7 @@ describe('$mdPanel', function() {
 
             expect(onOpenCompleteCalled).toBe(true);
             expect(PANEL_EL).toExist();
-            expect(PANEL_WRAPPER_CLASS).not.toHaveClass(HIDDEN_CLASS);
+            expect(PANEL_WRAPPER).not.toHaveClass(HIDDEN_CLASS);
           });
 
       it('should call onRemoving if provided after hiding the panel but before ' +
@@ -818,7 +820,7 @@ describe('$mdPanel', function() {
         expect(onRemovingCalled).toBe(true);
         expect(PANEL_EL).toExist();
         expect(hideResolved).toBe(true);
-        expect(PANEL_WRAPPER_CLASS).toHaveClass(HIDDEN_CLASS);
+        expect(PANEL_WRAPPER).toHaveClass(HIDDEN_CLASS);
       });
 
       it('should reject hide when onRemoving rejects', function() {
@@ -837,7 +839,7 @@ describe('$mdPanel', function() {
 
         expect(hideRejected).toBe(true);
         expect(PANEL_EL).toExist();
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass(HIDDEN_CLASS);
+        expect(PANEL_WRAPPER).not.toHaveClass(HIDDEN_CLASS);
       });
 
       it('should call onRemoving on escapeToClose', function() {
@@ -932,7 +934,7 @@ describe('$mdPanel', function() {
 
         panelRef.panelContainer.addClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).toHaveClass('my-class');
+        expect(PANEL_WRAPPER).toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
       });
 
@@ -941,7 +943,7 @@ describe('$mdPanel', function() {
 
         panelRef.panelEl.addClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).toHaveClass('my-class');
       });
 
@@ -950,12 +952,12 @@ describe('$mdPanel', function() {
 
         panelRef.panelContainer.addClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).toHaveClass('my-class');
+        expect(PANEL_WRAPPER).toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
 
         panelRef.panelContainer.removeClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
       });
 
@@ -964,12 +966,12 @@ describe('$mdPanel', function() {
 
         panelRef.panelEl.addClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).toHaveClass('my-class');
 
         panelRef.panelEl.removeClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
       });
 
@@ -978,12 +980,12 @@ describe('$mdPanel', function() {
 
         panelRef.panelContainer.toggleClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).toHaveClass('my-class');
+        expect(PANEL_WRAPPER).toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
 
         panelRef.panelContainer.toggleClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('my-class');
       });
 
@@ -992,12 +994,12 @@ describe('$mdPanel', function() {
 
         panelRef.panelEl.toggleClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).toHaveClass('my-class');
 
         panelRef.panelEl.toggleClass('my-class');
 
-        expect(PANEL_WRAPPER_CLASS).not.toHaveClass('my-class');
+        expect(PANEL_WRAPPER).not.toHaveClass('my-class');
         expect(PANEL_EL).not.toHaveClass('n-class');
       });
     });
@@ -1403,7 +1405,7 @@ describe('$mdPanel', function() {
     });
   });
 
-  describe('positioning logic', function() {
+  describe('positioning logic: ', function() {
     var config;
     var mdPanelPosition;
 
@@ -2366,7 +2368,7 @@ describe('$mdPanel', function() {
     });
   });
 
-  describe('animation logic', function() {
+  describe('animation logic: ', function() {
     var mdPanelAnimation;
     var myButton;
 
@@ -2711,6 +2713,72 @@ describe('$mdPanel', function() {
         expect(panelRef.isAttached).toBe(false);
       });
     });
+  });
+
+  describe('contentElement support: ', function() {
+    var config;
+
+    beforeEach(function() {
+      config = {
+        contentElement: angular.element('<div>'),
+        position: $mdPanel.newPanelPosition().absolute().center()
+      };
+    });
+
+    it('should wrap the content element in the proper HTML and assign ' +
+      'the wrapper to the panel reference', function() {
+        openPanel(config);
+
+        expect(panelRef.panelEl.parent())
+          .toHaveClass(PANEL_WRAPPER_CLASS);
+
+        expect(panelRef.panelContainer[0]).toBe(config.contentElement.parent()[0]);
+      });
+
+    it('should add the proper class to the panel element and assign ' +
+      'it to the panel reference', function() {
+        openPanel(config);
+
+        expect(panelRef.panelEl).toHaveClass(PANEL_EL_CLASS);
+        expect(panelRef.panelEl[0]).toBe(config.contentElement[0]);
+      });
+
+    it('should restore the inline styles and classes of the element on close',
+      function() {
+        var element = config.contentElement;
+
+        element.addClass('my-only-class');
+        element.css({ top: '42px', left: '1337px' });
+
+        openPanel(config);
+        closePanel();
+
+        expect(element.attr('class')).toBe('my-only-class');
+        expect(element.css('top')).toBe('42px');
+        expect(element.css('left')).toBe('1337px');
+      });
+
+    it('should clear out any panel-specific inline styles from the element',
+      function() {
+        openPanel(config);
+
+        expect(config.contentElement.attr('style')).toBeTruthy();
+
+        closePanel();
+
+        expect(config.contentElement.attr('style')).toBeFalsy();
+      });
+
+    it('should clean up the panel via the cleanup function from the compiler',
+      function() {
+        openPanel(config);
+
+        spyOn(panelRef, '_compilerCleanup');
+
+        closePanel();
+
+        expect(panelRef._compilerCleanup).toHaveBeenCalled();
+      });
   });
 
   /**


### PR DESCRIPTION
Hooks up the `contentElement` option from `$mdCompile` to `$mdPanel`, allowing for a pre-compiled element to be used as the panel's content.

Relates to #9675.
Fixes #9757.