### PR TITLE
chore(docs): remove outdated gradient syntax

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -406,10 +406,6 @@ body[dir=rtl] .menu-heading {
 .nav-header {
   background-color: #106CC8;
   background: linear-gradient(#185694, #106cc8);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0, #185694), color-stop(1, #106cc8));
-  background: -webkit-linear-gradient(top, #185694 0%, #106cc8 100%);
-  background: -moz-linear-gradient(top, #185694 0%, #106cc8 100%);
-  background: linear-gradient(top, #185694 0%, #106cc8 100%);
   border-bottom: 1px solid #267ED5;
   flex-shrink: 0;
   z-index: 2;


### PR DESCRIPTION
Removes an instance of the outdated gradient syntax from the docs CSS. This was causing a warning to be logged by Autoprefixer.