### PR TITLE
update(build): sort panel styles to the top

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -29,7 +29,10 @@ module.exports = {
     'src/core/style/mixins.scss',
     'src/core/style/structure.scss',
     'src/core/style/typography.scss',
-    'src/core/style/layout.scss'
+    'src/core/style/layout.scss',
+
+    // TODO(crisbeto): can be removed once mdPanel is in the core.
+    'src/components/panel/*.scss'
   ],
   scssLayoutFiles: [
     'src/core/style/variables.scss',
@@ -38,10 +41,10 @@ module.exports = {
     'src/core/services/layout/layout.scss'
   ],
   scssLayoutAttributeFiles: [
-      'src/core/style/variables.scss',
-      'src/core/style/mixins.scss',
-      'src/core/services/layout/layout-attributes.scss'
-    ],
+    'src/core/style/variables.scss',
+    'src/core/style/mixins.scss',
+    'src/core/services/layout/layout-attributes.scss'
+  ],
   scssPaths : [
     'src/components/**/*.scss',
     'src/core/services/**/*.scss'


### PR DESCRIPTION
Since the CSS is being compiled in alphabetical order, the mdPanel styles end up after most components in the compiled CSS, which makes it hard for components that implement mdPanel to override it's styles (the `opacity` in particular). This change sorts the panel styles to the top, right after all of the core structural CSS. This is a temporary solution until we get rid of interimElement and move mdPanel into the core.

CC @ErinCoughlan @bradrich 