### PR TITLE
change margin of md-input-container to md-autocomplete

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -46,11 +46,13 @@ md-autocomplete {
   }
   &[md-floating-label] {
     border-radius: 0;
+    margin: 18px 0px;
     background: transparent;
     height: auto;
 
     md-input-container {
       padding-bottom: 0px;
+      margin: 0px;
     }
     md-autocomplete-wrap {
       height: auto;


### PR DESCRIPTION
When applying md-floating-label to md-autocomplete,
the vertical margin 18px of md-input-container apply inside the md-autocomplete element.
If there are a md-autocomplete following a normal md-input-container, the space between will be 36px.
But I believe it should be same behaviour of multiple md-input-container in a form, which the space bewteen is 18px;