### PR TITLE
fix(toolbar): scroll shrink applied to inner md-content

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -122,7 +122,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
          *
          */
         function onChangeScrollShrink(shrinkWithScroll) {
-          var closestContent = element.siblings('md-content');
+          var closestContent = element.parent().children('md-content');
 
           // If we have a content element, fake the call; this might still fail
           // if the content element isn't a sibling of the toolbar

--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -122,7 +122,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
          *
          */
         function onChangeScrollShrink(shrinkWithScroll) {
-          var closestContent = element.parent().find('md-content');
+          var closestContent = element.siblings('md-content');
 
           // If we have a content element, fake the call; this might still fail
           // if the content element isn't a sibling of the toolbar

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -525,9 +525,38 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         parent.$$childHead = parent.$$childTail = child;
       }
     },
+    
+    /**
+     * Get an element direct children matching a given tag name
+     *
+     * @param element Element to start walking the DOM from
+     * @param tagName Tag name to match
+     */
+    getChildren: function getChildren(element, tagName) {
+      var upperCasedTagName = tagName.toUpperCase();
+      if (element instanceof angular.element) element = element[0];
+      return Array.prototype.filter.call(element.children, function(node) { 
+        return node.tagName === upperCasedTagName; 
+      });
+    },
+    
+    /**
+     * Get an element siblings matching a given tag name
+     *
+     * @param el Element to start walking the DOM from
+     * @param tagName Tag name to match
+     */
+    getSiblings: function getSiblings(element, tagName) {
+      var upperCasedTagName = tagName.toUpperCase();
+      if (element instanceof angular.element) element = element[0];
+      return Array.prototype.filter.call(element.parentNode.children, function(node) { 
+        return element !== node && node.tagName === upperCasedTagName; 
+      });
+    },
 
     /*
-     * getClosest replicates jQuery.closest() to walk up the DOM tree until it finds a matching nodeName
+     * get
+     replicates jQuery.closest() to walk up the DOM tree until it finds a matching nodeName
      *
      * @param el Element to start walking the DOM from
      * @param check Either a string or a function. If a string is passed, it will be evaluated against


### PR DESCRIPTION
I have a md-select nested within my toolbar which has scroll shrink activated.
When onChangeScrollShrink is called, closestContent contains the md-select's md-content, which is later moved to the body, but it's already too late, scroll listener have already been applied :/