### PR TITLE
fix(toolbar): scroll shrink is applied to md-content within toolbar

### DIFF
--- a/src/components/toolbar/toolbar.js
+++ b/src/components/toolbar/toolbar.js
@@ -122,7 +122,7 @@ function mdToolbarDirective($$rAF, $mdConstant, $mdUtil, $mdTheming, $animate) {
          *
          */
         function onChangeScrollShrink(shrinkWithScroll) {
-          var closestContent = element.parent().find('md-content');
+          var closestContent = $mdUtil.getSiblings(element, 'md-content');
 
           // If we have a content element, fake the call; this might still fail
           // if the content element isn't a sibling of the toolbar

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -526,6 +526,21 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       }
     },
 
+    /**
+     * Get an element siblings matching a given tag name
+     *
+     * @param el Element to start walking the DOM from
+     * @param tagName Tag name to match
+     */
+    getSiblings: function getSiblings(element, tagName) {
+      var upperCasedTagName = tagName.toUpperCase();
+      if (element instanceof angular.element) element = element[0];
+      var siblings = Array.prototype.filter.call(element.parentNode.children, function(node) {
+        return element !== node && node.tagName.toUpperCase() === upperCasedTagName;
+      });
+      return angular.element(siblings);
+    },
+
     /*
      * getClosest replicates jQuery.closest() to walk up the DOM tree until it finds a matching nodeName
      *

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -651,6 +651,31 @@ describe('util', function() {
     });
   });
 
+  describe('getSiblings', function() {
+    var $mdUtil;
+
+    beforeEach(inject(function(_$mdUtil_) {
+      $mdUtil = _$mdUtil_;
+    }));
+
+    it('should be able to get the siblings (wihout source element) of a particular node type', function() {
+      var parent = angular.element('<h1>');
+      var element = angular.element('<h2>');
+      var sibling = angular.element('<h2>');
+
+      parent.append(element);
+      parent.append(sibling);
+
+      var result = $mdUtil.getSiblings(element, 'h2');
+
+      expect(result).toBeTruthy();
+      expect(result.length).toBe(1);
+      expect(result[0]).toBe(sibling[0]);
+
+      parent.remove();
+    });
+  });
+
   describe('getClosest', function() {
     var $mdUtil;
 


### PR DESCRIPTION
I have a `md-select` nested within my `md-toolbar` which has scroll shrink activated.
When `onChangeScrollShrink` is called, `closestContent` contains the `md-select`'s `md-content`, which is later moved to the body, but it's already too late, scroll listeners have already been applied :/

Duplicate of #9856
This time I cloned the repo instead of inline editing via github...