### PR TITLE
fix(layout.scss): Prevent duplicate layout-row and layout-column rules

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -125,6 +125,16 @@
   .#{$flexName}-noshrink    { flex: 1 0 auto;  box-sizing: border-box; }
   .#{$flexName}-nogrow      { flex: 0 1 auto;  box-sizing: border-box; }
 
+   .layout-row {
+    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
+    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
+  }
+
+  .layout-column {
+    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
+    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }
+  }
+
   // (1-20) * 5 = 0-100%
   @for $i from 0 through 20 {
     $value : #{$i * 5 + '%'};
@@ -153,15 +163,7 @@
       box-sizing: border-box;
     }
 
-    .layout-row {
-	    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
-	    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
-	  }
-
-	  .layout-column {
-	    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
-	    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }
-	  }
+   
 
     .layout#{$name}-row > .#{$flexName}-#{$i * 5} {
       flex: 1 1 100%;

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -125,7 +125,7 @@
   .#{$flexName}-noshrink    { flex: 1 0 auto;  box-sizing: border-box; }
   .#{$flexName}-nogrow      { flex: 0 1 auto;  box-sizing: border-box; }
 
-   .layout-row {
+  .layout-row {
     > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 33.33%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
     > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 66.66%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
   }
@@ -163,45 +163,53 @@
       box-sizing: border-box;
     }
 
-   
+    // Prevent duplication of .layout-row rules if name is null
+    @if $name != '' {
+      .layout#{$name}-row > .#{$flexName}-#{$i * 5} {
+        flex: 1 1 100%;
+        max-width: #{$value};
+        max-height: 100%;
+        box-sizing: border-box;
 
-    .layout#{$name}-row > .#{$flexName}-#{$i * 5} {
-      flex: 1 1 100%;
-      max-width: #{$value};
-      max-height: 100%;
-      box-sizing: border-box;
+        // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+        @if $i == 0 {
+          min-width: 0;
+        }
+      }
 
-      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
-      @if $i == 0 {  min-width: 0;  }
+      .layout#{$name}-column > .#{$flexName}-#{$i * 5} {
+        flex: 1 1 100%;
+        max-width: 100%;
+        max-height: #{$value};
+        box-sizing: border-box;
+
+        // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+        @if $i == 0 {
+          min-height: 0;
+        }
+      }
+
     }
-
-    .layout#{$name}-column > .#{$flexName}-#{$i * 5} {
-      flex: 1 1 100%;
-      max-width: 100%;
-      max-height: #{$value};
-      box-sizing: border-box;
-
-      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
-      @if $i == 0 {  min-height: 0;  }
-    }
-
   }
 
-  .layout#{$name}-row {
-    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 100%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
-    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 100%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
+  // Prevent duplication of .layout-row rules if name is null
+  @if $name != '' {
+    .layout#{$name}-row {
+      > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 100%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
+      > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 100%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
 
-    // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
-    > .flex                                       { min-width: 0;   }
+      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+      > .flex                                       { min-width: 0;   }
 
-  }
+    }
 
-  .layout#{$name}-column {
-    > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 100%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
-    > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 100%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }
+    .layout#{$name}-column {
+      > .#{$flexName}-33   , > .#{$flexName}-33     {  flex: 1 1 100%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
+      > .#{$flexName}-66   , > .#{$flexName}-66     {  flex: 1 1 100%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }
 
-    // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
-    > .flex                                       { min-height: 0;   }
+      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+      > .flex                                       { min-height: 0;   }
+    }
   }
 
 }


### PR DESCRIPTION
I've found out that the .layout-row and .layout-column css rules are duplicated, by being inside the @for loop without any interaction with the $i variable. This creates unnecessary duplicate declarations.
