### PR TITLE
feat(autocomplete): Ability to hide clear icon.

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -235,6 +235,13 @@ md-autocomplete {
   }
 }
 
+// Allow hiding of the clear button
+.md-hide-clear-button {
+  .md-clear-button {
+    display: none;
+  }
+}
+
 // IE Only
 @media screen and (-ms-high-contrast: active) {
   md-autocomplete,

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -2391,4 +2391,63 @@ describe('<md-autocomplete>', function() {
     element.remove();
   });
 
+  describe('CSS API', function() {
+    describe('md-hide-clear-button', function() {
+      it('does not hide the clear button by default', function() {
+        var scope = createScope();
+        var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+
+        var element = compile(template, scope);
+        var ctrl = element.controller('mdAutocomplete');
+
+        // Make sure to append it to the page so getComputedStyle() works below
+        document.body.appendChild(element[0]);
+
+        scope.$apply('searchText = "fa"');
+
+        var clearButton = element[0].querySelector('.md-clear-button');
+
+        expect(window.getComputedStyle(clearButton).display).not.toEqual('none');
+
+        element.remove();
+      });
+
+      it('hides the clear button when utilized', function() {
+        var scope = createScope();
+        var template = '\
+          <md-autocomplete\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder"\
+              class="md-hide-clear-button">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+
+        var element = compile(template, scope);
+        var ctrl = element.controller('mdAutocomplete');
+
+        // Make sure to append it to the page so getComputedStyle() works below
+        document.body.appendChild(element[0]);
+
+        scope.$apply('searchText = "fa"');
+
+        var clearButton = element[0].querySelector('.md-clear-button');
+
+        expect(window.getComputedStyle(clearButton).display).toEqual('none');
+
+        element.remove();
+      });
+    });
+  });
+
 });

--- a/src/components/autocomplete/demoCustomTemplate/index.html
+++ b/src/components/autocomplete/demoCustomTemplate/index.html
@@ -2,6 +2,7 @@
   <md-content layout-padding layout="column">
     <form ng-submit="$event.preventDefault()">
       <p>Use <code>&lt;md-autocomplete&gt;</code> with custom templates to show styled autocomplete results.</p>
+      <p>Also use the <code>md-hide-clear-button</code> class to to hide the clear icon.</p>
       <md-autocomplete
           ng-disabled="ctrl.isDisabled"
           md-no-cache="ctrl.noCache"
@@ -13,7 +14,8 @@
           md-item-text="item.name"
           md-min-length="0"
           placeholder="Pick an Angular repository"
-          md-menu-class="autocomplete-custom-template">
+          md-menu-class="autocomplete-custom-template"
+          class="md-hide-clear-button">
         <md-item-template>
           <span class="item-title">
             <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -65,7 +65,10 @@ angular
  *   </md-autocomplete>
  * </hljs>
  *
+ * ### Styling & CSS
  *
+ * The autocomplete offers the `md-hide-clear-button` class since Version 1.1.2 to allow developers
+ * to hide the clear button if they do not wish to use it.
  *
  * @param {expression} md-items An expression in the format of `item in results` to iterate over
  *     matches for your search.<br/><br/>
@@ -366,6 +369,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 aria-activedescendant=""\
                 aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
             <button\
+                class="md-clear-button"\
                 type="button"\
                 tabindex="-1"\
                 ng-if="$mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled"\


### PR DESCRIPTION
Per multiple users' requests, we have added the `md-hide-clear-button`
class to the autocomplete so that users can hide the clear button.

Fixes #4841.