### PR TITLE
demo(navbar): Add closing div tag.

### DIFF
--- a/src/components/navBar/demoBasicUsage/index.html
+++ b/src/components/navBar/demoBasicUsage/index.html
@@ -10,6 +10,7 @@
       -->
     </md-nav-bar>
     <div class="ext-content">
-      External content for `<span>{{currentNavItem}}</span>`
+      External content for `<span>{{currentNavItem}}</span>`.
     </div>
   </md-content>
+</div>


### PR DESCRIPTION
Add a missing closing div tag to the basic usage demo for the navbar component.