### PR TITLE
fix(chips): use empty chip buffer if not a string

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1224,6 +1224,19 @@ describe('<md-chips>', function() {
               expect(scope.items.length).toBe(4);
               expect(scope.items[3]).toBe('Grape');
             }));
+
+          it('should use an empty string if ngModel value is falsy', inject(function($timeout) {
+            var element = buildChips(NG_MODEL_TEMPLATE);
+            var ctrl = element.controller('mdChips');
+
+            $timeout.flush();
+
+            var ngModelCtrl = ctrl.userInputNgModelCtrl;
+
+            expect(ngModelCtrl.$viewValue).toBeFalsy();
+            expect(ctrl.getChipBuffer()).toBe('');
+          }));
+
         });
 
         describe('without ngModel', function() {

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -383,12 +383,15 @@ MdChipsCtrl.prototype.useOnSelectExpression = function() {
  * model of an {@code md-autocomplete}, or, through some magic, the model
  * bound to any inpput or text area element found within a
  * {@code md-input-container} element.
- * @return {Object|string}
+ * @return {string}
  */
 MdChipsCtrl.prototype.getChipBuffer = function() {
-  return !this.userInputElement ? this.chipBuffer :
-      this.userInputNgModelCtrl ? this.userInputNgModelCtrl.$viewValue :
-          this.userInputElement[0].value;
+  var chipBuffer =  !this.userInputElement ? this.chipBuffer :
+                     this.userInputNgModelCtrl ? this.userInputNgModelCtrl.$viewValue :
+                     this.userInputElement[0].value;
+
+  // Ensure that the chip buffer is always a string. For example, the input element buffer might be falsy.
+  return angular.isString(chipBuffer) ? chipBuffer : '';
 };
 
 /**


### PR DESCRIPTION
- Sometimes the ngModel of the custom input element (provided by the user) does not have any initial $viewValue.
- The chips component always expects the chipBuffer to be a string and a non-string reference can cause Runtime Exceptions.

Fixes #9867.
