### PR TITLE
fix(panel): clickOutsideToClose with propagateContainerEvents

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1825,15 +1825,17 @@ MdPanelRef.prototype._configureEscapeToClose = function() {
  */
 MdPanelRef.prototype._configureClickOutsideToClose = function() {
   if (this.config['clickOutsideToClose']) {
-    var target = this.panelContainer;
-    var sourceElem;
+    var target = this.config['propagateContainerEvents'] ?
+        angular.element(document.body) :
+        this.panelContainer;
+    var sourceEl;
 
     // Keep track of the element on which the mouse originally went down
     // so that we can only close the backdrop when the 'click' started on it.
-    // A simple 'click' handler does not work,
-    // it sets the target object as the element the mouse went down on.
+    // A simple 'click' handler does not work, it sets the target object as the
+    // element the mouse went down on.
     var mousedownHandler = function(ev) {
-      sourceElem = ev.target;
+      sourceEl = ev.target;
     };
 
     // We check if our original element and the target is the backdrop
@@ -1841,7 +1843,15 @@ MdPanelRef.prototype._configureClickOutsideToClose = function() {
     // panel we don't want to panel to close.
     var self = this;
     var mouseupHandler = function(ev) {
-      if (sourceElem === target[0] && ev.target === target[0]) {
+      if (self.config['propagateContainerEvents']) {
+
+        // We check if the sourceEl of the event is the panel element or one
+        // of it's children. If it is not, then close the panel.
+        if (sourceEl !== self.panelEl[0] && !self.panelEl[0].contains(sourceEl)) {
+          self.close();
+        }
+
+      } else if (sourceEl === target[0] && ev.target === target[0]) {
         ev.stopPropagation();
         ev.preventDefault();
 
@@ -2713,6 +2723,7 @@ MdPanelPosition.prototype._constrainToViewport = function(panelEl) {
   }
 };
 
+
 /**
  * Switches between 'start' and 'end'.
  * @param {string} position Horizontal position of the panel
@@ -2902,6 +2913,7 @@ MdPanelAnimation.prototype.closeTo = function(closeTo) {
   return this;
 };
 
+
 /**
  * Specifies the duration of the animation in milliseconds.
  * @param {number|{open: number, close: number}} duration
@@ -2926,6 +2938,7 @@ MdPanelAnimation.prototype.duration = function(duration) {
     if (angular.isNumber(value)) return value / 1000;
   }
 };
+
 
 /**
  * Returns the element and bounds for the animation target.

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -544,6 +544,20 @@ describe('$mdPanel', function() {
       expect(PANEL_EL).not.toExist();
     });
 
+    it('should close when clickOutsideToClose set to true and ' +
+        'propagateContainerEvents is also set to true', function() {
+          var config = {
+            propagateContainerEvents: true,
+            clickOutsideToClose: true
+          };
+
+          openPanel(config);
+
+          clickPanelContainer(getElement('body'));
+
+          expect(PANEL_EL).not.toExist();
+        });
+
     it('should not close when escapeToClose set to false', function() {
       openPanel();
 
@@ -3025,12 +3039,22 @@ describe('$mdPanel', function() {
     attachedElements.push(element);
   }
 
-  function clickPanelContainer() {
+  /**
+   * Returns the angular element associated with a CSS selector or element.
+   * @param el {string|!angular.JQLite|!Element}
+   * @returns {!angular.JQLite}
+   */
+  function getElement(el) {
+    var queryResult = angular.isString(el) ? document.querySelector(el) : el;
+    return angular.element(queryResult);
+  }
+
+  function clickPanelContainer(container) {
     if (!panelRef) {
       return;
     }
 
-    var container = panelRef.panelContainer;
+    container = container || panelRef.panelContainer;
 
     container.triggerHandler({
       type: 'mousedown',


### PR DESCRIPTION
If both the `clickOutsideToClose` and `propagateContainerEvents` parameters are set to true within the panel configuration, then the panel will be closed when a click happens outside of the panel.

Fixes #9388
