### PR TITLE
chore: auto-use latest sauce connector binary

### DIFF
--- a/scripts/sauce/setup-tunnel.sh
+++ b/scripts/sauce/setup-tunnel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SAUCE_BINARY_FILE="sc-4.4.1-linux.tar.gz"
+SAUCE_BINARY_FILE="sc-latest-linux.tar.gz"
 SAUCE_BINARY_DIR="/tmp/sauce"
 SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 


### PR DESCRIPTION
* Automatically use the latest Saucelab Binaries, rather than always updating it manually when a new version is available.

Thanks to @jelbourn for the idea.

> FYI: Please wait for CI to finish.