### PR TITLE
fix(datepicker): reference error and calendar not being read out by nvda

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -90,7 +90,6 @@
             'class="md-datepicker-input" ' +
             'aria-haspopup="true" ' +
             'aria-expanded="{{ctrl.isCalendarOpen}}" ' +
-            'aria-owns="{{::ctrl.calendarPaneId}}"' +
             'ng-focus="ctrl.setFocused(true)" ' +
             'ng-blur="ctrl.setFocused(false)"> ' +
             triangleButton +
@@ -313,7 +312,7 @@
     this.calendarPaneOpenedFrom = null;
 
     /** @type {String} Unique id for the calendar pane. */
-    this.calendarPaneId = 'md-date-pane' + $mdUtil.nextUid();
+    this.calendarPaneId = 'md-date-pane-' + $mdUtil.nextUid();
 
     /** Pre-bound click handler is saved so that the event listener can be removed. */
     this.bodyClickHandler = angular.bind(this, this.handleBodyClick);
@@ -349,6 +348,8 @@
     } else {
       $attrs.$set('tabindex', '-1');
     }
+
+    $attrs.$set('aria-owns', this.calendarPaneId);
 
     $mdTheming($element);
     $mdTheming(angular.element(this.calendarPane));
@@ -866,7 +867,6 @@
     this.date = value;
     this.inputElement.value = this.dateLocale.formatDate(value, timezone);
     this.mdInputContainer && this.mdInputContainer.setHasValue(!!value);
-    this.closeCalendarPane();
     this.resizeInputElement();
     this.updateErrorState();
   };

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -805,7 +805,7 @@ describe('md-datepicker', function() {
     });
 
     it('should set the aria-owns value, corresponding to the id of the calendar pane', function() {
-      var ariaAttr = controller.ngInputElement.attr('aria-owns');
+      var ariaAttr = ngElement.attr('aria-owns');
 
       expect(ariaAttr).toBeTruthy();
       expect(controller.calendarPane.id).toBe(ariaAttr);


### PR DESCRIPTION
- Fixes a JS error in the datepicker, when used with `openOnFocus`, caused by `closeCalendarPane` being called twice in a row. This was introduced accidentally when combining a few redundant calls into the `onExternalChange` method.
- Fixes NVDA reading out "Unknown", instead of the calendar, due to the `aria-owns` attribute being set on the `input`. This change moves the `aria-owns` to the datepicker itself.

**Note:** these issues are still only in master, they weren't a part of 1.1.1
