### PR TITLE
update(autocomplete): remove unused css keyframes

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -1,37 +1,6 @@
 // The default item height is also specified in the JavaScript.
 $md-autocomplete-item-height: 48px !default;
 
-@keyframes md-autocomplete-list-out {
-  0% {
-    animation-timing-function: linear;
-  }
-  50% {
-    opacity: 0;
-    height: 40px;
-    animation-timing-function: ease-in;
-  }
-  100% {
-    height: 0;
-    opacity: 0;
-  }
-}
-
-@keyframes md-autocomplete-list-in {
-  0% {
-    opacity: 0;
-    height: 0;
-    animation-timing-function: ease-out;
-  }
-  50% {
-    opacity: 0;
-    height: 40px;
-  }
-  100% {
-    opacity: 1;
-    height: 40px;
-  }
-}
-
 md-autocomplete {
   border-radius: 2px;
   display: block;
@@ -50,7 +19,7 @@ md-autocomplete {
     height: auto;
 
     md-input-container {
-      padding-bottom: 0px;
+      padding-bottom: 0;
     }
     md-autocomplete-wrap {
       height: auto;
@@ -80,9 +49,9 @@ md-autocomplete {
 
     md-input-container, input {
       // Layout [flex]
-      flex:1 1 0%;
-      box-sizing:border-box;
-      min-width :0;
+      flex: 1 1 0%;
+      box-sizing: border-box;
+      min-width : 0;
     }
 
     md-progress-linear {


### PR DESCRIPTION
* The autocomplete used in the "very early" stages of its implementation some special keyframes for the dropdown entering / leaving.

* Those have been replaced with a simple opacity transition and the old keyframes are just unused and bloating the component SCSS.