### PR TITLE
fix(tabs): improve tab button focus styling logic

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -5,8 +5,8 @@ angular
 /**
  * @ngInject
  */
-function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple,
-                           $mdUtil, $animateCss, $attrs, $compile, $mdTheming) {
+function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipple, $mdUtil,
+                           $animateCss, $attrs, $compile, $mdTheming, $mdInteraction) {
   // define private properties
   var ctrl      = this,
       locked    = false,
@@ -42,7 +42,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   ctrl.tabs              = [];
   ctrl.lastSelectedIndex = null;
   ctrl.hasFocus          = false;
-  ctrl.lastClick         = true;
+  ctrl.styleTabItemFocus = false;
   ctrl.shouldCenterTabs  = shouldCenterTabs();
 
   // define public methods
@@ -291,7 +291,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         if (!locked) select(ctrl.focusIndex);
         break;
     }
-    ctrl.lastClick = false;
   }
 
   /**
@@ -302,7 +301,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function select (index, canSkipClick) {
     if (!locked) ctrl.focusIndex = ctrl.selectedIndex = index;
-    ctrl.lastClick = true;
     // skip the click event if noSelectClick is enabled
     if (canSkipClick && ctrl.noSelectClick) return;
     // nextTick is required to prevent errors in user-defined click events
@@ -339,7 +337,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       ctrl.offsetLeft = fixOffset(tab.offsetLeft);
     } else {
       /**
-       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let 
+       * Canvas width *smaller* than tab width: positioning at the *end* of current tab to let
        * pagination "for loop" to proceed correctly on next tab when nextPage() is called again
        */
       ctrl.offsetLeft = fixOffset(tab.offsetLeft + (tab.offsetWidth - viewportWidth + 1));
@@ -362,10 +360,10 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       ctrl.offsetLeft = fixOffset(tab.offsetLeft + tab.offsetWidth - elements.canvas.clientWidth);
     } else {
       /**
-       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let 
+       * Canvas width *smaller* than tab width: positioning at the *beginning* of current tab to let
        * pagination "for loop" to break correctly on previous tab when previousPage() is called again
        */
-      ctrl.offsetLeft = fixOffset(tab.offsetLeft);  
+      ctrl.offsetLeft = fixOffset(tab.offsetLeft);
     }
   }
 
@@ -429,7 +427,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
           isRight:      function () { return this.getIndex() > ctrl.selectedIndex; },
           shouldRender: function () { return !ctrl.noDisconnect || this.isActive(); },
           hasFocus:     function () {
-            return !ctrl.lastClick
+            return ctrl.styleTabItemFocus
                 && ctrl.hasFocus && this.getIndex() === ctrl.focusIndex;
           },
           id:           $mdUtil.nextUid()
@@ -654,6 +652,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * issues when attempting to focus an item that is out of view.
    */
   function redirectFocus () {
+    ctrl.styleTabItemFocus = ($mdInteraction.getLastInteractionType() === 'keyboard');
     getElements().dummies[ ctrl.focusIndex ].focus();
   }
 


### PR DESCRIPTION
Tab buttons did not receive focus style unless the user performed
certain keypress events while navigating. This logic did not account
for tabbing into the component
- Set variable when tab button is focused
- Use mdInteraction to detect keyboard interaction

This new logic is similar to that of mdCheckbox

Fixes #9039
