### PR TITLE
feat(core): add support for hybrid ngMd1+ngMd2 applications

### DIFF
--- a/gulp/tasks/build-scss.js
+++ b/gulp/tasks/build-scss.js
@@ -39,6 +39,7 @@ exports.task = function() {
       .pipe(concat('angular-material.scss'))
       .pipe(gulp.dest(dest))            // raw uncompiled SCSS
       .pipe(sass())
+      .pipe(util.applyMd2CompatibilityCss())
       .pipe(util.dedupeCss())
       .pipe(util.autoprefix())
       .pipe(insert.prepend(config.banner))
@@ -69,6 +70,7 @@ exports.task = function() {
         .pipe(insert.prepend(config.banner))
         .pipe(gulp.dest(layoutDest))      // raw uncompiled SCSS
         .pipe(sass())
+        .pipe(util.applyMd2CompatibilityCss())
         .pipe(util.dedupeCss())
         .pipe(util.autoprefix())
         .pipe(rename({ extname : '.css'}))
@@ -91,6 +93,7 @@ exports.task = function() {
           .pipe(sassUtils.hoistScssVariables())
           .pipe(gulp.dest(layoutDest))     // raw uncompiled SCSS
           .pipe(sass())
+          .pipe(util.applyMd2CompatibilityCss())
           .pipe(util.dedupeCss())
           .pipe(util.autoprefix())
           .pipe(rename({ extname : '.css'}))

--- a/gulp/util.js
+++ b/gulp/util.js
@@ -35,6 +35,7 @@ exports.readModuleArg = readModuleArg;
 exports.themeBuildStream = themeBuildStream;
 exports.minifyCss = minifyCss;
 exports.dedupeCss = dedupeCss;
+exports.applyMd2CompatibilityCss = applyMd2CompatibilityCss;
 exports.args = args;
 
 /**
@@ -184,6 +185,7 @@ function buildModule(module, opts) {
         // In some cases there are multiple theme SCSS files, which should be concatenated together.
         .pipe(gulpif, /default-theme.scss/, concat(name + '-default-theme.scss'))
         .pipe(sass)
+        .pipe(applyMd2CompatibilityCss)
         .pipe(dedupeCss)
         .pipe(utils.autoprefix)
     (); // Invoke the returning lazypipe function to create our new pipe.
@@ -225,6 +227,7 @@ function themeBuildStream() {
       .pipe(concat('default-theme.scss'))
       .pipe(utils.hoistScssVariables())
       .pipe(sass())
+      .pipe(applyMd2CompatibilityCss())
       .pipe(dedupeCss())
       // The PostCSS orderedValues plugin modifies the theme color expressions.
       .pipe(minifyCss({ orderedValues: false }))
@@ -274,4 +277,120 @@ function dedupeCss() {
       return value.indexOf('-') > -1 && prefixRegex.test(value);
     });
   }
+}
+
+function applyMd2CompatibilityCss() {
+
+  /**
+   * Map of element names and the class that should be added to its DOM element.
+   * Items commented out can be replaced, but it is not necessary since they
+   * do not conflict with MD2 CSS.
+   */
+  var classMap = {
+    // "md-autocomplete" : "md-autocomplete",
+    // "md-autocomplete-wrap": "md-autocomplete-wrap",
+    // "md-backdrop" : "md-backdrop",
+    // "md-bottom-sheet": "md-bottom-sheet",
+    // "md-calendar" : "md-calendar-element",
+    // "md-calendar-month": "md-calendar-month",
+    "md-card" : "md-card",
+    "md-card-actions": "md-card-actions",
+    // "md-card-avatar": "md-card-avatar",
+    "md-card-content": "md-card-content",
+    "md-card-footer": "md-card-footer",
+    "md-card-header": "md-card-header",
+    // "md-card-header-text" : "md-card-header-text",
+    // "md-card-icon-actions" : "md-card-icon-actions",
+    "md-card-title": "md-card-title",
+    // "md-card-title-media" : "md-card-title-media",
+    // "md-card-title-text" : "md-card-title-text",
+    "md-checkbox" : "md-checkbox",
+    // "md-chip" : "md-chip",
+    // "md-chip-remove": "md-chip-remove-element",
+    // "md-chips" : "md-chips-element",
+    // "md-content" : "md-content",
+    // "md-datepicker" : "md-datepicker",
+    // "md-dialog" : "md-dialog-element",
+    // "md-dialog-actions": "md-dialog-actions",
+    // "md-dialog-content": "md-dialog-content-element",
+    "md-divider" : "md-divider",
+    // "md-fab-actions": "md-fab-actions",
+    // "md-fab-speed-dial" : "md-fab-speed-dial",
+    // "md-fab-toolbar": "md-fab-toolbar",
+    // "md-fab-trigger": "md-fab-trigger",
+    "md-grid-list": "md-grid-list",
+    "md-grid-tile": "md-grid-tile",
+    "md-grid-tile-footer" : "md-grid-tile-footer",
+    "md-grid-tile-header" : "md-grid-tile-header",
+    "md-icon" : "md-icon-element",
+    "md-ink-bar": "md-ink-bar",
+    // "md-inline-icon": "md-inline-icon",
+    // "md-input-container": "md-input-container",
+    "md-list" : "md-list",
+    "md-list-item": "md-list-item",
+    "md-menu" : "md-menu-element",
+    // "md-menu-bar": "md-menu-bar",
+    // "md-menu-content": "md-menu-content",
+    // "md-menu-divider": "md-menu-divider",
+    // "md-menu-item": "md-menu-item",
+    // "md-nav-bar": "md-nav-bar-element",
+    // "md-nav-extra-content" : "md-nav-extra-content",
+    // "md-nav-ink-bar" : "md-nav-ink-bar",
+    // "md-next-button": "md-next-button",
+    // "md-optgroup" : "md-optgroup",
+    "md-option" : "md-option",
+    // "md-pagination-wrapper": "md-pagination-wrapper",
+    // "md-prev-button": "md-prev-button",
+    // "md-progress-circular": "md-progress-circular",
+    // "md-progress-linear": "md-progress-linear",
+    "md-radio-button": "md-radio-button",
+    "md-radio-group": "md-radio-group",
+    "md-select" : "md-select",
+    // "md-select-label" : "md-select-label",
+    // "md-select-menu": "md-select-menu",
+    "md-sidenav" : "md-sidenav",
+    "md-slider" : "md-slider",
+    // "md-slider-container": "md-slider-container",
+    // "md-switch" : "md-switch",
+    // "md-tab" : "md-tab-element",
+    // "md-tab-content": "md-tab-content",
+    // "md-tab-data": "md-tab-data",
+    // "md-tab-item": "md-tab-item",
+    // "md-tab-label": "md-tab-label",
+    // "md-tabs" : "md-tabs",
+    // "md-tabs-canvas": "md-tabs-canvas",
+    // "md-tabs-content-wrapper" : "md-tabs-content-wrapper",
+    // "md-tabs-wrapper": "md-tabs-wrapper",
+    // "md-toast" : "md-toast",
+    "md-toolbar" : "md-toolbar",
+    // "md-toolbar-filler": "md-toolbar-filler",
+    // "md-tooltip" : "md-tooltip",
+    // "md-whiteframe" : "md-whiteframe"
+  };
+
+  function classMapReplace(match, prefix, selector) {
+    for(var key in classMap) {
+      if (selector === key) {
+        return prefix + '.' + classMap[key];
+      }
+    }
+    return match;
+  }
+  return insert.transform(function(contents) {
+    // Parse the CSS into an AST.
+    var parsed = postcss.parse(contents);
+    parsed.walkRules(function(rule) {
+      if (rule.parent && rule.parent.name === 'keyframes') {
+        return;
+      }
+      rule.selectors = rule.selectors.map(function(selector) {
+        var newRule = selector
+          .replace(/(^|[\s>,}])(md[^\s>,{\[:.]+)/g, classMapReplace)
+          .replace(/(\()(md[^)]+)/g, classMapReplace)
+        return newRule;
+      });
+    });
+    // Turn the AST back into CSS.
+    return parsed.toResult().css;
+  });
 }

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -120,7 +120,9 @@ md-card {
   }
 
   md-card-content {
-    display: block;
+    &:not(.layout-column):not(.layout-row) {
+      display: block;
+    }
     padding: $card-padding;
 
     & > p {

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -93,6 +93,8 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
     };
 
     function postLink(scope, element, attr, ngModelCtrl) {
+      element.addClass('md-checkbox');
+
       var isIndeterminate;
       ngModelCtrl = ngModelCtrl || $mdUtil.fakeNgModel();
       $mdTheming(element);

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -101,7 +101,7 @@ describe('MdIcon directive', function() {
         el = make( '<md-icon md-font-set="fa">email</md-icon>');
 
         expect(el.text()).toEqual('email');
-        expect( clean(el.attr('class')) ).toEqual('fontawesome');
+        expect(el.hasClass('fontawesome')).toBeTruthy();
       });
 
       it('should remove old font set class and apply the new when set changed', function() {
@@ -110,12 +110,13 @@ describe('MdIcon directive', function() {
         el = make( '<md-icon md-font-set="{{ set }}">email</md-icon>');
 
         expect(el.text()).toEqual('email');
-        expect( clean(el.attr('class')) ).toEqual('fontawesome');
+        expect(el.hasClass('fontawesome')).toBeTruthy();
 
         $scope.set = 'material-icons';
         $scope.$apply();
 
-        expect( clean(el.attr('class')) ).toEqual('material-icons');
+        expect(el.hasClass('fontawesome')).toBeFalsy();
+        expect(el.hasClass('material-icons')).toBeTruthy();
       });
 
       it('should render correctly using a md-font-set alias', function() {
@@ -132,7 +133,7 @@ describe('MdIcon directive', function() {
         el = make( '<md-icon md-font-set="fontawesome">email</md-icon>');
 
         expect(el.text()).toEqual('email');
-        expect( clean(el.attr('class')) ).toEqual('fontawesome');
+        expect(el.hasClass('fontawesome')).toBeTruthy();
       });
     });
 
@@ -158,11 +159,13 @@ describe('MdIcon directive', function() {
         $mdIconProvider.defaultFontSet('');
 
         el = make( '<md-icon class="custom-cake"></md-icon>');
-        expect( clean(el.attr('class')) ).toEqual('custom-cake');
+        expect(el.hasClass('material-icons')).toBeFalsy();
+        expect(el.hasClass('custom-cake')).toBeTruthy();
 
         el = make( '<md-icon class="custom-cake">apple</md-icon>');
         expect(el.text()).toEqual('apple');
-        expect( clean(el.attr('class')) ).toEqual('custom-cake');
+        expect(el.hasClass('material-icons')).toBeFalsy();
+        expect(el.hasClass('custom-cake')).toBeTruthy();
 
       });
 
@@ -170,7 +173,8 @@ describe('MdIcon directive', function() {
         $mdIconProvider.defaultFontSet('fa');
 
         el = make( '<md-icon></md-icon>');
-        expect( clean(el.attr('class')) ).toEqual('fa');
+        expect(el.hasClass('material-icons')).toBeFalsy();
+        expect(el.hasClass('fa')).toBeTruthy();
 
         el = make( '<md-icon md-font-icon="fa-apple">apple</md-icon>');
         expect(el.text()).toEqual('apple');

--- a/src/components/toolbar/toolbar.spec.js
+++ b/src/components/toolbar/toolbar.spec.js
@@ -47,7 +47,9 @@ describe('<md-toolbar>', function() {
     });
 
     // Manually link so we can give our own elements with spies on them
-    mdToolbarDirective[0].link($rootScope, toolbar, {
+    mdToolbarDirective.filter(function(directive) {
+      return (directive.$$moduleName === 'material.components.toolbar');
+    })[0].link($rootScope, toolbar, {
       mdScrollShrink: true,
       mdShrinkSpeedFactor: 1,
       $observe: function() {}

--- a/src/core/services/md2/cssCompatibility.js
+++ b/src/core/services/md2/cssCompatibility.js
@@ -1,0 +1,131 @@
+(function() {
+  'use strict';
+
+  /**
+   * Map of element names and the class that should be added to its DOM element.
+   * Items commented out can be replaced, but it is not necessary since they
+   * do not conflict with MD2 CSS.
+   */
+  var classMap = {
+    // "md-autocomplete" : "md-autocomplete",
+    // "md-autocomplete-wrap": "md-autocomplete-wrap",
+    // "md-backdrop" : "md-backdrop",
+    // "md-bottom-sheet": "md-bottom-sheet",
+    // "md-calendar" : "md-calendar-element",
+    // "md-calendar-month": "md-calendar-month",
+    "md-card" : "md-card",
+    "md-card-actions": "md-card-actions",
+    // "md-card-avatar": "md-card-avatar",
+    "md-card-content": "md-card-content",
+    "md-card-footer": "md-card-footer",
+    "md-card-header": "md-card-header",
+    // "md-card-header-text" : "md-card-header-text",
+    // "md-card-icon-actions" : "md-card-icon-actions",
+    "md-card-title": "md-card-title",
+    // "md-card-title-media" : "md-card-title-media",
+    // "md-card-title-text" : "md-card-title-text",
+
+    /*
+     * Due to the way mdSwitch hooks into mdCheckbox, mdCheckbox cannot have more than one directive
+     */
+    // "md-checkbox" : "md-checkbox",
+
+    // "md-chip" : "md-chip",
+    // "md-chip-remove": "md-chip-remove-element",
+    // "md-chips" : "md-chips-element",
+    // "md-content" : "md-content",
+    // "md-datepicker" : "md-datepicker",
+    // "md-dialog" : "md-dialog-element",
+    // "md-dialog-actions": "md-dialog-actions",
+    // "md-dialog-content": "md-dialog-content-element",
+    "md-divider" : "md-divider",
+    // "md-fab-actions": "md-fab-actions",
+    // "md-fab-speed-dial" : "md-fab-speed-dial",
+    // "md-fab-toolbar": "md-fab-toolbar",
+    // "md-fab-trigger": "md-fab-trigger",
+    "md-grid-list": "md-grid-list",
+    "md-grid-tile": "md-grid-tile",
+    "md-grid-tile-footer" : "md-grid-tile-footer",
+    "md-grid-tile-header" : "md-grid-tile-header",
+    "md-icon" : "md-icon-element",
+    "md-ink-bar": "md-ink-bar",
+    // "md-inline-icon": "md-inline-icon",
+    // "md-input-container": "md-input-container",
+    "md-list" : "md-list",
+    "md-list-item": "md-list-item",
+    "md-menu" : "md-menu-element",
+    // "md-menu-bar": "md-menu-bar",
+    // "md-menu-content": "md-menu-content",
+    // "md-menu-divider": "md-menu-divider",
+    // "md-menu-item": "md-menu-item",
+    // "md-nav-bar": "md-nav-bar-element",
+    // "md-nav-extra-content" : "md-nav-extra-content",
+    // "md-nav-ink-bar" : "md-nav-ink-bar",
+    // "md-next-button": "md-next-button",
+    // "md-optgroup" : "md-optgroup",
+    "md-option" : "md-option",
+    // "md-pagination-wrapper": "md-pagination-wrapper",
+    // "md-prev-button": "md-prev-button",
+    // "md-progress-circular": "md-progress-circular",
+    // "md-progress-linear": "md-progress-linear",
+    "md-radio-button": "md-radio-button",
+    "md-radio-group": "md-radio-group",
+    "md-select" : "md-select",
+    // "md-select-label" : "md-select-label",
+    // "md-select-menu": "md-select-menu",
+    "md-sidenav" : "md-sidenav",
+    "md-slider" : "md-slider",
+    // "md-slider-container": "md-slider-container",
+    // "md-switch" : "md-switch",
+    // "md-tab" : "md-tab-element",
+    // "md-tab-content": "md-tab-content",
+    // "md-tab-data": "md-tab-data",
+    // "md-tab-item": "md-tab-item",
+    // "md-tab-label": "md-tab-label",
+    // "md-tabs" : "md-tabs",
+    // "md-tabs-canvas": "md-tabs-canvas",
+    // "md-tabs-content-wrapper" : "md-tabs-content-wrapper",
+    // "md-tabs-wrapper": "md-tabs-wrapper",
+    // "md-toast" : "md-toast",
+    "md-toolbar" : "md-toolbar",
+    // "md-toolbar-filler": "md-toolbar-filler",
+    // "md-tooltip" : "md-tooltip",
+    // "md-whiteframe" : "md-whiteframe"
+  };
+
+  var PREFIX_REGEXP = /^((?:x|data)[:\-_])/i;
+  var SPECIAL_CHARS_REGEXP = /[:\-_]+(.)/g;
+
+  /**
+   * Converts all accepted directives format into proper directive name.
+   * @param name Name to normalize
+   */
+  function directiveNormalize(name) {
+    return name
+      .replace(PREFIX_REGEXP, '')
+      .replace(SPECIAL_CHARS_REGEXP, fnCamelCaseReplace);
+  }
+
+  function fnCamelCaseReplace(all, letter) {
+    return letter.toUpperCase();
+  }
+
+  registerClasses( angular.module('material.core') );
+
+  function registerClasses(module) {
+    angular.forEach(classMap, function(value, key) {
+      module.directive(directiveNormalize(key), cssDirective);
+    });
+
+    function cssDirective() {
+      return {
+        restrict: 'E',
+        link: function(scope, element) {
+          var className = classMap[element[0].tagName.toLowerCase()];
+          className && element.addClass(className);
+        }
+      };
+    }
+  }
+
+})();


### PR DESCRIPTION
Angular Material 1 CSS should not conflict with Angular Material 2 CSS

* Use PostCSS to change Element based CSS selectors to target via a class
* Create directive for components that conflict with MD2
* Use directive to add a class during postLink phase
* Update md-icon spec tests to support extra classes
* Update md-toolbar spec test to support multiple directives
* Use mdCheckboxDirective to add "md-checkbox" class

Fixes #9824

Breaking Change:

In CSS, class selectors have higher specificity than element selectors by a factor of 10. This may break some custom user styles.