### PR TITLE
fix(panel): panel not being constrained to viewport on repeat openings

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -2679,7 +2679,7 @@ MdPanelPosition.prototype._reduceTranslateValues =
  * @private
  */
 MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
-  // Remove the class in case it has been added before.
+  // Remove the "position adjusted" class in case it has been added before.
   panelEl.removeClass('_md-panel-position-adjusted');
 
   // Only calculate the position if necessary.
@@ -2691,6 +2691,7 @@ MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
   if (this._actualPosition) {
     this._calculatePanelPosition(panelEl, this._actualPosition);
     this._setTransform(panelEl);
+    this._constrainToViewport(panelEl);
     return;
   }
 
@@ -2704,8 +2705,6 @@ MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
     }
   }
 
-  // Class that can be used to re-style the panel if it was repositioned.
-  panelEl.addClass('_md-panel-position-adjusted');
   this._constrainToViewport(panelEl);
 };
 
@@ -2717,6 +2716,8 @@ MdPanelPosition.prototype._setPanelPosition = function(panelEl) {
  */
 MdPanelPosition.prototype._constrainToViewport = function(panelEl) {
   var margin = MdPanelPosition.viewportMargin;
+  var initialTop = this._top;
+  var initialLeft = this._left;
 
   if (this.getTop()) {
     var top = parseInt(this.getTop());
@@ -2741,6 +2742,12 @@ MdPanelPosition.prototype._constrainToViewport = function(panelEl) {
       this._left = left - (right - viewportWidth + margin) + 'px';
     }
   }
+
+  // Class that can be used to re-style the panel if it was repositioned.
+  panelEl.toggleClass(
+    '_md-panel-position-adjusted',
+    this._top !== initialTop || this._left !== initialLeft
+  );
 };
 
 /**

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2350,6 +2350,39 @@ describe('$mdPanel', function() {
           });
       });
 
+      it('should keep the panel within the viewport on repeat openings',
+        function() {
+
+          config.position = mdPanelPosition
+            .relativeTo(myButton)
+            .addPanelPosition(xPosition.ALIGN_END, yPosition.ALIGN_TOPS);
+
+          var panelRef = $mdPanel.create(config);
+
+          myButton.css({
+            position: 'absolute',
+            left: '-100px',
+            margin: 0
+          });
+
+          panelRef.open();
+          flushPanel();
+
+          expect(panelRef.panelEl[0].offsetLeft).toBe(VIEWPORT_MARGIN);
+          expect(panelRef.panelEl[0]).toHaveClass(ADJUSTED_CLASS);
+
+          panelRef.close();
+          flushPanel();
+
+          panelRef.open();
+          flushPanel();
+
+          expect(panelRef.panelEl[0].offsetLeft).toBe(VIEWPORT_MARGIN);
+          expect(panelRef.panelEl[0]).toHaveClass(ADJUSTED_CLASS);
+
+          panelRef.destroy();
+        });
+
       describe('vertically', function() {
         it('above an element', function() {
           var position = mdPanelPosition


### PR DESCRIPTION
The panel wasn't being constrained to the viewport when opening it multiple times in a row, due to the "constrain to viewport" logic only running if the `_actualPosition` isn't known. These changes make it so the panel always gets constrained to the viewport.

Fixes #9942.
