### PR TITLE
fix(select): unable to switch between falsy options

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -861,7 +861,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
       var newVal = self.isMultiple ? values : values[0];
       var prevVal = self.ngModel.$modelValue;
 
-      if (usingTrackBy ? !angular.equals(prevVal, newVal) : prevVal != newVal) {
+      if (usingTrackBy ? !angular.equals(prevVal, newVal) : prevVal !== newVal) {
         self.ngModel.$setViewValue(newVal);
         self.ngModel.$render();
       }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -771,6 +771,15 @@ describe('<md-select>', function() {
         expect($rootScope.model).toBe(4);
       }));
 
+      it('should allow switching between falsy options', inject(function($rootScope) {
+        $rootScope.model = false;
+        var el = setupSelect('ng-model="$root.model"', [false, 0]);
+
+        openSelect(el);
+        clickOption(el, 1);
+
+        expect($rootScope.model).toBe(0);
+      }));
     });
   });
 


### PR DESCRIPTION
Fixes the select component being unable to switch between falsy options (e.g. `0` and `false`) due to a use of non-strict comparison.

Fixes #9533.
