### PR TITLE
chore(docs): fix js error on mobile

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -540,11 +540,12 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
               if (open && $li && $ul[0].scrollTop === 0) {
                 var activeHeight = $li.scrollHeight;
                 var activeOffset = $li.offsetTop;
-                var parentOffset = $li.offsetParent.offsetTop;
+                var offsetParent = $li.offsetParent;
+                var parentScrollPosition = offsetParent ? offsetParent.offsetTop : 0;
 
                 // Reduce it a bit (2 list items' height worth) so it doesn't touch the nav
                 var negativeOffset = activeHeight * 2;
-                var newScrollTop = activeOffset + parentOffset - negativeOffset;
+                var newScrollTop = activeOffset + parentScrollPosition - negativeOffset;
 
                 $mdUtil.animateScrollTo(document.querySelector('.docs-menu').parentNode, newScrollTop);
               }


### PR DESCRIPTION
Fixes a JS error in the docs site due to an assumption that the `offsetParent` of the list items will always be defined. This isn't the case on mobile since the sidenav is hidden off-screen.
