### PR TITLE
chore(dialog): fix broken demos

### DIFF
--- a/src/components/dialog/demoThemeInheritance/script.js
+++ b/src/components/dialog/demoThemeInheritance/script.js
@@ -1,4 +1,4 @@
-angular.module('dialogDemo1', ['ngMaterial'])
+angular.module('dialogDemo3', ['ngMaterial'])
   .config(function ($mdThemingProvider) {
     $mdThemingProvider.theme('red')
       .primaryPalette('red');


### PR DESCRIPTION
* Recently a new demo has been added in b7ae33ea0d16242f451f49671c341c3923e9f53.
  This demo uses the same Angular module name as the first demo (so they interfere and don't work)

Fixes #9977