### PR TITLE
fix(autocomplete): incorrect evaluation of available space in viewport

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -124,7 +124,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
 
     // Automatically determine dropdown placement based on available space in viewport.
     if (!position) {
-      position = (top > bot && root.height - hrect.bottom - MENU_PADDING < dropdownHeight) ? 'top' : 'bottom';
+      position = (top > bot && root.height - top - MENU_PADDING < dropdownHeight) ? 'top' : 'bottom';
     }
     // Adjust the width to account for the padding provided by `md-input-container`
     if ($attrs.mdFloatingLabel) {


### PR DESCRIPTION
The available space beneath a wrap included space above viewport. When heights of the body
and viewport did not match (e.g. on mobile) dropdown was displayed on the wrong side.
This change make it so available space is calculated properly.

Fixes #10188