### PR TITLE
feat(panel): Panel configuration provider

### DIFF
--- a/src/components/panel/demoConfigProvider/index.html
+++ b/src/components/panel/demoConfigProvider/index.html
@@ -1,0 +1,51 @@
+<div ng-controller="PanelProviderCtrl as ctrl" ng-cloak>
+
+  <md-content layout-padding>
+
+    <div layout="row" layout-align="space-between center" flex>
+      <md-button
+        class="md-fab md-primary"
+        aria-label="Navigation"
+        ng-click="ctrl.showMenu($event, ctrl.navigation)">
+        <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
+      </md-button>
+      <md-button
+        class="md-fab md-accent"
+        aria-label="Favorites"
+        ng-click="ctrl.showMenu($event, ctrl.favorites)">
+        <md-icon md-svg-icon="img/icons/favorite.svg"></md-icon>
+      </md-button>
+      <md-button
+        class="md-fab md-background"
+        aria-label="More"
+        ng-click="ctrl.showMenu($event, ctrl.more)">
+        <md-icon md-svg-icon="img/icons/more_vert.svg"></md-icon>
+      </md-button>
+    </div>
+
+    <p>
+      Configurations for upcoming panel elements can be created at the
+      <code>.config</code> level of your Angular application. To create a
+      configuration object, use the <code>$mdPanelConfigProvider</code>
+      dependency within a <code>.config</code> method and call
+      <code>$mdPanelConfigProvider.createConfig</code> with an object containing
+      a configuration name and options as it's argument. This object will be
+      stored for you so that you can retrieve it by using the
+      <code>$mdPanel.getConfig</code> method with the name of the configuration
+      object that you created as it's argument.
+    </p>
+    <p>
+      The configuration object takes all of the options found within the
+      <code>$mdPanel.create</code> method; however, it does not make sense to
+      include any options that depend on user interaction, panel positioning, or
+      panel animation.
+    </p>
+    <p>
+      This will help you reduce the necessary lines of configuration code that
+      are required to create a panel when you are wanting to have multiple
+      panels that are largely the same.
+    </p>
+
+  </md-content>
+
+</div>

--- a/src/components/panel/demoConfigProvider/script.js
+++ b/src/components/panel/demoConfigProvider/script.js
@@ -1,0 +1,95 @@
+(function() {
+  'use strict';
+
+  angular
+      .module('panelProviderDemo', ['ngMaterial'])
+      .config(PanelProviderConfig)
+      .controller('PanelProviderCtrl', PanelProviderCtrl)
+      .controller('PanelMenuCtrl', PanelMenuCtrl);
+
+  function PanelProviderConfig($mdPanelConfigProvider) {
+    var config = {
+      name: 'demoConfig',
+      options: {
+        attachTo: angular.element(document.body),
+        controller: PanelMenuCtrl,
+        controllerAs: 'ctrl',
+        template: '' +
+            '<div class="menu-panel" md-whiteframe="4">' +
+            '  <div class="menu-content">' +
+            '    <div class="menu-item" ng-repeat="item in ctrl.items">' +
+            '      <button class="md-button">' +
+            '        <span>{{item}}</span>' +
+            '      </button>' +
+            '    </div>' +
+            '    <md-divider></md-divider>' +
+            '    <div class="menu-item">' +
+            '      <button class="md-button" ng-click="ctrl.closeMenu()">' +
+            '        <span>Close Menu</span>' +
+            '      </button>' +
+            '    </div>' +
+            '  </div>' +
+            '</div>',
+        panelClass: 'menu-panel-container',
+        focusOnOpen: false,
+        zIndex: 100,
+        propagateContainerEvents: true,
+        groupName: 'menus'
+      }
+    };
+
+    $mdPanelConfigProvider.createConfig(config);
+  }
+
+  function PanelProviderCtrl($mdPanel) {
+    this.navigation = {
+      name: 'navigation',
+      items: [
+        'Home',
+        'About',
+        'Contact'
+      ]
+    };
+    this.favorites = {
+      name: 'favorites',
+      items: [
+        'Add to Favorites'
+      ]
+    };
+    this.more = {
+      name: 'more',
+      items: [
+        'Account',
+        'Sign Out'
+      ]
+    };
+
+    $mdPanel.newPanelGroup('menus', {
+      maxOpen: 2
+    });
+
+    this.showMenu = function($event, menu) {
+      var config = $mdPanel.getConfig('demoConfig');
+
+      config.id = 'menu_' + menu.name;
+      config.position = $mdPanel.newPanelPosition()
+          .relativeTo($event.srcElement)
+          .addPanelPosition(
+            $mdPanel.xPosition.ALIGN_START,
+            $mdPanel.yPosition.BELOW
+          );
+      config.locals = {
+        items: menu.items
+      };
+      config.openFrom = $event;
+
+      $mdPanel.open(config);
+    };
+  }
+
+  function PanelMenuCtrl(mdPanelRef) {
+    this.closeMenu = function() {
+      mdPanelRef && mdPanelRef.close();
+    };
+  }
+})();

--- a/src/components/panel/demoConfigProvider/style.global.css
+++ b/src/components/panel/demoConfigProvider/style.global.css
@@ -1,0 +1,77 @@
+.menu-panel-container {
+  pointer-events: auto;
+}
+
+.menu-panel {
+  width: 256px;
+  background-color: #fff;
+  border-radius: 4px;
+}
+
+.menu-panel .menu-divider {
+  width: 100%;
+  height: 1px;
+  min-height: 1px;
+  max-height: 1px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  background-color: rgba(0, 0, 0, 0.11);
+}
+
+.menu-panel .menu-content {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 0;
+  max-height: 305px;
+  overflow-y: auto;
+  min-width: 256px;
+}
+
+.menu-panel .menu-item {
+  display: flex;
+  flex-direction: row;
+  min-height: 48px;
+  height: 48px;
+  align-content: center;
+  justify-content: flex-start;
+}
+.menu-panel .menu-item > * {
+  width: 100%;
+  margin: auto 0;
+  padding-left: 16px;
+  padding-right: 16px;
+}
+.menu-panel .menu-item > a.md-button {
+  padding-top: 5px;
+}
+.menu-panel .menu-item > .md-button {
+  display: inline-block;
+  border-radius: 0;
+  margin: auto 0;
+  font-size: 15px;
+  text-transform: none;
+  font-weight: 400;
+  height: 100%;
+  padding-left: 16px;
+  padding-right: 16px;
+  width: 100%;
+  text-align: left;
+}
+.menu-panel .menu-item > .md-button::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+.menu-panel .menu-item > .md-button md-icon {
+  margin: auto 16px auto 0;
+}
+.menu-panel .menu-item > .md-button p {
+  display: inline-block;
+  margin: auto;
+}
+.menu-panel .menu-item > .md-button span {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+.menu-panel .menu-item > .md-button .md-ripple-container {
+  border-radius: inherit;
+}

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -1,6 +1,6 @@
 describe('$mdPanel', function() {
-  var $mdPanel, $rootScope, $rootEl, $templateCache, $q, $material, $mdConstant,
-      $mdUtil, $animate, $$rAF, $window;
+  var $mdPanelConfigProvider, $mdPanel, $rootScope, $rootEl, $templateCache, $q,
+      $material, $mdConstant, $mdUtil, $animate, $$rAF, $window;
   var panelRef;
   var attachedElements = [];
   var PANEL_WRAPPER = '.md-panel-outer-wrapper';
@@ -92,6 +92,84 @@ describe('$mdPanel', function() {
     // TODO(ErinCoughlan) - Remove when close destroys.
     panelRef = null;
     $animate.enabled(true);
+  });
+
+  describe('provider logic:', function() {
+    var config = {
+      name: 'testConfig',
+      options: DEFAULT_CONFIG
+    };
+    var config2 = {
+      name: 'testConfig2',
+      options: DEFAULT_CONFIG
+    };
+
+    it('should have the $mdPanelConfigProvider available',
+        inject(function($mdPanelConfig) {
+      var configProvider = $mdPanelConfig;
+
+      expect(configProvider).toBeDefined();
+    }));
+
+    it('should allow for a custom configuration objects to be created and ' +
+        'stored in the $mdPanelConfigProvider', inject(function($mdPanelConfig) {
+      $mdPanelConfig.createConfig(config);
+
+      expect(Object.keys($mdPanelConfig._configs).length).toBe(1);
+    }));
+
+    it('should allow for more than one custom configuration objects to be ' +
+        'created and stored in the $mdPanelConfigProvider',
+        inject(function($mdPanelConfig) {
+      $mdPanelConfig.createConfig(config);
+      $mdPanelConfig.createConfig(config2);
+
+      expect(Object.keys($mdPanelConfig._configs).length).toBe(2);
+    }));
+
+    it('should throw if a custom configuration object doesn\'t have a name ' +
+        'or options parameter', inject(function($mdPanelConfig) {
+      var testConfig, expression;
+
+      testConfig = {
+        options: DEFAULT_CONFIG
+      };
+      expression = function() {
+        $mdPanelConfig.createConfig(testConfig);
+      };
+
+      expect(expression).toThrow();
+
+      testConfig = {
+        name: 'testConfig'
+      };
+      expression = function() {
+        $mdPanelConfig.createConfig(testConfig);
+      };
+
+      expect(expression).toThrow();
+    }));
+
+    it('should retrieve a config from the $mdPanelConfigProvider',
+        inject(function($mdPanelConfig) {
+      $mdPanelConfig.createConfig(config);
+
+      var storedConfig = $mdPanel.getConfig('testConfig');
+      var testConfig = DEFAULT_CONFIG;
+
+      expect(storedConfig).toBeDefined();
+      expect(storedConfig).toEqual(testConfig);
+    }));
+
+    it('should throw if trying to retrieve a config from the ' +
+        '$mdPanelConfigProvider that has not been created',
+        inject(function($mdPanelConfig) {
+      var expression = function() {
+        $mdPanel.getConfig('notARegisteredConfig');
+      };
+
+      expect(expression).toThrow();
+    }));
   });
 
   it('should create and open a basic panel', function() {


### PR DESCRIPTION
Allows users to be able to add the `$mdPanelConfigProvider` to the config block of their application. They can use this provider to create one or more configurations for upcoming panel elements.

Fixes #10006