### PR TITLE
fix(progressCircular): update animation to spec

### DIFF
--- a/src/components/progressCircular/js/progressCircularProvider.js
+++ b/src/components/progressCircular/js/progressCircularProvider.js
@@ -46,9 +46,9 @@ function MdProgressCircularProvider() {
     duration: 100,
     easeFn: linearEase,
 
-    durationIndeterminate: 500,
-    startIndeterminate: 3,
-    endIndeterminate: 80,
+    durationIndeterminate: 1333,
+    startIndeterminate: 1,
+    endIndeterminate: 149,
     easeFnIndeterminate: materialEase,
 
     easingPresets: {

--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -1,4 +1,4 @@
-$progress-circular-indeterminate-duration: 2.9s !default;
+$progress-circular-indeterminate-duration: 1568.63ms !default;
 
 @keyframes indeterminate-rotate {
     0%       { transform: rotate(0deg); }

--- a/src/components/progressCircular/progress-circular.spec.js
+++ b/src/components/progressCircular/progress-circular.spec.js
@@ -95,7 +95,7 @@ describe('mdProgressCircular', function() {
       '<md-progress-circular md-diameter="' + diameter + '"></md-progress-circular>'
     ).find('path').eq(0);
 
-    expect(path.css('stroke-width')).toBe(diameter / ratio + 'px');
+    expect(parseFloat(path.attr('stroke-width'))).toBe(diameter / ratio);
   });
 
   it('should hide the element if is disabled', function() {


### PR DESCRIPTION
Previous animation did not properly animate the circle stroke

* Use persistent SVG path for all animations
* Change `stroke-dashoffset` to match spec on every requested frame
* Rotate object -90 degrees every iteration
* Correct overall counter clockwise animation timing in SCSS

Instead of creating a new SVG path every frame, we will instead simply
animate the `stroke-dashoffset` parameter. This allows us to match spec
while also increasing performance by simplifying logic per frame.

Fixes #9879