### PR TITLE
fix(mdTooltip): Tooltip role

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -92,7 +92,6 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
 
     // Remove the element from its current DOM position.
     element.detach();
-    element.attr('role', 'tooltip');
 
     updatePosition();
     bindEvents();
@@ -388,7 +387,9 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
         panelRef = $mdPanel.create(panelConfig);
       }
 
-      panelRef.open();
+      panelRef.open().then(function() {
+        panelRef.panelEl.attr('role', 'tooltip');
+      });
     }
 
     function hideTooltip() {


### PR DESCRIPTION
The tooltip role was being assigned to an element that is being detached and not re-attached, causing an a11y issue. The tooltip role is now being assigned to the panel element through the `role` attribute.

Fixes #10045