### PR TITLE
feat(dialog): optionally disable confirm in prompt

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -475,6 +475,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * - $mdDialogPreset#initialValue(string) - Sets the initial value for the prompt input.
  * - $mdDialogPreset#ok(string) - Sets the prompt "Okay" button text.
  * - $mdDialogPreset#cancel(string) - Sets the prompt "Cancel" button text.
+ * - $mdDialogPreset#required(bool) - When `true`, the "Okay" button is disabled until a value is entered.
  * - $mdDialogPreset#theme(string) - Sets the theme of the prompt dialog.
  * - $mdDialogPreset#targetEvent(DOMClickEvent=) - A click's event object. When passed in as an option,
  *     the location of the click will be used as the starting point for the opening animation
@@ -595,7 +596,7 @@ function MdDialogProvider($$interimElementProvider) {
     })
     .addPreset('confirm', {
       methods: ['title', 'htmlContent', 'textContent', 'content', 'ariaLabel', 'ok', 'cancel',
-          'theme', 'css'],
+          'theme', 'css', 'required'],
       options: advancedDialogOptions
     })
     .addPreset('prompt', {
@@ -626,7 +627,7 @@ function MdDialogProvider($$interimElementProvider) {
         '               ng-click="dialog.abort()" class="md-primary md-cancel-button">',
         '      {{ dialog.cancel }}',
         '    </md-button>',
-        '    <md-button ng-click="dialog.hide()" class="md-primary md-confirm-button" md-autofocus="dialog.$type===\'alert\'">',
+        '    <md-button ng-click="dialog.hide()" class="md-primary md-confirm-button" md-autofocus="dialog.$type===\'alert\'" ng-disabled="{{ ::dialog.$type == \'prompt\' && ::dialog.required && !dialog.result }}">',
         '      {{ dialog.ok }}',
         '    </md-button>',
         '  </md-dialog-actions>',

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -778,6 +778,26 @@ describe('$mdDialog', function() {
 
       expect(response).toBe('responsetext');
     }));
+
+    it('should disable the confirm button if required is set', function(){
+      var parent = angular.element('<div>');
+      var response;
+
+      $mdDialog.show(
+        $mdDialog
+          .prompt()
+          .parent(parent)
+          .require(true)
+          .textContent('Hello world')
+      );
+
+      $rootScope.$apply();
+      runAnimation();
+
+      var buttons = parent.find('md-button');
+
+      expect(buttons.eq(0).text()).toBeDisabled();
+    })
   });
 
   describe('#build()', function() {


### PR DESCRIPTION
Allows the user to call `.require()` on the dialog options to have the "Okay" button disabled in a prompt until a value is entered.

Please me know if I'm on the right path with this :P