### PR TITLE
fix(autocomplete): change highlight color to match material standards

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -19,7 +19,7 @@ md-autocomplete.md-THEME_NAME-theme {
   li {
     color: '{{background-900}}';
     .highlight {
-      color: '{{background-600}}';
+      color: '{{background-500}}';
     }
     &:hover,
     &.selected {


### PR DESCRIPTION
Change highlight color to provide a better contrast on highlighted text on items.

Closes #10060

[Standard example](https://material.google.com/components/text-fields.html#text-fields-auto-complete-text-field)
![image](https://cloud.githubusercontent.com/assets/9147600/20609620/3d77b360-b24c-11e6-9d77-d8fea2466c75.png)

With this PR:
![image](https://cloud.githubusercontent.com/assets/9147600/20609642/7d0cd352-b24c-11e6-8550-f7b1a6a68fff.png)
