### PR TITLE
Remove mdMaxlength directive forcing ng-trim

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -649,8 +649,9 @@ function mdMaxlengthDirective($animate, $mdUtil) {
 
       // Stop model from trimming. This makes it so whitespace
       // over the maxlength still counts as invalid.
-      attr.$set('ngTrim', 'false');
-
+      // Edit: Setting the trim is not needed, as the whitespace over maxlength will be trimmed 
+      // attr.$set('ngTrim', 'false');
+ 
       scope.$watch(attr.mdMaxlength, function(value) {
         maxlength = value;
         if (angular.isNumber(value) && value > 0) {
@@ -684,7 +685,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
 
       // Force the value into a string since it may be a number,
       // which does not have a length property.
-      charCountEl.text(String(element.val() || value || '').length + ' / ' + maxlength);
+      charCountEl.text(String(element.val().trim || value || '').length + ' / ' + maxlength);
       return value;
     }
   }


### PR DESCRIPTION
Adding ng-trim="false" to an input will cause the 'required' state to be fulfilled by empty spaces, essentially allowing a user to put in no content and pass required validation.  Allowing angular to trim, and trimming manually in the renderCharCount function works better (IMO).