### PR TITLE
docs(select) clarify multiple attribute

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -70,7 +70,7 @@ angular.module('material.components.select', [
  * `value="null"` will require the test `ng-if="myValue != 'null'"` rather than `ng-if="!myValue"`.
  *
  * @param {expression} ng-model The model!
- * @param {boolean=} multiple Whether it's multiple.
+ * @param {boolean=} multiple When set to true, allows for more than one option to be selected. The model is an array with the selected choices.
  * @param {expression=} md-on-close Expression to be evaluated when the select is closed.
  * @param {expression=} md-on-open Expression to be evaluated when opening the select.
  * Will hide the select options and show a spinner until the evaluated promise resolves.


### PR DESCRIPTION
The documentation for md-select's `multiple` attribute is repetitive and unhelpful.

![screen shot 2016-12-02 at 2 37 27 pm](https://cloud.githubusercontent.com/assets/8163408/20852830/e5bfefdc-b89c-11e6-93c2-c03fc8128044.png)

This PR adds language to clarify the ui and model changes when the attribute is set to true.
> When set to true, allows for more than one option to be selected. The model is an array with the selected choices.
