### PR TITLE
fix(mdTooltip): AngularJS 1.3.20 test failures.

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -297,6 +297,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       parent.one('$destroy', onElementDestroy);
       scope.$on('$destroy', function() {
         setVisible(false);
+        panelRef && panelRef.destroy();
         element.remove();
         attributeObserver && attributeObserver.disconnect();
       });

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -298,8 +298,8 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       scope.$on('$destroy', function() {
         setVisible(false);
         panelRef && panelRef.destroy();
-        element.remove();
         attributeObserver && attributeObserver.disconnect();
+        element.remove();
       });
 
       // Updates the aria-label when the element text changes. This watch


### PR DESCRIPTION
The test failures were occurring due to the tooltip using the panel API. All requests to destroy the scope need to also be accompanied by requests to destroy the panel.

Fixes #10114