### PR TITLE
fix(tabs): remove manual pagination sizing algorithm

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -606,21 +606,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    * Updates whether or not pagination should be displayed.
    */
   function updatePagination () {
-    updatePagingWidth();
     ctrl.maxTabWidth = getMaxTabWidth();
     ctrl.shouldPaginate = shouldPaginate();
-  }
-
-  /**
-   * Sets or clears fixed width for md-pagination-wrapper depending on if tabs should stretch.
-   */
-  function updatePagingWidth() {
-    var elements = getElements();
-    if (shouldStretchTabs()) {
-      angular.element(elements.paging).css('width', '');
-    } else {
-      angular.element(elements.paging).css('width', calcPagingWidth() + 'px');
-    }
   }
 
   /**

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -159,13 +159,11 @@ md-pagination-wrapper {
   display: flex;
   transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
   position: absolute;
-  width: 999999px;
   @include rtl-prop(left, right, 0, auto);
   transform: translate3d(0, 0, 0);
   &.md-center-tabs {
     position: relative;
-    width: auto;
-    margin: 0 auto;
+    justify-content: center;
   }
 }
 

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -515,36 +515,6 @@ describe('<md-tabs>', function () {
     }));
   });
 
-  describe('md-pagination-wrapper', function () {
-    var template =  '<md-tabs md-stretch-tabs="{{stretch}}">' +
-                    '  <md-tab label="label!">content!</md-tab>' +
-                    '</md-tabs>';
-
-    it('should have inline width if md-stretch-tabs="never"',
-      inject(function ($timeout, $document) {
-      var scope = { 'stretch': 'never' };
-      var element = setup(template, scope);
-      // Appending to body is required for style checks
-      angular.element($document.body).append(element);
-      // $timeout.flush required to run nextTick inside init();
-      $timeout.flush();
-      expect(element.find('md-pagination-wrapper').attr('style').indexOf('width')).toBeGreaterThan(-1);
-      element.remove();
-    }));
-
-    it('should not have inline width if md-stretch-tabs="always"',
-      inject(function ($timeout, $document) {
-      var scope = { 'stretch': 'always' };
-      var element = setup(template, scope);
-      // Appending to body is required for style checks
-      angular.element($document.body).append(element);
-      // $timeout.flush required to run nextTick inside init();
-      $timeout.flush();
-      expect(element.find('md-pagination-wrapper').attr('style').indexOf('width')).toBe(-1);
-      element.remove();
-    }));
-  });
-
   describe('no element content', function() {
     it('should not add the `md-no-tab-content` class if the element has content', function() {
       var tabs = setup(


### PR DESCRIPTION
Since tabs now use flexbox for sizing, manually sizing is no longer needed.
This solves issues related tabs inside flexible containers like dialogs.

* Remove updatePagingWidth() function
* Revert width to default values

Fixes #9429