### PR TITLE
feat(tabs): add the ability to align tabs to the end

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -66,7 +66,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     defineBooleanAttribute('noDisconnect');
     defineBooleanAttribute('autoselect');
     defineBooleanAttribute('noSelectClick');
-    defineBooleanAttribute('centerTabs', handleCenterTabs, false);
+    defineBooleanAttribute('centerTabs', handleCenterTabs, false);    
+    defineBooleanAttribute('alignRight', handleAlignRight, false);
     defineBooleanAttribute('enableDisconnect');
 
     // Define public properties
@@ -77,6 +78,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     ctrl.hasFocus          = false;
     ctrl.styleTabItemFocus = false;
     ctrl.shouldCenterTabs  = shouldCenterTabs();
+    ctrl.shouldAlignRight  = shouldAlignRight();
     ctrl.tabContentPrefix  = 'tab-content-';
 
     // Setup the tabs controller after all bindings are available.
@@ -185,6 +187,10 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     ctrl.shouldCenterTabs = shouldCenterTabs();
   }
 
+  function handleAlignRight (newValue) {
+    ctrl.shouldAlignRight = shouldAlignRight();
+  }
+
   function handleMaxTabWidth (newWidth, oldWidth) {
     if (newWidth !== oldWidth) {
       var elements = getElements();
@@ -200,6 +206,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (newValue !== oldValue) {
       ctrl.maxTabWidth      = getMaxTabWidth();
       ctrl.shouldCenterTabs = shouldCenterTabs();
+      ctrl.shouldAlignRight = shouldAlignRight();
       $mdUtil.nextTick(function () {
         ctrl.maxTabWidth = getMaxTabWidth();
         adjustOffset(ctrl.selectedIndex);
@@ -221,7 +228,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function handleOffsetChange (left) {
     var elements = getElements();
-    var newValue = ctrl.shouldCenterTabs ? '' : '-' + left + 'px';
+    var newValue = ctrl.shouldCenterTabs || ctrl.shouldAlignRight ? '' : '-' + left + 'px';
 
     angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate3d(' + newValue + ', 0, 0)');
     $scope.$broadcast('$mdTabsPaginationChanged');
@@ -547,6 +554,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function shouldCenterTabs () {
     return ctrl.centerTabs && !ctrl.shouldPaginate;
   }
+    function shouldAlignRight () {
+    return ctrl.alignRight && !ctrl.shouldPaginate;
+  }
 
   /**
    * Determines if pagination is necessary to display the tabs within the available space.
@@ -696,7 +706,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
 
     if (!angular.isNumber(index)) index = ctrl.focusIndex;
     if (!elements.tabs[ index ]) return;
-    if (ctrl.shouldCenterTabs) return;
+    if (ctrl.shouldCenterTabs || ctrl.shouldAlignRight) return;
     var tab         = elements.tabs[ index ],
         left        = tab.offsetLeft,
         right       = tab.offsetWidth + left;
@@ -823,7 +833,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         left       = tab.offsetLeft,
         right      = totalWidth - left - tab.offsetWidth;
 
-    if (ctrl.shouldCenterTabs) {
+    if (ctrl.shouldCenterTabs || ctrl.shouldAlignRight) {
       // We need to use the same calculate process as in the pagination wrapper, to avoid rounding deviations.
       var tabWidth = calcTabsWidth(elements.tabs);
 

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -67,7 +67,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     defineBooleanAttribute('autoselect');
     defineBooleanAttribute('noSelectClick');
     defineBooleanAttribute('centerTabs', handleCenterTabs, false);
-    defineBooleanAttribute('alignRight', handleAlignEnd, false);
+    defineBooleanAttribute('alignEnd', handleAlignEnd, false);
     defineBooleanAttribute('enableDisconnect');
 
     // Define public properties
@@ -555,7 +555,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     return ctrl.centerTabs && !ctrl.shouldPaginate;
   }
     function shouldAlignEnd () {
-    return ctrl.alignRight && !ctrl.shouldPaginate;
+    return ctrl.alignEnd && !ctrl.shouldPaginate;
   }
 
   /**

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -66,8 +66,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     defineBooleanAttribute('noDisconnect');
     defineBooleanAttribute('autoselect');
     defineBooleanAttribute('noSelectClick');
-    defineBooleanAttribute('centerTabs', handleCenterTabs, false);    
-    defineBooleanAttribute('alignRight', handleAlignRight, false);
+    defineBooleanAttribute('centerTabs', handleCenterTabs, false);
+    defineBooleanAttribute('alignRight', handleAlignEnd, false);
     defineBooleanAttribute('enableDisconnect');
 
     // Define public properties
@@ -78,7 +78,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     ctrl.hasFocus          = false;
     ctrl.styleTabItemFocus = false;
     ctrl.shouldCenterTabs  = shouldCenterTabs();
-    ctrl.shouldAlignRight  = shouldAlignRight();
+    ctrl.shouldAlignEnd  = shouldAlignEnd();
     ctrl.tabContentPrefix  = 'tab-content-';
 
     // Setup the tabs controller after all bindings are available.
@@ -187,8 +187,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     ctrl.shouldCenterTabs = shouldCenterTabs();
   }
 
-  function handleAlignRight (newValue) {
-    ctrl.shouldAlignRight = shouldAlignRight();
+  function handleAlignEnd (newValue) {
+    ctrl.shouldAlignEnd = shouldAlignEnd();
   }
 
   function handleMaxTabWidth (newWidth, oldWidth) {
@@ -206,7 +206,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     if (newValue !== oldValue) {
       ctrl.maxTabWidth      = getMaxTabWidth();
       ctrl.shouldCenterTabs = shouldCenterTabs();
-      ctrl.shouldAlignRight = shouldAlignRight();
+      ctrl.shouldAlignEnd = shouldAlignEnd();
       $mdUtil.nextTick(function () {
         ctrl.maxTabWidth = getMaxTabWidth();
         adjustOffset(ctrl.selectedIndex);
@@ -228,7 +228,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
    */
   function handleOffsetChange (left) {
     var elements = getElements();
-    var newValue = ctrl.shouldCenterTabs || ctrl.shouldAlignRight ? '' : '-' + left + 'px';
+    var newValue = ctrl.shouldCenterTabs || ctrl.shouldAlignEnd ? '' : '-' + left + 'px';
 
     angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate3d(' + newValue + ', 0, 0)');
     $scope.$broadcast('$mdTabsPaginationChanged');
@@ -554,7 +554,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   function shouldCenterTabs () {
     return ctrl.centerTabs && !ctrl.shouldPaginate;
   }
-    function shouldAlignRight () {
+    function shouldAlignEnd () {
     return ctrl.alignRight && !ctrl.shouldPaginate;
   }
 
@@ -706,7 +706,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
 
     if (!angular.isNumber(index)) index = ctrl.focusIndex;
     if (!elements.tabs[ index ]) return;
-    if (ctrl.shouldCenterTabs || ctrl.shouldAlignRight) return;
+    if (ctrl.shouldCenterTabs || ctrl.shouldAlignEnd) return;
     var tab         = elements.tabs[ index ],
         left        = tab.offsetLeft,
         right       = tab.offsetWidth + left;
@@ -833,7 +833,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         left       = tab.offsetLeft,
         right      = totalWidth - left - tab.offsetWidth;
 
-    if (ctrl.shouldCenterTabs || ctrl.shouldAlignRight) {
+    if (ctrl.shouldCenterTabs || ctrl.shouldAlignEnd) {
       // We need to use the same calculate process as in the pagination wrapper, to avoid rounding deviations.
       var tabWidth = calcTabsWidth(elements.tabs);
 

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -69,7 +69,7 @@
  * @param {boolean=} md-dynamic-height When enabled, the tab wrapper will resize based on the contents of the selected tab
  * @param {boolean=} md-border-bottom If present, shows a solid `1px` border between the tabs and their content
  * @param {boolean=} md-center-tabs When enabled, tabs will be centered provided there is no need for pagination
- * @param {boolean=} md-align-right When enabled, tabs will be aligned right provided there is no need for pagination
+ * @param {boolean=} md-align-end When enabled, tabs will be aligned to end provided there is no need for pagination
  * @param {boolean=} md-no-pagination When enabled, pagination will remain off
  * @param {boolean=} md-swipe-content When enabled, swipe gestures will be enabled for the content area to jump between tabs
  * @param {boolean=} md-enable-disconnect When enabled, scopes will be disconnected for tabs that are not being displayed.  This provides a performance boost, but may also cause unexpected issues and is not recommended for most users.
@@ -138,12 +138,12 @@ function MdTabs ($$mdSvgRegistry) {
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
                   '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +
-                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
+                  '\'md-align-end\': $mdTabsCtrl.shouldAlignEnd }" ' +
               'ng-keydown="$mdTabsCtrl.keydown($event)" ' +
               'role="tablist"> ' +
             '<md-pagination-wrapper ' +
                 'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +
-                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
+                  '\'md-align-end\': $mdTabsCtrl.shouldAlignEnd }" ' +
                 'md-tab-scroll="$mdTabsCtrl.scroll($event)"> ' +
               '<md-tab-item ' +
                   'tabindex="-1" ' +

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -69,6 +69,7 @@
  * @param {boolean=} md-dynamic-height When enabled, the tab wrapper will resize based on the contents of the selected tab
  * @param {boolean=} md-border-bottom If present, shows a solid `1px` border between the tabs and their content
  * @param {boolean=} md-center-tabs When enabled, tabs will be centered provided there is no need for pagination
+ * @param {boolean=} md-align-right When enabled, tabs will be aligned right provided there is no need for pagination
  * @param {boolean=} md-no-pagination When enabled, pagination will remain off
  * @param {boolean=} md-swipe-content When enabled, swipe gestures will be enabled for the content area to jump between tabs
  * @param {boolean=} md-enable-disconnect When enabled, scopes will be disconnected for tabs that are not being displayed.  This provides a performance boost, but may also cause unexpected issues and is not recommended for most users.
@@ -136,13 +137,12 @@ function MdTabs ($$mdSvgRegistry) {
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
-                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs ' +                  
-                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight ' +
-              '}" ' +
+                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +                  
+                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
               'ng-keydown="$mdTabsCtrl.keydown($event)" ' +
               'role="tablist"> ' +
             '<md-pagination-wrapper ' +
-                'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs,' +
+                'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +
                   '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
                 'md-tab-scroll="$mdTabsCtrl.scroll($event)"> ' +
               '<md-tab-item ' +

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -137,7 +137,7 @@ function MdTabs ($$mdSvgRegistry) {
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
-                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +                  
+                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs, ' +
                   '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
               'ng-keydown="$mdTabsCtrl.keydown($event)" ' +
               'role="tablist"> ' +

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -136,12 +136,14 @@ function MdTabs ($$mdSvgRegistry) {
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
-                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs ' +
+                  '\'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs ' +                  
+                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight ' +
               '}" ' +
               'ng-keydown="$mdTabsCtrl.keydown($event)" ' +
               'role="tablist"> ' +
             '<md-pagination-wrapper ' +
-                'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs }" ' +
+                'ng-class="{ \'md-center-tabs\': $mdTabsCtrl.shouldCenterTabs,' +
+                  '\'md-align-right\': $mdTabsCtrl.shouldAlignRight }" ' +
                 'md-tab-scroll="$mdTabsCtrl.scroll($event)"> ' +
               '<md-tab-item ' +
                   'tabindex="-1" ' +

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -167,7 +167,7 @@ md-pagination-wrapper {
     width: auto;
     margin: 0 auto;
   }
-  &.md-align-right {
+  &.md-align-end {
     position: relative;
     width: auto;
     margin: 0 0 0 auto; 

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -167,6 +167,11 @@ md-pagination-wrapper {
     width: auto;
     margin: 0 auto;
   }
+  &.md-align-right {
+    position: relative;
+    width: auto;
+    margin: 0 0 0 auto; 
+  }
 }
 
 md-tabs-content-wrapper {


### PR DESCRIPTION
Basically has the same functionality with `md-center-tabs` but aligning
the tabs right

* Define boolean attribute `md-align-right`
* Add .md-align-right class if enabled
* Add css rule for `.md-align-right`