### PR TITLE
mdButton: remove duplicate selectors

### DIFF
--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -171,14 +171,6 @@
       color: '{{accent-color}}';
 
       &:hover {
-        color: '{{accent-700}}';
-      }
-    }
-
-    &.md-accent {
-      color: '{{accent-color}}';
-
-      &:hover {
         color: '{{accent-A700}}';
       }
     }


### PR DESCRIPTION
There were two `&.md-accent` selector and the former one was obviously unnecessary.
Indeed, the `.md-accent` always use color `{{accent-A*}}` rather than `{{accent-*}}`.