### PR TITLE
fix(mdTooltip): Tooltip position and watcher issue.

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -910,9 +910,12 @@ MdPanelService.prototype.create = function(config) {
   config = config || {};
 
   // If the passed-in config contains an ID and the ID is within _trackedPanels,
-  // return the tracked panel.
+  // return the tracked panel after updating its config with the passed in
+  // config.
   if (angular.isDefined(config.id) && this._trackedPanels[config.id]) {
-    return this._trackedPanels[config.id];
+    var trackedPanel = this._trackedPanels[config.id];
+    angular.extend(trackedPanel.config, config);
+    return trackedPanel;
   }
 
   this._config = {

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -270,12 +270,13 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       if (element[0] && 'MutationObserver' in $window) {
         var attributeObserver = new MutationObserver(function(mutations) {
           mutations.forEach(function(mutation) {
-            if (mutation.attributeName === 'md-visible' &&
-                !scope.visibleWatcher ) {
-              scope.visibleWatcher = scope.$watch('mdVisible',
-                  onVisibleChanged);
-            } else if (mutation.attributeName === 'md-direction') {
-              $mdUtil.nextTick(updatePosition);
+            switch (mutation.attributeName) {
+              case "md-visible":
+                scope.visibleWatcher = scope.visibleWatcher || scope.$watch('mdVisible', onVisibleChanged);
+                break;
+              case "md-direction":
+                $mdUtil.nextTick(updatePosition);
+                break;
             }
           });
         });
@@ -311,8 +312,8 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       parent.one('$destroy', onElementDestroy);
       scope.$on('$destroy', function() {
         setVisible(false);
-        element.remove();
         attributeObserver && attributeObserver.disconnect();
+        element.remove();
       });
 
       // Updates the aria-label when the element text changes. This watch

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -24,7 +24,7 @@ describe('MdTooltip Component', function() {
     // Make sure to remove/cleanup after each test.
     element.remove();
     var scope = element && element.scope();
-    scope && scope.$destroy;
+    scope && scope.$destroy();
     element = undefined;
   });
 
@@ -102,7 +102,7 @@ describe('MdTooltip Component', function() {
 
         expect(element.attr('aria-label')).toBe('test 2');
       });
-  
+
   it('should not interpolate interpolated values', function() {
     buildTooltip(
         '<md-button>' +


### PR DESCRIPTION
Fixes #10162 - When the position was changed dynamically the resulting tooltip's panel would retain the position classes on its panelEl. Now when creating and recreating the tooltip with a different position class due to a position change, the panel will grab that tracked panel and update its configuration object so that the new position class can be used.

Fixes #10157 - There was a `mdDirection` watcher that was deleted due to a rebase/timing issue when moving to the `mdPanel` API. Reference to the previous PR: https://github.com/angular/material/pull/7822/files