### PR TITLE
fix(virtualRepeat): DOM manipulation may alter scroll

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -767,6 +767,8 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
       this.$scope.$eval(this.$attrs.mdStartIndex) :
       this.container.topIndex;
     this.container.scrollToIndex(startIndex);
+    // call it twice since DOM manipulations may alter scroll position
+    this.container.scrollToIndex(startIndex);
   }
 
   // Detach and pool any blocks that are no longer in the viewport.


### PR DESCRIPTION
Fixes [#10144](https://github.com/angular/material/issues/10144) - There is an issue with Chrome that when the browser window is small enough, the intial DOM manipulations alter the scroll, which leads to the caldendar opening to the wrong month. Scrolling twice on the first render to ensure that the position is correct fixes this.