### PR TITLE
fix(virtualRepeat): DOM manipulation may alter scroll

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -761,12 +761,14 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
     this.container.setScrollSize(itemsLength * this.itemSize);
   }
 
+  var cleanupFirstRender = false, firstRenderStartIndex;
   if (this.isFirstRender) {
+    cleanupFirstRender = true;
     this.isFirstRender = false;
-    var startIndex = this.$attrs.mdStartIndex ?
+    firstRenderStartIndex = this.$attrs.mdStartIndex ?
       this.$scope.$eval(this.$attrs.mdStartIndex) :
       this.container.topIndex;
-    this.container.scrollToIndex(startIndex);
+    this.container.scrollToIndex(firstRenderStartIndex);
   }
 
   // Detach and pool any blocks that are no longer in the viewport.
@@ -820,6 +822,10 @@ VirtualRepeatController.prototype.virtualRepeatUpdate_ = function(items, oldItem
         this.blocks[maxIndex] && this.blocks[maxIndex].element[0].nextSibling);
   }
 
+  // DOM manipulation may have altered scroll, so scroll again
+  if (cleanupFirstRender) {
+    this.container.scrollToIndex(firstRenderStartIndex);
+  }
   // Restore $$checkUrlChange.
   this.$browser.$$checkUrlChange = this.browserCheckUrlChange;
 


### PR DESCRIPTION
Fixes [#10144](https://github.com/angular/material/issues/10144) - There is an issue with Chrome that when the browser window is small enough, the intial DOM manipulations alter the scroll, which leads to the caldendar opening to the wrong month. Scrolling twice on the first render to ensure that the position is correct fixes this.

CodePens:
- [Broken Datepicker](http://codepen.io/phillypham/pen/gLJXgY)
- [Fixed Datepicker](http://codepen.io/phillypham/pen/xRNPdJ)