### PR TITLE
BugFix to $$interimElement

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -526,20 +526,19 @@ function InterimElementProvider() {
 
           if ( options.$destroy === true ) {
 
-            return hideElement(options.element, options).then(function(){
-              (isCancelled && rejectAll(response)) || resolveAll(response);
-            });
+            return hideElement(options.element, options).then(hideSuccessful);
 
           } else {
             $q.when(showAction).finally(function() {
-              hideElement(options.element, options).then(function() {
-                isCancelled ? rejectAll(response) : resolveAll(response);
-              }, rejectAll);
+              hideElement(hideSuccessful, rejectAll);
             });
 
             return self.deferred.promise;
           }
 
+          function hideSuccessful(hideResult){
+              (isCancelled && rejectAll(hideResult)) || resolveAll(hideResult);            
+          }
 
           /**
            * The `show()` returns a promise that will be resolved when the interim


### PR DESCRIPTION
This affects mdDialog at the very least. I'm guessing this is somewhat of a typo, where someone forgot to add a paramter name to the resolve function. What happens is that another reponse value is captured, which is the promise that $mdDialog.show returns, so the result is we resolve a promise with itself, which Angular detects and and throws, so kudos to them.

Other weird things I noticed, but didn't look into :
1. The hideElement call on 529, doesn't call rejectAll on rejected promise. I would guess it should. 
2. if isCancelled is true, there is a call to rejectAll with the success result of the call of hideElement. Seems a bit weird.