### PR TITLE
fix(menu): avoid runtime errors when menu-content isn't set.

### DIFF
--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -177,26 +177,33 @@ function MenuDirective($mdUtil) {
 
   function compile(templateElement) {
     templateElement.addClass('md-menu');
-    var triggerElement = templateElement.children()[0];
+
+    var triggerEl = templateElement.children()[0];
+    var contentEl = templateElement.children()[1];
+
     var prefixer = $mdUtil.prefixer();
 
-    if (!prefixer.hasAttribute(triggerElement, 'ng-click')) {
-      triggerElement = triggerElement
-          .querySelector(prefixer.buildSelector(['ng-click', 'ng-mouseenter'])) || triggerElement;
-    }
-    if (triggerElement && (
-      triggerElement.nodeName == 'MD-BUTTON' ||
-      triggerElement.nodeName == 'BUTTON'
-    ) && !triggerElement.hasAttribute('type')) {
-      triggerElement.setAttribute('type', 'button');
+    if (!prefixer.hasAttribute(triggerEl, 'ng-click')) {
+      triggerEl = triggerEl
+          .querySelector(prefixer.buildSelector(['ng-click', 'ng-mouseenter'])) || triggerEl;
     }
 
-    if (templateElement.children().length != 2) {
-      throw Error(INVALID_PREFIX + 'Expected two children elements.');
+    var isButtonTrigger = triggerEl.nodeName === 'MD-BUTTON' || triggerEl.nodeName === 'BUTTON';
+
+    if (triggerEl && isButtonTrigger && !triggerEl.hasAttribute('type')) {
+      triggerEl.setAttribute('type', 'button');
+    }
+
+    if (!triggerEl) {
+      throw Error(INVALID_PREFIX + 'Expected the menu to have a trigger element.');
+    }
+
+    if (!contentEl || contentEl.nodeName !== 'MD-MENU-CONTENT') {
+      throw Error(INVALID_PREFIX + 'Expected the menu to contain a `md-menu-content` element.');
     }
 
     // Default element for ARIA attributes has the ngClick or ngMouseenter expression
-    triggerElement && triggerElement.setAttribute('aria-haspopup', 'true');
+    triggerEl && triggerEl.setAttribute('aria-haspopup', 'true');
 
     var nestedMenus = templateElement[0].querySelectorAll('md-menu');
     var nestingDepth = parseInt(templateElement[0].getAttribute('md-nest-level'), 10) || 0;

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -22,7 +22,9 @@ function MenuProvider($$interimElementProvider) {
     });
 
   /* @ngInject */
-  function menuDefaultOptions($mdUtil, $mdTheming, $mdConstant, $document, $window, $q, $$rAF, $animateCss, $animate) {
+  function menuDefaultOptions($mdUtil, $mdTheming, $mdConstant, $document, $window, $q, $$rAF,
+                              $animateCss, $animate, $log) {
+
     var prefixer = $mdUtil.prefixer();
     var animator = $mdUtil.dom.animator;
 
@@ -74,9 +76,13 @@ function MenuProvider($$interimElementProvider) {
      * and backdrop
      */
     function onRemove(scope, element, opts) {
-      opts.cleanupInteraction && opts.cleanupInteraction();
+      opts.cleanupInteraction();
+      opts.cleanupBackdrop();
       opts.cleanupResizing();
       opts.hideBackdrop();
+
+      // Before the menu is closing remove the clickable class.
+      element.removeClass('md-clickable');
 
       // For navigation $destroy events, do a quick, non-animated removal,
       // but for normal closes (from clicks, etc) animate the removal
@@ -109,9 +115,17 @@ function MenuProvider($$interimElementProvider) {
     function onShow(scope, element, opts) {
       sanitizeAndConfigure(opts);
 
-      // Wire up theming on our menu element
-      $mdTheming.inherit(opts.menuContentEl, opts.target);
-
+      if (opts.menuContentEl[0]) {
+        // Inherit the theme from the target element.
+        $mdTheming(opts.menuContentEl, opts.target);
+      } else {
+        $log.warn(
+          '$mdMenu: Menu elements should always contain a `md-menu-content` element,' +
+          'otherwise interactivity features will not work properly.',
+          element
+        );
+      }
+      
       // Register various listeners to move menu on resize/orientation change
       opts.cleanupResizing = startRepositioningOnResize();
       opts.hideBackdrop = showBackdrop(scope, element, opts);
@@ -121,6 +135,11 @@ function MenuProvider($$interimElementProvider) {
         .then(function(response) {
           opts.alreadyOpen = true;
           opts.cleanupInteraction = activateInteraction();
+          opts.cleanupBackdrop = setupBackdrop();
+
+          // Since the menu finished its animation, mark the menu as clickable.
+          element.addClass('md-clickable');
+
           return response;
         });
 
@@ -194,14 +213,34 @@ function MenuProvider($$interimElementProvider) {
       }
 
       /**
-       * Activate interaction on the menu. Wire up keyboard listerns for
-       * clicks, keypresses, backdrop closing, etc.
+       * Sets up the backdrop and listens for click elements.
+       * Once the backdrop will be clicked, the menu will automatically close.
+       * @returns {!Function} Function to remove the backdrop.
+       */
+      function setupBackdrop() {
+        if (!opts.backdrop) return angular.noop;
+
+        opts.backdrop.on('click', function(event) {
+          event.preventDefault();
+          event.stopPropagation();
+
+          scope.$apply(function() {
+            opts.mdMenuCtrl.close(true, { closeAll: true });
+          });
+        });
+
+        return function() {
+          opts.backdrop.off('click', onBackdropClick);
+        }
+      }
+
+      /**
+       * Activate interaction on the menu. Resolves the focus target and closes the menu on
+       * escape or option click.
+       * @returns {!Function} Function to deactivate the interaction listeners.
        */
       function activateInteraction() {
-        element.addClass('md-clickable');
-
-        // close on backdrop click
-        if (opts.backdrop) opts.backdrop.on('click', onBackdropClick);
+        if (!opts.menuContentEl[0]) return angular.noop;
 
         // Wire up keyboard listeners.
         // - Close on escape,
@@ -232,8 +271,6 @@ function MenuProvider($$interimElementProvider) {
         focusTarget && focusTarget.focus();
 
         return function cleanupInteraction() {
-          element.removeClass('md-clickable');
-          if (opts.backdrop) opts.backdrop.off('click', onBackdropClick);
           opts.menuContentEl.off('keydown', onMenuKeyDown);
           opts.menuContentEl[0].removeEventListener('click', captureClickListener, true);
         };

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -220,18 +220,24 @@ function MenuProvider($$interimElementProvider) {
       function setupBackdrop() {
         if (!opts.backdrop) return angular.noop;
 
-        opts.backdrop.on('click', function(event) {
-          event.preventDefault();
-          event.stopPropagation();
-
-          scope.$apply(function() {
-            opts.mdMenuCtrl.close(true, { closeAll: true });
-          });
-        });
+        opts.backdrop.on('click', onBackdropClick);
 
         return function() {
           opts.backdrop.off('click', onBackdropClick);
         }
+      }
+
+      /**
+       * Function to be called whenever the backdrop is clicked.
+       * @param {!MouseEvent} event
+       */
+      function onBackdropClick(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        scope.$apply(function() {
+          opts.mdMenuCtrl.close(true, { closeAll: true });
+        });
       }
 
       /**

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -369,7 +369,7 @@ describe('material.components.menu', function() {
       $log = $injector.get('$log');
     }));
 
-    fit('should warn when the md-menu-content element is missing', function() {
+    it('should warn when the md-menu-content element is missing', function() {
       spyOn($log, 'warn');
 
       var parent = angular.element('<div>');
@@ -393,6 +393,10 @@ describe('material.components.menu', function() {
       $timeout.flush();
 
       expect($log.warn).toHaveBeenCalledTimes(1);
+
+      // Close the menu and remove the parent container
+      $mdMenu.hide();
+      parent.remove();
     });
 
     function createFakeMenuController() {

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -27,12 +27,28 @@ describe('material.components.menu', function() {
       expect(element.hasClass('_md')).toBe(true);
     });
 
-    it('errors on invalid markup', inject(function($compile, $rootScope) {
-      function buildBadMenu() {
-        $compile('<md-menu></md-menu>')($rootScope);
+    it('should throw when trigger element is missing', inject(function($compile, $rootScope) {
+      function createInvalidMenu() {
+        $compile(
+          '<md-menu>' +
+          '  <md-menu-content>Menu Content</md-menu-content>' +
+          '</md-menu>'
+        )($rootScope);
       }
 
-      expect(buildBadMenu).toThrow();
+      expect(createInvalidMenu).toThrow();
+    }));
+
+    it('should throw when md-menu-content is missing', inject(function($compile, $rootScope) {
+      function createInvalidMenu() {
+        $compile(
+          '<md-menu>' +
+          '  <button ng-click="null">Trigger Element</button>' +
+          '</md-menu>'
+        )($rootScope);
+      }
+
+      expect(createInvalidMenu).toThrow();
     }));
 
     it('specifies button type', inject(function($compile, $rootScope) {
@@ -339,6 +355,55 @@ describe('material.components.menu', function() {
       attachedElements.push(menu);
       return menu;
     }
+  });
+
+  describe('with $mdMenu service', function() {
+
+    var $mdMenu, $rootScope, $compile, $timeout, $log = null;
+
+    beforeEach(inject(function($injector) {
+      $mdMenu = $injector.get('$mdMenu');
+      $rootScope = $injector.get('$rootScope');
+      $compile = $injector.get('$compile');
+      $timeout = $injector.get('$timeout');
+      $log = $injector.get('$log');
+    }));
+
+    fit('should warn when the md-menu-content element is missing', function() {
+      spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      var menuEl = angular.element(
+        '<md-menu>' +
+        '  <button ng-click="null">Trigger</button>' +
+        '</md-menu>'
+      );
+
+      expect($log.warn).not.toHaveBeenCalled();
+
+      $mdMenu.show({
+        scope: $rootScope,
+        mdMenuCtrl: createFakeMenuController(),
+        element: menuEl,
+        target: document.body,
+        preserveElement: true,
+        parent: parent
+      });
+
+      $timeout.flush();
+
+      expect($log.warn).toHaveBeenCalledTimes(1);
+    });
+
+    function createFakeMenuController() {
+      return {
+        open: function() {},
+        close: function() { $mdMenu.hide(); },
+        positionMode: function() { return { left: 'left', top: 'target' }; },
+        offsets: function() { return { top: 0, left: 0 }; }
+      }
+    }
+
   });
 
 


### PR DESCRIPTION
No longer throws runtime exceptions in the $mdMenu service when no `md-menu-content` element is specified.

> When the `$mdMenu` service is used programmatically it will show a warning and just doesn't setup the interaction.

When the `md-menu` directive misses the `md-menu-content` element a normal error will be thrown, so developers can detect before actually opening the menu, that the `md-menu-content` element is missing.

Fixes #9709.