### PR TITLE
fix(menu): menu content should inherit theme

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -117,7 +117,7 @@ function MenuProvider($$interimElementProvider) {
 
       if (opts.menuContentEl[0]) {
         // Inherit the theme from the target element.
-        $mdTheming(opts.menuContentEl, opts.target);
+        $mdTheming.inherit(opts.menuContentEl, opts.target);
       } else {
         $log.warn(
           '$mdMenu: Menu elements should always contain a `md-menu-content` element,' +


### PR DESCRIPTION
* Re-adds the accidentally removed `inherit` function from commit 0b65e08e24fd017250e0637a96b445f25f76c754