### PR TITLE
fix(chips): failing unit tests against Angular 1.3

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -842,7 +842,8 @@ describe('<md-chips>', function() {
         expect(document.activeElement).toHaveClass('md-chip-content');
 
         // At/after 300ms timeout, focus should be on the input
-        $timeout.flush(1);
+        $timeout.flush();
+
         expect(document.activeElement.tagName.toUpperCase()).toEqual('INPUT');
 
         // cleanup
@@ -864,7 +865,7 @@ describe('<md-chips>', function() {
         expect(document.activeElement).toHaveClass('md-chip-content');
 
         // At/after custom timeout, focus should be on the input
-        $timeout.flush(1);
+        $timeout.flush();
         expect(document.activeElement.tagName.toUpperCase()).toEqual('INPUT');
 
         // cleanup


### PR DESCRIPTION
Fixes a couple of chips tests which were failing against Angular 1.3.x due to a timeout that wasn't being flushed.