### PR TITLE
fix(select/datepicker): Fix dropdown icon colors.

### DIFF
--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -33,10 +33,6 @@
 
   .md-datepicker-triangle-button {
     .md-datepicker-expand-triangle {
-      border-top-color: '{{foreground-3}}';
-    }
-
-    &:hover .md-datepicker-expand-triangle {
       border-top-color: '{{foreground-2}}';
     }
   }

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -45,6 +45,7 @@ md-select.md-THEME_NAME-theme {
     background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
     background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
   }
+
   .md-select-value {
     border-bottom-color: '{{foreground-4}}';
 
@@ -56,18 +57,22 @@ md-select.md-THEME_NAME-theme {
       color: '{{warn-A700}}'
     }
   }
+
   &.md-no-underline .md-select-value {
     border-bottom-color: transparent !important;
   }
+
   &.ng-invalid.ng-touched {
     .md-select-value {
       color: '{{warn-A700}}' !important;
       border-bottom-color: '{{warn-A700}}' !important;
     }
+
     &.md-no-underline .md-select-value {
       border-bottom-color: transparent !important;
     }
   }
+
   &:not([disabled]):focus {
     .md-select-value {
       border-bottom-color: '{{primary-color}}';
@@ -76,31 +81,36 @@ md-select.md-THEME_NAME-theme {
         color: '{{ foreground-1 }}';
       }
     }
+
     &.md-no-underline .md-select-value {
       border-bottom-color: transparent !important;
     }
+
     &.md-accent .md-select-value {
       border-bottom-color: '{{accent-color}}';
     }
+
     &.md-warn .md-select-value {
       border-bottom-color: '{{warn-color}}';
     }
   }
+
   &[disabled] {
     .md-select-value {
       color: '{{foreground-3}}';
+
       &.md-select-placeholder {
         color: '{{foreground-3}}';
       }
     }
+
+    .md-select-icon {
+      color: '{{foreground-3}}';
+    }
   }
 
   .md-select-icon {
-    color: '{{foreground-3}}';
-
-    &:hover {
-      color: '{{foreground-2}}';
-    }
+    color: '{{foreground-2}}';
   }
 }
 


### PR DESCRIPTION
Change the dropdown icon colors for Select and Datepicker to be
darker by default.

**Old Styles**

 - Default: foreground-3 (light grey)
 - Hover: foreground-2 (darker grey)

**New Styles**

 - Default: foreground-2 (darker grey)
 - Disabled: foreground-3 (light grey; select only; datepicker
   hides the icon when disabled)

Note that the hover effect appeared not to work and since it used
the proper default color, it has been removed.

Also added some newlines for clarity.