### PR TITLE
chore: run tests for angular 1.6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ env:
   - BROWSER_STACK_USERNAME=angularteam1
   - BROWSER_STACK_ACCESS_KEY=BWCd4SynLzdDcv8xtzsB
   - secure: X7CNmOMemAJ9Jqrsmv6MXyeh8n8TIL5CKzE9LYsZUbsyKo0l5CyyysJq0y/AbpQS6awsSv2qP/cZ/kand6r6z0wMFbUcxa4HjMZEfRwv3sGtwj1OKJko/GvjcZQzD54FtHy1NU7wR0mYhAlE5IwH7f8bMa/nUiijgD/TOCTtKH8=
+  matrix:
+    - NG_VERSION=1.5.9
+    - NG_VERSION=1.6.1
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: "NG_VERSION=1.6.1"
 
 cache:
   directories:

--- a/config/sauce-browsers.json
+++ b/config/sauce-browsers.json
@@ -3,7 +3,7 @@
     "base": "SauceLabs",
     "browserName": "chrome",
     "platform": "Windows 10",
-    "version": "50"
+    "version": "latest"
   },
   "SL_CHROMEBETA": {
     "base": "SauceLabs",
@@ -19,7 +19,7 @@
     "base": "SauceLabs",
     "browserName": "firefox",
     "platform": "Windows 10",
-    "version": "46"
+    "version": "latest"
   },
   "SL_FIREFOXBETA": {
     "base": "SauceLabs",

--- a/scripts/sauce/setup-tunnel.sh
+++ b/scripts/sauce/setup-tunnel.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SAUCE_BINARY_FILE="sc-4.4.1-linux.tar.gz"
+SAUCE_BINARY_FILE="sc-4.4.2-linux.tar.gz"
 SAUCE_BINARY_DIR="/tmp/sauce"
 SAUCE_ACCESS_KEY=`echo $SAUCE_ACCESS_KEY | rev`
 

--- a/scripts/travis-run-script.sh
+++ b/scripts/travis-run-script.sh
@@ -13,6 +13,12 @@ gulp build
 # Wait for the tunnel to be ready
 ./scripts/sauce/wait-tunnel.sh
 
+# When Travis CI specifies an Angular version, try to install those for tests.
+if [[ -n "$NG_VERSION" ]]; then
+  npm i angular@$NG_VERSION \
+        angular-{animate,aria,messages,mocks,route,sanitize,touch}@$NG_VERSION
+fi
+
 gulp karma --config=config/karma-sauce.conf.js --browsers=$BROWSER --reporters='dots'
 
 # Shutdown the tunnel

--- a/scripts/travis-run-script.sh
+++ b/scripts/travis-run-script.sh
@@ -3,6 +3,12 @@
 # Terminate the execution if anything fails in the pipeline.
 set -e
 
+# When Travis CI specifies an Angular version, try to install those for tests.
+if [[ -n "$NG_VERSION" ]]; then
+  npm i angular@$NG_VERSION \
+        angular-{animate,aria,messages,mocks,route,sanitize,touch}@$NG_VERSION
+fi
+
 # Run our check to make sure all tests will actually run
 gulp ddescribe-iit
 gulp build
@@ -12,12 +18,6 @@ gulp build
 
 # Wait for the tunnel to be ready
 ./scripts/sauce/wait-tunnel.sh
-
-# When Travis CI specifies an Angular version, try to install those for tests.
-if [[ -n "$NG_VERSION" ]]; then
-  npm i angular@$NG_VERSION \
-        angular-{animate,aria,messages,mocks,route,sanitize,touch}@$NG_VERSION
-fi
 
 gulp karma --config=config/karma-sauce.conf.js --browsers=$BROWSER --reporters='dots'
 


### PR DESCRIPTION
* Now runs tests for Angular v1.6.1 on the Travis CI in an optional mode.

Closes #10205