### PR TITLE
chore: rollback to firefox 49 sauce browser

### DIFF
--- a/config/sauce-browsers.json
+++ b/config/sauce-browsers.json
@@ -19,7 +19,7 @@
     "base": "SauceLabs",
     "browserName": "firefox",
     "platform": "Windows 10",
-    "version": "latest"
+    "version": "latest-1"
   },
   "SL_FIREFOXBETA": {
     "base": "SauceLabs",


### PR DESCRIPTION
* Currently in Saucelabs for Firefox v50 a single unit test for the input component fails
  A few people from the team were asked to reproduce it, but nobody was able to reproduce it locally.

* Reverting this change from SHA e8d29db61f7dc9ebe476406f9e3321e792eb3418 to make the CI green. We are investigating, but this should not affect the CI