### PR TITLE
fix(mdTooltip): Tooltip parent aria label override

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -75,6 +75,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
 
   function linkFunc(scope, element, attr) {
     // Set constants.
+    var tooltipId = 'tooltip-' + $mdUtil.nextUid();
     var parent = $mdUtil.getParentWithPointerEvents(element);
     var debouncedOnResize = $$rAF.throttle(updatePosition);
     var mouseActive = false;
@@ -102,12 +103,24 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
     }
 
-    function addAriaLabel(override) {
-      if (override || !parent.attr('aria-label')) {
-        // Only interpolate the text from the HTML element because otherwise the custom text
-        // could be interpolated twice and cause XSS violations.
-        var interpolatedText = override || $interpolate(element.text().trim())(parent.scope);
+    function addAriaLabel(labelText) {
+      // Only interpolate the text from the HTML element because otherwise the custom text could
+      // be interpolated twice and cause XSS violations.
+      var interpolatedText = labelText || $interpolate(element.text().trim())(parent.scope);
+
+      // Only add the `aria-label` to the parent if there isn't already one, if there isn't an
+      // already present `aria-labelledby`, or if the previous `aria-label` was added by the
+      // tooltip directive.
+      if (
+        (!parent.attr('aria-label') && !parent.attr('aria-labelledby')) ||
+        parent.attr('aria-labelledby') === tooltipId
+      ) {
         parent.attr('aria-label', interpolatedText);
+
+        // Set the `aria-labelledby` attribute if it has not already been set.
+        if (!parent.attr('aria-labelledby')) {
+          parent.attr('aria-labelledby', tooltipId);
+        }
       }
     }
 
@@ -360,7 +373,6 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
 
       if (!panelRef) {
-        var id = 'tooltip-' + $mdUtil.nextUid();
         var attachTo = angular.element(document.body);
         var panelAnimation = $mdPanel.newPanelAnimation()
             .openFrom(parent)
@@ -371,7 +383,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
             });
 
         var panelConfig = {
-          id: id,
+          id: tooltipId,
           attachTo: attachTo,
           contentElement: element,
           propagateContainerEvents: true,

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -75,7 +75,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
 
   function linkFunc(scope, element, attr) {
     // Set constants.
-    var tooltipId = 'tooltip-' + $mdUtil.nextUid();
+    var tooltipId = 'md-tooltip-' + $mdUtil.nextUid();
     var parent = $mdUtil.getParentWithPointerEvents(element);
     var debouncedOnResize = $$rAF.throttle(updatePosition);
     var mouseActive = false;

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -82,6 +82,34 @@ describe('MdTooltip Component', function() {
     );
 
     expect(element.attr('aria-label')).toEqual('Tooltip');
+    expect(element.attr('aria-labelledby')).toBeDefined();
+  });
+
+  it('should not label the parent if it already has a label', function() {
+    buildTooltip(
+      '<md-button aria-label="Button Label">' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+          'Tooltip' +
+        '</md-tooltip>' +
+      '</md-button>'
+    );
+
+    expect(element.attr('aria-label')).toEqual('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+  });
+
+  it('should not label the parent if it has already been labelled by ' +
+      'another element.', function() {
+    buildTooltip(
+      '<md-button aria-labelledby="button-1">' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+          'Tooltip' +
+        '</md-tooltip>' +
+      '</md-button>'
+    );
+
+    expect(element.attr('aria-label')).toBeUndefined();
+    expect(element.attr('aria-labelledby')).toEqual('button-1');
   });
 
   it('should interpolate the aria-label', function() {
@@ -92,47 +120,86 @@ describe('MdTooltip Component', function() {
     );
 
     expect(element.attr('aria-label')).toBe('HELLO');
+    expect(element.attr('aria-labelledby')).toBeDefined();
   });
 
   it('should update the aria-label when the interpolated value changes',
       function() {
-        buildTooltip(
-          '<md-button>' +
-            '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
-          '</md-button>'
-        );
+    var ariaLabelledby;
+    var ariaLabelledby2;
 
-        $rootScope.$apply(function() {
-          $rootScope.testModel.ariaText = 'test 1';
-        });
-
-        expect(element.attr('aria-label')).toBe('test 1');
-
-        $rootScope.$apply(function() {
-          $rootScope.testModel.ariaText = 'test 2';
-        });
-
-        expect(element.attr('aria-label')).toBe('test 2');
-      });
-  
-  it('should not interpolate interpolated values', function() {
     buildTooltip(
-        '<md-button>' +
-         '<md-tooltip>{{ testModel.ariaTest }}</md-tooltip>' +
-        '</md-button>'
-      );
+      '<md-button>' +
+        '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
+      '</md-button>'
+    );
 
-      $rootScope.$apply(function() {
-        $rootScope.testModel.ariaTest = 'test {{1+1}}';
-      });
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaText = 'test 1';
+    });
 
-      expect(element.attr('aria-label')).toBe('test {{1+1}}');
+    expect(element.attr('aria-label')).toBe('test 1');
+    ariaLabelledby = element.attr('aria-labelledby');
+    expect(ariaLabelledby).toBeDefined();
 
-      $rootScope.$apply(function() {
-        $rootScope.testModel.ariaTest = 'test {{1+1336}}';
-      });
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaText = 'test 2';
+    });
 
-      expect(element.attr('aria-label')).toBe('test {{1+1336}}');
+    expect(element.attr('aria-label')).toBe('test 2');
+    ariaLabelledby2 = element.attr('aria-labelledby');
+    expect(ariaLabelledby2).toEqual(ariaLabelledby);
+  });
+
+  it('should not update the parent aria-label when the interpolated' +
+      'value changes and the parent has a label that was not set by ' +
+      'the tooltip', function() {
+    buildTooltip(
+      '<md-button aria-label="Button Label">' +
+        '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
+      '</md-button>'
+    );
+
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaText = 'test 1';
+    });
+
+    expect(element.attr('aria-label')).toBe('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaText = 'test 2';
+    });
+
+    expect(element.attr('aria-label')).toBe('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+  });
+
+  it('should not interpolate interpolated values', function() {
+    var ariaLabelledby;
+    var ariaLabelledby2;
+
+    buildTooltip(
+      '<md-button>' +
+       '<md-tooltip>{{ testModel.ariaTest }}</md-tooltip>' +
+      '</md-button>'
+    );
+
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaTest = 'test {{1+1}}';
+    });
+
+    expect(element.attr('aria-label')).toBe('test {{1+1}}');
+    ariaLabelledby = element.attr('aria-labelledby');
+    expect(ariaLabelledby).toBeDefined();
+
+    $rootScope.$apply(function() {
+      $rootScope.testModel.ariaTest = 'test {{1+1336}}';
+    });
+
+    expect(element.attr('aria-label')).toBe('test {{1+1336}}');
+    ariaLabelledby2 = element.attr('aria-labelledby');
+    expect(ariaLabelledby2).toEqual(ariaLabelledby);
   });
 
   it('should not set parent to items with no pointer events',


### PR DESCRIPTION
Fixes #10242 - The tooltip now does not override or update the parent element `aria-label` unless the parent's `aria-label` does not exist, or it has been previously set by the tooltip. It determines if it has been set by the tooltip by placing the `aria-labelledby` attribute on the parent element and setting it to `tooltip`.