### PR TITLE
feat(autocomplete): add inline autocomplete options

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -2771,4 +2771,130 @@ describe('<md-autocomplete>', function() {
     }));
   });
 
+  describe('inline options', function() {
+    it('should replace input text on item select', inject(function($timeout, $mdConstant, $material) {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-inline-option="replace"\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+
+      $material.flushInterimElement();
+
+      expect(scope.searchText).toBe('');
+      expect(scope.selectedItem).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      scope.$apply('searchText = "b"');
+      $timeout.flush();
+      waitForVirtualRepeat(element);
+
+      // Check expectations
+      expect(scope.searchText).toBe('b');
+      expect(scope.match(scope.searchText).length).toBe(2);
+
+      expect(ul.find('li').length).toBe(2);
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $timeout.flush();
+
+      expect(input[0].value).toBe('bar');
+      expect(scope.searchText).toBe('b');
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $timeout.flush();
+
+      expect(input[0].value).toBe('baz');
+      expect(scope.searchText).toBe('b');
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+      $timeout.flush();
+
+      expect(scope.searchText).toBe('baz');
+
+      element.remove();
+    }));
+
+    it('should append text on item select', inject(function($timeout, $mdConstant, $material) {
+      var scope = createScope();
+      var template = '\
+          <md-autocomplete\
+              md-inline-option="append"\
+              md-selected-item="selectedItem"\
+              md-search-text="searchText"\
+              md-items="item in match(searchText)"\
+              md-item-text="item.display"\
+              placeholder="placeholder">\
+            <span md-highlight-text="searchText">{{item.display}}</span>\
+          </md-autocomplete>';
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+
+      // Add the element to the document's body to read the text selection data
+      document.body.appendChild(element[0]);
+
+      $material.flushInterimElement();
+
+      expect(scope.searchText).toBe('');
+      expect(scope.selectedItem).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      scope.$apply('searchText = "b"');
+      $timeout.flush();
+      waitForVirtualRepeat(element);
+
+      // Check expectations
+      expect(scope.searchText).toBe('b');
+      expect(scope.match(scope.searchText).length).toBe(2);
+
+      expect(ul.find('li').length).toBe(2);
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $timeout.flush();
+
+      expect(input[0].value).toBe('bar');
+      expect(input[0].selectionStart).toBe(1);
+      expect(input[0].selectionEnd).toBe(3);
+      expect(scope.searchText).toBe('b');
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $timeout.flush();
+
+      expect(input[0].value).toBe('baz');
+      expect(input[0].selectionStart).toBe(1);
+      expect(input[0].selectionEnd).toBe(3);
+      expect(scope.searchText).toBe('b');
+
+      // Run our key events
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+      $timeout.flush();
+
+      expect(scope.searchText).toBe('baz');
+
+      element.remove();
+    }));
+  });
 });

--- a/src/components/autocomplete/demoBasicUsage/index.html
+++ b/src/components/autocomplete/demoBasicUsage/index.html
@@ -4,6 +4,8 @@
       <p>Use <code>md-autocomplete</code> to search for matches from local or remote data sources.</p>
       <md-autocomplete
           ng-disabled="ctrl.isDisabled"
+          md-escape-options="clear"
+          md-inline-option="{{ctrl.inlineOption}}"
           md-no-cache="ctrl.noCache"
           md-selected-item="ctrl.selectedItem"
           md-search-text-change="ctrl.searchTextChange(ctrl.searchText)"
@@ -25,6 +27,17 @@
       <md-checkbox ng-model="ctrl.simulateQuery">Simulate query for results?</md-checkbox>
       <md-checkbox ng-model="ctrl.noCache">Disable caching of queries?</md-checkbox>
       <md-checkbox ng-model="ctrl.isDisabled">Disable the input?</md-checkbox>
+      <div layout="row">
+        <div>Inline Option:</div>
+        <div style="padding:0 8px"></div>
+        <div>
+          <md-radio-group ng-model="ctrl.inlineOption" layout="row">
+            <md-radio-button value="none">None</md-radio-button>
+            <md-radio-button value="replace">Replace</md-radio-button>
+            <md-radio-button value="append">Append</md-radio-button>
+          </md-radio-group>
+        </div>
+      </div>
 
       <p>By default, <code>md-autocomplete</code> will cache results when performing a query.  After the initial call is performed, it will use the cached results to eliminate unnecessary server requests or lookup logic. This can be disabled above.</p>
     </form>

--- a/src/components/autocomplete/demoBasicUsage/script.js
+++ b/src/components/autocomplete/demoBasicUsage/script.js
@@ -9,6 +9,7 @@
 
     self.simulateQuery = false;
     self.isDisabled    = false;
+    self.inlineOption  = "none";
 
     // list of `state` value/display objects
     self.states        = loadAll();

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -128,6 +128,8 @@ angular
  *     Defaults to true.
  * @param {string=} ng-pattern Adds the pattern validator to the ngModel of the search text.
  *     [ngPattern Directive](https://docs.angularjs.org/api/ng/directive/ngPattern)
+ * @param {boolean=} md-inline-option Add optional inline option. Default is `none`.<br/>
+ *     Options: `append`, `replace`, `none`
  *
  * @usage
  * ### Basic Example
@@ -253,7 +255,8 @@ function MdAutocomplete ($$mdSvgRegistry) {
       escapeOptions:    '@?mdEscapeOptions',
       dropdownItems:    '=?mdDropdownItems',
       dropdownPosition: '@?mdDropdownPosition',
-      clearButton:      '=?mdClearButton'
+      clearButton:      '=?mdClearButton',
+      inlineOption:     '@?mdInlineOption'
     },
     compile: function(tElement, tAttrs) {
       var attributes = ['md-select-on-focus', 'md-no-asterisk', 'ng-trim', 'ng-pattern'];
@@ -359,7 +362,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   ng-minlength="inputMinlength"\
                   ng-maxlength="inputMaxlength"\
                   ng-disabled="$mdAutocompleteCtrl.isDisabled"\
-                  ng-model="$mdAutocompleteCtrl.scope.searchText"\
+                  ng-model="$mdAutocompleteCtrl.scope.inputText"\
                   ng-model-options="{ allowInvalid: true }"\
                   ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                   ng-blur="$mdAutocompleteCtrl.blur($event)"\
@@ -386,7 +389,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-readonly="$mdAutocompleteCtrl.isReadonly"\
                 ng-minlength="inputMinlength"\
                 ng-maxlength="inputMaxlength"\
-                ng-model="$mdAutocompleteCtrl.scope.searchText"\
+                ng-model="$mdAutocompleteCtrl.scope.inputText"\
                 ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\

--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -1137,7 +1137,8 @@ describe('<md-chips>', function() {
           input.val('    ');
           input.triggerHandler('input');
 
-          expect(input.controller('ngModel').$modelValue).toBe('');
+          // IE sets the value to undefined while other browsers use ''
+          expect(input.controller('ngModel').$modelValue).toBeFalsy();
           // Since the `md-chips` component is testing the backspace select previous chip functionality by
           // checking the current caret / cursor position, we have to set the cursor to the end of the current
           // value.


### PR DESCRIPTION
Creates an option for adding inline options for input text by tracking keyboard
events and dropdown navigation

* Add `md-inline-option` option with possible values of `append` or `replace`
* Update docs to show inline options
* Create a new model called `inputText` representing the input box text
* Do not change `searchText` unless the user changes the input box or accepts
  a dropdown value

Note: This creates added complexity to autocomplete, since the user changes
the `inputText` model, and then the `searchText` is updated. Essentially,
this will decouple the text that exists inside the input box from the text
from which queries are run against.

Autocomplete UX Research: https://docs.google.com/document/d/1t60A2_Qni3IOSZDRqwwum3r5EVPjANJAkvFuMoqGfQA/

Fixes #9584