### PR TITLE
fix(mdButton): Add transition to md-button.md-fab md-icon

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -147,7 +147,7 @@ button.md-button::-moz-focus-inner {
     transition-property: background-color, box-shadow, transform;
     md-icon {
         transition: $swift-ease-in;
-        transition-property: background-color, box-shadow, transform;
+        transition-property: background-color, color, transform;
     }
     .md-ripple-container {
       border-radius: $button-fab-border-radius;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -145,6 +145,10 @@ button.md-button::-moz-focus-inner {
 
     transition: $swift-ease-in;
     transition-property: background-color, box-shadow, transform;
+    md-icon {
+        transition: $swift-ease-in;
+        transition-property: background-color, box-shadow, transform;
+    }
     .md-ripple-container {
       border-radius: $button-fab-border-radius;
       background-clip: padding-box;


### PR DESCRIPTION
I copied the transition value for the icons inside. This is to ensure that the button background color and the color of the icons have changed in parallel. Now, if you change the appearance of the button, the background - is animated, and the color of the icon - not.