### PR TITLE
fix(select): don't override initial model value

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -889,7 +889,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
       var newVal = self.isMultiple ? values : values[0];
       var prevVal = self.ngModel.$modelValue;
 
-      if (usingTrackBy ? !angular.equals(prevVal, newVal) : prevVal !== newVal) {
+      if (usingTrackBy ? !angular.equals(prevVal, newVal) : (prevVal + '') !== newVal) {
         self.ngModel.$setViewValue(newVal);
         self.ngModel.$render();
       }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -807,6 +807,18 @@ describe('<md-select>', function() {
 
         expect($rootScope.model).toBe(0);
       }));
+
+      it('should not override the initial model value', inject(function($rootScope) {
+        $rootScope.model = 2;
+
+        var el = setupSelect('ng-model="$root.model"', ['1', '2', '3']);
+        var selectedOption = selectedOptions(el)[0];
+
+        expect($rootScope.model).toBe(2, 'Expected value not to have been overwritten.');
+        expect(selectedOption).toBeTruthy('Expected an option to be selected.');
+        expect(selectedOption.getAttribute('value')).toBe('2',
+            'Expected the corresponding option to have been selected');
+      }));
     });
   });
 


### PR DESCRIPTION
Fixes an issue, introduced in #9945, that caused the select to override the initial model value.

CC @jelbourn 