### PR TITLE
fix(radioButton): set checked based on object equality if viewValue is an object

### DIFF
--- a/src/components/radioButton/radio-button.js
+++ b/src/components/radioButton/radio-button.js
@@ -314,7 +314,8 @@ function mdRadioButtonDirective($mdAria, $mdUtil, $mdTheming) {
      *  Update the `aria-activedescendant` attribute.
      */
     function render() {
-      var checked = rgCtrl.getViewValue() == attr.value;
+      var viewValue = rgCtrl.getViewValue();
+      var checked = typeof viewValue =='object' ? angular.equals(viewValue, attr.value) : viewValue == attr.value;
 
       if (checked === lastChecked) return;
 


### PR DESCRIPTION
Fix mdRadioButtonDirective.render to set checked based on object equality if viewValue is object