### PR TITLE
layout: add flex-grow to .layout-fill class due to issues with safari

### DIFF
--- a/src/core/services/layout/layout.scss
+++ b/src/core/services/layout/layout.scss
@@ -26,6 +26,7 @@
     width: 100%;
     min-height: 100%;
     height: 100%;
+    flex-grow: 1;
   }
 }
 

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -425,6 +425,7 @@
     width: 100%;
     min-height: 100%;
     height: 100%;
+    flex-grow: 1;
   }
 }
 


### PR DESCRIPTION
If many cases when you use md-content and layout-fill Safari doesn't show element 100% height. Adding flex-grow: 1 fixes the issue.
Fixes f.e. #5492