### PR TITLE
fix(gestures): slider and swipe touch

### DIFF
--- a/src/components/swipe/swipe.js
+++ b/src/components/swipe/swipe.js
@@ -84,6 +84,8 @@ function getDirective(name) {
   function DirectiveFactory($parse) {
       return { restrict: 'A', link: postLink };
       function postLink(scope, element, attr) {
+        element.css('touch-action', 'none');
+
         var fn = $parse(attr[directiveName]);
         element.on(eventName, function(ev) {
           scope.$applyAsync(function() { fn(scope, { $event: ev }); });

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -248,7 +248,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
         if (touchActionProperty) {
           // We check for horizontal to be false, because otherwise we would overwrite the default opts.
           this.oldTouchAction = element[0].style[touchActionProperty];
-          element[0].style[touchActionProperty] = options.horizontal === false ? 'pan-y' : 'pan-x';
+          element[0].style[touchActionProperty] = options.horizontal ? 'pan-y' : 'pan-x';
         }
       },
       onCleanup: function(element) {


### PR DESCRIPTION
- slider was based on mdGesture service that set `touch-action: pan-x` in case the gesture was horizontal;
according the [google pointer-events documentation](https://developers.google.com/web/updates/2016/10/pointer-events):
```
pan-x: The browser is only allowed to perform the horizontal scroll default action.
```
that means we should had enabled `pan-y` and vice-versa instead.

- swipe directive didn't had any `touch-action` css styles, added `touch-action: none` on the directive element on link

fixes #10294, #10187, #10145