### PR TITLE
fix(dialog): re-add md-actions deprecation class.

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -749,8 +749,18 @@ function MdDialogProvider($$interimElementProvider) {
       return dialogPopIn(element, options)
         .then(function() {
           lockScreenReader(element, options);
+          warnDeprecatedActions();
           focusOnOpen();
         });
+
+      /**
+       * Check to see if they used the deprecated .md-actions class and log a warning
+       */
+      function warnDeprecatedActions() {
+        if (element[0].querySelector('.md-actions')) {
+          $log.warn('Using a class of md-actions is deprecated, please use <md-dialog-actions>.');
+        }
+      }
 
       /**
        * For alerts, focus on content... otherwise focus on

--- a/src/components/dialog/dialog.scss
+++ b/src/components/dialog/dialog.scss
@@ -80,7 +80,7 @@ md-dialog {
     }
   }
 
-  md-dialog-actions {
+  .md-actions, md-dialog-actions {
     display: flex;
     order: 2;
     box-sizing: border-box;
@@ -100,7 +100,7 @@ md-dialog {
     }
   }
   &.md-content-overflow {
-    md-dialog-actions {
+    .md-actions, md-dialog-actions {
       border-top-width: 1px;
       border-top-style: solid;
     }

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -1273,6 +1273,25 @@ describe('$mdDialog', function() {
       expect($document.activeElement).toBe(parent[0].querySelector('#focus-target'));
     }));
 
+    it('should warn if the deprecated .md-actions class is used', inject(function($mdDialog, $rootScope, $log, $timeout) {
+       spyOn($log, 'warn');
+
+      var parent = angular.element('<div>');
+      $mdDialog.show({
+        template:
+          '<md-dialog>' +
+            '<div class="md-actions">' +
+              '<button class="md-button">Ok good</button>' +
+            '</div>' +
+          '</md-dialog>',
+        parent: parent
+      });
+
+      runAnimation();
+
+      expect($log.warn).toHaveBeenCalled();
+    }));
+
     it('should only allow one open at a time', inject(function($mdDialog, $rootScope, $animate) {
       var parent = angular.element('<div>');
       $mdDialog.show({


### PR DESCRIPTION
I was asked by @EladBezalel to revert SHA https://github.com/angular/material/commit/2c286b41d6a4d85f2be88986d1331f84241a9b3a.

The deprecation needs to be re-introduced to support older Angular applications, which didn't update yet.