### PR TITLE
fix(panel): use class instead of style attribute to fix CSP violation

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1309,7 +1309,7 @@ MdPanelService.prototype._wrapTemplate = function(origTemplate) {
   // height and width for positioning.
   return '' +
       '<div class="md-panel-outer-wrapper">' +
-      '  <div class="md-panel" style="left: -9999px;">' + template + '</div>' +
+      '  <div class="md-panel _md-panel-offscreen">' + template + '</div>' +
       '</div>';
 };
 
@@ -1325,7 +1325,7 @@ MdPanelService.prototype._wrapTemplate = function(origTemplate) {
 MdPanelService.prototype._wrapContentElement = function(contentElement) {
   var wrapper = angular.element('<div class="md-panel-outer-wrapper">');
 
-  contentElement.addClass('md-panel').css('left', '-9999px');
+  contentElement.addClass('md-panel _md-panel-offscreen');
   wrapper.append(contentElement);
 
   return wrapper;
@@ -1918,8 +1918,8 @@ MdPanelRef.prototype._addStyles = function() {
       // Theme the element and container.
       self._setTheming();
 
-      // Remove left: -9999px and add hidden class.
-      self.panelEl.css('left', '');
+      // Remove offscreen class and add hidden class.
+      self.panelEl.removeClass('_md-panel-offscreen');
       self.panelContainer.addClass(MD_PANEL_HIDDEN);
 
       resolve(self);

--- a/src/components/panel/panel.scss
+++ b/src/components/panel/panel.scss
@@ -10,6 +10,10 @@
   display: none;
 }
 
+._md-panel-offscreen {
+  left: -9999px;
+}
+
 ._md-panel-fullscreen {
   border-radius: 0;
   left: 0;


### PR DESCRIPTION
Using a style attribute is prohibited when using strict CSP rules. Fixes #10085.