### PR TITLE
chore: fix response from docs.json

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -339,6 +339,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
 
   $http.get("/docs.json")
       .then(function(response) {
+        response = response.data;
         var versionId = getVersionIdFromPath();
         var head = { type: 'version', url: '/HEAD', id: 'head', name: 'HEAD (master)', github: '' };
         var commonVersions = versionId === 'head' ? [] : [ head ];


### PR DESCRIPTION
During the last release, the docs site navigation was broken for a bit because the response from `docs.json` wasn't parsed properly. As a result, the versions were `[]` and didn't display.  Seems that the resp object wasn't updated when we switched from `success()` to `then()`.  