### PR TITLE
fix(list): add `rel` to copied attributes for `md-list-item` buttons …

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -406,7 +406,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       function copyAttributes(source, destination, extraAttrs) {
         var copiedAttrs = $mdUtil.prefixer([
           'ng-if', 'ng-click', 'ng-dblclick', 'aria-label', 'ng-disabled', 'ui-sref',
-          'href', 'ng-href', 'target', 'ng-attr-ui-sref', 'ui-sref-opts'
+          'href', 'ng-href', 'rel', 'target', 'ng-attr-ui-sref', 'ui-sref-opts'
         ]);
 
         if (extraAttrs) {


### PR DESCRIPTION
…#10351

This is to add support for rel attribute to be copied to generated links.
See https://developers.google.com/web/tools/lighthouse/audits/noopener for more details.