### PR TITLE
Allow users to configure where to append the styles

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -256,7 +256,8 @@ var themeConfig = {
   disableTheming : false,   // Generate our themes at run time; also disable stylesheet DOM injection
   generateOnDemand : false, // Whether or not themes are to be generated on-demand (vs. eagerly).
   registeredStyles : [],    // Custom styles registered to be used in the theming of custom components.
-  nonce : null              // Nonce to be added as an attribute to the generated themes style tags.
+  nonce : null,              // Nonce to be added as an attribute to the generated themes style tags.
+  appendTo: document.head
 };
 
 /**
@@ -632,7 +633,7 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
     applyTheme.inherit = inheritTheme;
     applyTheme.registered = registered;
     applyTheme.defaultTheme = function() { return defaultTheme; };
-    applyTheme.generateTheme = function(name) { generateTheme(THEMES[name], name, themeConfig.nonce); };
+    applyTheme.generateTheme = function(name) { generateTheme(THEMES[name], name, themeConfig.nonce, themeConfig.appendTo); };
     applyTheme.defineTheme = function(name, options) {
       options = options || {};
 
@@ -973,7 +974,7 @@ function generateAllThemes($injector, $mdTheming) {
 
   angular.forEach($mdTheming.THEMES, function(theme) {
     if (!GENERATED[theme.name] && !($mdTheming.defaultTheme() !== 'default' && theme.name === 'default')) {
-      generateTheme(theme, theme.name, themeConfig.nonce);
+      generateTheme(theme, theme.name, themeConfig.nonce, themeConfig.appendTo);
     }
   });
 
@@ -1039,8 +1040,7 @@ function generateAllThemes($injector, $mdTheming) {
   }
 }
 
-function generateTheme(theme, name, nonce) {
-  var head = document.head;
+function generateTheme(theme, name, nonce, head) {
   var firstChild = head ? head.firstElementChild : null;
 
   if (!GENERATED[name]) {

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -342,7 +342,8 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
       return angular.extend( { }, themeConfig, {
         defaultTheme : defaultTheme,
         alwaysWatchTheme : alwaysWatchTheme,
-        registeredStyles : [].concat(themeConfig.registeredStyles)
+        registeredStyles : [].concat(themeConfig.registeredStyles),
+        appendTo: appendTo
       });
     },
 
@@ -375,7 +376,7 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
       alwaysWatchTheme = alwaysWatch;
     },
 
-    appendTo: function (head) {
+    appendTo: function(head) {
       themeConfig.appendTo = head;
     },
 

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -257,7 +257,7 @@ var themeConfig = {
   generateOnDemand : false, // Whether or not themes are to be generated on-demand (vs. eagerly).
   registeredStyles : [],    // Custom styles registered to be used in the theming of custom components.
   nonce : null,              // Nonce to be added as an attribute to the generated themes style tags.
-  appendTo: document.head
+  appendTo: document.head   // Allow users to decide where to append the themes.
 };
 
 /**

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -145,6 +145,12 @@ function detectDisabledThemes($mdThemingProvider) {
 
 /**
  * @ngdoc method
+ * @name $mdThemingProvider#appendTo
+ * @param {element} element to append the styles too. By default it picks document head
+ */
+
+/**
+ * @ngdoc method
  * @name $mdThemingProvider#enableBrowserColor
  * @param {Object=} options Options object for the browser color<br/>
  * `theme`   - A defined theme via `$mdThemeProvider` to use the palettes from. Default is `default` theme. <br/>
@@ -257,7 +263,7 @@ var themeConfig = {
   generateOnDemand : false, // Whether or not themes are to be generated on-demand (vs. eagerly).
   registeredStyles : [],    // Custom styles registered to be used in the theming of custom components.
   nonce : null,              // Nonce to be added as an attribute to the generated themes style tags.
-  appendTo: document.head   // Allow users to decide where to append the themes.
+  appendTo: document.head
 };
 
 /**
@@ -367,6 +373,10 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
 
     alwaysWatchTheme: function(alwaysWatch) {
       alwaysWatchTheme = alwaysWatch;
+    },
+
+    appendTo: function (head) {
+      themeConfig.appendTo = head;
     },
 
     enableBrowserColor: enableBrowserColor,

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -342,8 +342,7 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
       return angular.extend( { }, themeConfig, {
         defaultTheme : defaultTheme,
         alwaysWatchTheme : alwaysWatchTheme,
-        registeredStyles : [].concat(themeConfig.registeredStyles),
-        appendTo: appendTo
+        registeredStyles : [].concat(themeConfig.registeredStyles)
       });
     },
 


### PR DESCRIPTION
A lot of people use ShadowDom api now. In this case, the styles by default appending to head isn't ideal. Ideal scenario is if users get an option where to append the styles too.