### PR TITLE
doc(mdDateLocaleProvider): Fix typo

### DIFF
--- a/src/components/datepicker/js/dateLocaleProvider.js
+++ b/src/components/datepicker/js/dateLocaleProvider.js
@@ -26,7 +26,7 @@
    * @property {(function(Date): string)=} monthHeaderFormatter Function that returns the label for
    *     a month given a date.
    * @property {(function(Date): string)=} monthFormatter Function that returns the full name of a month
-   *     for a giben date.
+   *     for a given date.
    * @property {(function(number): string)=} weekNumberFormatter Function that returns a label for
    *     a week given the week number.
    * @property {(string)=} msgCalendar Translation of the label "Calendar" for the current locale.


### PR DESCRIPTION
doc(mdDateLocaleProvider): Fix typo

Fix a typo in `$mdDateLocaleProvider.monthFormatter` documentation.



