### PR TITLE
Minor doc fix, changed @param {integer} to @param {number}

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -61,7 +61,7 @@
  * `always`          | stretched | stretched
  * `never`           | ---       | ---
  *
- * @param {integer=} md-selected Index of the active/selected tab
+ * @param {number=} md-selected Index of the active/selected tab
  * @param {boolean=} md-no-ink If present, disables ink ripple effects.
  * @param {boolean=} md-no-ink-bar If present, disables the selection ink bar.
  * @param {string=}  md-align-tabs Attribute to indicate position of tab buttons: `bottom` or `top`; default is `top`

--- a/src/core/util/iterator.js
+++ b/src/core/util/iterator.js
@@ -195,7 +195,7 @@
      * @param {boolean} backwards Specifies the direction of searching (forwards/backwards)
      * @param {*} item The item whose subsequent item we are looking for
      * @param {Function=} validate The `validate` function
-     * @param {integer=} limit The recursion limit
+     * @param {number=} limit The recursion limit
      *
      * @returns {*} The subsequent item or null
      */


### PR DESCRIPTION
There were two instances of @param {integer=} in the ngdocs. Everywhere else @param {number=} was being used, so I replaced these two instances.