### PR TITLE
fix(mdTooltip): Tooltip parent aria label override

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -75,6 +75,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
 
   function linkFunc(scope, element, attr) {
     // Set constants.
+    var tooltipId = 'md-tooltip-' + $mdUtil.nextUid();
     var parent = $mdUtil.getParentWithPointerEvents(element);
     var debouncedOnResize = $$rAF.throttle(updatePosition);
     var mouseActive = false;
@@ -102,12 +103,24 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
     }
 
-    function addAriaLabel(override) {
-      if (override || !parent.attr('aria-label')) {
-        // Only interpolate the text from the HTML element because otherwise the custom text
-        // could be interpolated twice and cause XSS violations.
-        var interpolatedText = override || $interpolate(element.text().trim())(scope.$parent);
+    function addAriaLabel(labelText) {
+      // Only interpolate the text from the HTML element because otherwise the custom text could
+      // be interpolated twice and cause XSS violations.
+      var interpolatedText = labelText || $interpolate(element.text().trim())(parent.scope);
+
+      // Only add the `aria-label` to the parent if there isn't already one, if there isn't an
+      // already present `aria-labelledby`, or if the previous `aria-label` was added by the
+      // tooltip directive.
+      if (
+        (!parent.attr('aria-label') && !parent.attr('aria-labelledby')) ||
+        parent.attr('aria-labelledby') === tooltipId
+      ) {
         parent.attr('aria-label', interpolatedText);
+
+        // Set the `aria-labelledby` attribute if it has not already been set.
+        if (!parent.attr('aria-labelledby')) {
+          parent.attr('aria-labelledby', tooltipId);
+        }
       }
     }
 
@@ -360,7 +373,6 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
 
       if (!panelRef) {
-        var id = 'tooltip-' + $mdUtil.nextUid();
         var attachTo = angular.element(document.body);
         var panelAnimation = $mdPanel.newPanelAnimation()
             .openFrom(parent)
@@ -371,7 +383,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
             });
 
         var panelConfig = {
-          id: id,
+          id: tooltipId,
           attachTo: attachTo,
           contentElement: element,
           propagateContainerEvents: true,

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -1,11 +1,10 @@
 describe('MdTooltip Component', function() {
-  var $compile, $rootScope, parentScope, $material, $timeout, $mdPanel, $$mdTooltipRegistry;
+  var $compile, parentScope, $material, $timeout, $mdPanel, $$mdTooltipRegistry;
   var element;
 
   var injectLocals = function($injector) {
     $compile = $injector.get('$compile');
-    $rootScope = $injector.get('$rootScope');
-    parentScope = $rootScope.$new();
+    parentScope = $injector.get('$rootScope').$new();
     $material = $injector.get('$material');
     $timeout = $injector.get('$timeout');
     $mdPanel = $injector.get('$mdPanel');
@@ -15,7 +14,7 @@ describe('MdTooltip Component', function() {
   // Test filter for ensuring tooltip expressions are evaluated against the correct scope.
   angular.module('fullNameFilter', []).filter('fullName', function() {
     return function(user) {
-      return user.name.first + ' ' + user.name.last;
+      return user ? user.name.first + ' ' + user.name.last : "";
     }
   });
 
@@ -41,8 +40,8 @@ describe('MdTooltip Component', function() {
     expect(function() {
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip md-direction="{{direction}}">Tooltip</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip md-direction="{{direction}}">Tooltip</md-tooltip>' +
         '</md-button>'
       );
     }).not.toThrow();
@@ -51,7 +50,7 @@ describe('MdTooltip Component', function() {
   it('should set the position to "bottom" if it is undefined', function() {
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+      '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
       '</md-button>'
     );
 
@@ -63,7 +62,7 @@ describe('MdTooltip Component', function() {
 
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip md-visible="true">{{name}}</md-tooltip>' +
+      '<md-tooltip md-visible="true">{{name}}</md-tooltip>' +
       '</md-button>'
     );
 
@@ -77,7 +76,7 @@ describe('MdTooltip Component', function() {
     // thrown if user is not given correctly.
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip md-visible="true">{{user | fullName}}</md-tooltip>' +
+      '<md-tooltip md-visible="true">{{user | fullName}}</md-tooltip>' +
       '</md-button>'
     );
 
@@ -87,8 +86,8 @@ describe('MdTooltip Component', function() {
   it('should preserve parent text', function() {
     buildTooltip(
       '<md-button>' +
-        'Hello' +
-        '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
+      'Hello' +
+      '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
       '</md-button>'
     );
 
@@ -98,93 +97,159 @@ describe('MdTooltip Component', function() {
   it('should label parent', function() {
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip md-visible="testModel.isVisible">' +
-          'Tooltip' +
-        '</md-tooltip>' +
+      '<md-tooltip md-visible="testModel.isVisible">' +
+      'Tooltip' +
+      '</md-tooltip>' +
       '</md-button>'
     );
 
     expect(element.attr('aria-label')).toEqual('Tooltip');
+    expect(element.attr('aria-labelledby')).toBeDefined();
+  });
+
+  it('should not label the parent if it already has a label', function() {
+    buildTooltip(
+      '<md-button aria-label="Button Label">' +
+      '<md-tooltip md-visible="testModel.isVisible">' +
+      'Tooltip' +
+      '</md-tooltip>' +
+      '</md-button>'
+    );
+
+    expect(element.attr('aria-label')).toEqual('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+  });
+
+  it('should not label the parent if it has already been labelled by ' +
+    'another element.', function() {
+    buildTooltip(
+      '<md-button aria-labelledby="button-1">' +
+      '<md-tooltip md-visible="testModel.isVisible">' +
+      'Tooltip' +
+      '</md-tooltip>' +
+      '</md-button>'
+    );
+
+    expect(element.attr('aria-label')).toBeUndefined();
+    expect(element.attr('aria-labelledby')).toEqual('button-1');
   });
 
   it('should interpolate the aria-label', function() {
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip>{{ "hello" | uppercase }}</md-tooltip>' +
+      '<md-tooltip>{{ "hello" | uppercase }}</md-tooltip>' +
       '</md-button>'
     );
 
     expect(element.attr('aria-label')).toBe('HELLO');
+    expect(element.attr('aria-labelledby')).toBeDefined();
   });
 
-  it('should update the aria-label when the interpolated value changes',
-      function() {
-        buildTooltip(
-          '<md-button>' +
-            '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
-          '</md-button>'
-        );
+  it('should update the aria-label when the interpolated value changes', function() {
+    var ariaLabelledby;
+    var ariaLabelledby2;
 
-        parentScope.$apply(function() {
-          parentScope.testModel.ariaText = 'test 1';
-        });
-
-        expect(element.attr('aria-label')).toBe('test 1');
-
-        parentScope.$apply(function() {
-          parentScope.testModel.ariaText = 'test 2';
-        });
-
-        expect(element.attr('aria-label')).toBe('test 2');
-      });
-  
-  it('should not interpolate interpolated values', function() {
     buildTooltip(
-        '<md-button>' +
-         '<md-tooltip>{{ testModel.ariaTest }}</md-tooltip>' +
-        '</md-button>'
-      );
+      '<md-button>' +
+      '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
+      '</md-button>'
+    );
 
-      parentScope.$apply(function() {
-        parentScope.testModel.ariaTest = 'test {{1+1}}';
-      });
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaText = 'test 1';
+    });
 
-      expect(element.attr('aria-label')).toBe('test {{1+1}}');
+    expect(element.attr('aria-label')).toBe('test 1');
+    ariaLabelledby = element.attr('aria-labelledby');
+    expect(ariaLabelledby).toBeDefined();
 
-      parentScope.$apply(function() {
-        parentScope.testModel.ariaTest = 'test {{1+1336}}';
-      });
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaText = 'test 2';
+    });
 
-      expect(element.attr('aria-label')).toBe('test {{1+1336}}');
+    expect(element.attr('aria-label')).toBe('test 2');
+    ariaLabelledby2 = element.attr('aria-labelledby');
+    expect(ariaLabelledby2).toEqual(ariaLabelledby);
+  });
+
+  it('should not update the parent aria-label when the interpolated' +
+    'value changes and the parent has a label that was not set by ' +
+    'the tooltip', function() {
+    buildTooltip(
+      '<md-button aria-label="Button Label">' +
+      '<md-tooltip>{{ testModel.ariaText }}</md-tooltip>' +
+      '</md-button>'
+    );
+
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaText = 'test 1';
+    });
+
+    expect(element.attr('aria-label')).toBe('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaText = 'test 2';
+    });
+
+    expect(element.attr('aria-label')).toBe('Button Label');
+    expect(element.attr('aria-labelledby')).toBeUndefined();
+  });
+
+  it('should not interpolate interpolated values', function() {
+    var ariaLabelledby;
+    var ariaLabelledby2;
+
+    buildTooltip(
+      '<md-button>' +
+      '<md-tooltip>{{ testModel.ariaTest }}</md-tooltip>' +
+      '</md-button>'
+    );
+
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaTest = 'test {{1+1}}';
+    });
+
+    expect(element.attr('aria-label')).toBe('test {{1+1}}');
+    ariaLabelledby = element.attr('aria-labelledby');
+    expect(ariaLabelledby).toBeDefined();
+
+    parentScope.$apply(function() {
+      parentScope.testModel.ariaTest = 'test {{1+1336}}';
+    });
+
+    expect(element.attr('aria-label')).toBe('test {{1+1336}}');
+    ariaLabelledby2 = element.attr('aria-labelledby');
+    expect(ariaLabelledby2).toEqual(ariaLabelledby);
   });
 
   it('should not set parent to items with no pointer events',
-      inject(function($window) {
-        spyOn($window, 'getComputedStyle').and.callFake(function(el) {
-          return { 'pointer-events': el ? 'none' : '' };
-        });
+    inject(function($window) {
+      spyOn($window, 'getComputedStyle').and.callFake(function(el) {
+        return {'pointer-events': el ? 'none' : ''};
+      });
 
-        buildTooltip(
-          '<outer>' +
-            '<inner>' +
-              '<md-tooltip md-visible="testModel.isVisible">' +
-                'Hello world' +
-              '</md-tooltip>' +
-            '</inner>' +
-          '</outer>'
-        );
+      buildTooltip(
+        '<outer>' +
+        '<inner>' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        'Hello world' +
+        '</md-tooltip>' +
+        '</inner>' +
+        '</outer>'
+      );
 
-        triggerEvent('mouseenter', true);
-        expect(parentScope.testModel.isVisible).toBeUndefined();
-      }));
+      triggerEvent('mouseenter', true);
+      expect(parentScope.testModel.isVisible).toBeUndefined();
+    }));
 
   it('should show after tooltipDelay ms', function() {
     buildTooltip(
       '<md-button>' +
-        'Hello' +
-        '<md-tooltip md-visible="testModel.isVisible" md-delay="99">' +
-          'Tooltip' +
-        '</md-tooltip>' +
+      'Hello' +
+      '<md-tooltip md-visible="testModel.isVisible" md-delay="99">' +
+      'Tooltip' +
+      '</md-tooltip>' +
       '</md-button>'
     );
 
@@ -205,7 +270,7 @@ describe('MdTooltip Component', function() {
 
     buildTooltip(
       '<md-button>' +
-        '<md-tooltip>Tooltip</md-tooltip>' +
+      '<md-tooltip>Tooltip</md-tooltip>' +
       '</md-button>'
     );
 
@@ -218,10 +283,10 @@ describe('MdTooltip Component', function() {
 
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip md-visible="testModel.isVisible">' +
-            'Tooltip' +
-          '</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        'Tooltip' +
+        '</md-tooltip>' +
         '</md-button>'
       );
 
@@ -239,10 +304,10 @@ describe('MdTooltip Component', function() {
     it('should set visible on mouseenter and mouseleave', function() {
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip md-visible="testModel.isVisible">' +
-            'Tooltip' +
-          '</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        'Tooltip' +
+        '</md-tooltip>' +
         '</md-button>'
       );
 
@@ -254,35 +319,35 @@ describe('MdTooltip Component', function() {
     });
 
     it('should toggle visibility on the next touch',
-        inject(function($document) {
-          buildTooltip(
-            '<md-button>' +
-              'Hello' +
-              '<md-tooltip md-visible="testModel.isVisible">' +
-                'Tooltip' +
-              '</md-tooltip>' +
-            '</md-button>'
-          );
+      inject(function($document) {
+        buildTooltip(
+          '<md-button>' +
+          'Hello' +
+          '<md-tooltip md-visible="testModel.isVisible">' +
+          'Tooltip' +
+          '</md-tooltip>' +
+          '</md-button>'
+        );
 
-          triggerEvent('touchstart');
-          expect(parentScope.testModel.isVisible).toBe(true);
-          triggerEvent('touchend');
+        triggerEvent('touchstart');
+        expect(parentScope.testModel.isVisible).toBe(true);
+        triggerEvent('touchend');
 
-          $document.triggerHandler('touchend');
-          $timeout.flush();
-          expect(parentScope.testModel.isVisible).toBe(false);
-        }));
+        $document.triggerHandler('touchend');
+        $timeout.flush();
+        expect(parentScope.testModel.isVisible).toBe(false);
+      }));
 
     it('should cancel when mouseleave was before the delay', function() {
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip ' +
-            'md-delay="99" ' +
-            'md-autohide ' +
-            'md-visible="testModel.isVisible">' +
-            'Tooltip' +
-          '</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip ' +
+        'md-delay="99" ' +
+        'md-autohide ' +
+        'md-visible="testModel.isVisible">' +
+        'Tooltip' +
+        '</md-tooltip>' +
         '</md-button>'
       );
 
@@ -301,10 +366,10 @@ describe('MdTooltip Component', function() {
     it('should throw when the tooltip text is empty', function() {
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip md-visible="testModel.isVisible">' +
-            '{{ textContent }}' +
-          '</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        '{{ textContent }}' +
+        '</md-tooltip>' +
         '</md-button>'
       );
 
@@ -316,10 +381,10 @@ describe('MdTooltip Component', function() {
     it('should set visible on focus and blur', function() {
       buildTooltip(
         '<md-button>' +
-          'Hello' +
-          '<md-tooltip md-visible="testModel.isVisible">' +
-            'Tooltip' +
-          '</md-tooltip>' +
+        'Hello' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        'Tooltip' +
+        '</md-tooltip>' +
         '</md-button>'
       );
 
@@ -331,67 +396,67 @@ describe('MdTooltip Component', function() {
     });
 
     it('should not be visible on mousedown and then mouseleave',
-        inject(function($document) {
-          buildTooltip(
-            '<md-button>' +
-              'Hello' +
-              '<md-tooltip md-visible="testModel.isVisible">' +
-                'Tooltip' +
-              '</md-tooltip>' +
-            '</md-button>'
-          );
+      inject(function($document) {
+        buildTooltip(
+          '<md-button>' +
+          'Hello' +
+          '<md-tooltip md-visible="testModel.isVisible">' +
+          'Tooltip' +
+          '</md-tooltip>' +
+          '</md-button>'
+        );
 
-          // Append element to DOM so it can be set as activeElement.
-          $document[0].body.appendChild(element[0]);
-          element[0].focus();
-          triggerEvent('focus,mousedown');
+        // Append element to DOM so it can be set as activeElement.
+        $document[0].body.appendChild(element[0]);
+        element[0].focus();
+        triggerEvent('focus,mousedown');
 
-          expect($document[0].activeElement).toBe(element[0]);
-          expect(parentScope.testModel.isVisible).toBe(true);
+        expect($document[0].activeElement).toBe(element[0]);
+        expect(parentScope.testModel.isVisible).toBe(true);
 
-          triggerEvent('mouseleave');
-          expect(parentScope.testModel.isVisible).toBe(false);
+        triggerEvent('mouseleave');
+        expect(parentScope.testModel.isVisible).toBe(false);
 
-          // Clean up document.body.
-          // element.remove();
-        }));
+        // Clean up document.body.
+        // element.remove();
+      }));
 
     it('should not be visible when the window is refocused',
-        inject(function($window, $document) {
-          buildTooltip(
-            '<md-button>' +
-              'Hello' +
-              '<md-tooltip md-visible="testModel.isVisible">' +
-                'Tooltip' +
-              '</md-tooltip>' +
-            '</md-button>'
-          );
+      inject(function($window, $document) {
+        buildTooltip(
+          '<md-button>' +
+          'Hello' +
+          '<md-tooltip md-visible="testModel.isVisible">' +
+          'Tooltip' +
+          '</md-tooltip>' +
+          '</md-button>'
+        );
 
-          // Append element to DOM so it can be set as activeElement.
-          $document[0].body.appendChild(element[0]);
-          element[0].focus();
-          triggerEvent('focus,mousedown');
-          expect(document.activeElement).toBe(element[0]);
+        // Append element to DOM so it can be set as activeElement.
+        $document[0].body.appendChild(element[0]);
+        element[0].focus();
+        triggerEvent('focus,mousedown');
+        expect(document.activeElement).toBe(element[0]);
 
-          triggerEvent('mouseleave');
+        triggerEvent('mouseleave');
 
-          // Simulate tabbing away.
-          angular.element($window).triggerHandler('blur');
+        // Simulate tabbing away.
+        angular.element($window).triggerHandler('blur');
 
-          // Simulate focus event that occurs when tabbing back to the window.
-          triggerEvent('focus');
-          expect(parentScope.testModel.isVisible).toBe(false);
+        // Simulate focus event that occurs when tabbing back to the window.
+        triggerEvent('focus');
+        expect(parentScope.testModel.isVisible).toBe(false);
 
-          // Clean up document.body.
-          $document[0].body.removeChild(element[0]);
-        }));
+        // Clean up document.body.
+        $document[0].body.removeChild(element[0]);
+      }));
   });
 
   describe('cleanup', function() {
     it('should clean up if the parent scope was destroyed', function() {
       buildTooltip(
         '<md-button>' +
-          '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
         '</md-button>'
       );
       var tooltip = findTooltip();
@@ -407,7 +472,7 @@ describe('MdTooltip Component', function() {
     it('should remove the tooltip when its own scope is destroyed', function() {
       buildTooltip(
         '<md-button>' +
-          '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
         '</md-button>'
       );
       var tooltip = findTooltip();
@@ -418,40 +483,40 @@ describe('MdTooltip Component', function() {
     });
 
     it('should remove itself from the $$mdTooltipRegistry when the parent ' +
-        'scope is destroyed', function() {
-          buildTooltip(
-            '<md-button>' +
-              '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
-            '</md-button>'
-          );
+      'scope is destroyed', function() {
+      buildTooltip(
+        '<md-button>' +
+        '<md-tooltip md-visible="true">Tooltip</md-tooltip>' +
+        '</md-button>'
+      );
 
-          spyOn($$mdTooltipRegistry, 'deregister');
-          element.scope().$destroy();
-          expect($$mdTooltipRegistry.deregister).toHaveBeenCalled();
-        });
+      spyOn($$mdTooltipRegistry, 'deregister');
+      element.scope().$destroy();
+      expect($$mdTooltipRegistry.deregister).toHaveBeenCalled();
+    });
 
     it('should not re-appear if it was outside the DOM when the parent was ' +
-        'removed', function() {
-          buildTooltip(
-            '<md-button>' +
-              '<md-tooltip md-visible="testModel.isVisible">' +
-                'Tooltip' +
-              '</md-tooltip>' +
-            '</md-button>'
-          );
+      'removed', function() {
+      buildTooltip(
+        '<md-button>' +
+        '<md-tooltip md-visible="testModel.isVisible">' +
+        'Tooltip' +
+        '</md-tooltip>' +
+        '</md-button>'
+      );
 
-          showTooltip(false);
-          expect(findTooltip().length).toBe(0);
+      showTooltip(false);
+      expect(findTooltip().length).toBe(0);
 
-          element.remove();
-          showTooltip(true);
-          expect(findTooltip().length).toBe(0);
-        });
+      element.remove();
+      showTooltip(true);
+      expect(findTooltip().length).toBe(0);
+    });
 
     it('should unbind the parent listeners when it gets destroyed', function() {
       buildTooltip(
         '<md-button>' +
-           '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
+        '<md-tooltip md-visible="testModel.isVisible">Tooltip</md-tooltip>' +
         '</md-button>'
       );
 
@@ -499,7 +564,6 @@ describe('MdTooltip Component', function() {
   }
 });
 
-
 // ******************************************************
 // mdTooltipRegistry Testing
 // ******************************************************
@@ -517,7 +581,10 @@ describe('$$mdTooltipRegistry service', function() {
   });
 
   it('should allow for registering event handlers on the window', function() {
-    var obj = { callback: function() {} };
+    var obj = {
+      callback: function() {
+      }
+    };
 
     spyOn(obj, 'callback');
     tooltipRegistry.register('resize', obj.callback);
@@ -531,7 +598,10 @@ describe('$$mdTooltipRegistry service', function() {
   });
 
   it('should allow deregistering of the callbacks', function() {
-    var obj = { callback: function() {} };
+    var obj = {
+      callback: function() {
+      }
+    };
 
     spyOn(obj, 'callback');
     tooltipRegistry.register('resize', obj.callback);


### PR DESCRIPTION
The tooltip now does not override or update the parent
element `aria-label` unless the parent's `aria-label` does not exist,
or it has been previously set by the tooltip. It determines if it
has been set by the tooltip by placing the `aria-labelledby` attribute
on the parent element and setting it to `tooltip`.

Thx to @bradrich  for original PR.

Fixes #10242.