### PR TITLE
Update calendarMonth.js

### DIFF
--- a/src/components/datepicker/js/calendarMonth.js
+++ b/src/components/datepicker/js/calendarMonth.js
@@ -153,7 +153,7 @@
     return this.dateUtil.getMonthDistance(
       calendarCtrl.firstRenderableDate,
       calendarCtrl.displayDate || calendarCtrl.selectedDate || calendarCtrl.today
-    );
+    ) -1;
   };
 
   /**


### PR DESCRIPTION
correcting value returned from getMonthDistance so that the calendar scrolls to current month not following one. We've made this change to a branch of the 1.1.1 we use and have submitted the pr so that when we update in the future the problem will be fixed in the pure repo.