### PR TITLE
fix(checkbox): click handling when ngCheckbox is set

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -184,7 +184,7 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
 
         scope.$apply(function() {
           // Toggle the checkbox value...
-          var viewValue = attr.ngChecked ? attr.checked : !ngModelCtrl.$viewValue;
+          var viewValue = attr.ngChecked && attr.ngClick ? attr.checked : !ngModelCtrl.$viewValue;
 
           ngModelCtrl.$setViewValue(viewValue, ev && ev.type);
           ngModelCtrl.$render();

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -272,6 +272,14 @@ describe('mdCheckbox', function() {
       expect(checkbox.hasClass(CHECKED_CSS)).toBe(false);
     });
 
+    it('properly handles click event when ng-checked is set', function() {
+      pageScope.checked = false;
+      var checkbox = compileAndLink('<md-checkbox ng-checked="checked"></md-checkbox>');
+
+      checkbox.triggerHandler('click');
+      expect(isChecked(checkbox)).toBe(true);
+    });
+
     it('should mark the checkbox as selected on load with ng-checked', function() {
       pageScope.isChecked = function() { return true; };
 


### PR DESCRIPTION
When md-checkbox has ng-checked set, checkbox should still be clickable, and work as regular checkbox. 
The only case I see right now where `attr.checked` should be used as `$viewValue`  is when `ng-click` && `ng-checked` is provided - we can then assume `ng-checked` could be changed by `ng-click` callback. This behavior is used in `demoSyncing` for example.

Fixes #10468