### PR TITLE
polish(tooltip): change transition duration to 150ms

### DIFF
--- a/src/components/tooltip/tooltip.scss
+++ b/src/components/tooltip/tooltip.scss
@@ -55,12 +55,13 @@ $tooltip-max-width: 32px !default;
   }
   &.md-show {
     transition: $swift-ease-out;
+    transition-duration: 150ms;
     transform: scale(1);
     opacity: 0.9;
   }
   &.md-hide {
     transition: $swift-ease-in;
-    transition-duration: .1s;
+    transition-duration: 150ms;
     transform: scale(0);
     opacity: 0;
   }


### PR DESCRIPTION
- according the [spec](https://material.io/guidelines/components/tooltips.html#tooltips-interaction) show and hide duration should be 150ms

fixes #10467