### PR TITLE
fix(chips): validate input before adding chip on enter

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -330,14 +330,14 @@ describe('<md-chips>', function() {
           var ctrl = element.controller('mdChips');
           var input = element.find('input');
 
-          expect(ctrl.shouldAddOnBlur()).toBeFalsy();
+          expect(ctrl.shouldAdd(true)).toBeFalsy();
 
           // Flush the initial timeout of the md-autocomplete.
           $timeout.flush();
 
           scope.$apply('searchText = "Hello"');
 
-          expect(ctrl.shouldAddOnBlur()).toBeFalsy();
+          expect(ctrl.shouldAdd(true)).toBeFalsy();
         });
 
         it('should not append a new chip on blur when the autocomplete is showing', function() {
@@ -358,7 +358,7 @@ describe('<md-chips>', function() {
           var ctrl = element.controller('mdChips');
           var input = element.find('input');
 
-          expect(ctrl.shouldAddOnBlur()).toBeFalsy();
+          expect(ctrl.shouldAdd(true)).toBeFalsy();
 
           // Flush the initial timeout of the md-autocomplete.
           $timeout.flush();
@@ -369,7 +369,7 @@ describe('<md-chips>', function() {
           scope.$apply('searchText = "Ki"');
           autocompleteCtrl.focus();
 
-          expect(ctrl.shouldAddOnBlur()).toBeFalsy();
+          expect(ctrl.shouldAdd(true)).toBeFalsy();
         });
 
       });

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -267,7 +267,7 @@ MdChipsCtrl.prototype.inputKeydown = function(event) {
     event.preventDefault();
 
     // Only append the chip and reset the chip buffer if the max chips limit isn't reached.
-    if (this.hasMaxChipsReached()) return;
+    if (!this.shouldAdd()) return;
 
     this.appendChip(chipBuffer.trim());
     this.resetChipBuffer();
@@ -710,7 +710,7 @@ MdChipsCtrl.prototype.onInputFocus = function () {
 MdChipsCtrl.prototype.onInputBlur = function () {
   this.inputHasFocus = false;
 
-  if (this.shouldAddOnBlur()) {
+  if (this.shouldAdd(true)) {
     this.appendChip(this.getChipBuffer().trim());
     this.resetChipBuffer();
   }
@@ -770,7 +770,7 @@ MdChipsCtrl.prototype.configureAutocomplete = function(ctrl) {
  * Whether the current chip buffer should be added on input blur or not.
  * @returns {boolean}
  */
-MdChipsCtrl.prototype.shouldAddOnBlur = function() {
+MdChipsCtrl.prototype.shouldAdd = function(onBlur) {
 
   // Update the custom ngModel validators from the chips component.
   this.validateModel();
@@ -783,7 +783,7 @@ MdChipsCtrl.prototype.shouldAddOnBlur = function() {
     isModelValid = isModelValid && this.userInputNgModelCtrl.$valid;
   }
 
-  return this.addOnBlur && !this.requireMatch && chipBuffer && isModelValid && !isAutocompleteShowing;
+  return (!onBlur || this.addOnBlur) && !this.requireMatch && chipBuffer && isModelValid && !isAutocompleteShowing;
 };
 
 MdChipsCtrl.prototype.hasFocus = function () {


### PR DESCRIPTION
userInputNgModelCtrl is tested for validity before adding chip only when
adding on blur, but not on enter (or separator key).
Add validation consistent validation on both events.

Signed-off-by: Adrian Panella <ianchi74@outlook.com>