### PR TITLE
ng-messages node must be outside the md-autocomplete element

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -184,10 +184,10 @@ angular
  *     <md-item-template>
  *       <span md-highlight-text="searchText">{{item.display}}</span>
  *     </md-item-template>
- *     <div ng-messages="autocompleteForm.autocomplete.$error">
- *       <div ng-message="required">This field is required</div>
- *     </div>
  *   </md-autocomplete>
+ *   <div ng-messages="autocompleteForm.autocomplete.$error">
+ *     <div ng-message="required">This field is required</div>
+ *   </div>
  * </form>
  * </hljs>
  *


### PR DESCRIPTION
My ng-messages were not visible with the element placed inside the md-autocomplete element. It works perfectly when placed just outside of it. If that is correct, then this example would benefit from this update.