### PR TITLE
fix(md-chips): change md-icon class to inherit size

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -129,6 +129,8 @@ $contact-chip-name-width: rem(12) !default;
       md-icon {
         height: $chip-delete-icon-size;
         width: $chip-delete-icon-size;
+        min-height: $chip-delete-icon-size;
+        min-width: $chip-delete-icon-size;
         position: absolute;
         top: 50%;
         left: 50%;


### PR DESCRIPTION
fix(chips): md-chips remove icon not inheriting class size

This fix will allow the chip remove icon to inherit the proper size from the css class.

This addresses issue #9619 