### PR TITLE
fix(panel): fix propagateContainerEvents

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1881,6 +1881,7 @@ MdPanelRef.prototype._createPanel = function() {
       // Handle click and touch events for the panel container.
       if (self.config['propagateContainerEvents']) {
         self.panelContainer.css('pointer-events', 'none');
+        self.panelEl.css('pointer-events', 'all');
       }
 
       // Panel may be outside the $rootElement, tell ngAnimate to animate


### PR DESCRIPTION
Change $mdPanel with propagateContainerEvents set to true to not close when it is clicked. #GoodnessSquad

Fixes: #10495