### PR TITLE
Fix casing and add clarity to documentaton on mdPanelRef

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -111,6 +111,7 @@ angular
  *   }
  *
  *   function PanelMenuCtrl(mdPanelRef) {
+ *     // The controller is provided with an import named 'mdPanelRef'
  *     this.closeMenu = function() {
  *       mdPanelRef && mdPanelRef.close();
  *     };
@@ -235,7 +236,8 @@ angular
  *   - `locals` - `{Object=}`: An object containing key/value pairs. The keys
  *     will be used as names of values to inject into the controller. For
  *     example, `locals: {three: 3}` would inject `three` into the controller,
- *     with the value 3.
+ *     with the value 3. 'mdPanelRef' is a reserved key, and will always 
+ *     be set to the created MdPanelRef instance.
  *   - `resolve` - `{Object=}`: Similar to locals, except it takes promises as
  *     values. The panel will not open until all of the promises resolve.
  *   - `attachTo` - `{(string|!angular.JQLite|!Element)=}`: The element to


### PR DESCRIPTION
This adds more documentation so that users of $mdPanel are able to easily inject the correct reference to the created panel in their controller.

The example source code has 'mdPanelRef' as the name of its import, but the rendered HTML in the docs site, converts this to 'MdPanelRef'.

This might be indicative of a larger problem with the dgeni process; Either way, I think the lines I added to the documentation should be enough to remove confusion.