### PR TITLE
fix(datepicker): Fix validation in IE.

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -607,7 +607,29 @@
       this.ngModelCtrl.$setValidity('valid', date == null);
     }
 
+    var input = this.inputElement.value;
+    var parsedDate = this.locale.parseDate(input);
+
+    if (!this.isInputValid(input, parsedDate) && this.ngModelCtrl.$valid) {
+      this.ngModelCtrl.$setValidity('valid', date == null);
+    }
+
     angular.element(this.inputContainer).toggleClass(INVALID_CLASS, !this.ngModelCtrl.$valid);
+  };
+
+  /**
+   * Check to see if the input is valid as the validation should fail if the model is invalid
+   *
+   * @param {String} inputString
+   * @param {Date} parsedDate
+   * @return {boolean} Whether the input is valid
+   */
+  DatePickerCtrl.prototype.isInputValid = function (inputString, parsedDate) {
+    return inputString == '' || (
+            this.dateUtil.isValidDate(parsedDate) &&
+            this.locale.isDateComplete(inputString) &&
+            this.isDateEnabled(parsedDate)
+        );
   };
 
   /** Clears any error flags set by `updateErrorState`. */
@@ -634,11 +656,7 @@
 
     // An input string is valid if it is either empty (representing no date)
     // or if it parses to a valid date that the user is allowed to select.
-    var isValidInput = inputString == '' || (
-      this.dateUtil.isValidDate(parsedDate) &&
-      this.locale.isDateComplete(inputString) &&
-      this.isDateEnabled(parsedDate)
-    );
+    var isValidInput = this.isInputValid(inputString, parsedDate);
 
     // The datepicker's model is only updated when there is a valid input.
     if (isValidInput) {

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -344,6 +344,16 @@ describe('md-datepicker', function() {
       expect(controller.ngModelCtrl.$error['mindate']).toBe(true);
     });
 
+    it('should apply ngMessages errors when the date becomes invalid from keyboard input', function() {
+      populateInputElement('5/30/2012');
+      pageScope.$apply();
+      expect(controller.ngModelCtrl.$error['valid']).toBeFalsy();
+
+      populateInputElement('5/30/2012z');
+      pageScope.$apply();
+      expect(controller.ngModelCtrl.$error['valid']).toBeTruthy();
+    });
+
     it('should evaluate ngChange expression when date changes from keyboard input', function() {
       populateInputElement('2/14/1976');
 


### PR DESCRIPTION
Adds in validation for the input as a last check as IE interpreted the date '11/14/2016d' as valid which is incorrect.

_Note: This PR supersedes #10015 by adding a test._

Fixes #9994. Closes #10015.