### PR TITLE
fix(textarea): getHeight() does not take into account the size of border

### DIFF
--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -506,9 +506,7 @@ function inputTextareaDirective($mdUtil, $window, $mdAria, $timeout, $mdGesture)
       }
 
       function getHeight() {
-        var offsetHeight = node.offsetHeight;
-        var line = node.scrollHeight - offsetHeight;
-        return offsetHeight + Math.max(line, 0);
+        return node.offsetHeight + Math.max(node.scrollHeight - node.clientHeight, 0);
       }
 
       function formattersListener(value) {


### PR DESCRIPTION
css height includes border size because textarea has `'border-sizing: border-box'` style
`getHeight` does not take into account the size of border,  because `scrollHeight` does not include border size
