### PR TITLE
fix(util): scrollTop set on proper scroll target

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -285,6 +285,11 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         var clientWidth = body.clientWidth;
         var hasVerticalScrollbar = body.scrollHeight > body.clientHeight + 1;
 
+        // Scroll may be set on <html> element (for example by overflow-y: scroll)
+        // but Chrome is reporting the scrollTop position always on <body>.
+        // scrollElement will allow to restore the scrollTop position to proper target.
+        var scrollElement = documentElement.scrollTop > 0 ? documentElement : body;
+
         if (hasVerticalScrollbar) {
           angular.element(body).css({
             position: 'fixed',
@@ -309,8 +314,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           body.style.cssText = prevBodyStyle;
           documentElement.style.cssText = prevDocumentStyle;
 
-          // The body loses its scroll position while being fixed.
-          body.scrollTop = viewportTop;
+          // The scroll position while being fixed
+          scrollElement.scrollTop = viewportTop;
         };
       }
 


### PR DESCRIPTION
`scrollTop` value is restored on `documentElement `instead of `body `when
`overflow-y: scroll` is defined on `html `element.

Closes #10272 #10432