### PR TITLE
fix(progress-linear-theme): add md-primary support to progress-linear (buffer mode)

### DIFF
--- a/src/components/progressLinear/progress-linear-theme.scss
+++ b/src/components/progressLinear/progress-linear-theme.scss
@@ -28,6 +28,14 @@ md-progress-linear.md-THEME_NAME-theme {
   }
 
   &[md-mode=buffer] {
+    &.md-primary {
+	  .md-bar1 {
+        background-color: '{{primary-100}}';
+      }
+      .md-dashed:before {
+        background: radial-gradient('{{primary-100}}' 0%, '{{primary-100}}' 16%, transparent 42%);
+      } 
+	}
     &.md-warn {
       .md-bar1 {
         background-color: '{{warn-100}}';


### PR DESCRIPTION
Style the buffer bar and dashed bar for color intention md-primary in progress-linear buffer mode

Fixes [#10078](https://github.com/angular/material/issues/10078)