### PR TITLE
fix(tooltip): resolve expressions against correct scope

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -106,7 +106,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
     function addAriaLabel(labelText) {
       // Only interpolate the text from the HTML element because otherwise the custom text could
       // be interpolated twice and cause XSS violations.
-      var interpolatedText = labelText || $interpolate(element.text().trim())(parent.scope);
+      var interpolatedText = labelText || $interpolate(element.text().trim())(scope.$parent);
 
       // Only add the `aria-label` to the parent if there isn't already one, if there isn't an
       // already present `aria-labelledby`, or if the previous `aria-label` was added by the

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -14,7 +14,8 @@ describe('MdTooltip Component', function() {
   // Test filter for ensuring tooltip expressions are evaluated against the correct scope.
   angular.module('fullNameFilter', []).filter('fullName', function() {
     return function(user) {
-      return user ? user.name.first + ' ' + user.name.last : "";
+        // Intentionally dereference user without checking whether it is defined. Do not change!
+        return user.name.first + ' ' + user.name.last;
     }
   });
 


### PR DESCRIPTION
Reinstates scope fix from https://github.com/angular/material/commit/685b9029d699c486ef27f9d00a0c49b90a363552, which was accidentally reverted in https://github.com/angular/material/pull/10464.  Blocking 1.1 release due to Google test failures.

cc: @ThomasBurleson 