### PR TITLE
update(autoComplete): allow clear button even if directive is disabled

### DIFF
--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -407,7 +407,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
               'type="button" ' +
               'aria-label="Clear Input" ' +
               'tabindex="-1" ' +
-              'ng-if="clearButton && $mdAutocompleteCtrl.scope.searchText && !$mdAutocompleteCtrl.isDisabled" ' +
+              'ng-if="clearButton && $mdAutocompleteCtrl.scope.searchText" ' +
               'ng-click="$mdAutocompleteCtrl.clear($event)">' +
             '<md-icon md-svg-src="' + $$mdSvgRegistry.mdClose + '"></md-icon>' +
           '</button>';


### PR DESCRIPTION
I am attempting to use md-autocomplete and 'lock' in a users selection once an autocomplete is selected. I ng-disable the directive accordingly. However, I still want the user to be able to clear the autocomplete, even if it is disabled - I simply don't want them to be able to edit the existing text. This pull request will still allow the clear button to be shown even if it is disabled. If the developer doesn't want a clear button when the control is disabled, they can simply update their boolean expression inside of the md-clear-button attribute.