### PR TITLE
fix(panel): bounds not unfolded for positioning

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1376,6 +1376,9 @@ function MdPanelRef(config, $injector) {
   /** @private @const {!angular.$window} */
   this._$window = $injector.get('$window');
 
+  /** @private @const {!angular.$timeout} */
+  this._$timeout = $injector.get('$timeout');
+
   /** @private @const {!Function} */
   this._$$rAF = $injector.get('$$rAF');
 
@@ -1939,14 +1942,19 @@ MdPanelRef.prototype._addStyles = function() {
 
     // Wait for angular to finish processing the template
     self._$rootScope['$$postDigest'](function() {
-      // Position it correctly. This is necessary so that the panel will have a
-      // defined height and width.
-      self._updatePosition(true);
+      // Wait one digest cycle to ensure that updatePosition can retrieve the
+      // final bounds of the panel. If we don't wait, we risk a race-condition
+      // where the bounds of the panel are partially still 0.
+      self._$timeout(function() {
+        // Position it correctly. This is necessary so that the panel will have a
+        // defined height and width.
+        self._updatePosition(true);
 
-      // Theme the element and container.
-      self._setTheming();
+        // Theme the element and container.
+        self._setTheming();
 
-      resolve(self);
+        resolve(self);
+      });
     });
   });
 };

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -1,6 +1,6 @@
 describe('$mdPanel', function() {
   var $mdPanelProvider, $mdPanel, $rootScope, $rootEl, $templateCache, $q,
-      $material, $mdConstant, $mdUtil, $animate, $$rAF, $window;
+      $material, $mdConstant, $mdUtil, $animate, $$rAF, $window, $timeout;
   var panelRef;
   var attachedElements = [];
   var PANEL_WRAPPER = '.md-panel-outer-wrapper';
@@ -33,6 +33,7 @@ describe('$mdPanel', function() {
     $mdUtil = $injector.get('$mdUtil');
     $animate = $injector.get('$animate');
     $window = $injector.get('$window');
+    $timeout = $injector.get('$timeout');
     $$rAF = $injector.get('$$rAF');
   };
 
@@ -3394,6 +3395,7 @@ describe('$mdPanel', function() {
   }
 
   function flushPanel() {
+    $timeout.flush();
     $rootScope.$apply();
     $material.flushOutstandingAnimations();
   }

--- a/src/components/tooltip/tooltip.spec.js
+++ b/src/components/tooltip/tooltip.spec.js
@@ -550,6 +550,7 @@ describe('MdTooltip Component', function() {
     }
     parentScope.testModel.isVisible = !!isVisible;
     parentScope.$apply();
+    $timeout.flush();
     $material.flushOutstandingAnimations();
   }
 


### PR DESCRIPTION
When Angular debug information is disabled, operation is sped up enough so that the bounds of the panel are not always unfolded when they are checked during positioning.
This change introduces a delay of one digest cycle to let the element unfold.

Closes #10543