### PR TITLE
fix(panel): loosen up bounds assessment

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -3100,8 +3100,8 @@ MdPanelPosition.prototype._bidi = function(position) {
 MdPanelPosition.prototype._calculatePanelPosition = function(panelEl, position) {
 
   var panelBounds = panelEl[0].getBoundingClientRect();
-  var panelWidth = panelBounds.width;
-  var panelHeight = panelBounds.height;
+  var panelWidth = Math.max(panelBounds.width, panelEl[0].clientWidth);
+  var panelHeight = Math.max(panelBounds.height, panelEl[0].clientHeight);
 
   var targetBounds = this._relativeToEl[0].getBoundingClientRect();
 


### PR DESCRIPTION
`getBoundingClientRect()` will return a width of 0 in certain scenarios.
Retrieving the width through `clientWidth` will hold the desired width for the position calculation.

As this can be reversed for other situations, we take the max of both values.

Closes #10543