### PR TITLE
fix(autocomplete): avoid creating two chips on KEY_CODE.ENTER

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -55,6 +55,7 @@ describe('<md-autocomplete>', function() {
     return {
       keyCode: keyCode,
       stopPropagation: angular.noop,
+      stopImmediatePropagation: angular.noop,
       preventDefault: angular.noop
     };
   }

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -562,7 +562,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       case $mdConstant.KEY_CODE.ENTER:
         if (ctrl.hidden || ctrl.loading || ctrl.index < 0 || ctrl.matches.length < 1) return;
         if (hasSelection()) return;
-        event.stopPropagation();
+        event.stopImmediatePropagation();
         event.preventDefault();
         select(ctrl.index);
         break;


### PR DESCRIPTION
IE11: Autocomplete cancels its keyboard event using preventDefault(), but following listeners still have the original keyboard event.

Fixes #10640