### PR TITLE
Don't assume that the scrollMask is present when closing the md-dialog

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -264,7 +264,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           scrollMask.off('wheel');
           scrollMask.off('touchmove');
 
-          if (!options.disableScrollMask) {
+          if (!options.disableScrollMask && scrollMask[0].parentNode ) {
             scrollMask[0].parentNode.removeChild(scrollMask[0]);
           }
         };


### PR DESCRIPTION
Fixed an issue where md-dialog contains md-autocomplete elements. These elements remove the scroll mask before the dialog is closed, resulting in an exception when closing the dialog. This a symptom fix. I don't assume that the mask is still there before I try to delete it. But now the dialog closed properly and no errors.