### PR TITLE
fix(panel): correctly reverse x-position in RTL

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -3071,7 +3071,7 @@ MdPanelPosition.prototype._constrainToViewport = function(panelEl) {
  */
 MdPanelPosition.prototype._reverseXPosition = function(position) {
   if (position === MdPanelPosition.xPosition.CENTER) {
-    return;
+    return position;
   }
 
   var start = 'start';


### PR DESCRIPTION
Return 'center' instead of undefined when on an RTL page.

Fixes #10536