### PR TITLE
docs(tabs): add `md-swipe-content` attribute to demo

### DIFF
--- a/src/components/tabs/demoDynamicTabs/index.html
+++ b/src/components/tabs/demoDynamicTabs/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="AppCtrl" class="sample" layout="column" ng-cloak>
   <md-content class="md-padding">
-    <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect>
+    <md-tabs md-selected="selectedIndex" md-border-bottom md-autoselect md-swipe-content>
       <md-tab ng-repeat="tab in tabs"
               ng-disabled="tab.disabled"
               label="{{tab.title}}">


### PR DESCRIPTION
Add `md-swipe-content` to tabs demo to be consistent with the tab two description.

Description says: "You can swipe left and right on a mobile device to change tabs."