### PR TITLE
chore(codepen): changed codepen access to https

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -6,8 +6,10 @@
   // Provides a service to open a code example in codepen.
   function Codepen($demoAngularScripts, $document, codepenDataAdapter) {
 
-    // The following URL must be HTTP and not HTTPS to allow us to do localhost testing
-    var CODEPEN_API = 'http://codepen.io/pen/define/';
+    // The following URL used to be HTTP and not HTTPS to allow us to do localhost testing
+    // It's no longer working, for more info:
+    // https://blog.codepen.io/2017/03/31/codepen-going-https/
+    var CODEPEN_API = 'https://codepen.io/pen/define/';
 
     return {
       editOnCodepen: editOnCodepen


### PR DESCRIPTION
codepen updated their api to only support https
https://blog.codepen.io/2017/03/31/codepen-going-https/

> NOTE: this breaks development codepens since it's being block by codepen itself

fixes #10692