### PR TITLE
fix(dialog): generate `aria-label` with dialog title (if exists) when `.ariaLabel()` is not specified

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1083,9 +1083,15 @@ function MdDialogProvider($$interimElementProvider) {
       }
       else {
         $mdAria.expectAsync(element, 'aria-label', function() {
-          var words = dialogContent.text().split(/\s+/);
-          if (words.length > 3) words = words.slice(0, 3).concat('...');
-          return words.join(' ');
+          // If dialog title is specified, set aria-label with it
+          // See https://github.com/angular/material/issues/10582
+          if (options.title) {
+            return options.title;
+          } else {
+            var words = dialogContent.text().split(/\s+/);
+            if (words.length > 3) words = words.slice(0, 3).concat('...');
+            return words.join(' ');
+          }
         });
       }
 

--- a/src/components/dialog/dialog.spec.js
+++ b/src/components/dialog/dialog.spec.js
@@ -114,6 +114,7 @@ describe('$mdDialog', function() {
       expect(css).toContain('someClass');
       expect(css).toContain('anotherClass');
       expect(mdDialog.attr('role')).toBe('alertdialog');
+      expect(mdDialog.attr('aria-label')).toBe('Title');
 
       buttons.eq(0).triggerHandler('click');
 
@@ -374,6 +375,7 @@ describe('$mdDialog', function() {
       expect(buttons.length).toBe(2);
       expect(buttons.eq(0).text()).toBe('Next');
       expect(buttons.eq(1).text()).toBe('Forget it');
+      expect(dialog.attr('aria-label')).toBe('Title');
 
       buttons.eq(1).triggerHandler('click');
       runAnimation();
@@ -679,6 +681,7 @@ describe('$mdDialog', function() {
       expect(css).toContain('someClass');
       expect(css).toContain('anotherClass');
       expect(mdDialog.attr('role')).toBe('dialog');
+      expect(mdDialog.attr('aria-label')).toBe('Title');
 
       inputElement.eq(0).text('responsetext');
       inputElement.scope().$apply("dialog.result = 'responsetext'");
@@ -1622,7 +1625,7 @@ describe('$mdDialog', function() {
         expect(childNodes.indexOf(contentElement[0])).toBe(0);
 
         document.body.removeChild(contentParent[0]);
-      })
+      });
 
     });
 


### PR DESCRIPTION

Fixes #10582