### PR TITLE
update(scripts): use ANGULARJS_MATERIAL_BUILDS_TOKEN

### DIFF
--- a/scripts/bower-material-release.sh
+++ b/scripts/bower-material-release.sh
@@ -16,7 +16,7 @@ function run {
 
   echo "-- Cloning bower-material..."
   rm -rf bower-material
-  git clone https://angular:$GH_TOKEN@github.com/angular/bower-material \
+  git clone https://github.com/angular/bower-material \
     bower-material --depth=2
 
   echo "-- Copying in build files..."
@@ -29,6 +29,8 @@ function run {
   cp -Rf dist/* bower-material/
 
   cd bower-material
+  # GitHub token specified as Travis environment variable
+  echo "https://${ANGULARJS_MATERIAL_BOWER_TOKEN}:@github.com" > .git/credentials
 
   # Remove stale files from older builds
   rm -f ./angular-material.layouts.css

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,9 +7,17 @@ ARG_DEFS=(
 function run {
   cd ../
 
-  if [[ "$GH_TOKEN" == "" ]]; then
-    echo "ERROR: Environment variable GH_TOKEN needed to push a release."
-    echo "Please set GH_TOKEN to a valid github push token for angular/material,"
+
+  # GitHub token specified as Travis environment variable
+  #   e.g. echo "https://${ANGULARJS_MATERIAL_BOWER_TOKEN}:@github.com" > .git/credentials
+  #
+  # Both `snapshot-docs-site.sh` and `bower-material-release.sh` use
+  # this ANGULARJS_MATERIAL_BOWER_TOKEN variable
+
+
+  if [[ "$ANGULARJS_MATERIAL_BOWER_TOKEN" == "" ]]; then
+    echo "ERROR: Environment variable ANGULARJS_MATERIAL_BOWER_TOKEN needed to push a release."
+    echo "Please set ANGULARJS_MATERIAL_BOWER_TOKEN to a valid github push token for angular/material,"
     echo "then try again."
     exit 1
   fi

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -13,7 +13,7 @@ function run {
 
   echo "-- Cloning code.material.angularjs.org..."
   rm -rf code.material.angularjs.org
-  git clone https://angular:$GH_TOKEN@github.com/angular/code.material.angularjs.org.git --depth=1
+  git clone https://github.com/angular/code.material.angularjs.org --depth=1
 
   echo "-- Remove previous snapshot..."
   rm -rf code.material.angularjs.org/HEAD
@@ -27,6 +27,8 @@ function run {
   cp -Rf dist/docs code.material.angularjs.org/HEAD
 
   cd code.material.angularjs.org
+  # GitHub token specified as Travis environment variable
+  echo "https://${ANGULARJS_MATERIAL_DOCS_SITE_TOKEN}:@github.com" > .git/credentials
 
   echo "-- Commiting snapshot..."
   git add -A


### PR DESCRIPTION
Replace deprecated GH_TOKEN with new ANGULARJS_MATERIAL_BUILDS_TOKEN environment variable name.

Fixes #10692, #10734