### PR TITLE
fix(select multiple): set the element dirty when the selected options change

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -699,7 +699,6 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         // reference. This allowed the developer to also push and pop from their array.
         $scope.$watchCollection(self.modelBinding, function(value) {
           if (validateArray(value)) renderMultiple(value);
-          self.ngModel.$setPristine();
         });
 
         ngModel.$isEmpty = function(value) {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1195,6 +1195,27 @@ describe('<md-select>', function() {
         expect(selectMenu.hasAttribute('multiple')).toBe(false);
       });
 
+      it('should set the element dirty when selected options changes', function () {
+        $rootScope.model = 2;
+        $rootScope.opts = [1, 2, 3, 4];
+        var form = $compile('<form name="testForm">' +
+          '<md-select multiple="multiple" ng-model="model" name="multiSelect">' +
+            '<md-option ng-repeat="opt in opts" ng-value="opt">{{opt}}</md-option>' +
+          '</md-select></form>')($rootScope);
+        var el = form.find('md-select');
+        
+        $rootScope.$digest();
+        $timeout.flush();
+
+        expect($rootScope.testForm.multiSelect.$pristine).toBe(true);
+        expect($rootScope.testForm.multiSelect.$dirty).toBe(false);
+
+        openSelect(el);
+        clickOption(el, 0);
+
+        expect($rootScope.testForm.multiSelect.$pristine).toBe(false);
+        expect($rootScope.testForm.multiSelect.$dirty).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #10584.
`ngModel.$setPristine()` was executed each time the selected options changed.