### PR TITLE
fix(md-tab): Adding no keypress to allow input inside md-tab 

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -67,6 +67,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     defineBooleanAttribute('noDisconnect');
     defineBooleanAttribute('autoselect');
     defineBooleanAttribute('noSelectClick');
+    defineBooleanAttribute('noKeypress');
     defineBooleanAttribute('centerTabs', handleCenterTabs, false);
     defineBooleanAttribute('enableDisconnect');
 
@@ -300,10 +301,11 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   // Event handlers / actions
 
   /**
-   * Handle user keyboard interactions
+   * Handle user keyboard interactions if `md-no-keypress` are false.
    * @param event
    */
   function keydown (event) {
+    if (ctrl.noKeypress) return;
     switch (event.keyCode) {
       case $mdConstant.KEY_CODE.LEFT_ARROW:
         event.preventDefault();

--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -74,6 +74,7 @@
  * @param {boolean=} md-enable-disconnect When enabled, scopes will be disconnected for tabs that are not being displayed.  This provides a performance boost, but may also cause unexpected issues and is not recommended for most users.
  * @param {boolean=} md-autoselect When present, any tabs added after the initial load will be automatically selected
  * @param {boolean=} md-no-select-click When enabled, click events will not be fired when selecting tabs
+ * @param {boolean=} md-no-keypress When enabled, keyboard events will not be fired
  *
  * @usage
  * <hljs lang="html">

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -151,6 +151,20 @@ describe('<md-tabs>', function () {
       expect(tabItems.eq(1).attr('tabindex')).toBe('-1');
     }));
 
+    it('should not select tab on space or enter if md-no-keypress is true', inject(function ($document, $mdConstant) {
+      var tabs     = setup('<md-tabs md-no-keypress="true">' +
+                           '<md-tab></md-tab>' +
+                           '<md-tab></md-tab>' +
+                           '</md-tabs>');
+      var tabItems = tabs.find('md-tab-item');
+      tabs.find('md-tab-item').eq(0).triggerHandler('click');
+      // All keypress events will not have any affect.
+      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
+      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.ENTER);
+      expect(tabItems.eq(1)).not.toBeActiveTab();
+      expect(tabItems.eq(1).attr('tabindex')).not.toBe('0');
+    }));
+
     it('should bind to selected', function () {
       var tabs      = setup('<md-tabs md-selected="current">' +
                             '<md-tab></md-tab>' +


### PR DESCRIPTION
## Current situation
Keypress preventdefault is causing issues with some use cases, like input inside `md-tabs`. See issue [10751](https://github.com/angular/material/issues/10751)

## Before
`keydown` was activated all times.

## AFTER
`md-no-keypress` allow users to choose if to use keypress in `md-tabs` default is false.