### PR TITLE
fix/refactor(autocomplete): use real <label> instead of placeholder

### DIFF
--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -110,9 +110,18 @@ md-autocomplete {
     padding: 0 15px;
     line-height: 40px;
     height: 40px;
+    position: absolute;
+  }
+  // Dimensions of md-autocomplete-placeholder should match md-autocomplete.
+  .md-autocomplete-placeholder {
+    color: #757575;
+    font-size: 14px;
+    line-height: 40px;
+    padding: 0 15px;
   }
   .md-show-clear-button button {
-    position: relative;
+    position: absolute;
+    right: 0;
     line-height: 20px;
     text-align: center;
     width: $md-autocomplete-clear-size;
@@ -123,7 +132,7 @@ md-autocomplete {
     padding: 0;
     font-size: 12px;
     background: transparent;
-    margin: auto 5px;
+    margin: 5px;
     &:after {
       content: '';
       position: absolute;

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -312,15 +312,16 @@ function MdAutocomplete ($$mdSvgRegistry) {
               ng-mouseup="$mdAutocompleteCtrl.mouseUp()"\
               ng-hide="$mdAutocompleteCtrl.hidden"\
               class="md-autocomplete-suggestions-container md-whiteframe-z1"\
-              ng-class="{ \'md-not-found\': $mdAutocompleteCtrl.notFoundVisible() }"\
-              role="presentation">\
+              ng-class="{ \'md-not-found\': $mdAutocompleteCtrl.notFoundVisible() }">\
             <ul class="md-autocomplete-suggestions"\
                 ng-class="::menuClass"\
-                id="ul-{{$mdAutocompleteCtrl.id}}">\
+                id="ul-{{$mdAutocompleteCtrl.id}}"\
+                role="listbox">\
               <li md-virtual-repeat="item in $mdAutocompleteCtrl.matches"\
                   ng-class="{ selected: $index === $mdAutocompleteCtrl.index }"\
                   ng-click="$mdAutocompleteCtrl.select($index)"\
-                  md-extra-name="$mdAutocompleteCtrl.itemName">\
+                  md-extra-name="$mdAutocompleteCtrl.itemName"\
+                  role="option">\
                   ' + itemTemplate + '\
                   </li>' + noItemsTemplate + '\
             </ul>\
@@ -339,6 +340,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
             template = templateTag.length ? templateTag.html() : '';
         return template
             ? '<li ng-if="$mdAutocompleteCtrl.notFoundVisible()"\
+                         role="option"\
                          md-autocomplete-parent-scope>' + template + '</li>'
             : '';
 
@@ -368,13 +370,17 @@ function MdAutocomplete ($$mdSvgRegistry) {
                   aria-label="{{floatingLabel}}"\
                   aria-autocomplete="list"\
                   role="combobox"\
-                  aria-haspopup="true"\
                   aria-activedescendant=""\
                   aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>\
               <div md-autocomplete-parent-scope md-autocomplete-replace>' + leftover + '</div>\
             </md-input-container>';
         } else {
           return '\
+            <label for="{{ inputId || \'input-\' + $mdAutocompleteCtrl.id }}"\
+                class="md-autocomplete-placeholder"\
+                ng-class="{\'md-visually-hidden\': $mdAutocompleteCtrl.scope.searchText.length > 0}">\
+              {{placeholder}}\
+            </label>\
             <input type="search"\
                 ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
                 id="{{ inputId || \'input-\' + $mdAutocompleteCtrl.id }}"\
@@ -390,12 +396,9 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\
-                placeholder="{{placeholder}}"\
                 aria-owns="ul-{{$mdAutocompleteCtrl.id}}"\
-                aria-label="{{placeholder}}"\
                 aria-autocomplete="list"\
                 role="combobox"\
-                aria-haspopup="true"\
                 aria-activedescendant=""\
                 aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"/>';
         }

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -158,11 +158,20 @@ $contact-chip-name-width: rem(12) !default;
       height: $chip-height;
     }
     md-autocomplete {
+      box-shadow: none;
+
       md-autocomplete-wrap {
         box-shadow: none;
+
+        .md-autocomplete-placeholder {
+          font-family: $font-family;
+          font-size: $chip-font-size;
+          line-height: $chip-height;
+          padding: 0;
+        }
       }
       input {
-        position: relative;
+        position: absolute;
       }
     }
     input {
@@ -172,15 +181,6 @@ $contact-chip-name-width: rem(12) !default;
       padding: 0;
       &:focus {
         outline:none;
-      }
-    }
-    md-autocomplete, md-autocomplete-wrap {
-      height: $chip-height;
-    }
-    md-autocomplete {
-      box-shadow: none;
-      input {
-        position: relative;
       }
     }
     &:not(:first-child) {

--- a/src/components/chips/contact-chips.spec.js
+++ b/src/components/chips/contact-chips.spec.js
@@ -50,12 +50,12 @@ describe('<md-contact-chips>', function() {
   });
 
   describe('basic functionality', function() {
-    it('should show the placeholder', inject(function() {
+    it('should show the "placeholder" label inline', inject(function() {
       var element = buildChips(CONTACT_CHIPS_TEMPLATE);
       var ctrl = element.controller('mdContactChips');
 
-      expect(element.find('input').length).toBe(1);
-      expect(element.find('input')[0].placeholder).toBe('To');
+      expect(element.find('label').length).toBe(1);
+      expect(element.find('label')[0].textContent.trim()).toBe('To');
     }));
 
     it('binds the md-highlight-flags to the controller', function() {


### PR DESCRIPTION
This affects the autocomplete version with "placeholder" specified
(not the md-floating-label version). This means that it also affects the chips component.

BREAKING CHANGE (STYLE): The text is no longer a placeholder, so styling that
previously used the webkit/moz placeholder attributes will no longer
apply. Now, styles should be applied to ".md-autocomplete-placeholder". This is actually slightly cleaner for cross-browser style consistency.

Before this change, placeholder and aria-label are identical, resulting
in some screenreaders (like JAWS) reading what seems like duplicate
text. After this change, a is used instead of both the
aria-label and the placeholder, resulting in only a single reading of
the single specified label.

Also change the roles of the autocomplete list to be more compliant with
ARIA practices by adding role="listbox" and role="option". Remove
aria-haspopup="true" because role="combobox" elements have aria-haspopup
set to true by default.

CSS positioning is used to ensure that the layering order is as follows
(from bottom to top):
autocomplete container
placeholder
text input field
This way, the placeholder text is on top of the white background, but
behind the transparent text input, allowing us to see it, yet still be
able to click on the text field.

Some style changes were combined/duplicates were removed from the chips.scss.
From the history/blame, it didn't seem like intentional cascading, but I couldn't tell,
so please do sanity check me.