### PR TITLE
fix(tabs): Hide md-tab-content elements entirely when inactive.

### DIFF
--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -205,7 +205,7 @@ md-tab-content {
   &.md-left:not(.md-active) {
     @include rtl(transform, translateX(-100%), translateX(+100%));
     animation: 2 * $swift-ease-in-out-duration md-tab-content-hide;
-    opacity: 0;
+    visibility: hidden;
     * {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;
@@ -215,7 +215,7 @@ md-tab-content {
   &.md-right:not(.md-active) {
     @include rtl(transform, translateX(100%), translateX(-100%));
     animation: 2 * $swift-ease-in-out-duration md-tab-content-hide;
-    opacity: 0;
+    visibility: hidden;
     * {
       transition: visibility 0s linear;
       transition-delay: $swift-ease-in-out-duration;


### PR DESCRIPTION
Make md-tab-content elements visibility: hidden; entirely instead of setting opacity to zero when inactive. This prevents screen readers and other assistive technology from seeing and interacting with the visibly hidden containers.