### PR TITLE
fix(tabs): allow right and left arrows to cycle through tabs

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -684,6 +684,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     for (newIndex = index + inc;
          ctrl.tabs[ newIndex ] && ctrl.tabs[ newIndex ].scope.disabled;
          newIndex += inc) {}
+
+    newIndex = (index + inc + ctrl.tabs.length) % ctrl.tabs.length;
+
     if (ctrl.tabs[ newIndex ]) {
       ctrl[ key ] = newIndex;
     }

--- a/src/components/tabs/tabs.spec.js
+++ b/src/components/tabs/tabs.spec.js
@@ -100,23 +100,24 @@ describe('<md-tabs>', function () {
                            '<md-tab ng-disabled="true"></md-tab>' +
                            '<md-tab></md-tab>' +
                            '</md-tabs>');
+      var ctrl = tabs.controller('mdTabs');
       var tabItems = tabs.find('md-tab-item');
 
       expect(tabItems.eq(0)).toBeActiveTab();
 
-      // Boundary case, do nothing
+      // Focus should move to the last tab if left arrow is pressed
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.LEFT_ARROW);
-      expect(tabItems.eq(0)).toBeActiveTab();
+      expect(ctrl.getFocusedTabId()).toBe(tabItems.eq(2).attr('id'));
+
+      // Focus should move to the first tab if right arrow is pressed
+      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
+      expect(ctrl.getFocusedTabId()).toBe(tabItems.eq(0).attr('id'));
 
       // Tab 0 should still be active, but tab 2 focused (skip tab 1 it's disabled)
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
       expect(tabItems.eq(0)).toBeActiveTab();
 
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.ENTER);
-      expect(tabItems.eq(2)).toBeActiveTab();
-
-      // Boundary case, do nothing
-      triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.RIGHT_ARROW);
       expect(tabItems.eq(2)).toBeActiveTab();
 
       triggerKeydown(tabs.find('md-tabs-canvas').eq(0), $mdConstant.KEY_CODE.ENTER);


### PR DESCRIPTION
As per the ARIA spec on tabs
(https://www.w3.org/TR/wai-aria-practices-1.1/#tabpanel, see "Keyboard
Interaction" section), LEFT ARROW should move the focus to the last tab
if it's currently on the first tab. RIGHT ARROW should move the focus to
the first tab if it's currently on the last tab. Previously, LEFT ARROW
stopped moving focus once it hit the first tab and RIGHT ARROW stopped
moving focus once it hit the last tab.