### PR TITLE
fix(layout): add missing media query overrides

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -172,6 +172,28 @@
       // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
       @if $i == 0 {  min-height: 0;  }
     }
+
+    @if ($name != '') {
+      .layout#{$name}-row > .flex-#{$i * 5} {
+        flex: 1 1 100%;
+        max-width: #{$value};
+        max-height: 100%;
+        box-sizing: border-box;
+
+        // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+        @if $i == 0 {  min-width: 0;  }
+      }
+
+      .layout#{$name}-column > .flex-#{$i * 5} {
+        flex: 1 1 100%;
+        max-width: 100%;
+        max-height: #{$value};
+        box-sizing: border-box;
+
+        // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+        @if $i == 0 {  min-height: 0;  }
+      }
+    }
   }
 
   .layout-row {
@@ -190,7 +212,6 @@
 
     // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
     > .flex { min-width: 0;  }
-
   }
 
   .layout#{$name}-column {
@@ -199,6 +220,24 @@
 
     // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
     > .flex { min-height: 0; }
+  }
+
+  @if ($name != '') {
+    .layout#{$name}-row {
+      > .flex-33 { flex: 1 1 100%;  max-width: 33.33%;  max-height: 100%; box-sizing: border-box; }
+      > .flex-66 { flex: 1 1 100%;  max-width: 66.66%;  max-height: 100%; box-sizing: border-box; }
+
+      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+      > .flex { min-width: 0;  }
+    }
+
+    .layout#{$name}-column {
+      > .flex-33 { flex: 1 1 100%;  max-width: 100%;  max-height: 33.33%; box-sizing: border-box; }
+      > .flex-66 { flex: 1 1 100%;  max-width: 100%;  max-height: 66.66%; box-sizing: border-box; }
+
+      // Bug workaround for http://crbug.com/546034 - flex issues on Chrome 48
+      > .flex { min-height: 0; }
+    }
   }
 
 }


### PR DESCRIPTION
The current implementation's CSS rules did not properly override
other rules when using @media sizes.

* Add SCSS rules for flex-0 to flex-100
* Add SCSS rules for flex-33 and flex-66

Fixes #9546