### PR TITLE
fix(menu): fix dynamically created nested menu

### DIFF
--- a/src/components/menu/js/menuController.js
+++ b/src/components/menu/js/menuController.js
@@ -14,13 +14,12 @@ function MenuController($mdMenu, $attrs, $element, $scope, $mdUtil, $timeout, $r
   var self = this;
   var triggerElement;
 
-  this.nestLevel = parseInt($attrs.mdNestLevel, 10) || 0;
-
   /**
    * Called by our linking fn to provide access to the menu-content
    * element removed during link
    */
   this.init = function init(setMenuContainer, opts) {
+    self.nestLevel = parseInt($attrs.mdNestLevel, 10) || 0;
     opts = opts || {};
     menuContainer = setMenuContainer;
 


### PR DESCRIPTION
… (#10595)

When create cascade/nested menu dynamically, and switch between menus, it closes every submenu expect the root.
This happens because from angular 1.6 it is necessary to bind properties at init.