### PR TITLE
add moveLiveRegion function to keep live regions within autocomplete element

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -87,6 +87,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
 
       gatherElements();
       moveDropdown();
+      moveLiveRegion();
 
       // Forward all focus events to the input element when autofocus is enabled
       if ($scope.autofocus) {
@@ -193,6 +194,16 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     elements.$.scrollContainer.detach();
     elements.$.root.append(elements.$.scrollContainer);
     if ($animate.pin) $animate.pin(elements.$.scrollContainer, $rootElement);
+  }
+
+  /**
+   * Moves the live region within the autocomplete to ensure the live region is
+   * is not hidden from screen readers when the autocomplete appears within
+   * a dialog
+   */
+  function moveLiveRegion () {
+    angular.element($mdLiveAnnouncer._liveElement).detach();
+    elements.$.main.append($mdLiveAnnouncer._liveElement)
   }
 
   /**


### PR DESCRIPTION
Fixes #10804 

Adds a function (called on init) to the autocompleteController.js that moves the component's live region within the md-autocomplete element to fix an issue that arises when autocompletes are used inside of dialogs. The issue is that the dialog will look to apply aria-hidden=true to any element that is not an ancestor or child of the dialog.

The fix works because it guarantees that aria-hidden will not be applied to the live region for the autocomplete being created within the dialog.