### PR TITLE
fix(all): remove all direct use of browser globals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -261,9 +261,6 @@
             "parserOptions": {
                 "ecmaVersion": 5
             },
-            "env": {
-                "browser": true
-            },
             "rules": {
                 "arrow-parens": "error",
                 "global-require": "error",
@@ -272,6 +269,9 @@
                 ],
                 "no-process-env": "error",
                 "no-sync": "error"
+            },
+            "env": {
+              "node": false
             },
             "globals": {
                 "angular": true,
@@ -292,6 +292,7 @@
                 "**/*.spec.js"
             ],
             "env": {
+                "browser": true,
                 "jasmine": true
             },
             "rules": {

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -512,7 +512,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
   };
 })
 
-.directive('menuToggle', ['$mdUtil', '$animateCss', '$$rAF', function($mdUtil, $animateCss, $$rAF) {
+.directive('menuToggle', ['$mdUtil', '$animateCss', '$$rAF', '$document', function($mdUtil, $animateCss, $$rAF, $document) {
   return {
     scope: {
       section: '='
@@ -567,7 +567,7 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
                 var negativeOffset = activeHeight * 2;
                 var newScrollTop = activeOffset + parentScrollPosition - negativeOffset;
 
-                $mdUtil.animateScrollTo(document.querySelector('.docs-menu').parentNode, newScrollTop);
+                $mdUtil.animateScrollTo($document[0].querySelector('.docs-menu').parentNode, newScrollTop);
               }
             });
           });
@@ -594,7 +594,8 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES, $location, $rootScope, $http, $wind
   '$location',
   '$rootScope',
   '$mdUtil',
-function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu, $location, $rootScope, $mdUtil) {
+  '$document',
+function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu, $location, $rootScope, $mdUtil, $document) {
   var self = this;
 
   $scope.COMPONENTS = COMPONENTS;
@@ -634,7 +635,7 @@ function($scope, COMPONENTS, BUILDCONFIG, $mdSidenav, $timeout, $mdDialog, menu,
   this.autoFocusContent = false;
 
 
-  var mainContentArea = document.querySelector("[role='main']");
+  var mainContentArea = $document[0].querySelector("[role='main']");
   var scrollContentEl = mainContentArea.querySelector('md-content[md-scroll-y]');
 
 
@@ -752,8 +753,8 @@ function($scope, $attrs, $location, $rootScope) {
   };
 }])
 
-.controller('LayoutTipsCtrl', [
-function() {
+.controller('LayoutTipsCtrl', ['$document',
+function($document) {
   var self = this;
 
   /*
@@ -762,7 +763,7 @@ function() {
   self.toggleButtonText = "Hide";
 
   self.toggleContentSize = function() {
-    var contentEl = angular.element(document.getElementById('toHide'));
+    var contentEl = angular.element($document[0].getElementById('toHide'));
 
     contentEl.toggleClass("ng-hide");
 

--- a/docs/app/js/demoInclude.js
+++ b/docs/app/js/demoInclude.js
@@ -2,7 +2,8 @@ angular.module('docsApp').directive('demoInclude', [
   '$q',
   '$compile',
   '$timeout',
-function($q, $compile, $timeout) {
+  '$document',
+function($q, $compile, $timeout, $document) {
   return {
     restrict: 'E',
     link: postLink
@@ -71,7 +72,7 @@ function($q, $compile, $timeout) {
         styles = styles.join('\n'); //join styles as one string
 
         var styleElement = angular.element('<style>' + styles + '</style>');
-        document.body.appendChild(styleElement[0]);
+        $document[0].body.appendChild(styleElement[0]);
 
         scope.$on('$destroy', function() {
           styleElement.remove();

--- a/src/components/autocomplete/demoBasicUsage/index.html
+++ b/src/components/autocomplete/demoBasicUsage/index.html
@@ -21,7 +21,7 @@
         </md-item-template>
         <md-not-found>
           No states matching "{{ctrl.searchText}}" were found.
-          <a ng-click="ctrl.newState(ctrl.searchText)">Create a new one!</a>
+          <md-button ng-click="ctrl.newState(ctrl.searchText, $event)">Create a new one!</md-button>
         </md-not-found>
       </md-autocomplete>
       <br/>

--- a/src/components/autocomplete/demoBasicUsage/script.js
+++ b/src/components/autocomplete/demoBasicUsage/script.js
@@ -4,7 +4,7 @@
       .module('autocompleteDemo', ['ngMaterial'])
       .controller('DemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($timeout, $q, $log) {
+  function DemoCtrl ($timeout, $q, $log, $mdDialog) {
     var self = this;
 
     self.simulateQuery = false;
@@ -18,8 +18,14 @@
 
     self.newState = newState;
 
-    function newState(state) {
-      alert("Sorry! You'll need to create a Constitution for " + state + " first!");
+    function newState(state, $event) {
+      $mdDialog.show(
+        $mdDialog
+          .alert()
+          .title('state creation failed.')
+          .textContent("Sorry! You'll need to create a Constitution for " + state + " first!")
+          .targetEvent($event)
+      );
     }
 
     // ******************************

--- a/src/components/autocomplete/demoInsideDialog/script.js
+++ b/src/components/autocomplete/demoInsideDialog/script.js
@@ -4,7 +4,7 @@
       .module('autocompleteDemoInsideDialog', ['ngMaterial'])
       .controller('DemoCtrl', DemoCtrl);
 
-  function DemoCtrl($mdDialog) {
+  function DemoCtrl($mdDialog, $document) {
     var self = this;
 
     self.openDialog = function($event) {
@@ -12,7 +12,7 @@
         controller: DialogCtrl,
         controllerAs: 'ctrl',
         templateUrl: 'dialog.tmpl.html',
-        parent: angular.element(document.body),
+        parent: $document.find('body'),
         targetEvent: $event,
         clickOutsideToClose:true
       });

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -8,7 +8,8 @@ var ITEM_HEIGHT   = 48,
     INPUT_PADDING = 2; // Padding provided by `md-input-container`
 
 function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming, $window,
-                             $animate, $rootElement, $attrs, $q, $log, $mdLiveAnnouncer) {
+                             $animate, $rootElement, $attrs, $q, $log, $mdLiveAnnouncer,
+                             $document) {
 
   // Internal Variables.
   var ctrl                 = this,
@@ -22,7 +23,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       fetchesInProgress    = 0,
       enableWrapScroll     = null,
       inputModelCtrl       = null,
-      debouncedOnResize    = $mdUtil.debounce(onWindowResize);
+      debouncedOnResize    = $mdUtil.debounce(onWindowResize),
+      document             = $document[0];
 
   // Public Exported Variables with handlers
   defineProperty('hidden', handleHiddenChange, true);

--- a/src/components/autocomplete/js/highlightController.js
+++ b/src/components/autocomplete/js/highlightController.js
@@ -2,10 +2,11 @@ angular
     .module('material.components.autocomplete')
     .controller('MdHighlightCtrl', MdHighlightCtrl);
 
-function MdHighlightCtrl ($scope, $element, $attrs) {
+function MdHighlightCtrl ($scope, $element, $attrs, $document) {
   this.$scope = $scope;
   this.$element = $element;
   this.$attrs = $attrs;
+  this.$document = $document;
 
   // Cache the Regex to avoid rebuilding each time.
   this.regex = null;
@@ -64,7 +65,7 @@ MdHighlightCtrl.prototype.applyRegex = function(text) {
 
       this.$element.append(tokenEl);
     } else {
-      this.$element.append(document.createTextNode(token));
+      this.$element.append(this.$document[0].createTextNode(token));
     }
 
   }.bind(this));

--- a/src/components/chips/demoContactChips/index.html
+++ b/src/components/chips/demoContactChips/index.html
@@ -1,6 +1,6 @@
 <div ng-controller="ContactChipDemoCtrl as ctrl" layout="column" ng-cloak>
 
-  <md-content class="md-padding autocomplete" layout="column">
+  <md-content class="md-padding autocomplete" layout="column" ng-if="ctrl.allContacts">
     <md-contact-chips
         ng-model="ctrl.contacts"
         ng-change="ctrl.onModelChange(ctrl.contacts)"

--- a/src/components/chips/demoContactChips/script.js
+++ b/src/components/chips/demoContactChips/script.js
@@ -2,23 +2,61 @@
   'use strict';
 
   // If we do not have CryptoJS defined; import it
-  if (typeof CryptoJS === 'undefined') {
-    var cryptoSrc = 'https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/md5.js';
-    var scriptTag = document.createElement('script');
-    scriptTag.setAttribute('src', cryptoSrc);
-    document.body.appendChild(scriptTag);
+  function cryptoJsLoader() {
+    var prom;
+    var src = '//cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.2/rollups/md5.js';
+    function loadCryptoJSInner($document, $q, $window) {
+      var document = $document[0];
+
+      function resolveCrypto() {
+        if (typeof $window.CryptoJS !== 'undefined') {
+          return $q.resolve($window.CryptoJS);
+        }
+
+        return $q.reject(new Error("Can't resolve CryptoJS"));
+      }
+
+      function loadCrypto() {
+        return $q(function (resolve, reject) {
+          var s;
+          s = document.createElement('script');
+          s.src = src;
+          s.onload = resolve;
+          s.onerror = reject;
+          document.head.appendChild(s);
+        });
+      }
+
+      return $q.resolve(undefined)
+        .then(resolveCrypto)
+        .catch(loadCrypto)
+        .then(resolveCrypto);
+    }
+
+    return function($document, $q, $window) {
+      if (prom) {
+        return prom;
+      }
+
+      prom = loadCryptoJSInner($document, $q, $window);
+    };
   }
+
+  var loader = cryptoJsLoader();
 
   angular
       .module('contactChipsDemo', ['ngMaterial'])
       .controller('ContactChipDemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($q, $timeout, $log, $mdConstant) {
+  function DemoCtrl ($q, $timeout, $log, $mdConstant, $document, $window) {
     var self = this;
     var pendingSearch, cancelSearch = angular.noop;
     var lastSearch;
 
-    self.allContacts = loadContacts();
+    loader($document, $q, $window).then(function (CryptoJS) {
+      self.allContacts = loadContacts(CryptoJS);
+    });
+ 
     self.contacts = [self.allContacts[0]];
     self.asyncContacts = [];
     self.keys = [$mdConstant.KEY_CODE.COMMA];
@@ -89,7 +127,7 @@
       $log.log('The model has changed to ' + JSON.stringify(newModel) + '.');
     }
 
-    function loadContacts() {
+    function loadContacts(CryptoJS) {
       var contacts = [
         'Marina Augustine',
         'Oddr Sarno',

--- a/src/components/chips/js/chipController.js
+++ b/src/components/chips/js/chipController.js
@@ -13,7 +13,7 @@ angular
  * @param $mdUtil
  * @constructor
  */
-function MdChipCtrl ($scope, $element, $mdConstant, $timeout, $mdUtil) {
+function MdChipCtrl ($scope, $element, $mdConstant, $timeout, $mdUtil, $document) {
   /**
    * @type {$scope}
    */
@@ -38,6 +38,11 @@ function MdChipCtrl ($scope, $element, $mdConstant, $timeout, $mdUtil) {
    * @type {$mdUtil}
    */
   this.$mdUtil = $mdUtil;
+
+  /**
+   * @type {$document}
+   */
+  this.$document = $document;
 
   /**
    * @type {boolean}
@@ -140,6 +145,8 @@ MdChipCtrl.prototype.goOutOfEditMode = function() {
  * @param {Element} node
  */
 MdChipCtrl.prototype.selectNodeContents = function(node) {
+  var document = this.$document[0];
+  var window = this.$window;
   var range, selection;
   if (document.body.createTextRange) {
     range = document.body.createTextRange();

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -103,7 +103,7 @@
    * @ngInject @constructor
    */
   function CalendarCtrl($element, $scope, $$mdDateUtil, $mdUtil,
-    $mdConstant, $mdTheming, $$rAF, $attrs, $mdDateLocale) {
+    $mdConstant, $mdTheming, $$rAF, $attrs, $mdDateLocale, $document) {
 
     $mdTheming($element);
 
@@ -127,6 +127,9 @@
 
     /** @final */
     this.$mdDateLocale = $mdDateLocale;
+
+    /** @final */
+    this.$document = $document;
 
     /** @final {Date} */
     this.today = this.dateUtil.createDateAtMidnight();
@@ -213,7 +216,7 @@
 
     var handleKeyElement;
     if ($element.parent().hasClass('md-datepicker-calendar')) {
-      handleKeyElement = angular.element(document.body);
+      handleKeyElement = angular.element($document[0].body);
     } else {
       handleKeyElement = $element;
     }
@@ -341,7 +344,7 @@
       }
 
       var cellId = this.getDateId(date, this.currentView);
-      var cell = document.getElementById(cellId);
+      var cell = this.$document[0].getElementById(cellId);
       if (cell) {
         cell.classList.add(this.FOCUSED_DATE_CLASS);
         cell.focus();

--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -375,7 +375,7 @@
 
     // Apply the select class to the new selected date if it is set.
     if (date) {
-      var dateCell = document.getElementById(this.getDateId(date, this.currentView));
+      var dateCell = this.$document[0].getElementById(this.getDateId(date, this.currentView));
       if (dateCell) {
         dateCell.classList.add(selectedDateClass);
         dateCell.setAttribute('aria-selected', 'true');

--- a/src/components/datepicker/js/calendarMonth.js
+++ b/src/components/datepicker/js/calendarMonth.js
@@ -165,6 +165,7 @@
    */
   CalendarMonthCtrl.prototype.changeSelectedDate = function(date) {
     var self = this;
+    var $document = this.$document;
     var calendarCtrl = self.calendarCtrl;
     var previousSelectedDate = calendarCtrl.selectedDate;
     calendarCtrl.selectedDate = date;
@@ -175,7 +176,7 @@
 
       // Remove the selected class from the previously selected date, if any.
       if (previousSelectedDate) {
-        var prevDateCell = this.$document[0].getElementById(calendarCtrl.getDateId(previousSelectedDate, namespace));
+        var prevDateCell = $document[0].getElementById(calendarCtrl.getDateId(previousSelectedDate, namespace));
         if (prevDateCell) {
           prevDateCell.classList.remove(selectedDateClass);
           prevDateCell.setAttribute('aria-selected', 'false');
@@ -184,7 +185,7 @@
 
       // Apply the select class to the new selected date if it is set.
       if (date) {
-        var dateCell = this.$document[0].getElementById(calendarCtrl.getDateId(date, namespace));
+        var dateCell = $document[0].getElementById(calendarCtrl.getDateId(date, namespace));
         if (dateCell) {
           dateCell.classList.add(selectedDateClass);
           dateCell.setAttribute('aria-selected', 'true');

--- a/src/components/datepicker/js/calendarMonth.js
+++ b/src/components/datepicker/js/calendarMonth.js
@@ -59,7 +59,7 @@
    * @ngInject @constructor
    */
   function CalendarMonthCtrl($element, $scope, $animate, $q,
-    $$mdDateUtil, $mdDateLocale) {
+    $$mdDateUtil, $mdDateLocale, $document) {
 
     /** @final {!angular.JQLite} */
     this.$element = $element;
@@ -78,6 +78,9 @@
 
     /** @final */
     this.dateLocale = $mdDateLocale;
+
+    /** @final */
+    this.$document = $document;
 
     /** @final {HTMLElement} */
     this.calendarScroller = $element[0].querySelector('.md-virtual-repeat-scroller');
@@ -157,6 +160,40 @@
   };
 
   /**
+   * Change the selected date in the calendar (ngModel value has already been changed).
+   * @param {Date} date
+   */
+  CalendarMonthCtrl.prototype.changeSelectedDate = function(date) {
+    var self = this;
+    var calendarCtrl = self.calendarCtrl;
+    var previousSelectedDate = calendarCtrl.selectedDate;
+    calendarCtrl.selectedDate = date;
+
+    this.changeDisplayDate(date).then(function() {
+      var selectedDateClass = calendarCtrl.SELECTED_DATE_CLASS;
+      var namespace = 'month';
+
+      // Remove the selected class from the previously selected date, if any.
+      if (previousSelectedDate) {
+        var prevDateCell = this.$document[0].getElementById(calendarCtrl.getDateId(previousSelectedDate, namespace));
+        if (prevDateCell) {
+          prevDateCell.classList.remove(selectedDateClass);
+          prevDateCell.setAttribute('aria-selected', 'false');
+        }
+      }
+
+      // Apply the select class to the new selected date if it is set.
+      if (date) {
+        var dateCell = this.$document[0].getElementById(calendarCtrl.getDateId(date, namespace));
+        if (dateCell) {
+          dateCell.classList.add(selectedDateClass);
+          dateCell.setAttribute('aria-selected', 'true');
+        }
+      }
+    });
+  };
+
+  /**
    * Change the date that is being shown in the calendar. If the given date is in a different
    * month, the displayed month will be transitioned.
    * @param {Date} date
@@ -210,6 +247,7 @@
   CalendarMonthCtrl.prototype.buildWeekHeader = function() {
     var firstDayOfWeek = this.dateLocale.firstDayOfWeek;
     var shortDays = this.dateLocale.shortDays;
+    var document = this.$document[0];
 
     var row = document.createElement('tr');
     for (var i = 0; i < 7; i++) {

--- a/src/components/datepicker/js/calendarMonthBody.js
+++ b/src/components/datepicker/js/calendarMonthBody.js
@@ -46,7 +46,7 @@
    * Controller for a single calendar month.
    * @ngInject @constructor
    */
-  function CalendarMonthBodyCtrl($element, $$mdDateUtil, $mdDateLocale) {
+  function CalendarMonthBodyCtrl($element, $$mdDateUtil, $mdDateLocale, $document) {
     /** @final {!angular.JQLite} */
     this.$element = $element;
 
@@ -55,6 +55,9 @@
 
     /** @final */
     this.dateLocale = $mdDateLocale;
+
+    /** @final */
+    this.$document = $document;
 
     /** @type {Object} Reference to the month view. */
     this.monthCtrl = null;
@@ -103,7 +106,7 @@
     var calendarCtrl = this.calendarCtrl;
 
     // TODO(jelbourn): cloneNode is likely a faster way of doing this.
-    var cell = document.createElement('td');
+    var cell = this.$document[0].createElement('td');
     cell.tabIndex = -1;
     cell.classList.add('md-calendar-date');
     cell.setAttribute('role', 'gridcell');
@@ -132,7 +135,7 @@
 
       if (this.isDateEnabled(opt_date)) {
         // Add a indicator for select, hover, and focus states.
-        var selectionIndicator = document.createElement('span');
+        var selectionIndicator = this.$document[0].createElement('span');
         selectionIndicator.classList.add('md-calendar-date-selection-indicator');
         selectionIndicator.textContent = cellText;
         cell.appendChild(selectionIndicator);
@@ -168,7 +171,7 @@
    * @returns {HTMLElement}
    */
   CalendarMonthBodyCtrl.prototype.buildDateRow = function(rowNumber) {
-    var row = document.createElement('tr');
+    var row = this.$document[0].createElement('tr');
     row.setAttribute('role', 'row');
 
     // Because of an NVDA bug (with Firefox), the row needs an aria-label in order
@@ -186,6 +189,7 @@
    */
   CalendarMonthBodyCtrl.prototype.buildCalendarForMonth = function(opt_dateInMonth) {
     var date = this.dateUtil.isValidDate(opt_dateInMonth) ? opt_dateInMonth : new Date();
+    var document = this.$document[0];
 
     var firstDayOfMonth = this.dateUtil.getFirstDateOfMonth(date);
     var firstDayOfTheWeek = this.getLocaleDay_(firstDayOfMonth);

--- a/src/components/datepicker/js/calendarYearBody.js
+++ b/src/components/datepicker/js/calendarYearBody.js
@@ -36,7 +36,7 @@
    * Controller for a single year.
    * @ngInject @constructor
    */
-  function CalendarYearBodyCtrl($element, $$mdDateUtil, $mdDateLocale) {
+  function CalendarYearBodyCtrl($element, $$mdDateUtil, $mdDateLocale, $document) {
     /** @final {!angular.JQLite} */
     this.$element = $element;
 
@@ -45,6 +45,9 @@
 
     /** @final */
     this.dateLocale = $mdDateLocale;
+
+    /** @final */
+    this.$document = $document;
 
     /** @type {Object} Reference to the calendar. */
     this.calendarCtrl = null;
@@ -88,6 +91,7 @@
    * @returns {HTMLElement}
    */
   CalendarYearBodyCtrl.prototype.buildMonthCell = function(year, month) {
+    var $document = this.$document;
     var calendarCtrl = this.calendarCtrl;
     var yearCtrl = this.yearCtrl;
     var cell = this.buildBlankCell();
@@ -114,7 +118,7 @@
 
     if (this.dateUtil.isMonthWithinRange(firstOfMonth,
         calendarCtrl.minDate, calendarCtrl.maxDate)) {
-      var selectionIndicator = document.createElement('span');
+      var selectionIndicator = $document[0].createElement('span');
       selectionIndicator.classList.add('md-calendar-date-selection-indicator');
       selectionIndicator.textContent = cellText;
       cell.appendChild(selectionIndicator);
@@ -136,7 +140,7 @@
    * @return {HTMLTableCellElement}
    */
   CalendarYearBodyCtrl.prototype.buildBlankCell = function() {
-    var cell = document.createElement('td');
+    var cell = this.$document[0].createElement('td');
     cell.tabIndex = -1;
     cell.classList.add('md-calendar-date');
     cell.setAttribute('role', 'gridcell');
@@ -151,6 +155,7 @@
    * @returns {DocumentFragment} A document fragment containing the months within the year.
    */
   CalendarYearBodyCtrl.prototype.buildCalendarForYear = function(date) {
+    var document = this.$document[0];
     // Store rows for the month in a document fragment so that we can append them all at once.
     var year = date.getFullYear();
     var yearBody = document.createDocumentFragment();

--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -253,7 +253,7 @@
    * @ngInject @constructor
    */
   function DatePickerCtrl($scope, $element, $attrs, $window, $mdConstant,
-    $mdTheming, $mdUtil, $mdDateLocale, $$mdDateUtil, $$rAF, $filter) {
+    $mdTheming, $mdUtil, $mdDateLocale, $$mdDateUtil, $$rAF, $filter, $document) {
 
     /** @final */
     this.$window = $window;
@@ -273,6 +273,9 @@
     /** @final */
     this.$mdDateLocale = $mdDateLocale;
 
+    /** @final */
+    this.$document = $document;
+
     /**
      * The root document element. This is used for attaching a top-level click handler to
      * close the calendar panel when a click outside said panel occurs. We use `documentElement`
@@ -280,7 +283,7 @@
      * to be completely off the screen and propagate events directly to the html element.
      * @type {!angular.JQLite}
      */
-    this.documentElement = angular.element(document.documentElement);
+    this.documentElement = angular.element($document[0].documentElement);
 
     /** @type {!angular.NgModelController} */
     this.ngModelCtrl = null;
@@ -353,7 +356,7 @@
      * triggers whenever the browser zooms in on a focused input.
      */
     this.windowEventName = IS_MOBILE_REGEX.test(
-      navigator.userAgent || navigator.vendor || window.opera
+      $window.navigator.userAgent || $window.navigator.vendor || $window.opera
     ) ? 'orientationchange' : 'resize';
 
     /** Pre-bound close handler so that the event listener can be removed. */
@@ -679,8 +682,9 @@
 
   /** Position and attach the floating calendar to the document. */
   DatePickerCtrl.prototype.attachCalendarPane = function() {
+    var $document = this.$document;
     var calendarPane = this.calendarPane;
-    var body = document.body;
+    var body = $document[0].body;
 
     calendarPane.style.transform = '';
     this.$element.addClass(OPEN_CLASS);
@@ -703,13 +707,13 @@
     // then it's possible that the already-scrolled body has a negative top/left. In this case,
     // we want to treat the "real" top as (0 - bodyRect.top). In a normal scrolling situation,
     // though, the top of the viewport should just be the body's scroll position.
-    var viewportTop = (bodyRect.top < 0 && document.body.scrollTop == 0) ?
+    var viewportTop = (bodyRect.top < 0 && body.scrollTop == 0) ?
         -bodyRect.top :
-        document.body.scrollTop;
+        body.scrollTop;
 
-    var viewportLeft = (bodyRect.left < 0 && document.body.scrollLeft == 0) ?
+    var viewportLeft = (bodyRect.left < 0 && body.scrollLeft == 0) ?
         -bodyRect.left :
-        document.body.scrollLeft;
+        body.scrollLeft;
 
     var viewportBottom = viewportTop + this.$window.innerHeight;
     var viewportRight = viewportLeft + this.$window.innerWidth;
@@ -751,7 +755,7 @@
 
     calendarPane.style.left = paneLeft + 'px';
     calendarPane.style.top = paneTop + 'px';
-    document.body.appendChild(calendarPane);
+    body.appendChild(calendarPane);
 
     // Add CSS class after one frame to trigger open animation.
     this.$$rAF(function() {
@@ -761,9 +765,10 @@
 
   /** Detach the floating calendar pane from the document. */
   DatePickerCtrl.prototype.detachCalendarPane = function() {
+    var $document = this.$document;
     this.$element.removeClass(OPEN_CLASS);
     this.mdInputContainer && this.mdInputContainer.element.removeClass(OPEN_CLASS);
-    angular.element(document.body).removeClass('md-datepicker-is-showing');
+    angular.element($document[0].body).removeClass('md-datepicker-is-showing');
     this.calendarPane.classList.remove('md-pane-open');
     this.calendarPane.classList.remove('md-datepicker-pos-adjusted');
 
@@ -783,6 +788,7 @@
    * @param {Event} event
    */
   DatePickerCtrl.prototype.openCalendarPane = function(event) {
+    var $window = this.$window;
     if (!this.isCalendarOpen && !this.isDisabled && !this.inputFocusedOnWindowBlur) {
       this.isCalendarOpen = this.isOpen = true;
       this.calendarPaneOpenedFrom = event.target;
@@ -808,12 +814,13 @@
         self.documentElement.on('click touchstart', self.bodyClickHandler);
       }, false);
 
-      window.addEventListener(this.windowEventName, this.windowEventHandler);
+      $window.addEventListener(this.windowEventName, this.windowEventHandler);
     }
   };
 
   /** Close the floating calendar pane. */
   DatePickerCtrl.prototype.closeCalendarPane = function() {
+    var $window = this.$window;
     if (this.isCalendarOpen) {
       var self = this;
 
@@ -822,7 +829,7 @@
       self.evalAttr('ngBlur');
 
       self.documentElement.off('click touchstart', self.bodyClickHandler);
-      window.removeEventListener(self.windowEventName, self.windowEventHandler);
+      $window.removeEventListener(self.windowEventName, self.windowEventHandler);
 
       self.calendarPaneOpenedFrom.focus();
       self.calendarPaneOpenedFrom = null;
@@ -899,7 +906,7 @@
    * from re-opening.
    */
   DatePickerCtrl.prototype.handleWindowBlur = function() {
-    this.inputFocusedOnWindowBlur = document.activeElement === this.inputElement;
+    this.inputFocusedOnWindowBlur = this.$document[0].activeElement === this.inputElement;
   };
 
   /**

--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -258,6 +258,10 @@
     /** @final */
     this.$window = $window;
 
+    // Super secret window that the tests don't muck with.
+    /** @final */
+    this.$$window = $window;
+
     /** @final */
     this.dateUtil = $$mdDateUtil;
 
@@ -788,7 +792,7 @@
    * @param {Event} event
    */
   DatePickerCtrl.prototype.openCalendarPane = function(event) {
-    var $window = this.$window;
+    var $$window = this.$$window;
     if (!this.isCalendarOpen && !this.isDisabled && !this.inputFocusedOnWindowBlur) {
       this.isCalendarOpen = this.isOpen = true;
       this.calendarPaneOpenedFrom = event.target;
@@ -814,7 +818,7 @@
         self.documentElement.on('click touchstart', self.bodyClickHandler);
       }, false);
 
-      $window.addEventListener(this.windowEventName, this.windowEventHandler);
+      $$window.addEventListener(this.windowEventName, this.windowEventHandler);
     }
   };
 

--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -1,6 +1,6 @@
 angular.module('dialogDemo1', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdDialog) {
+.controller('AppCtrl', function($scope, $mdDialog, $document) {
   $scope.status = '  ';
   $scope.customFullscreen = false;
 
@@ -10,7 +10,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
     // to prevent interaction outside of dialog
     $mdDialog.show(
       $mdDialog.alert()
-        .parent(angular.element(document.querySelector('#popupContainer')))
+        .parent(angular.element($document[0].querySelector('#popupContainer')))
         .clickOutsideToClose(true)
         .title('This is an alert title')
         .textContent('You can specify some description text in here.')
@@ -61,7 +61,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
     $mdDialog.show({
       controller: DialogController,
       templateUrl: 'dialog1.tmpl.html',
-      parent: angular.element(document.body),
+      parent: angular.element($document[0].body),
       targetEvent: ev,
       clickOutsideToClose:true,
       fullscreen: $scope.customFullscreen // Only for -xs, -sm breakpoints.
@@ -77,7 +77,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
     $mdDialog.show({
       controller: DialogController,
       templateUrl: 'tabDialog.tmpl.html',
-      parent: angular.element(document.body),
+      parent: angular.element($document[0].body),
       targetEvent: ev,
       clickOutsideToClose:true
     })
@@ -91,7 +91,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
   $scope.showPrerenderedDialog = function(ev) {
     $mdDialog.show({
       contentElement: '#myDialog',
-      parent: angular.element(document.body),
+      parent: angular.element($document[0].body),
       targetEvent: ev,
       clickOutsideToClose: true
     });

--- a/src/components/dialog/demoOpenFromCloseTo/script.js
+++ b/src/components/dialog/demoOpenFromCloseTo/script.js
@@ -1,6 +1,6 @@
 angular.module('dialogDemo2', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdDialog) {
+.controller('AppCtrl', function($scope, $mdDialog, $document) {
   $scope.openFromLeft = function() {
     $mdDialog.show(
       $mdDialog.alert()
@@ -12,7 +12,7 @@ angular.module('dialogDemo2', ['ngMaterial'])
         // You can specify either sting with query selector
         .openFrom('#left')
         // or an element
-        .closeTo(angular.element(document.querySelector('#right')))
+        .closeTo(angular.element($document[0].querySelector('#right')))
     );
   };
 

--- a/src/components/dialog/demoThemeInheritance/script.js
+++ b/src/components/dialog/demoThemeInheritance/script.js
@@ -7,7 +7,7 @@ angular.module('dialogDemo3', ['ngMaterial'])
       .primaryPalette('blue');
 
   })
-.controller('AppCtrl', function($scope, $mdDialog, $interval) {
+.controller('AppCtrl', function($scope, $mdDialog, $interval, $document) {
   $scope.theme = 'red';
 
   var isThemeRed = true;
@@ -22,7 +22,7 @@ angular.module('dialogDemo3', ['ngMaterial'])
     $mdDialog.show({
       controller: DialogController,
       templateUrl: 'dialog1.tmpl.html',
-      parent: angular.element(document.body),
+      parent: angular.element($document[0].body),
       targetEvent: ev,
       clickOutsideToClose:true
     })

--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1115,7 +1115,7 @@ function MdDialogProvider($$interimElementProvider) {
 
       // Set up elements before and after the dialog content to capture focus and
       // redirect back into the dialog.
-      topFocusTrap = document.createElement('div');
+      topFocusTrap = $document[0].createElement('div');
       topFocusTrap.classList.add('md-dialog-focus-trap');
       topFocusTrap.tabIndex = 0;
 
@@ -1159,7 +1159,7 @@ function MdDialogProvider($$interimElementProvider) {
       function getParents(element) {
         var parents = [];
         while (element.parentNode) {
-          if (element === document.body) {
+          if (element === $document[0].body) {
             return parents;
           }
           var children = element.parentNode.children;

--- a/src/components/fabSpeedDial/fabController.js
+++ b/src/components/fabSpeedDial/fabController.js
@@ -4,7 +4,7 @@
   angular.module('material.components.fabShared', ['material.core'])
     .controller('MdFabController', MdFabController);
 
-  function MdFabController($scope, $element, $animate, $mdUtil, $mdConstant, $timeout) {
+  function MdFabController($scope, $element, $animate, $mdUtil, $mdConstant, $timeout, $document) {
     var vm = this;
     var initialAnimationAttempts = 0;
 
@@ -175,7 +175,7 @@
       // On the next tick, setup a check for outside clicks; we do this on the next tick to avoid
       // clicks/touches that result in the isOpen attribute changing (e.g. a bound radio button)
       $mdUtil.nextTick(function() {
-        angular.element(document).on('click touchend', checkForOutsideClick);
+        $document.on('click touchend', checkForOutsideClick);
       });
 
       // TODO: On desktop, we should be able to reset the indexes so you cannot tab through, but
@@ -185,7 +185,7 @@
 
     function disableKeyboard() {
       $element.off('keydown', keyPressed);
-      angular.element(document).off('click touchend', checkForOutsideClick);
+      $document.off('click touchend', checkForOutsideClick);
     }
 
     function checkForOutsideClick(event) {

--- a/src/components/fabSpeedDial/fabSpeedDial.js
+++ b/src/components/fabSpeedDial/fabSpeedDial.js
@@ -117,7 +117,7 @@
     }
   }
 
-  function MdFabSpeedDialFlingAnimation($timeout) {
+  function MdFabSpeedDialFlingAnimation($timeout, $window) {
     function delayDone(done) { $timeout(done, cssAnimationDuration, false); }
 
     function runAnimation(element) {
@@ -137,7 +137,7 @@
       var variablesElement = el.querySelector('._md-css-variables');
 
       // Setup JS variables based on our CSS variables
-      var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);
+      var startZIndex = parseInt($window.getComputedStyle(variablesElement).zIndex);
 
       // Always reset the items to their natural position/state
       angular.forEach(items, function(item, index) {
@@ -208,7 +208,7 @@
     };
   }
 
-  function MdFabSpeedDialScaleAnimation($timeout) {
+  function MdFabSpeedDialScaleAnimation($timeout, $window) {
     function delayDone(done) { $timeout(done, cssAnimationDuration, false); }
 
     var delay = 65;
@@ -222,7 +222,7 @@
       var variablesElement = el.querySelector('._md-css-variables');
 
       // Setup JS variables based on our CSS variables
-      var startZIndex = parseInt(window.getComputedStyle(variablesElement).zIndex);
+      var startZIndex = parseInt($window.getComputedStyle(variablesElement).zIndex);
 
       // Always reset the items to their natural position/state
       angular.forEach(items, function(item, index) {

--- a/src/components/fabToolbar/fabToolbar.js
+++ b/src/components/fabToolbar/fabToolbar.js
@@ -101,7 +101,10 @@
     }
   }
 
-  function MdFabToolbarAnimation() {
+  /**
+   * @ngInject
+   */
+  function MdFabToolbarAnimation($window) {
 
     function runAnimation(element, className, done) {
       // If no className was specified, don't do anything
@@ -122,7 +125,7 @@
       // If we have both elements, use them to position the new background
       if (triggerElement && backgroundElement) {
         // Get our variables
-        var color = window.getComputedStyle(triggerElement).getPropertyValue('background-color');
+        var color = $window.getComputedStyle(triggerElement).getPropertyValue('background-color');
         var width = el.offsetWidth;
         var height = el.offsetHeight;
 

--- a/src/components/gridList/grid-list.js
+++ b/src/components/gridList/grid-list.js
@@ -93,7 +93,7 @@ angular.module('material.components.gridList', ['material.core'])
  * </md-grid-list>
  * </hljs>
  */
-function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
+function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia, $document) {
   return {
     restrict: 'E',
     controller: GridListController,
@@ -270,6 +270,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
 
       // The width and horizontal position of each tile is always calculated the same way, but the
       // height and vertical position depends on the rowMode.
+      var document = $document[0];
       var ltr = document.dir != 'rtl' && document.body.dir != 'rtl';
       var style = ltr ? {
           left: POSITION({ unit: hUnit, offset: position.col, gutter: gutter }),

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -400,7 +400,7 @@ function ConfigurationItem(url, viewBoxSize) {
  */
 
 /* @ngInject */
-function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
+function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce, $window) {
   var iconCache = {};
   var svgCache = {};
   var urlRegex = /[-\w@:%+.~#?&//=]{2,}\.[a-z]{2,4}\b(\/[-\w@:%+.~#?&//=]*)?/i;
@@ -534,7 +534,7 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
     function loadByDataUrl(url) {
       var results = dataUrlRegex.exec(url);
       var isBase64 = /base64/i.test(url);
-      var data = isBase64 ? window.atob(results[2]) : results[2];
+      var data = isBase64 ? $window.atob(results[2]) : results[2];
 
       return $q.when(angular.element(data)[0]);
     }

--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -489,7 +489,7 @@ function MdNavItem($mdAria, $$rAF, $mdUtil, $window) {
               mdNavItem.disabled = $mdUtil.parseAttributeBoolean(attrs[mutationList[0].attributeName], false);
             });
           };
-          var observer = new MutationObserver(mutationCallback);
+          var observer = new $window.MutationObserver(mutationCallback);
           observer.observe(targetNode, config);
           disconnect = observer.disconnect.bind(observer);
         } else {

--- a/src/components/panel/demoBasicUsage/script.js
+++ b/src/components/panel/demoBasicUsage/script.js
@@ -6,8 +6,9 @@ angular.module('panelDemo', ['ngMaterial'])
     .controller('PanelDialogCtrl', PanelDialogCtrl);
 
 
-function BasicDemoCtrl($mdPanel) {
+function BasicDemoCtrl($mdPanel, $document) {
   this._mdPanel = $mdPanel;
+  this.$document = $document;
 
   this.desserts = [
     'Apple Pie',
@@ -24,12 +25,13 @@ function BasicDemoCtrl($mdPanel) {
 
 
 BasicDemoCtrl.prototype.showDialog = function() {
+  var $document = this.$document;
   var position = this._mdPanel.newPanelPosition()
       .absolute()
       .center();
 
   var config = {
-    attachTo: angular.element(document.body),
+    attachTo: angular.element($document[0].body),
     controller: PanelDialogCtrl,
     controllerAs: 'ctrl',
     disableParentScroll: this.disableParentScroll,
@@ -49,12 +51,13 @@ BasicDemoCtrl.prototype.showDialog = function() {
 
 
 BasicDemoCtrl.prototype.showMenu = function(ev) {
+  var $document = this.$document;
   var position = this._mdPanel.newPanelPosition()
       .relativeTo('.demo-menu-open-button')
       .addPanelPosition(this._mdPanel.xPosition.ALIGN_START, this._mdPanel.yPosition.BELOW);
 
   var config = {
-    attachTo: angular.element(document.body),
+    attachTo: angular.element($document[0].body),
     controller: PanelMenuCtrl,
     controllerAs: 'ctrl',
     template:
@@ -95,10 +98,11 @@ function PanelDialogCtrl(mdPanelRef) {
 
 
 PanelDialogCtrl.prototype.closeDialog = function() {
+  var $document = this.$document;
   var panelRef = this._mdPanelRef;
 
   panelRef && panelRef.close().then(function() {
-    angular.element(document.querySelector('.demo-dialog-open-button')).focus();
+    angular.element($document[0].querySelector('.demo-dialog-open-button')).focus();
     panelRef.destroy();
   });
 };
@@ -106,41 +110,44 @@ PanelDialogCtrl.prototype.closeDialog = function() {
 
 
 function PanelMenuCtrl(mdPanelRef, $timeout) {
+  var $document = this.$document;
   this._mdPanelRef = mdPanelRef;
   this.favoriteDessert = this.selected.favoriteDessert;
   $timeout(function() {
-    var selected = document.querySelector('.demo-menu-item.selected');
+    var selected = $document[0].querySelector('.demo-menu-item.selected');
     if (selected) {
       angular.element(selected).focus();
     } else {
-      angular.element(document.querySelectorAll('.demo-menu-item')[0]).focus();
+      angular.element($document[0].querySelectorAll('.demo-menu-item')[0]).focus();
     }
   });
 }
 
 
 PanelMenuCtrl.prototype.selectDessert = function(dessert) {
+  var $document = this.$document;
   this.selected.favoriteDessert = dessert;
   this._mdPanelRef && this._mdPanelRef.close().then(function() {
-    angular.element(document.querySelector('.demo-menu-open-button')).focus();
+    angular.element($document[0].querySelector('.demo-menu-open-button')).focus();
   });
 };
 
 
 PanelMenuCtrl.prototype.onKeydown = function($event, dessert) {
+  var $document = this.$document;
   var handled, els, index, prevIndex, nextIndex;
   switch ($event.which) {
     case 38: // Up Arrow.
-      els = document.querySelectorAll('.demo-menu-item');
-      index = indexOf(els, document.activeElement);
+      els = $document[0].querySelectorAll('.demo-menu-item');
+      index = indexOf(els, $document[0].activeElement);
       prevIndex = (index + els.length - 1) % els.length;
       els[prevIndex].focus();
       handled = true;
       break;
 
     case 40: // Down Arrow.
-      els = document.querySelectorAll('.demo-menu-item');
-      index = indexOf(els, document.activeElement);
+      els = $document[0].querySelectorAll('.demo-menu-item');
+      index = indexOf(els, $document[0].activeElement);
       nextIndex = (index + 1) % els.length;
       els[nextIndex].focus();
       handled = true;

--- a/src/components/panel/demoGroups/script.js
+++ b/src/components/panel/demoGroups/script.js
@@ -6,7 +6,7 @@
     .controller('PanelGroupsCtrl', PanelGroupsCtrl)
     .controller('PanelMenuCtrl', PanelMenuCtrl);
 
-  function PanelGroupsCtrl($mdPanel) {
+  function PanelGroupsCtrl($mdPanel, $document) {
     this.settings = {
       name: 'settings',
       items: [
@@ -80,7 +80,7 @@
 
       var config = {
         id: 'toolbar_' + menu.name,
-        attachTo: angular.element(document.body),
+        attachTo: angular.element($document[0].body),
         controller: PanelMenuCtrl,
         controllerAs: 'ctrl',
         template: template,
@@ -111,7 +111,7 @@
 
       var config = {
         id: 'content_' + menu.name,
-        attachTo: angular.element(document.body),
+        attachTo: angular.element($document[0].body),
         controller: PanelMenuCtrl,
         controllerAs: 'ctrl',
         template: template,

--- a/src/components/panel/demoPanelAnimations/script.js
+++ b/src/components/panel/demoPanelAnimations/script.js
@@ -6,7 +6,7 @@ angular.module('panelAnimationsDemo', ['ngMaterial'])
     .controller('DialogCtrl', DialogCtrl);
 
 
-function AnimationCtrl($mdPanel) {
+function AnimationCtrl($mdPanel, $document) {
   this._mdPanel = $mdPanel;
   this.openFrom = 'button';
   this.closeTo = 'button';
@@ -26,6 +26,7 @@ AnimationCtrl.prototype.showDialog = function() {
       .top();
 
   var animation = this._mdPanel.newPanelAnimation();
+  var document = this.$document[0];
 
   animation.duration(this.duration || this.separateDurations);
 

--- a/src/components/panel/demoPanelProvider/script.js
+++ b/src/components/panel/demoPanelProvider/script.js
@@ -17,32 +17,34 @@
    *     API.
    */
   function PanelProviderConfig($mdPanelProvider) {
-    $mdPanelProvider.definePreset('demoPreset', {
-      attachTo: angular.element(document.body),
-      controller: PanelMenuCtrl,
-      controllerAs: 'ctrl',
-      template: '' +
-          '<div class="menu-panel" md-whiteframe="4">' +
-          '  <div class="menu-content">' +
-          '    <div class="menu-item" ng-repeat="item in ctrl.items">' +
-          '      <button class="md-button">' +
-          '        <span>{{item}}</span>' +
-          '      </button>' +
-          '    </div>' +
-          '    <md-divider></md-divider>' +
-          '    <div class="menu-item">' +
-          '      <button class="md-button" ng-click="ctrl.closeMenu()">' +
-          '        <span>Close Menu</span>' +
-          '      </button>' +
-          '    </div>' +
-          '  </div>' +
-          '</div>',
-      panelClass: 'menu-panel-container',
-      focusOnOpen: false,
-      zIndex: 100,
-      propagateContainerEvents: true,
-      groupName: 'menus'
-    });
+    $mdPanelProvider.definePreset('demoPreset', ['$document', function($document) {
+      return {
+        attachTo: angular.element($document[0].body),
+        controller: PanelMenuCtrl,
+        controllerAs: 'ctrl',
+        template: '' +
+            '<div class="menu-panel" md-whiteframe="4">' +
+            '  <div class="menu-content">' +
+            '    <div class="menu-item" ng-repeat="item in ctrl.items">' +
+            '      <button class="md-button">' +
+            '        <span>{{item}}</span>' +
+            '      </button>' +
+            '    </div>' +
+            '    <md-divider></md-divider>' +
+            '    <div class="menu-item">' +
+            '      <button class="md-button" ng-click="ctrl.closeMenu()">' +
+            '        <span>Close Menu</span>' +
+            '      </button>' +
+            '    </div>' +
+            '  </div>' +
+            '</div>',
+        panelClass: 'menu-panel-container',
+        focusOnOpen: false,
+        zIndex: 100,
+        propagateContainerEvents: true,
+        groupName: 'menus'
+     };
+    }]);
   }
 
   function PanelProviderCtrl($mdPanel) {

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -1393,8 +1393,8 @@ function MdPanelRef(config, $injector) {
   /** @private @const {!angular.$window} */
   this._$window = $injector.get('$window');
 
-  /** @private @const {!angular.$window} */
-  this._$window = $injector.get('$window');
+  /** @private @const {!angular.$document} */
+  this._$document = $injector.get('$document');
 
   /** @private @const {!Function} */
   this._$$rAF = $injector.get('$$rAF');

--- a/src/components/radioButton/demoBasicUsage/index.html
+++ b/src/components/radioButton/demoBasicUsage/index.html
@@ -1,5 +1,5 @@
 <div>
-  <form ng-submit="submit()" ng-controller="AppCtrl" ng-cloak>
+  <form ng-submit="submit($event)" ng-controller="AppCtrl" ng-cloak>
     <p>Selected Value: <span class="radioValue">{{ data.group1 }}</span> </p>
 
     <md-radio-group ng-model="data.group1">

--- a/src/components/radioButton/demoBasicUsage/script.js
+++ b/src/components/radioButton/demoBasicUsage/script.js
@@ -1,7 +1,7 @@
 
 angular
   .module('radioDemo1', ['ngMaterial'])
-  .controller('AppCtrl', function($scope) {
+  .controller('AppCtrl', function($scope, $mdDialog) {
 
     $scope.data = {
       group1 : 'Banana',
@@ -31,8 +31,14 @@ angular
     ];
 
 
-    $scope.submit = function() {
-      alert('submit');
+    $scope.submit = function($event) {
+      $mdDialog.show(
+        $mdDialog
+          .alert()
+          .title('Action')
+          .textContent('submit')
+          .event($event)
+      );
     };
 
     $scope.addItem = function() {

--- a/src/components/select/demoValidations/index.html
+++ b/src/components/select/demoValidations/index.html
@@ -33,7 +33,7 @@
 
     <div layout="row" layout-align="end" flex>
       <md-button ng-click="clearValue()" ng-disabled="!(quest || favoriteColor)">Clear</md-button>
-      <md-button ng-click="save()" class="md-primary">Save</md-button>
+      <md-button ng-click="save($event)" class="md-primary">Save</md-button>
     </div>
   </form>
 </div>

--- a/src/components/select/demoValidations/script.js
+++ b/src/components/select/demoValidations/script.js
@@ -1,16 +1,21 @@
 angular.module('selectDemoValidation', ['ngMaterial', 'ngMessages'])
-.controller('AppCtrl', function($scope) {
+.controller('AppCtrl', function($scope, $mdDialog) {
   $scope.clearValue = function() {
     $scope.quest = undefined;
     $scope.favoriteColor = undefined;
     $scope.myForm.$setPristine();
   };
-  $scope.save = function() {
-    if ($scope.myForm.$valid) {
+  $scope.save = function(event) {
+    var valid = $scope.myForm.$valid;
+    if (valid) {
       $scope.myForm.$setSubmitted();
-      alert('Form was valid.');
-    } else {
-      alert('Form was invalid!');
     }
+
+    $mdDialog.show(
+      $mdDialog
+        .alert()
+        .title('Form submit attempt.')
+        .textContent('Form was ' + valid ? 'valid' : 'invalid!')
+    );
   };
 });

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -1639,7 +1639,7 @@ function SelectProvider($$interimElementProvider) {
 
         minWidth = Math.min(targetRect.width + centeredRect.paddingLeft + centeredRect.paddingRight, maxWidth);
 
-        fontSize = window.getComputedStyle(targetNode)['font-size'];
+        fontSize = $window.getComputedStyle(targetNode)['font-size'];
       }
 
       // Keep left and top within the window

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -675,7 +675,15 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
     }
   }
 
-  function SelectMenuController($scope, $attrs, $element) {
+  function SelectMenuController($scope, $attrs, $element, $timeout) {
+    function setTimeout(fn, delay) {
+      return $timeout(fn, delay, false);
+    }
+
+    function clearTimeout(obj) {
+      $timeout.cancel(obj);
+    }
+
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);
     // selected is an object with keys matching all of the selected options' hashed values

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -30,7 +30,10 @@ angular.module('material.components.slider', [
  *  </md-slider-container>
  * </hljs>
  */
-function SliderContainerDirective() {
+/**
+ * @ngInject
+ */
+function SliderContainerDirective($window) {
   return {
     controller: function () {},
     compile: function (elem) {
@@ -82,7 +85,7 @@ function SliderContainerDirective() {
           var input = element[0].querySelector('md-input-container');
 
           if (input) {
-            var computedStyle = getComputedStyle(input);
+            var computedStyle = $window.getComputedStyle(input);
             var minWidth = parseInt(computedStyle.minWidth);
             var padding = parseInt(computedStyle.paddingLeft) + parseInt(computedStyle.paddingRight);
 
@@ -173,6 +176,10 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       '</div>',
     compile: compile
   };
+
+  function setTimeout(fn, delay) {
+    return $timeout(fn, delay, false);
+  }
 
   // **********************************************************
   // Private Methods

--- a/src/components/swipe/demoBasicUsage/index.html
+++ b/src/components/swipe/demoBasicUsage/index.html
@@ -1,23 +1,23 @@
 <div ng-controller="demoSwipeCtrl" ng-cloak layout="row">
   <div flex>
-    <div class="demo-swipe" md-swipe-left="onSwipeLeft($event, $target)">
+    <div class="demo-swipe" md-swipe-left="onSwipe('left', $event, $target)">
       <span class="no-select">Swipe me to the left</span>
       <md-icon md-font-icon="android" aria-label="android"></md-icon>
     </div>
     <md-divider></md-divider>
-    <div class="demo-swipe" md-swipe-right="onSwipeRight($event, $target)">
+    <div class="demo-swipe" md-swipe-right="onSwipe('right', $event, $target)">
       <span class="no-select">Swipe me to the right</span>
     </div>
   </div>
   <md-divider></md-divider>
   <div flex layout="row">
     <div flex layout="row" layout-align="center center"
-         class="demo-swipe" md-swipe-up="onSwipeUp($event, $target)">
+         class="demo-swipe" md-swipe-up="onSwipe('up', $event, $target)">
       <span class="no-select">Swipe me up</span>
     </div>
     <md-divider></md-divider>
     <div flex layout="row" layout-align="center center"
-         class="demo-swipe" md-swipe-down="onSwipeDown($event, $target)">
+         class="demo-swipe" md-swipe-down="onSwipe('down', $event, $target)">
       <span class="no-select">Swipe me down</span>
     </div>
   </div>

--- a/src/components/swipe/demoBasicUsage/script.js
+++ b/src/components/swipe/demoBasicUsage/script.js
@@ -1,33 +1,16 @@
 angular.module('demoSwipe', ['ngMaterial'])
-  .controller('demoSwipeCtrl', function($scope, $log) {
-    $scope.onSwipeLeft = function(ev, target) {
-      alert('You swiped left!!');
-
+  .controller('demoSwipeCtrl', function($scope, $mdDialog, $log) {
+    $scope.onSwipe = function onSwipe(direction, ev, target) {
       $log.log('Event Target: ', ev.target);
       $log.log('Event Current Target: ', ev.currentTarget);
       $log.log('Original Current Target: ', target.current);
-    };
 
-    $scope.onSwipeRight = function(ev, target) {
-      alert('You swiped right!!');
-
-      $log.log('Event Target: ', ev.target);
-      $log.log('Event Current Target: ', ev.currentTarget);
-      $log.log('Original Current Target: ', target.current);
-    };
-    $scope.onSwipeUp = function(ev, target) {
-      alert('You swiped up!!');
-
-      $log.log('Event Target: ', ev.target);
-      $log.log('Event Current Target: ', ev.currentTarget);
-      $log.log('Original Current Target: ', target.current);
-    };
-
-    $scope.onSwipeDown = function(ev, target) {
-      alert('You swiped down!!');
-
-      $log.log('Event Target: ', ev.target);
-      $log.log('Event Current Target: ', ev.currentTarget);
-      $log.log('Original Current Target: ', target.current);
+      $mdDialog.show(
+        $mdDialog
+          .alert()
+          .title('Swipe action')
+          .textContent('You swiped ' + direction + '!!')
+          .event(ev)
+      );
     };
   });

--- a/src/components/tabs/js/tabsDummyWrapperDirective.js
+++ b/src/components/tabs/js/tabsDummyWrapperDirective.js
@@ -36,7 +36,7 @@ function MdTabsDummyWrapper ($mdUtil, $window) {
           characterData: true
         };
 
-        observer = new MutationObserver(mutationCallback);
+        observer = new $window.MutationObserver(mutationCallback);
         observer.observe(element[0], config);
         disconnect = observer.disconnect.bind(observer);
       } else {

--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -1,7 +1,7 @@
 
 angular.module('toastDemo1', ['ngMaterial'])
 
-.controller('AppCtrl', function($scope, $mdToast) {
+.controller('AppCtrl', function($scope, $mdToast, $mdDialog) {
   var last = {
       bottom: false,
       top: true,
@@ -52,7 +52,12 @@ angular.module('toastDemo1', ['ngMaterial'])
 
     $mdToast.show(toast).then(function(response) {
       if ( response == 'ok' ) {
-        alert('You clicked the \'UNDO\' action.');
+        $mdDialog.show(
+          $mdDialog
+            .alert()
+            .title('Action clicked')
+            .textContent("You clicked the 'UNDO' action.")
+        );
       }
     });
   };

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -365,7 +365,7 @@ function MdToastProvider($$interimElementProvider) {
   }
 
   /* @ngInject */
-  function toastDefaultOptions($animate, $mdToast, $mdUtil, $mdMedia) {
+  function toastDefaultOptions($animate, $mdToast, $mdUtil, $mdMedia, $document) {
     var SWIPE_EVENTS = '$md.swipeleft $md.swiperight $md.swipeup $md.swipedown';
     return {
       onShow: onShow,
@@ -382,7 +382,7 @@ function MdToastProvider($$interimElementProvider) {
           // Root element of template will be <md-toast>. We need to wrap all of its content inside of
           // of <div class="md-toast-content">. All templates provided here should be static, developer-controlled
           // content (meaning we're not attempting to guard against XSS).
-          var templateRoot = document.createElement('md-template');
+          var templateRoot = $document[0].createElement('md-template');
           templateRoot.innerHTML = template;
 
           // Iterate through all root children, to detect possible md-toast directives.

--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -159,7 +159,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       // for it in the form of viable host(parent[0]).
       if (parent[0] && 'MutationObserver' in $window) {
         // Use a mutationObserver to tackle #2602.
-        var attributeObserver = new MutationObserver(function(mutations) {
+        var attributeObserver = new $window.MutationObserver(function(mutations) {
           if (isDisabledMutation(mutations)) {
             $mdUtil.nextTick(function() {
               setVisible(false);
@@ -197,7 +197,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
 
       function windowBlurEventHandler() {
-        elementFocusedOnWindowBlur = document.activeElement === parent[0];
+        elementFocusedOnWindowBlur = $document[0].activeElement === parent[0];
       }
 
       function enterEventHandler($event) {
@@ -268,7 +268,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
 
     function configureWatchers() {
       if (element[0] && 'MutationObserver' in $window) {
-        var attributeObserver = new MutationObserver(function(mutations) {
+        var attributeObserver = new $window.MutationObserver(function(mutations) {
           mutations.forEach(function(mutation) {
             if (mutation.attributeName === 'md-visible' &&
                 !scope.visibleWatcher ) {
@@ -373,7 +373,7 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
       }
 
       if (!panelRef) {
-        var attachTo = angular.element(document.body);
+        var attachTo = angular.element($document[0].body);
         var panelAnimation = $mdPanel.newPanelAnimation()
             .openFrom(parent)
             .closeTo(parent)
@@ -420,9 +420,9 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
  *
  * @ngInject
  */
-function MdTooltipRegistry() {
+function MdTooltipRegistry($window) {
   var listeners = {};
-  var ngWindow = angular.element(window);
+  var ngWindow = angular.element($window);
 
   return {
     register: register,
@@ -452,7 +452,7 @@ function MdTooltipRegistry() {
     var handlers = listeners[type] = listeners[type] || [];
 
     if (!handlers.length) {
-      useCapture ? window.addEventListener(type, globalEventHandler, true) :
+      useCapture ? $window.addEventListener(type, globalEventHandler, true) :
           ngWindow.on(type, globalEventHandler);
     }
 
@@ -475,7 +475,7 @@ function MdTooltipRegistry() {
       handlers.splice(index, 1);
 
       if (handlers.length === 0) {
-        useCapture ? window.removeEventListener(type, globalEventHandler, true) :
+        useCapture ? $window.removeEventListener(type, globalEventHandler, true) :
             ngWindow.off(type, globalEventHandler);
       }
     }

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -97,11 +97,12 @@ var NUM_EXTRA = 3;
 
 /** @ngInject */
 function VirtualRepeatContainerController($$rAF, $mdUtil, $mdConstant, $parse, $rootScope, $window,
-                                          $scope, $element, $attrs) {
+                                          $scope, $element, $attrs, $document) {
   this.$rootScope = $rootScope;
   this.$scope = $scope;
   this.$element = $element;
   this.$attrs = $attrs;
+  this.$document = $document;
 
   /** @type {number} The width or height of the container */
   this.size = 0;
@@ -258,6 +259,7 @@ VirtualRepeatContainerController.prototype.getDimensionName_ = function() {
 VirtualRepeatContainerController.prototype.sizeScroller_ = function(size) {
   var dimension =  this.getDimensionName_();
   var crossDimension = this.isHorizontal() ? 'height' : 'width';
+  var $document = this.$document;
 
   // Clear any existing dimensions.
   this.sizer.innerHTML = '';
@@ -275,7 +277,7 @@ VirtualRepeatContainerController.prototype.sizeScroller_ = function(size) {
     var numChildren = Math.floor(size / this.maxElementPixels);
 
     // Element template to clone for each max-size piece.
-    var sizerChild = document.createElement('div');
+    var sizerChild = $document[0].createElement('div');
     sizerChild.style[dimension] = this.maxElementPixels + 'px';
     sizerChild.style[crossDimension] = '1px';
 
@@ -381,6 +383,7 @@ VirtualRepeatContainerController.prototype.resetScroll = function() {
 
 
 VirtualRepeatContainerController.prototype.handleScroll_ = function() {
+  var document = this.$document[0];
   var ltr = document.dir !== 'rtl' && document.body.dir !== 'rtl';
   if(!ltr && !this.maxSize) {
     this.scroller.scrollLeft = this.scrollSize;

--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -55,7 +55,7 @@ function MdAriaProvider() {
 /*
  * @ngInject
  */
-function MdAriaService($$rAF, $log, $window, $interpolate) {
+function MdAriaService($$rAF, $log, $window, $interpolate, $document) {
 
   // Load the showWarnings option from the current context and store it inside of a scope variable,
   // because the context will be probably lost in some function calls.
@@ -130,7 +130,7 @@ function MdAriaService($$rAF, $log, $window, $interpolate) {
 
   function getText(element) {
     element = element[0] || element;
-    var walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT, null, false);
+    var walker = $document[0].createTreeWalker(element, $window.NodeFilter.SHOW_TEXT, null, false);
     var text = '';
 
     var node;

--- a/src/core/services/aria/aria.js
+++ b/src/core/services/aria/aria.js
@@ -37,8 +37,8 @@ function MdAriaProvider() {
 
   return {
     disableWarnings: disableWarnings,
-    $get: function($$rAF, $log, $window, $interpolate) {
-      return MdAriaService.apply(config, arguments);
+    $get: function($injector) {
+      return $injector.invoke(mdAriaService, undefined, config);
     }
   };
 
@@ -55,12 +55,7 @@ function MdAriaProvider() {
 /*
  * @ngInject
  */
-function MdAriaService($$rAF, $log, $window, $interpolate, $document) {
-
-  // Load the showWarnings option from the current context and store it inside of a scope variable,
-  // because the context will be probably lost in some function calls.
-  var showWarnings = this.showWarnings;
-
+function mdAriaService($$rAF, $log, $window, $interpolate, $document, showWarnings) {
   return {
     expect: expect,
     expectAsync: expectAsync,

--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -191,9 +191,9 @@ function MdCompilerProvider($compileProvider) {
     return false;
   }
 
-  this.$get = ["$q", "$templateRequest", "$injector", "$compile", "$controller",
-    function($q, $templateRequest, $injector, $compile, $controller) {
-      return new MdCompilerService($q, $templateRequest, $injector, $compile, $controller);
+  this.$get = ["$injector",
+    function($injector) {
+      return $injector.instantiate(MdCompilerService);
     }];
 
   /**
@@ -269,7 +269,10 @@ function MdCompilerProvider($compileProvider) {
    * </hljs>
    *
    */
-  function MdCompilerService($q, $templateRequest, $injector, $compile, $controller) {
+  /**
+   * @ngInject
+   */
+  function MdCompilerService($q, $templateRequest, $injector, $compile, $controller, $document) {
 
     /** @private @const {!angular.$q} */
     this.$q = $q;
@@ -285,6 +288,9 @@ function MdCompilerProvider($compileProvider) {
 
     /** @private @const {!angular.$controller} */
     this.$controller = $controller;
+
+    /** @private @const {!angular.$controller} */
+    this.$document = $document;
   }
 
   /**
@@ -506,7 +512,7 @@ function MdCompilerProvider($compileProvider) {
    * @returns {{element: !JQLite, restore: !function}}
    */
   MdCompilerService.prototype._fetchContentElement = function(options) {
-
+    var document = this.$document[0];
     var contentEl = options.contentElement;
     var restoreFn = null;
 

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -98,8 +98,8 @@ MdGestureProvider.prototype = {
    * $get is used to build an instance of $mdGesture
    * @ngInject
    */
-  $get : function($$MdGestureHandler, $$rAF, $timeout) {
-       return new MdGesture($$MdGestureHandler, $$rAF, $timeout);
+  $get : function($injector) {
+    return $injector.instantiate(MdGesture);
   }
 };
 

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -109,7 +109,9 @@ MdGestureProvider.prototype = {
  * MdGesture factory construction function
  * @ngInject
  */
-function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
+function MdGesture($$MdGestureHandler, $$rAF, $timeout, $window, $document) {
+  var window = $window;
+  var navigator = $window.navigator;
   var userAgent = navigator.userAgent || navigator.vendor || window.opera;
   var isIos = userAgent.match(/ipad|iphone|ipod/i);
   var isAndroid = userAgent.match(/android/i);
@@ -362,7 +364,7 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
     });
 
   function getTouchAction() {
-    var testEl = document.createElement('div');
+    var testEl = $document[0].createElement('div');
     var vendorPrefixes = ['', 'webkit', 'Moz', 'MS', 'ms', 'o'];
 
     for (var i = 0; i < vendorPrefixes.length; i++) {
@@ -392,8 +394,11 @@ function GestureHandler (name) {
   this.state = {};
 }
 
-function MdGestureHandler() {
-  var hasJQuery =  (typeof window.jQuery !== 'undefined') && (angular.element === window.jQuery);
+/**
+ * @ngInject
+ */
+function MdGestureHandler($window, $document) {
+  var hasJQuery =  (typeof $window.jQuery !== 'undefined') && (angular.element === $window.jQuery);
 
   GestureHandler.prototype = {
     options: {},
@@ -515,13 +520,14 @@ function MdGestureHandler() {
    * @param eventPointer the pointer object that matches this event.
    */
   function nativeDispatchEvent(srcEvent, eventType, eventPointer) {
+    var document = $document[0];
     eventPointer = eventPointer || pointer;
     var eventObj;
 
     if (eventType === 'click' || eventType === 'mouseup' || eventType === 'mousedown' ) {
       eventObj = document.createEvent('MouseEvents');
       eventObj.initMouseEvent(
-        eventType, true, true, window, srcEvent.detail,
+        eventType, true, true, $window, srcEvent.detail,
         eventPointer.x, eventPointer.y, eventPointer.x, eventPointer.y,
         srcEvent.ctrlKey, srcEvent.altKey, srcEvent.shiftKey, srcEvent.metaKey,
         srcEvent.button, srcEvent.relatedTarget || null
@@ -543,13 +549,14 @@ function MdGestureHandler() {
  * Attach Gestures: hook document and check shouldHijack clicks
  * @ngInject
  */
-function attachToDocument( $mdGesture, $$MdGestureHandler ) {
+function attachToDocument( $mdGesture, $$MdGestureHandler, $document) {
   if (disableAllGestures) {
     return;
   }
 
   // Polyfill document.contains for IE11.
-  // TODO: move to util
+  // TODO: avoid muating $document!
+  var document = $document[0];
   document.contains || (document.contains = function (node) {
     return document.body.contains(node);
   });

--- a/src/core/services/interaction/interaction.js
+++ b/src/core/services/interaction/interaction.js
@@ -33,10 +33,14 @@ angular
  * </hljs>
  *
  */
+/**
+ * @ngInject
+ */
 function MdInteractionService($timeout, $mdUtil, $document, $window) {
   this.$timeout = $timeout;
   this.$mdUtil = $mdUtil;
   this.$window = $window;
+  this.$document = $document;
 
   this.bodyElement = angular.element($document[0].body);
   this.isBuffering = false;

--- a/src/core/services/interaction/interaction.js
+++ b/src/core/services/interaction/interaction.js
@@ -33,11 +33,12 @@ angular
  * </hljs>
  *
  */
-function MdInteractionService($timeout, $mdUtil) {
+function MdInteractionService($timeout, $mdUtil, $document, $window) {
   this.$timeout = $timeout;
   this.$mdUtil = $mdUtil;
+  this.$window = $window;
 
-  this.bodyElement = angular.element(document.body);
+  this.bodyElement = angular.element($document[0].body);
   this.isBuffering = false;
   this.bufferTimeout = null;
   this.lastInteractionType = null;
@@ -72,6 +73,8 @@ function MdInteractionService($timeout, $mdUtil) {
  * body element.
  */
 MdInteractionService.prototype.initializeEvents = function() {
+  var window = this.$window;
+  var document = this.$document[0];
   // IE browsers can also trigger pointer events, which also leads to an interaction.
   var pointerEvent = 'MSPointerEvent' in window ? 'MSPointerDown' : 'PointerEvent' in window ? 'pointerdown' : null;
 

--- a/src/core/services/liveAnnouncer/live-announcer.js
+++ b/src/core/services/liveAnnouncer/live-announcer.js
@@ -30,12 +30,12 @@ angular
  * </hljs>
  *
  */
-function MdLiveAnnouncer($timeout) {
+function MdLiveAnnouncer($timeout, $document) {
   /** @private @const @type {!angular.$timeout} */
   this._$timeout = $timeout;
 
   /** @private @const @type {!HTMLElement} */
-  this._liveElement = this._createLiveElement();
+  this._liveElement = createLiveElement($document[0]);
 
   /** @private @const @type {!number} */
   this._announceTimeout = 100;
@@ -72,9 +72,8 @@ MdLiveAnnouncer.prototype.announce = function(message, politeness) {
  * Creates a live announcer element, which listens for DOM changes and announces them
  * to the screenreaders.
  * @returns {!HTMLElement}
- * @private
  */
-MdLiveAnnouncer.prototype._createLiveElement = function() {
+function createLiveElement(document) {
   var liveEl = document.createElement('div');
 
   liveEl.classList.add('md-visually-hidden');
@@ -85,4 +84,4 @@ MdLiveAnnouncer.prototype._createLiveElement = function() {
   document.body.appendChild(liveEl);
 
   return liveEl;
-};
+}

--- a/src/core/services/meta/meta.js
+++ b/src/core/services/meta/meta.js
@@ -5,16 +5,16 @@
  *
  * @description
  *
- * A provider and a service that simplifies meta tags access
+ * A service that simplifies meta tags access
  *
  * Note: This is intended only for use with dynamic meta tags such as browser color and title.
  * Tags that are only processed when the page is rendered (such as `charset`, and `http-equiv`)
  * will not work since `$$mdMeta` adds the tags after the page has already been loaded.
  *
  * ```js
- * app.config(function($$mdMetaProvider) {
- *   var removeMeta = $$mdMetaProvider.setMeta('meta-name', 'content');
- *   var metaValue  = $$mdMetaProvider.getMeta('meta-name'); // -> 'content'
+ * app.run(function($$mdMeta) {
+ *   var removeMeta = $$mdMeta.setMeta('meta-name', 'content');
+ *   var metaValue  = $$mdMeta.getMeta('meta-name'); // -> 'content'
  *
  *   removeMeta();
  * });
@@ -31,8 +31,8 @@
  *
  */
 angular.module('material.core.meta', [])
-  .provider('$$mdMeta', function () {
-    var head = angular.element(document.head);
+  .factory('$$mdMeta', ['$document', function ($document) {
+    var head = angular.element($document[0].head);
     var metaElements = {};
 
     /**
@@ -46,7 +46,7 @@ angular.module('material.core.meta', [])
         return true;
       }
 
-      var element = document.getElementsByName(name)[0];
+      var element = $document[0].getElementsByName(name)[0];
 
       if (!element) {
         return false;
@@ -107,14 +107,8 @@ angular.module('material.core.meta', [])
       return metaElements[name].attr('content');
     }
 
-    var module = {
+    return {
       setMeta: setMeta,
       getMeta: getMeta
     };
-
-    return angular.extend({}, module, {
-      $get: function () {
-        return module;
-      }
-    });
-  });
+  }]);

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -1042,6 +1042,7 @@ function generateAllThemes($injector, $mdTheming, $document) {
    * If yes, then immediately disable all theme stylesheet generation and DOM injection
    */
   var isDisabled = (
+    !$mdTheming.isDisabled ||  // tests tinker with $mdTheming
     $mdTheming.isDisabled() ||
     $document[0].querySelector('[md-themes-disabled]')
   );
@@ -1050,7 +1051,7 @@ function generateAllThemes($injector, $mdTheming, $document) {
   var themeCss = !isDisabled && $injector.has('$MD_THEME_CSS') ? $injector.get('$MD_THEME_CSS') : '';
 
   // Append our custom registered styles to the theme stylesheet.
-  themeCss += $mdTheming.registeredStyles();
+  themeCss += $mdTheming.registeredStyles ? $mdTheming.registeredStyles() : '';
 
   if ( !firstChild ) return;
   if (themeCss.length === 0) return; // no rules, so no point in running this expensive task
@@ -1098,7 +1099,7 @@ function generateAllThemes($injector, $mdTheming, $document) {
 
   angular.forEach($mdTheming.THEMES, function(theme) {
     if (!GENERATED[theme.name] && !($mdTheming.defaultTheme() !== 'default' && theme.name === 'default')) {
-      generateTheme(theme, theme.name, $mdTheming.nonce());
+      generateTheme($document[0], theme, theme.name, $mdTheming.nonce());
     }
   });
 

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -361,7 +361,7 @@ function ThemingProvider($mdColorPalette, $injector) {
     },
 
     $get: ['$injector', function($injector) {
-      return $injector.invoke(themingService, undefined, { browserColor: browserColor });
+      return $injector.invoke(ThemingService, undefined, { browserColor: browserColor });
     }],
     _LIGHT_DEFAULT_HUES: LIGHT_DEFAULT_HUES,
     _DARK_DEFAULT_HUES: DARK_DEFAULT_HUES,

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -11,20 +11,7 @@ angular.module('material.core.theming', ['material.core.theming.palette', 'mater
   .directive('mdThemable', ThemableDirective)
   .directive('mdThemesDisabled', disableThemesDirective )
   .provider('$mdTheming', ThemingProvider)
-  .config( detectDisabledThemes )
   .run(generateAllThemes);
-
-/**
- * Detect if the HTML or the BODY tags has a [md-themes-disabled] attribute
- * If yes, then immediately disable all theme stylesheet generation and DOM injection
- */
-/**
- * @ngInject
- */
-function detectDisabledThemes($mdThemingProvider, $document) {
-  var isDisabled = !!$document[0].querySelector('[md-themes-disabled]');
-  $mdThemingProvider.disableTheming(isDisabled);
-}
 
 /**
  * @ngdoc service
@@ -216,13 +203,6 @@ var VALID_HUE_VALUES = [
   '700', '800', '900', 'A100', 'A200', 'A400', 'A700'
 ];
 
-var themeConfig = {
-  disableTheming : false,   // Generate our themes at run time; also disable stylesheet DOM injection
-  generateOnDemand : false, // Whether or not themes are to be generated on-demand (vs. eagerly).
-  registeredStyles : [],    // Custom styles registered to be used in the theming of custom components.
-  nonce : null              // Nonce to be added as an attribute to the generated themes style tags.
-};
-
 /**
  * @ngInject
  */
@@ -285,6 +265,13 @@ function ThemingProvider($mdColorPalette, $injector) {
     var color = angular.isObject(palette[hue]) ? palette[hue].hex : palette[hue];
 
     return setBrowserColor($$mdMeta, color);
+  };
+
+  var themeConfig = {
+    disableTheming : false,   // Generate our themes at run time; also disable stylesheet DOM injection
+    generateOnDemand : false, // Whether or not themes are to be generated on-demand (vs. eagerly).
+    registeredStyles : [],    // Custom styles registered to be used in the theming of custom components.
+    nonce : null              // Nonce to be added as an attribute to the generated themes style tags.
   };
 
   return themingProvider = {
@@ -749,6 +736,22 @@ function ThemingProvider($mdColorPalette, $injector) {
       applyTheme.setBrowserColor(browserColor);
     }
 
+    applyTheme.isDisabled = function() {
+      return themeConfig.disableTheming;
+    };
+
+    applyTheme.registeredStyles = function() {
+      return themeConfig.registeredStyles.join('');
+    };
+
+    applyTheme.generateOnDemand = function() {
+      return themeConfig.generateOnDemand;
+    };
+
+    applyTheme.nonce = function() {
+      return themeConfig.nonce;
+    };
+
     return applyTheme;
 
     /**
@@ -943,8 +946,6 @@ function ThemingDirective($mdTheming, $interpolate, $parse, $mdUtil, $q, $log) {
  *
  */
 function disableThemesDirective() {
-  themeConfig.disableTheming = true;
-
   // Return a 1x-only, first-match attribute directive
   return {
     restrict : 'A',
@@ -1023,12 +1024,20 @@ var rulesByType = {};
  * @ngInject
  */
 function generateAllThemes($injector, $mdTheming, $document) {
+  /**
+   * Detect if the HTML or the BODY tags has a [md-themes-disabled] attribute
+   * If yes, then immediately disable all theme stylesheet generation and DOM injection
+   */
+  var isDisabled = (
+    $mdTheming.isDisabled() ||
+    $document[0].querySelector('[md-themes-disabled]')
+  );
   var head = $document[0].head;
   var firstChild = head ? head.firstElementChild : null;
-  var themeCss = !themeConfig.disableTheming && $injector.has('$MD_THEME_CSS') ? $injector.get('$MD_THEME_CSS') : '';
+  var themeCss = !isDisabled && $injector.has('$MD_THEME_CSS') ? $injector.get('$MD_THEME_CSS') : '';
 
   // Append our custom registered styles to the theme stylesheet.
-  themeCss += themeConfig.registeredStyles.join('');
+  themeCss += $mdTheming.registeredStyles();
 
   if ( !firstChild ) return;
   if (themeCss.length === 0) return; // no rules, so no point in running this expensive task
@@ -1072,11 +1081,11 @@ function generateAllThemes($injector, $mdTheming, $document) {
 
   // If themes are being generated on-demand, quit here. The user will later manually
   // call generateTheme to do this on a theme-by-theme basis.
-  if (themeConfig.generateOnDemand) return;
+  if ($mdTheming.generateOnDemand()) return;
 
   angular.forEach($mdTheming.THEMES, function(theme) {
     if (!GENERATED[theme.name] && !($mdTheming.defaultTheme() !== 'default' && theme.name === 'default')) {
-      generateTheme(theme, theme.name, themeConfig.nonce);
+      generateTheme(theme, theme.name, $mdTheming.nonce());
     }
   });
 

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -203,6 +203,16 @@ var VALID_HUE_VALUES = [
   '700', '800', '900', 'A100', 'A200', 'A400', 'A700'
 ];
 
+function browserColorSetter() {
+  var browserColor = {};
+  return {
+    setBrowserColor: function setBrowserColor(color) {
+      browserColor.color = color;
+    },
+    browserColor: browserColor,
+  }
+}
+
 /**
  * @ngInject
  */
@@ -211,11 +221,12 @@ function ThemingProvider($mdColorPalette, $injector) {
   var THEMES = { };
 
   var themingProvider;
-  var browserColor;
-  var doEnableBrowserColor;
 
   var alwaysWatchTheme = false;
   var defaultTheme = 'default';
+  var bcs = browserColorSetter();
+  var doBrowserColor = bcs.setBrowserColor;
+  var browserColor = bcs.browserColor;
 
   // Load JS Defined Palettes
   angular.extend(PALETTES, $mdColorPalette);
@@ -227,7 +238,7 @@ function ThemingProvider($mdColorPalette, $injector) {
    * @param {string} color Hex value of the wanted browser color
    * @returns {function} Remove function of the meta tags
    */
-  var setBrowserColor = function (color, $$mdMeta) {
+  var setBrowserColor = function ($$mdMeta, color) {
     // Chrome, Firefox OS and Opera
     var removeChrome = $$mdMeta.setMeta('theme-color', color);
     // Windows Phone
@@ -346,15 +357,12 @@ function ThemingProvider($mdColorPalette, $injector) {
     },
 
     enableBrowserColor: function(color) {
-      if ($injector.has('$mdTheming')) {
-        $injector.get('$mdTheming').setBrowserColor(color);
-      } else {
-        doEnableBrowserColor = true;
-        browserColor = color;
-      }
+      doBrowserColor(color);
     },
 
-    $get: ThemingService,
+    $get: ['$injector', function($injector) {
+      return $injector.invoke(themingService, undefined, { browserColor: browserColor });
+    }],
     _LIGHT_DEFAULT_HUES: LIGHT_DEFAULT_HUES,
     _DARK_DEFAULT_HUES: DARK_DEFAULT_HUES,
     _PALETTES: PALETTES,
@@ -674,7 +682,7 @@ function ThemingProvider($mdColorPalette, $injector) {
    */
 
   /* @ngInject */
-  function ThemingService($rootScope, $mdUtil, $q, $log, $document, $$mdMeta) {
+  function ThemingService($rootScope, $mdUtil, $q, $log, $document, $$mdMeta, browserColor) {
     // Allow us to be invoked via a linking function signature.
     var applyTheme = function (scope, el) {
       if (el === undefined) { el = scope; scope = undefined; }
@@ -731,9 +739,14 @@ function ThemingProvider($mdColorPalette, $injector) {
       return enableBrowserColor($$mdMeta, color);
     };
 
-    if (doEnableBrowserColor) {
+    doBrowserColor = function (color) {
       $log.warn("$mdThemingProvider.enableBrowserColor() is deprecated, use $mdTheming.setBrowserColor(); in run.");
-      applyTheme.setBrowserColor(browserColor);
+      applyTheme.setBrowserColor(color);
+    };
+
+    if ('color' in browserColor) {
+      doBrowserColor(browserColor.color);
+      delete browserColor.color;
     }
 
     applyTheme.isDisabled = function() {

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -5,6 +5,7 @@ describe('$mdThemingProvider', function() {
   var testTheme;
   var testPalette;
   var startAngular = inject;
+  var postRun;
 
   beforeEach(function() {
 
@@ -20,7 +21,21 @@ describe('$mdThemingProvider', function() {
   });
 
   function setup() {
-    module('material.core', function($mdThemingProvider) {
+    var testM = 'material.theming.test';
+    var coreM = 'material.core';
+    var didRun;
+    // eslint-disable-next-line no-undef
+    postRun = new Promise(function (resolve) {
+      didRun = resolve;
+    });
+
+    angular
+      .module(testM, [coreM])
+      .run(function ($mdTheming) {
+        didRun();
+      });
+
+    module(coreM, testM, function($mdThemingProvider) {
       themingProvider = $mdThemingProvider;
 
       testPalette = themingProvider._PALETTES.testPalette = themingProvider._PALETTES.otherTestPalette = {
@@ -369,8 +384,10 @@ describe('$mdThemingProvider', function() {
 
       themingProvider.enableBrowserColor();
 
-      expect(document.getElementsByName(name).length).toBe(1);
-      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      return postRun.then(function() {
+        expect(document.getElementsByName(name).length).toBe(1);
+        expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      });
     });
 
     it('should use default primary color with hue `200`', function () {
@@ -384,8 +401,10 @@ describe('$mdThemingProvider', function() {
 
       themingProvider.enableBrowserColor({ hue: hue });
 
-      expect(document.getElementsByName(name).length).toBe(1);
-      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      return postRun.then(function() {
+        expect(document.getElementsByName(name).length).toBe(1);
+        expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      });
     });
 
     it('should use red palette', function () {
@@ -397,8 +416,10 @@ describe('$mdThemingProvider', function() {
 
       themingProvider.enableBrowserColor({ palette: 'red' });
 
-      expect(document.getElementsByName(name).length).toBe(1);
-      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      return postRun.then(function() {
+        expect(document.getElementsByName(name).length).toBe(1);
+        expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      });
     });
 
     it('should use test theme', function () {
@@ -410,10 +431,12 @@ describe('$mdThemingProvider', function() {
 
       themingProvider.enableBrowserColor({ theme: 'test' });
 
-      expect(document.getElementsByName(name).length).toBe(1);
-      expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      return postRun.then(function() {
+        expect(document.getElementsByName(name).length).toBe(1);
+        expect(angular.element(document.getElementsByName(name)[0]).attr('content')).toBe(content);
+      });
     });
-  })
+  });
 
   describe('configuration', function () {
     beforeEach(function () {

--- a/src/core/util/animation/animate.js
+++ b/src/core/util/animation/animate.js
@@ -1,20 +1,23 @@
 // Polyfill angular < 1.4 (provide $animateCss)
 angular
   .module('material.core')
-  .factory('$$mdAnimate', function($q, $timeout, $mdConstant, $animateCss){
+  .factory('$$mdAnimate', function($injector){
 
      // Since $$mdAnimate is injected into $mdUtil... use a wrapper function
      // to subsequently inject $mdUtil as an argument to the AnimateDomUtils
 
      return function($mdUtil) {
-       return AnimateDomUtils( $mdUtil, $q, $timeout, $mdConstant, $animateCss);
+       return $injector.invoke(animateDomUtils, undefined, { $mdUtil: $mdUtil });
      };
    });
 
 /**
  * Factory function that requires special injections
  */
-function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss, $window) {
+/**
+ * @ngInject
+ */
+function animateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss, $window) {
   var self;
   return self = {
     /**

--- a/src/core/util/animation/animate.js
+++ b/src/core/util/animation/animate.js
@@ -14,7 +14,7 @@ angular
 /**
  * Factory function that requires special injections
  */
-function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
+function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss, $window) {
   var self;
   return self = {
     /**
@@ -92,7 +92,7 @@ function AnimateDomUtils($mdUtil, $q, $timeout, $mdConstant, $animateCss) {
          * @returns {boolean} True if there is no transition/duration; false otherwise.
          */
         function noTransitionFound(styles) {
-          styles = styles || window.getComputedStyle(element[0]);
+          styles = styles || $window.getComputedStyle(element[0]);
 
           return styles.transitionDuration == '0s' || (!styles.transition && !styles.transitionProperty);
         }

--- a/src/core/util/animation/animateCss.js
+++ b/src/core/util/animation/animateCss.js
@@ -6,14 +6,6 @@ if (angular.version.minor >= 4) {
 
   var forEach = angular.forEach;
 
-  var WEBKIT = angular.isDefined(document.documentElement.style.WebkitAppearance);
-  var TRANSITION_PROP = WEBKIT ? 'WebkitTransition' : 'transition';
-  var ANIMATION_PROP = WEBKIT ? 'WebkitAnimation' : 'animation';
-  var PREFIX = WEBKIT ? '-webkit-' : '';
-
-  var TRANSITION_EVENTS = (WEBKIT ? 'webkitTransitionEnd ' : '') + 'transitionend';
-  var ANIMATION_EVENTS = (WEBKIT ? 'webkitAnimationEnd ' : '') + 'animationend';
-
   var $$ForceReflowFactory = ['$document', function($document) {
     return function() {
       return $document[0].body.clientWidth + 1;
@@ -155,8 +147,16 @@ if (angular.version.minor >= 4) {
     .factory('$$forceReflow', $$ForceReflowFactory)
     .factory('$$AnimateRunner', $$AnimateRunnerFactory)
     .factory('$$rAFMutex', $$rAFMutexFactory)
-    .factory('$animateCss', ['$window', '$$rAF', '$$AnimateRunner', '$$forceReflow', '$$jqLite', '$timeout', '$animate',
-                     function($window,   $$rAF,   $$AnimateRunner,   $$forceReflow,   $$jqLite,   $timeout, $animate) {
+    .factory('$animateCss', ['$window', '$$rAF', '$$AnimateRunner', '$$forceReflow', '$$jqLite', '$timeout', '$animate', '$document',
+                     function($window,   $$rAF,   $$AnimateRunner,   $$forceReflow,   $$jqLite,   $timeout, $animate, $document) {
+
+      var WEBKIT = angular.isDefined($document[0].documentElement.style.WebkitAppearance);
+      var TRANSITION_PROP = WEBKIT ? 'WebkitTransition' : 'transition';
+      var ANIMATION_PROP = WEBKIT ? 'WebkitAnimation' : 'animation';
+      var PREFIX = WEBKIT ? '-webkit-' : '';
+
+      var TRANSITION_EVENTS = (WEBKIT ? 'webkitTransitionEnd ' : '') + 'transitionend';
+      var ANIMATION_EVENTS = (WEBKIT ? 'webkitAnimationEnd ' : '') + 'animationend';
 
       function init(element, options) {
 

--- a/src/core/util/constant.js
+++ b/src/core/util/constant.js
@@ -5,9 +5,9 @@ angular.module('material.core')
  * Factory function that creates the grab-bag $mdConstant service.
  * @ngInject
  */
-function MdConstantFactory() {
+function MdConstantFactory($document) {
 
-  var prefixTestEl = document.createElement('div');
+  var prefixTestEl = $document[0].createElement('div');
   var vendorPrefix = getVendorPrefix(prefixTestEl);
   var isWebkit = /webkit/i.test(vendorPrefix);
   var SPECIAL_CHARS_REGEXP = /([:\-_]+(.))/g;

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -59,8 +59,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
   var $mdUtil = {
     dom: {},
-    now: window.performance && window.performance.now ?
-      angular.bind(window.performance, window.performance.now) : Date.now || function() {
+    now: $window.performance && $window.performance.now ?
+      angular.bind($window.performance, $window.performance.now) : Date.now || function() {
       return new Date().getTime();
     },
 
@@ -121,7 +121,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
     clientRect: function(element, offsetParent, isOffsetRect) {
       var node = getNode(element);
-      offsetParent = getNode(offsetParent || node.offsetParent || document.body);
+      offsetParent = getNode(offsetParent || node.offsetParent || $document[0].body);
       var nodeRect = node.getBoundingClientRect();
 
       // The user can ask for an offsetRect: a rect relative to the offsetParent,
@@ -157,7 +157,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * @returns {number}
      */
     getViewportTop: function() {
-      return window.scrollY || window.pageYOffset || 0;
+      return $window.scrollY || $window.pageYOffset || 0;
     },
 
     /**
@@ -348,7 +348,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     forceFocus: function(element) {
       var node = element[0] || element;
 
-      document.addEventListener('click', function focusOnClick(ev) {
+      $document[0].addEventListener('click', function focusOnClick(ev) {
         if (ev.target === node && ev.$focus) {
           node.focus();
           ev.stopImmediatePropagation();
@@ -357,8 +357,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
         }
       }, true);
 
-      var newEvent = document.createEvent('MouseEvents');
-      newEvent.initMouseEvent('click', false, true, window, {}, 0, 0, 0, 0,
+      var newEvent = $document[0].createEvent('MouseEvents');
+      newEvent.initMouseEvent('click', false, true, $window, {}, 0, 0, 0, 0,
         false, false, false, false, 0, null);
       newEvent.$material = true;
       newEvent.$focus = true;
@@ -570,7 +570,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * Build polyfill for the Node.contains feature (if needed)
      */
     elementContains: function(node, child) {
-      var hasContains = (window.Node && window.Node.prototype && Node.prototype.contains);
+      var hasContains = ($window.Node && $window.Node.prototype && $window.Node.prototype.contains);
       var findFn = hasContains ? angular.bind(node, node.contains) : angular.bind(node, function(arg) {
         // compares the positions of two nodes and returns a bitmask
         return (node === child) || !!(this.compareDocumentPosition(arg) & 16);
@@ -738,7 +738,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     getNearestContentElement: function (element) {
       var current = element.parent()[0];
       // Look for the nearest parent md-content, stopping at the rootElement.
-      while (current && current !== $rootElement[0] && current !== document.body && current.nodeName.toUpperCase() !== 'MD-CONTENT') {
+      while (current && current !== $rootElement[0] && current !== $document[0].body && current.nodeName.toUpperCase() !== 'MD-CONTENT') {
         current = current.parentNode;
       }
       return current;


### PR DESCRIPTION
use injectable $window and $document instead.

* This removes the private provider $$mdMetaProvider because it used to access `document` before it was available. Meta headers can only be changed via the $$mdMeta service.
* This updates and deprecates $mdThemingProvider.enableBrowserColor() to queue up color changes and dispatch them in the actual service when $$mdMeta is available.
* This adds support for defining panel presets with an injectable function for the case where you want to
define a preset that sets `attachTo: angular.element($document[0].body)` inside a config function.
* This replaces all alert() calls with `$mdDialog.show($mdDialog.alert()...);` calls

This depends on eslint to find the misuse of global variables: https://github.com/angular/material/pull/10824

What are $window and $document?
============================
According to the AngularJS documentation: https://docs.angularjs.org/api/ng/service/$window
> A reference to the browser's window object. While window is globally available in JavaScript, it causes testability problems, because it is a global variable. In **AngularJS we always refer to it through the $window service**, so it may be overridden, removed or mocked for testing.

$document is similar

Why is this needed?
================

* Before $window, window and document, $document were being used **interchangeably**, this PR ensures **consistency**.
* using an injectable $window and $document allows ...
  * ... multiple angular apps to co-exist without destructively altering each other.
  * ... users of angular-material to patch out those values in tests.
  * ... angular-material to work in non-browser environments without those globals: extensions, webworkers and node.
  *  ... material-tools to work without virtual_context https://github.com/angular/material-tools/issues/31