### PR TITLE
fix(list): don't strip download attribute from list items

### DIFF
--- a/src/components/list/list.js
+++ b/src/components/list/list.js
@@ -406,7 +406,7 @@ function mdListItemDirective($mdAria, $mdConstant, $mdUtil, $timeout) {
       function copyAttributes(source, destination, extraAttrs) {
         var copiedAttrs = $mdUtil.prefixer([
           'ng-if', 'ng-click', 'ng-dblclick', 'aria-label', 'ng-disabled', 'ui-sref',
-          'href', 'ng-href', 'rel', 'target', 'ng-attr-ui-sref', 'ui-sref-opts'
+          'href', 'ng-href', 'rel', 'target', 'ng-attr-ui-sref', 'ui-sref-opts', 'download'
         ]);
 
         if (extraAttrs) {


### PR DESCRIPTION
Clickable list items containing the `ng-href` attribute currently can't be downloaded on click.