### PR TITLE
fix(autocomplete): infinite $digest loop

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -19,6 +19,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       noBlur               = false,
       selectedItemWatchers = [],
       hasFocus             = false,
+      hasUpdated           = false,
       fetchesInProgress    = 0,
       enableWrapScroll     = null,
       inputModelCtrl       = null,
@@ -520,6 +521,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
    */
   function focus($event) {
     hasFocus = true;
+    if(!hasUpdated) {
+        return;
+    } else {
+        hasUpdated = false;
+    }
 
     if (isSearchable() && isMinLengthMet()) {
       handleQuery();
@@ -587,6 +593,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         break;
       default:
     }
+    hasUpdated = true;
   }
 
   //-- getters


### PR DESCRIPTION
I have the same issue with ticket #8563.
```
Error: $rootScope:infdig Infinite $digest Loop for angular 1.6.6 and angular material 1.1.4+
```
It turns out the keydown event fires multiple times. Adding a variable to stop the loop if searchText is not updated.