### PR TITLE
Make ES6 classes work as dialog controllers

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -379,7 +379,7 @@ function MdCompilerProvider($compileProvider) {
     var ctrl = invokeCtrl();
 
     if (!getPreAssignBindingsEnabled() && options.bindToController) {
-      angular.extend(invokeCtrl.instance, locals);
+      angular.extend(ctrl, locals);
     }
 
     // Call the $onInit hook if it's present on the controller.


### PR DESCRIPTION
If the controller is a function, `invokeCtrl.instance === ctrl`

If the controller is an ES6 Class, `invokeCtrl.instance` is some other object separate from `ctrl`.

Either way, `ctrl` is the correct reference in all cases for post-binding locals.  `invokeCtrl.instance` is the correct reference for pre-binding locals (which only works for function controllers anyways).