### PR TITLE
feat(navBar): add disabled attribute

### DIFF
--- a/src/components/navBar/demoBasicUsage/index.html
+++ b/src/components/navBar/demoBasicUsage/index.html
@@ -7,11 +7,14 @@
       <md-nav-item md-nav-click="goto('page1')" name="page1">
         Page One
       </md-nav-item>
-      <md-nav-item md-nav-click="goto('page2')" name="page2">
+      <md-nav-item md-nav-click="goto('page2')" name="page2" ng-disabled="secondTabDisabled">
         Page Two
       </md-nav-item>
       <md-nav-item md-nav-click="goto('page3')" name="page3">
         Page Three
+      </md-nav-item>
+      <md-nav-item md-nav-click="goto('page4')" name="page4" disabled>
+        Page Four
       </md-nav-item>
       <!-- these require actual routing with ui-router or ng-route, so they
       won't work in the demo
@@ -28,6 +31,10 @@
     </div>
 
     <md-checkbox ng-model="disableInkBar">Disable Ink Bar</md-checkbox>
+
+    <md-checkbox ng-model="secondTabDisabled" aria-label="Disable Second Tab" style="margin: 5px;">
+      Disable Second Tab
+    </md-checkbox>
 
   </md-content>
 </div>

--- a/src/components/navBar/navBar.scss
+++ b/src/components/navBar/navBar.scss
@@ -38,6 +38,7 @@ $md-nav-bar-height: 48px;
   &:hover {
     background-color: inherit;
   }
+
 }
 
 md-nav-ink-bar {

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -176,6 +176,40 @@ describe('mdNavBar', function() {
               .toBe('{"reload":true,"notify":true}');
         });
 
+      it('should set the disabled attribute', function () {
+          create('<md-nav-bar>' +
+              '  <md-nav-item md-nav-href="#1" name="tab1">' +
+              '    tab1' +
+              '  </md-nav-item>' +
+              '  <md-nav-item md-nav-href="#2" name="tab2" disabled>' +
+              '    tab2' +
+              '  </md-nav-item>' +
+              '</md-nav-bar>');
+          $timeout(function(){
+            var tabCtrl = getTabCtrl('tab2');
+            expect(tabCtrl.disabled).toBe(true);
+          });
+      });
+
+      it('should observe the disabled attribute', function () {
+          $scope.tabDisabled = false;
+          create('<md-nav-bar>' +
+              '  <md-nav-item md-nav-href="#1" name="tab1">' +
+              '    tab1' +
+              '  </md-nav-item>' +
+              '  <md-nav-item md-nav-href="#2" name="tab2" ng-disabled="tabDisabled">' +
+              '    tab2' +
+              '  </md-nav-item>' +
+              '</md-nav-bar>');
+          $timeout(function(){
+            var tabCtrl = getTabCtrl('tab2');
+            expect(tabCtrl.disabled).toBe(false);
+            $scope.tabDisabled = true;
+            $scope.$apply();
+            expect(tabCtrl.disabled).toBe(true);
+          });
+      });
+
     it('does not update tabs if tab controller is undefined', function() {
       $scope.selectedTabRoute = 'tab1';
 


### PR DESCRIPTION
Resubmitting @maxjoehnk PR #10202 
* Originally developed by: @maxjoehnk - made a small change, not using $mdUtils which was used by @maxjoehnk in his version. I'm just resubmitting
* Add disabled attribute to navitem
* Update demo to showcase ng-disabled and disabled usage
* Add tests

My Additions: 
* disabled style (reduced opacity and not-allowed cursor) 

fixes #9667