### PR TITLE
fix(util): nodes.item is not a function

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -146,7 +146,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
       var results = [];
       for (var i = 0; i < nodes.length; ++i) {
-        results.push(nodes.item(i));
+        results.push(nodes[i]);
       }
       return results;
     },


### PR DESCRIPTION
Fixed an error where Firefox 57.0.1 threw this error: `Error: nodes.item is not a function`

![image](https://user-images.githubusercontent.com/7137075/34048103-b6cdfa62-e1b2-11e7-9d6c-8067fcafa742.png)
