### PR TITLE
fix(gridList): demo example responsiveness broken on Safari

### DIFF
--- a/src/components/gridList/demoBasicUsage/styles.css
+++ b/src/components/gridList/demoBasicUsage/styles.css
@@ -5,9 +5,3 @@ md-grid-list { margin: 8px; }
 .blue { background: #84ffff; }
 .purple { background: #b388ff; }
 .red { background: #ff8a80; }
-
-
-
-md-grid-tile {
-  transition: all 400ms ease-out 50ms;
-}

--- a/src/components/gridList/demoDynamicTiles/style.scss
+++ b/src/components/gridList/demoDynamicTiles/style.scss
@@ -50,11 +50,6 @@ md-grid-list {
   background: #ff80ab; }
 
 
-md-grid-tile {
-  transition: all 300ms ease-out 50ms;
-}
-
-
 md-grid-tile md-icon {
   padding-bottom: 32px;
 }


### PR DESCRIPTION
Tested Safari Version: 11.0.2
Machine: Macbook Pro

Left: Safari, grid not responsive to browser resizing
Right: Chrome, behave as expected
<img width="1122" alt="screen shot 2017-12-22 at 3 51 07 pm" src="https://user-images.githubusercontent.com/221029/34289966-f92968ce-e72f-11e7-93a8-12924a9058c6.png">
