### PR TITLE
fix($mdGesture):reAdd isAndroid & isIos to $get

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -87,6 +87,8 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
   var self = {
     handler: addHandler,
     register: register,
+    isAndroid: isAndroid,
+    isIos: isIos,
     // On mobile w/out jQuery, we normally intercept clicks. Should we skip that?
     isHijackingClicks: (isIos || isAndroid) && !hasJQuery && !forceSkipClickHijack
   };


### PR DESCRIPTION
This was removed as part of this commit : https://github.com/angular/material/pull/9803
I think it was observed that isAndroid and isIos is not used anywhere else in material, so it was removed.
But the normal usages of $mdGesture would be broken after this commit , I mean a developer can't simply inject `$mdGesture` and use it as :
```javascript
if($mdGesture.isAndroid):{
  this.suggestDownloadOurAndroidApp()
}
```

in our use case, after updating from material 1.1.1 to 1.1.5, a part of our app broke.