### PR TITLE
docs(getting-started): fix anchor in installing AngularJS Material link

### DIFF
--- a/docs/app/partials/getting-started.tmpl.html
+++ b/docs/app/partials/getting-started.tmpl.html
@@ -111,7 +111,7 @@
     <p>
       You can install the AngularJS Material library (and its dependent libraries) in your local
       project using either
-      <a href="https://github.com/angular/bower-material/#installing-angular-material"
+      <a href="https://github.com/angular/bower-material/#installing-angularjs-material"
          target="_blank">NPM, JSPM, or Bower</a>.
     </p>
 


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The anchor in the link doesn't work as it was renamed from angular to angularjs.

Issue Number: 
N/A

## What is the new behavior?
The link goes to bower-material and then scrolls down to the section of the readme for installing AngularJS Material.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
N/A