### PR TITLE
fix(mdChips): change input width to fill empty space

### DIFF
--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -54,7 +54,9 @@ $contact-chip-name-width: rem(12) !default;
 .md-chips {
   @include pie-clearfix();
 
-  display: block;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
   font-family: $font-family;
   font-size: $chip-font-size;
   @include rtl(padding, $chip-wrap-padding, rtl-value($chip-wrap-padding));
@@ -148,6 +150,7 @@ $contact-chip-name-width: rem(12) !default;
         height: $chip-height;
         line-height: $chip-height;
         padding: 0;
+        width: 100%;
         &:focus {
           outline: none;
         }


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Clicking on the far right of the chips component (a part of it that doesn't have the chip-input-container directly under your click) does not transfer focus to the input (which is confusing, as the actual width of the input is not readily obvious). Placeholders are cropped off at the edge of the input. See the "Custom Inputs" section at https://material.angularjs.org/latest/demo/chips. The placeholder shows "Enter a numb".

Issue Number: #10344


## What is the new behavior?
This change sets the input's width to fill all available space, allowing for focus when clicking on the edge, as well as allowing for longer placeholders. Clicking on the far right of the chips component (a part of it that doesn't have the chip-input-container directly under your click) transfers focus to the input.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This issue was introduced in v1.1.2, most likely after implementing accessibility support. The same method for setting the input's width is being used in angular/material2.