### PR TITLE
fix(tooltip): changing direction causes invalid position

### DIFF
--- a/src/components/tooltip/tooltip.js
+++ b/src/components/tooltip/tooltip.js
@@ -387,11 +387,14 @@ function MdTooltipDirective($timeout, $window, $$rAF, $document, $interpolate,
           attachTo: attachTo,
           contentElement: element,
           propagateContainerEvents: true,
-          panelClass: 'md-tooltip ' + origin,
+          panelClass: 'md-tooltip',
           animation: panelAnimation,
           position: panelPosition,
           zIndex: scope.mdZIndex,
-          focusOnOpen: false
+          focusOnOpen: false,
+          onDomAdded: function() {
+            panelRef.panelEl.addClass(origin);
+          }
         };
 
         panelRef = $mdPanel.create(panelConfig);


### PR DESCRIPTION
Providing the initial origin through the `panelClass` of the panel is not the right approach. `mdPanel` remembers the original panel configuration and the provided `panelClass` and will restore it when the element is reused. This results in the new origin and the default (bottom) origin style to be placed on the element at the same time.

Fixes #10405

## PR Checklist
Please check that your PR fulfills the following requirements:

- [X] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When the direction of a tooltip is changed, the resulting position will not be correctly applied, resulting in off-center placement of tooltips.

Issue Number: #10405

## What is the new behavior?
The tooltip is correctly positioned after the direction was adjusted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
