### PR TITLE
docs(codepen): add missing space in module declaration

### DIFF
--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -206,7 +206,7 @@
 
       // See scripts.js for list of external AngularJS libraries used for the demos
 
-      return file.replace(matchAngularModule, ".module('MyApp',"+ modules + ")");
+      return file.replace(matchAngularModule, ".module('MyApp', "+ modules + ")");
     }
   }
 })();


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
CodePens are generated with `module('MyApp',['ngMaterial',`. It's a minor issue but it always annoys me.

Issue Number: 
N/A

## What is the new behavior?
CodePens are generated with `module('MyApp', ['ngMaterial',`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
was `module('MyApp',['ngMaterial',`
now `module('MyApp', ['ngMaterial',`