### PR TITLE
docs(contributing): fix Markdown formatting issues

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Please read and follow our
 [Code of Conduct](https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md).
 
 <br/>
+
 ## <a name="question"></a> Have a Question, Problem, or Idea?
 
 If you have questions or ideas regarding AngularJS Material, please direct these to the
@@ -116,6 +117,7 @@ working on a related PR.
   [Pull Request Guidelines](../docs/guides/PULL_REQUESTS.md)
 
 <br/>
+
 ## <a name="commit"></a> Git Commit Guidelines
 
 We have very precise rules over how our git commit messages can be formatted. This leads to **more
@@ -177,6 +179,7 @@ reference GitHub issues that this commit **Closes**.
   users to modify their code with this commit.
 
 <br/>
+
 ##### Sample Commit message:
 
 ```text
@@ -198,6 +201,7 @@ refactor(content): prefix mdContent scroll- attributes
 ```
 
 <br/>
+
 ## <a name="pr_forks"></a> Guidelines for Developer Commit Authorizations
 
 Please review the [Commit Level and Authorization Guidelines](../docs/guides/COMMIT_LEVELS.md) for
@@ -209,6 +213,7 @@ and how to submit Pull Requests.
 
 
 <br/>
+
 ## <a name="cla"></a> Signing the CLA
 
 Please sign our Contributor License Agreement (CLA) before sending pull requests. For any code


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The contributing page is poorly formatted due to changes in GitHub's Markdown.

Issue Number: 
N/A

## What is the new behavior?
The contributing page is properly formatted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
N/A