### PR TITLE
test: remove AngularJS 1.4 from test-versions.sh

### DIFF
--- a/scripts/test-versions.sh
+++ b/scripts/test-versions.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # The purpose of this file is to download
 # assigned AngularJS source files and test
 # them against this build of AngularJS Material.
@@ -21,7 +23,7 @@
 # [CONFIG VALUES]
 
 # Available Options are: 1.X, 1.X.X, 1.X.X-(beta|rc).X or snapshot
-VERSIONS=(1.4 1.5 1.6 snapshot)
+VERSIONS=(1.5 1.6 snapshot)
 BROWSERS="Chrome"
 
 #


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Test "should assign bindings by $onInit for ES6 classes" fails on AngularJS 1.4.
Jenkins output: https://207.254.73.19/job/angular-material1-quarterly-build-versions-testing/871/console

Issue Number: 
Relates to #10977

## What is the new behavior?
Tests are only run against AngularJS 1.5, 1.6, and snapshot which lines up with our current TravisCI configuration.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
"should assign bindings by $onInit for ES6 classes" fails on 1.4
add missing shebang

Relates to #10977