### PR TITLE
fix(menu): close menu on tab

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -292,6 +292,12 @@ function MenuProvider($$interimElementProvider) {
               opts.mdMenuCtrl.close(false, { closeAll: true });
               handled = true;
               break;
+            case $mdConstant.KEY_CODE.TAB:
+              opts.mdMenuCtrl.close(false, { closeAll: true });
+              // Don't prevent default or stop propagation on this event as we want tab
+              // to move the focus to the next focusable element on the page.
+              handled = false;
+              break;
             case $mdConstant.KEY_CODE.UP_ARROW:
               if (!focusMenuItem(ev, opts.menuContentEl, opts, -1) && !opts.nestLevel) {
                 opts.mdMenuCtrl.triggerContainerProxy(ev);
@@ -406,7 +412,7 @@ function MenuProvider($$interimElementProvider) {
      * Attempts to focus an element. Checks whether that element is the currently
      * focused element after attempting.
      * @param {HTMLElement} el - the element to attempt focus on
-     * @returns {bool} - whether the element was successfully focused
+     * @returns {boolean} - whether the element was successfully focused
      */
     function attemptFocus(el) {
       if (el && el.getAttribute('tabindex') != -1) {

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -166,6 +166,19 @@ describe('material.components.menu', function() {
       expect(getOpenMenuContainer(menu).length).toBe(0);
     }));
 
+    it('closes on tab', inject(function($document, $mdConstant) {
+      var menu = setup();
+      openMenu(menu);
+      expect(getOpenMenuContainer(menu).length).toBe(1);
+
+      var openMenuEl = $document[0].querySelector('md-menu-content');
+
+      pressKey(openMenuEl, $mdConstant.KEY_CODE.TAB);
+      waitForMenuClose();
+
+      expect(getOpenMenuContainer(menu).length).toBe(0);
+    }));
+
     describe('default focus', function() {
       it('should focus on first item automatically', inject(function($compile, $rootScope, $document) {
         var menu = $compile(


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Pressing tab inside of a menu panel (`md-menu-content`) can cause the focus to escape the panel and move to other parts of the page (with the menu panel still open).

Issue Number: 
Fixes #11123

## What is the new behavior?
Use only arrow keys to navigate menus (not tabs).
Resolve issue where tab can escape the panel by closing the menu when the `TAB` keyCode is detected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
N/A