### PR TITLE
fix(checkbox): handle links in transcluded label in an a11y-friendly way

### DIFF
--- a/src/components/checkbox/checkbox.scss
+++ b/src/components/checkbox/checkbox.scss
@@ -94,3 +94,19 @@ md-checkbox {
 
   }
 }
+md-input-container .md-checkbox-link-label {
+  box-sizing: border-box;
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+  white-space: normal;
+  user-select: text;
+  cursor: pointer;
+  // The span is actually after the checkbox in the DOM, but we need it to line up, so we move it up
+  // while not introducing any breaking changes to existing styles.
+  top: -21px;
+
+  // In this mode, the checkbox's width needs to be factored in as well.
+  @include rtl(margin-left, $checkbox-text-margin - $checkbox-width, 0);
+  @include rtl(margin-right, 0, $checkbox-text-margin - $checkbox-width);
+}

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -41,6 +41,21 @@ describe('mdCheckbox', function() {
     expect(checkboxElement.attr('aria-label')).toBe('Some text');
   });
 
+  it('should handle text content that contains a link', function() {
+    var element = compileAndLink(
+        '<md-input-container>' +
+          '<md-checkbox ng-model="blue">I agree to the <a href="/license">license</a>.</md-checkbox>' +
+        '</md-input-container>');
+
+    var checkboxElement = element.find('md-checkbox').eq(0);
+    expect(checkboxElement.attr('aria-labelledby')).toContain('label-');
+    var labelElement = element.children()[1];
+    expect(labelElement.getAttribute('id')).toContain('label-');
+    expect(labelElement.innerHTML).toContain('I agree to the ');
+    var linkElement = element.find('A').eq(0);
+    expect(linkElement[0].innerHTML).toBe('license');
+  });
+
   it('should set checked css class and aria-checked attributes', function() {
     var element = compileAndLink(
         '<div>' +

--- a/src/components/checkbox/demoLabels/index.html
+++ b/src/components/checkbox/demoLabels/index.html
@@ -1,0 +1,38 @@
+<div ng-controller="AppCtrl" class="md-padding" ng-cloak>
+  <div>
+    <fieldset class="standard">
+      <legend>Using Different Layouts and Labels</legend>
+      <div layout="column">
+        <div class="md-dense" layout="column">
+          <md-checkbox ng-model="data.cb1">
+            Default Checkbox and Label
+          </md-checkbox>
+          <md-checkbox ng-model="data.cb2">
+            Dynamic Label: {{data.cb2 ? 'Checked' : 'Unchecked'}}
+          </md-checkbox>
+        </div>
+        <div layout="row" layout-align="start center" class="md-dense">
+          <!-- Extra work is needed by the developer to make this work, including a11y. -->
+          <label for="label-in-front" ng-click="data.cb3 = !data.cb3"
+                 aria-hidden="true" tabindex="-1">
+            Label in Front
+          </label>
+          <md-checkbox ng-model="data.cb3" id="label-in-front"
+                       aria-label="Label in Front">
+          </md-checkbox>
+        </div>
+        <md-input-container>
+          <md-checkbox ng-model="data.cb4">
+            Checkbox in an md-input-container
+          </md-checkbox>
+        </md-input-container>
+        <md-subheader>Checkbox with an accessible link in the label</md-subheader>
+        <md-input-container>
+          <md-checkbox ng-model="data.cb5">
+            I agree to the <a href="/license">license</a>.
+          </md-checkbox>
+        </md-input-container>
+      </div>
+    </fieldset>
+  </div>
+</div>

--- a/src/components/checkbox/demoLabels/script.js
+++ b/src/components/checkbox/demoLabels/script.js
@@ -1,0 +1,10 @@
+angular.module('checkboxDemo1', ['ngMaterial'])
+
+.controller('AppCtrl', function($scope) {
+  $scope.data = {};
+  $scope.data.cb1 = true;
+  $scope.data.cb2 = true;
+  $scope.data.cb3 = false;
+  $scope.data.cb4 = false;
+  $scope.data.cb5 = false;
+});

--- a/src/components/checkbox/demoLabels/style.css
+++ b/src/components/checkbox/demoLabels/style.css
@@ -1,0 +1,12 @@
+fieldset.standard {
+  border: 1px solid;
+}
+legend {
+  color: #3F51B5;
+}
+label {
+  cursor: pointer;
+  margin-right: 10px;
+  user-select: none;
+  height: 16px;
+}


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
JAWS and Voiceover can't get to links in `md-checkbox` labels.

Issue Number: 
Fixes #11134

## What is the new behavior?

- JAWS and Voiceover should properly handle links in `md-checkbox` labels.
- Wrapping the checkbox in `md-input-container` is required for using links in checkbox labels due to layout considerations.
- Add new demos for different types of a11y checkbox labels.
- don't toggle the checkbox on link actions
- don't output aria warnings when using aria-labelledby
- require md-input-container when using links in checkbox labels
- update license copyright year


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information

- [x] Need to add unit tests.
- [x] Need to determine if additional docs changes are needed

![Screen Shot 2020-06-29 at 20 23 15](https://user-images.githubusercontent.com/3506071/86069275-706f2d00-ba47-11ea-8623-c1fe02ca7567.png)
