### PR TITLE
fix(chips): md-chip-append-delay of 0 does not get converted to 300

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -190,7 +190,8 @@ MdChipsCtrl.prototype.init = function() {
 
   this.deRegister.push(
     this.$attrs.$observe('mdChipAppendDelay', function(newValue) {
-      ctrl.chipAppendDelay = parseInt(newValue) || DEFAULT_CHIP_APPEND_DELAY;
+      var numberValue = parseInt(newValue);
+      ctrl.chipAppendDelay = isNaN(numberValue) ? DEFAULT_CHIP_APPEND_DELAY : numberValue;
     })
   );
 };


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Using 0 for `md-chip-append-delay` causes the directive to convert 0 to 300ms due to a bad if check. This is a regression caused by the chips a11y updates in 1.1.2.

Issue Number: 
Fixes #10408

## What is the new behavior?
Setting `md-chip-append-delay` to 0 now removes the delay completely as expected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Thanks to @mgol for the report and corrected code snippet.