### PR TITLE
fix(toast): update style direction to flex-direction

### DIFF
--- a/src/components/toast/toast.scss
+++ b/src/components/toast/toast.scss
@@ -26,7 +26,7 @@ md-toast {
 
   .md-toast-content {
     display: flex;
-    direction: row;
+    flex-direction: row;
     align-items: center;
 
     max-height: 7 * $toast-height;


### PR DESCRIPTION
In the component md-toast the property "direction" is set to "row". It seems like it's intended to use "flex-direction", as "row" is not a valid value for the property direction, which should indicate the direction of text. 

This doesn't change the behaviour of md-toast, just cleaning up a small typo :)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to a relevant issue. -->

The css property "direction" is set to the value of "row" in the md-toast component.

## What is the new behavior?

In the component md-toast the property "direction" is set to "row". It seems like it's intended to use "flex-direction" instead of "direction", as "row" is not a valid value for the property direction, which should indicate the direction of text. 

This doesn't change the behaviour of md-toast, just cleaning up a small typo :)

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
