### PR TITLE
fix(nav-bar): initial disabled state is now respected

### DIFF
--- a/src/components/button/button.js
+++ b/src/components/button/button.js
@@ -77,11 +77,12 @@ function MdAnchorDirective($mdTheming) {
  *   <md-button class="md-no-focus">No Focus Style</md-button>
  * </hljs>
  *
- * @param {boolean=} md-no-ink If present, disable ripple ink effects.
- * @param {expression=} ng-disabled En/Disable based on the expression
- * @param {string=} md-ripple-size Overrides the default ripple size logic. Options: `full`, `partial`, `auto`
  * @param {string=} aria-label Adds alternative text to button for accessibility, useful for icon buttons.
  * If no default text is found, a warning will be logged.
+ * @param {boolean=} md-no-ink If present, disable ink ripple effects.
+ * @param {string=} md-ripple-size Overrides the default ripple size logic. Options: `full`, `partial`, `auto`.
+ * @param {expression=} ng-disabled Disable the button when the expression is truthy.
+ * @param {expression=} ng-blur Expression evaluated when focus is removed from the button.
  *
  * @usage
  *

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -185,14 +185,13 @@ describe('mdNavBar', function() {
               '    tab2' +
               '  </md-nav-item>' +
               '</md-nav-bar>');
-          $timeout(function(){
-            var tabCtrl = getTabCtrl('tab2');
-            expect(tabCtrl.disabled).toBe(true);
-          });
+
+          var tabCtrl = getTabCtrl('tab2');
+          expect(tabCtrl.disabled).toBe(true);
       });
 
       it('should observe the disabled attribute', function () {
-          $scope.tabDisabled = false;
+          $scope.$apply('tabDisabled = false');
           create('<md-nav-bar>' +
               '  <md-nav-item md-nav-href="#1" name="tab1">' +
               '    tab1' +
@@ -201,11 +200,11 @@ describe('mdNavBar', function() {
               '    tab2' +
               '  </md-nav-item>' +
               '</md-nav-bar>');
-          $timeout(function(){
-            var tabCtrl = getTabCtrl('tab2');
-            expect(tabCtrl.disabled).toBe(false);
-            $scope.tabDisabled = true;
-            $scope.$apply();
+
+          var tabCtrl = getTabCtrl('tab2');
+          expect(tabCtrl.disabled).toBe(false);
+          $scope.$apply('tabDisabled = true');
+          $timeout(function() {
             expect(tabCtrl.disabled).toBe(true);
           });
       });


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The initial value of the `disabled` attribute is not read or respected. It is only read when it changes via `MutationObserver` or `attrs.$observe`.

Issue Number: 
Closes #11172. Relates to #10688.

## What is the new behavior?
The initial value of the `disabled` attribute is now read and respected.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
remove issues with tests that hid this bug
improve docs for nav-bar and nav-item
add ng-blur to button docs as its used by nav-item