### PR TITLE
docs: use AngularJS logo instead of Angular logo

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -397,7 +397,8 @@ body[dir=rtl] .menu-heading {
   outline: none;
 }
 .docs-logo > img {
-  height: 150px;
+  margin-top: 19px;
+  height: 120px;
   width: auto;
   display: block;
   transform-origin: 50% 0;
@@ -418,6 +419,8 @@ a.docs-logo {
   text-align: center;
   font-weight: 400;
   font-size: 26px;
+  margin-bottom: 1rem;
+  margin-top: 21px;
 }
 .docs-menu-separator-icon {
   margin: 0;

--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -20,7 +20,7 @@
 
     <header class="nav-header">
       <a ng-href="/" class="docs-logo">
-        <img src="img/icons/angular-logo.svg" alt="" />
+        <img src="img/logo.svg" alt="AngularJS Logo" />
         <h1 class="docs-logotype md-heading">AngularJS Material</h1>
       </a>
     </header>


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The docs site uses the Angular (v2+) logo instead of the AngularJS (v1) logo. This may be confusing to developers. This could be part of the confusion that leads a lot of Angular Material issues to be misfiled in this repository.

Issue Number: 
Relates to #11173.

## What is the new behavior?
The docs site uses the AngularJS (v1) logo.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Before:
![screen shot 2018-03-23 at 6 17 21 am](https://user-images.githubusercontent.com/3506071/37824101-f0101bb0-2e61-11e8-9d0d-b208c2ad70fe.png)
After:
![screen shot 2018-03-23 at 6 17 06 am](https://user-images.githubusercontent.com/3506071/37824100-f00123f8-2e61-11e8-80ea-6e2b27add2af.png)
