### PR TITLE
fix(select): options panel theme supports dark mode

### DIFF
--- a/src/components/select/demoSelectedText/index.html
+++ b/src/components/select/demoSelectedText/index.html
@@ -1,15 +1,13 @@
 <div ng-controller="SelectedTextController" class="md-padding" ng-cloak>
-  <div>
-    <h1 class="md-title">Pick an item below</h1>
-    <div layout="row">
-      <md-input-container>
-        <label>Items</label>
-        <md-select ng-model="selectedItem" md-selected-text="getSelectedText()">
-          <md-optgroup label="items">
-            <md-option ng-value="item" ng-repeat="item in items">Item {{item}}</md-option>
-          </md-optgroup>
-        </md-select>
-      </md-input-container>
-    </div>
+  <h1 class="md-title">Pick an item below</h1>
+  <div layout="row">
+    <md-input-container>
+      <label>Items</label>
+      <md-select ng-model="selectedItem" md-selected-text="getSelectedText()">
+        <md-optgroup label="items">
+          <md-option ng-repeat="item in items" ng-value="item">Item {{item}}</md-option>
+        </md-optgroup>
+      </md-select>
+    </md-input-container>
   </div>
 </div>

--- a/src/components/select/demoSelectedText/script.js
+++ b/src/components/select/demoSelectedText/script.js
@@ -1,13 +1,14 @@
 angular
-    .module('selectDemoSelectedText', ['ngMaterial'])
-    .controller('SelectedTextController', function($scope) {
-      $scope.items = [1, 2, 3, 4, 5, 6, 7];
-      $scope.selectedItem;
-      $scope.getSelectedText = function() {
-        if ($scope.selectedItem !== undefined) {
-          return "You have selected: Item " + $scope.selectedItem;
-        } else {
-          return "Please select an item";
-        }
-      };
-    });
+  .module('selectDemoSelectedText', ['ngMaterial'])
+  .controller('SelectedTextController', function ($scope) {
+    $scope.items = [1, 2, 3, 4, 5, 6, 7];
+    $scope.selectedItem = undefined;
+
+    $scope.getSelectedText = function () {
+      if ($scope.selectedItem !== undefined) {
+        return "You have selected: Item " + $scope.selectedItem;
+      } else {
+        return "Please select an item";
+      }
+    };
+  });

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -116,25 +116,25 @@ md-select.md-THEME_NAME-theme {
 
 md-select-menu.md-THEME_NAME-theme {
   md-content {
-    background: '{{background-A100}}';
+    background-color: '{{background-hue-1}}';
 
     md-optgroup {
-      color: '{{background-600-0.87}}';
+      color: '{{foreground-2}}';
     }
 
     md-option {
-      color: '{{background-900-0.87}}';
+      color: '{{foreground-1}}';
 
       &[disabled] {
         .md-text {
-          color: '{{background-400-0.87}}';
+          color: '{{foreground-3}}';
         }
       }
 
       &:not([disabled]) {
         &:focus,
         &:hover {
-          background: '{{background-200}}'
+          background-color: '{{background-500-0.18}}'
         }
       }
 
@@ -158,6 +158,6 @@ md-select-menu.md-THEME_NAME-theme {
   @include checkbox-primary('[selected]');
 
   md-option .md-text {
-    color: '{{background-900-0.87}}';
+    color: '{{foreground-1}}';
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The select's option panel is always using light mode hues even when the theme is dark mode.

Issue Number: 
Fixes #3379.

## What is the new behavior?
The select's option panel use dark mode hues when the theme is set to dark mode.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
I'm going to try and presubmit this for 1.1.9, but I understand that this might trigger some screenshot failures in Google apps. If that happens, we'll need to evaluate pushing this to 1.2.0.

Dark Before:
![screen shot 2018-03-28 at 5 59 25 pm](https://user-images.githubusercontent.com/3506071/38058754-fb2974a2-32b1-11e8-8a66-86b067715419.png)

Dark After with Item 1 selected:
![screen shot 2018-04-07 at 4 05 18 am](https://user-images.githubusercontent.com/3506071/38452782-0a4cc88a-3a19-11e8-93d8-199997348f77.png)

Light Before:
![screen shot 2018-04-07 at 4 04 37 am](https://user-images.githubusercontent.com/3506071/38452787-1a270a68-3a19-11e8-80cf-e7c14730ea37.png)

Light After:
![screen shot 2018-04-07 at 4 07 55 am](https://user-images.githubusercontent.com/3506071/38452800-511b7ff4-3a19-11e8-8349-476efaf19564.png)
