### PR TITLE
fix(datepicker): calendar panel theme supports dark mode

### DIFF
--- a/src/components/datepicker/calendar-theme.scss
+++ b/src/components/datepicker/calendar-theme.scss
@@ -1,17 +1,17 @@
 /** Theme styles for mdCalendar. */
 
 .md-calendar.md-THEME_NAME-theme {
-  background: '{{background-A100}}';
-  color: '{{background-A200-0.87}}';
+  background: '{{background-hue-1}}';
+  color: '{{foreground-1-0.87}}';
 
   tr:last-child td {
-    border-bottom-color: '{{background-200}}';
+    border-bottom-color: '{{background-hue-2}}';
   }
 }
 .md-THEME_NAME-theme {
   .md-calendar-day-header {
-    background: '{{background-300}}';
-    color: '{{background-A200-0.87}}';
+    background: '{{background-500-0.32}}';
+    color: '{{foreground-1-0.87}}';
   }
 
   .md-calendar-date.md-calendar-date-today {
@@ -28,7 +28,7 @@
   .md-calendar-date-selection-indicator {
     .md-calendar-date.md-focus &,
     &:hover {
-      background: '{{background-300}}';
+      background: '{{background-500-0.32}}';
     }
   }
 
@@ -44,10 +44,6 @@
 
   .md-calendar-date-disabled,
   .md-calendar-month-label-disabled {
-    // Note that this uses half the opacity of the default text color,
-    // because the calendar is white, even on the dark theme, otherwise
-    // the default disabled color `foreground-3` blends in with the
-    // background.
-    color: '{{background-A200-0.435}}';
+    color: '{{foreground-3}}';
   }
 }

--- a/src/components/datepicker/datePicker-theme.scss
+++ b/src/components/datepicker/datePicker-theme.scss
@@ -57,7 +57,7 @@
   }
 
   .md-datepicker-calendar {
-    background: '{{background-A100}}';
+    background: '{{background-hue-1}}';
   }
 
   $mask-color: '{{background-hue-1}}';


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The datepicker calendar panel is always using light mode hues even when the theme is dark mode.

Issue Number: 
#11200

## What is the new behavior?
The datepicker calendar panel use dark mode hues when the theme is set to dark mode.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Before dark mode:
![](https://i.imgur.com/sADW9gs.png)

After dark mode:
![](https://i.imgur.com/kAb7RPz.png)
![](https://i.imgur.com/gUBcEt7.png)

After light mode:
![](https://i.imgur.com/HDdFKYY.png)
![](https://i.imgur.com/UCWpkd4.png)
