### PR TITLE
fix(autocomplete): autocomplete panel theme supports dark mode

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -1,7 +1,7 @@
 md-autocomplete.md-THEME_NAME-theme {
-  background: '{{background-A100}}';
+  background: '{{background-hue-1}}';
   &[disabled]:not([md-floating-label]) {
-    background: '{{background-100}}';
+    background: '{{background-hue-2}}';
   }
   button {
     md-icon {
@@ -13,17 +13,20 @@ md-autocomplete.md-THEME_NAME-theme {
       background: '{{background-600-0.3}}';
     }
   }
+  input {
+    color: '{{foreground-1}}';
+  }
 }
 .md-autocomplete-suggestions-container.md-THEME_NAME-theme {
-  background: '{{background-A100}}';
+  background: '{{background-hue-1}}';
   li {
-    color: '{{background-900}}';
+    color: '{{foreground-1}}';
     .highlight {
       color: '{{background-600}}';
     }
     &:hover,
     &.selected {
-      background: '{{background-200}}';
+      background: '{{background-500-0.18}}';
     }
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The autocomplete panel is always using light mode hues even when the theme is dark mode.

Issue Number: 
#11202

## What is the new behavior?
The autocomplete panel use dark mode hues when the theme is set to dark mode.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
Before:
![](https://i.imgur.com/eZLh0oi.png)

After:
![](https://i.imgur.com/QGIzMfQ.png)