### PR TITLE
fix(slider-container): numeric inputs cut off on Firefox and Edge

### DIFF
--- a/src/components/slider/demoBasicUsage/index.html
+++ b/src/components/slider/demoBasicUsage/index.html
@@ -1,41 +1,45 @@
-
 <div ng-controller="AppCtrl" ng-cloak>
   <md-content style="margin: 16px; padding:16px">
 
     <h3>
-      RGB <span ng-attr-style="border: 1px solid #333; background: rgb({{color.red}},{{color.green}},{{color.blue}})">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
+      RGB <span ng-attr-style="border: 1px solid #333; background: rgb({{color.red}},{{color.green}},{{color.blue}})">
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      </span>
     </h3>
 
     <md-slider-container>
       <span>R</span>
-      <md-slider flex min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider">
+      <md-slider min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider"
+                 class="md-warn">
       </md-slider>
       <md-input-container>
-        <input flex type="number" ng-model="color.red" aria-label="red" aria-controls="red-slider">
+        <input type="number" ng-model="color.red" aria-label="red" aria-controls="red-slider">
       </md-input-container>
     </md-slider-container>
 
     <md-slider-container>
       <span>G</span>
-      <md-slider flex ng-model="color.green" min="0" max="255" aria-label="green" id="green-slider" class="md-accent">
+      <md-slider ng-model="color.green" min="0" max="255" aria-label="green" id="green-slider"
+                 class="md-accent">
       </md-slider>
       <md-input-container>
-        <input flex type="number" ng-model="color.green" aria-label="green" aria-controls="green-slider">
+        <input type="number" ng-model="color.green" aria-label="green" aria-controls="green-slider">
       </md-input-container>
     </md-slider-container>
 
     <md-slider-container>
       <span class="md-body-1">B</span>
-      <md-slider flex ng-model="color.blue" min="0" max="255" aria-label="blue" id="blue-slider" class="md-primary">
+      <md-slider ng-model="color.blue" min="0" max="255" aria-label="blue" id="blue-slider"
+                 class="md-primary">
       </md-slider>
       <md-input-container>
-        <input flex type="number" ng-model="color.blue" aria-label="blue" aria-controls="blue-slider">
+        <input type="number" ng-model="color.blue" aria-label="blue" aria-controls="blue-slider">
       </md-input-container>
     </md-slider-container>
 
     <div style="margin-top: 50px;"></div>
 
-    <h3>Rating: {{rating}}/5 - demo of theming classes</h3>
+    <h3>Rating: {{rating1}}/5 - demo of theming classes</h3>
     <div layout>
       <div flex="10" layout layout-align="center center">
         <span class="md-body-1">default</span>
@@ -47,14 +51,16 @@
       <div flex="10" layout layout-align="center center">
         <span class="md-body-1">md-warn</span>
       </div>
-      <md-slider flex class="md-warn" md-discrete ng-model="rating2" step="1" min="1" max="5" aria-label="rating">
+      <md-slider flex class="md-warn" md-discrete ng-model="rating2" step="1" min="1" max="5"
+                 aria-label="rating">
       </md-slider>
     </div>
     <div layout>
       <div flex="10" layout layout-align="center center">
         <span class="md-body-1">md-primary</span>
       </div>
-      <md-slider flex class="md-primary" md-discrete ng-model="rating3" step="1" min="1" max="5" aria-label="rating">
+      <md-slider flex class="md-primary" md-discrete ng-model="rating3" step="1" min="1" max="5"
+                 aria-label="rating">
       </md-slider>
     </div>
 
@@ -63,10 +69,10 @@
     <h3>Disabled</h3>
     <md-slider-container ng-disabled="isDisabled">
       <md-icon md-svg-icon="device:brightness-low"></md-icon>
-      <md-slider ng-model="disabled1" aria-label="Disabled 1" flex md-discrete ng-readonly="readonly"></md-slider>
-
+      <md-slider ng-model="disabled1" aria-label="Disabled 1" md-discrete ng-readonly="readonly">
+      </md-slider>
       <md-input-container>
-        <input flex type="number" ng-model="disabled1" aria-label="green" aria-controls="green-slider">
+        <input type="number" ng-model="disabled1" aria-label="green" aria-controls="green-slider">
       </md-input-container>
     </md-slider-container>
     <md-checkbox ng-model="isDisabled">Is disabled</md-checkbox>
@@ -75,8 +81,10 @@
     <div style="margin-top: 50px;"></div>
 
     <h3>Disabled, Discrete, Read Only</h3>
-    <md-slider ng-model="disabled2" ng-disabled="true" step="3" md-discrete min="0" max="10" aria-label="Disabled discrete 2"></md-slider>
-    <md-slider ng-model="disabled3" ng-disabled="true" step="10" md-discrete aria-label="Disabled discrete 3" ng-readonly="readonly"></md-slider>
+    <md-slider ng-model="disabled2" ng-disabled="true" step="3" md-discrete min="0" max="10"
+               aria-label="Disabled discrete 2"></md-slider>
+    <md-slider ng-model="disabled3" ng-disabled="true" step="10" md-discrete
+               aria-label="Disabled discrete 3" ng-readonly="readonly"></md-slider>
     <md-checkbox ng-model="readonly">Read only</md-checkbox>
 
     <div style="margin-top: 50px;"></div>
@@ -88,7 +96,7 @@
       <md-slider ng-model="invert" min="0" max="100" aria-label="regular slider"></md-slider>
 
       <md-input-container>
-        <input flex type="number" ng-model="invert" aria-label="regular-slider">
+        <input type="number" ng-model="invert" aria-label="regular-slider">
       </md-input-container>
     </md-slider-container>
     <md-slider-container>
@@ -98,7 +106,7 @@
       <md-slider md-invert ng-model="invert" min="0" max="100" aria-label="invertd slider"></md-slider>
 
       <md-input-container>
-        <input flex type="number" ng-model="invert" aria-label="invert-slider">
+        <input type="number" ng-model="invert" aria-label="invert-slider">
       </md-input-container>
     </md-slider-container>
 

--- a/src/components/slider/demoBasicUsage/script.js
+++ b/src/components/slider/demoBasicUsage/script.js
@@ -1,26 +1,24 @@
-
 angular.module('sliderDemo1', ['ngMaterial'])
-  .config(function($mdIconProvider) {
-    $mdIconProvider
-      .iconSet('device', 'img/icons/sets/device-icons.svg', 24);
+  .config(function ($mdIconProvider) {
+    $mdIconProvider.iconSet('device', 'img/icons/sets/device-icons.svg', 24);
   })
-.controller('AppCtrl', function($scope) {
+  .controller('AppCtrl', function ($scope) {
 
-  $scope.color = {
-    red: Math.floor(Math.random() * 255),
-    green: Math.floor(Math.random() * 255),
-    blue: Math.floor(Math.random() * 255)
-  };
+    $scope.color = {
+      red: Math.floor(Math.random() * 255),
+      green: Math.floor(Math.random() * 255),
+      blue: Math.floor(Math.random() * 255)
+    };
 
-  $scope.rating1 = 3;
-  $scope.rating2 = 2;
-  $scope.rating3 = 4;
+    $scope.rating1 = 3;
+    $scope.rating2 = 2;
+    $scope.rating3 = 4;
 
-  $scope.disabled1 = Math.floor(Math.random() * 100);
-  $scope.disabled2 = 0;
-  $scope.disabled3 = 70;
+    $scope.disabled1 = Math.floor(Math.random() * 100);
+    $scope.disabled2 = 0;
+    $scope.disabled3 = 70;
 
-  $scope.invert = Math.floor(Math.random() * 100);
+    $scope.invert = Math.floor(Math.random() * 100);
 
-  $scope.isDisabled = true;
-});
+    $scope.isDisabled = true;
+  });

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -1,12 +1,12 @@
-  /**
-   * @ngdoc module
-   * @name material.components.slider
-   */
-  angular.module('material.components.slider', [
-    'material.core'
-  ])
-  .directive('mdSlider', SliderDirective)
-  .directive('mdSliderContainer', SliderContainerDirective);
+/**
+ * @ngdoc module
+ * @name material.components.slider
+ */
+angular.module('material.components.slider', [
+  'material.core'
+])
+.directive('mdSlider', SliderDirective)
+.directive('mdSliderContainer', SliderContainerDirective);
 
 /**
  * @ngdoc directive
@@ -14,12 +14,20 @@
  * @module material.components.slider
  * @restrict E
  * @description
- * The `<md-slider-container>` contains slider with two other elements.
- *
+ * The `<md-slider-container>` can hold the slider with two other elements.
+ * In this case, the other elements are a `span` for the label and an `input` for displaying
+ * the model value.
  *
  * @usage
- * <h4>Normal Mode</h4>
  * <hljs lang="html">
+ *  <md-slider-container>
+ *    <span>Red</span>
+ *    <md-slider min="0" max="255" ng-model="color.red" aria-label="red" id="red-slider">
+ *    </md-slider>
+ *    <md-input-container>
+ *      <input type="number" ng-model="color.red" aria-label="Red" aria-controls="red-slider">
+ *    </md-input-container>
+ *  </md-slider-container>
  * </hljs>
  */
 function SliderContainerDirective() {
@@ -76,7 +84,7 @@ function SliderContainerDirective() {
           if (input) {
             var computedStyle = getComputedStyle(input);
             var minWidth = parseInt(computedStyle.minWidth);
-            var padding = parseInt(computedStyle.padding) * 2;
+            var padding = parseInt(computedStyle.paddingLeft) + parseInt(computedStyle.paddingRight);
 
             initialMaxWidth = initialMaxWidth || parseInt(computedStyle.maxWidth);
             var newMaxWidth = Math.max(initialMaxWidth, minWidth + padding + (minWidth / 2 * length));
@@ -95,20 +103,22 @@ function SliderContainerDirective() {
  * @module material.components.slider
  * @restrict E
  * @description
- * The `<md-slider>` component allows the user to choose from a range of
- * values.
+ * The `<md-slider>` component allows the user to choose from a range of values.
  *
- * As per the [material design spec](http://www.google.com/design/spec/style/color.html#color-ui-color-application)
+ * As per the [material design spec](https://material.io/guidelines/style/color.html#color-color-system)
  * the slider is in the accent color by default. The primary color palette may be used with
  * the `md-primary` class.
  *
- * It has two modes: 'normal' mode, where the user slides between a wide range
- * of values, and 'discrete' mode, where the user slides between only a few
- * select values.
+ * It has two modes:
+ * - "normal" mode where the user slides between a wide range of values
+ * - "discrete" mode where the user slides between only a few select values
  *
- * To enable discrete mode, add the `md-discrete` attribute to a slider,
+ * To enable discrete mode, add the `md-discrete` attribute to a slider
  * and use the `step` attribute to change the distance between
  * values the user is allowed to pick.
+ *
+ * When using the keyboard, holding the Meta, Control, or Alt key while pressing the left
+ * and right arrow buttons will cause the slider to move 4 steps.
  *
  * @usage
  * <h4>Normal Mode</h4>
@@ -127,14 +137,18 @@ function SliderContainerDirective() {
  * </md-slider>
  * </hljs>
  *
+ * @param {expression} ng-model Assignable angular expression to be data-bound.
+ *  The expression should evaluate to a `number`.
  * @param {boolean=} md-discrete Whether to enable discrete mode.
  * @param {boolean=} md-invert Whether to enable invert mode.
- * @param {number=} step The distance between values the user is allowed to pick. Default 1.
- * @param {number=} min The minimum value the user is allowed to pick. Default 0.
- * @param {number=} max The maximum value the user is allowed to pick. Default 100.
- * @param {number=} round The amount of numbers after the decimal point, maximum is 6 to prevent scientific notation. Default 3.
+ * @param {number=} step The distance between values the user is allowed to pick. Default `1`.
+ * @param {number=} min The minimum value the user is allowed to pick. Default `0`.
+ * @param {number=} max The maximum value the user is allowed to pick. Default `100`.
+ * @param {number=} round The amount of numbers after the decimal point. The maximum is 6 to
+ *  prevent scientific notation. Default `3`.
  */
-function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture, $parse, $log, $timeout) {
+function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture,
+                         $parse, $log, $timeout) {
   return {
     scope: {},
     require: ['?ngModel', '?^mdSliderContainer'],


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
numeric inputs cut off on Firefox and Edge
empty docs for md-slider-container
needless flex attributes in md-slider-containers in demo
broken rating binding in demo
old material spec URL for md-slider

Issue Number: 
Fixes #9559. Fixes #10909.

## What is the new behavior?
numeric inputs no longer cut off on Firefox and Edge
fix empty docs for md-slider-container
remove needless flex attributes from md-slider-containers in demo
fix missing rating in demo
fix old material spec URL for md-slider

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
N/A