### PR TITLE
fix(icon): should always transform the icon

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -451,7 +451,7 @@ describe('MdIcon service', function() {
       it('should append configured SVG single icon', function() {
         var expected = updateDefaults('<svg><g id="android"></g></svg>');
         $mdIcon('android').then(function(el) {
-          //expect(el.outerHTML).toEqual(expected);
+
           expect(el.outerHTML.indexOf('android') !== -1).toBe(true);
           expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });
@@ -461,7 +461,6 @@ describe('MdIcon service', function() {
       it('should append configured SVG icon from named group', function() {
         var expected = updateDefaults('<svg xmlns="http://www.w3.org/2000/svg"><g id="s1"></g></svg>');
         $mdIcon('social:s1').then(function(el) {
-          // expect(el.outerHTML).toEqual(expected);
           expect(el.outerHTML.indexOf('s1') !== -1).toBe(true);
           expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });

--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -451,7 +451,9 @@ describe('MdIcon service', function() {
       it('should append configured SVG single icon', function() {
         var expected = updateDefaults('<svg><g id="android"></g></svg>');
         $mdIcon('android').then(function(el) {
-          expect(el.outerHTML).toEqual(expected);
+          //expect(el.outerHTML).toEqual(expected);
+          expect(el.outerHTML.indexOf('android') !== -1).toBe(true);
+          expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });
         $scope.$digest();
       });
@@ -459,7 +461,9 @@ describe('MdIcon service', function() {
       it('should append configured SVG icon from named group', function() {
         var expected = updateDefaults('<svg xmlns="http://www.w3.org/2000/svg"><g id="s1"></g></svg>');
         $mdIcon('social:s1').then(function(el) {
-          expect(el.outerHTML).toEqual(expected);
+          // expect(el.outerHTML).toEqual(expected);
+          expect(el.outerHTML.indexOf('s1') !== -1).toBe(true);
+          expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });
         $scope.$digest();
       });
@@ -467,7 +471,9 @@ describe('MdIcon service', function() {
       it('should append configured SVG icon from default group', function() {
         var expected = updateDefaults('<svg xmlns="http://www.w3.org/2000/svg"><g id="c1"></g></svg>');
         $mdIcon('c1').then(function(el) {
-          expect(el.outerHTML).toEqual(expected);
+          //expect(el.outerHTML).toEqual(expected);
+          expect(el.outerHTML.indexOf('c1') !== -1).toBe(true);
+          expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });
         $scope.$digest();
       });
@@ -491,7 +497,9 @@ describe('MdIcon service', function() {
 
       it('should return correct SVG markup', function() {
         $mdIcon('android.svg').then(function(el) {
-          expect(el.outerHTML).toEqual( updateDefaults('<svg><g id="android"></g></svg>') );
+          //expect(el.outerHTML).toEqual( updateDefaults('<svg><g id="android"></g></svg>') );
+          expect(el.outerHTML.indexOf('android') !== -1).toBe(true);
+          expect(el.outerHTML.indexOf('_cache') !== -1).toBe(true);
         });
         $scope.$digest();
       });

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -478,14 +478,15 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
   }
 
   /**
-   * Prepare and cache the loaded icon for the specified `id`
-   */
+   * Prepare and cache the loaded icon for the specified `id`.
+   * Make sure the id is always altered by calling transformClone
+   */  
   function cacheIcon(id) {
 
     return function updateCache(icon) {
       iconCache[id] = isIcon(icon) ? icon : new Icon(icon, config[id]);
 
-      return iconCache[id].clone();
+      return transformClone(iconCache[id]);
     };
   }
 


### PR DESCRIPTION
If page loads and the cache is not yet available, svgs will still get duplicate IDs. By always calling the transformClone method, this can be prevented.

# PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
If a page has multiple SVGs they will all get the same ID if the cache is not ready. 

Issue Number: 
??

## What is the new behavior?
All SVGs will have a unique ID

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
