### PR TITLE
fix(menu): md-menu panel theme supports dark mode

### DIFF
--- a/src/components/menu/menu-theme.scss
+++ b/src/components/menu/menu-theme.scss
@@ -1,24 +1,24 @@
 md-menu-content.md-THEME_NAME-theme {
-  background-color: '{{background-A100}}';
+  background-color: '{{background-hue-1}}';
 
   md-menu-item {
-    color: '{{background-A200-0.87}}';
+    color: '{{foreground-1}}';
 
     md-icon {
-      color: '{{background-A200-0.54}}';
+      color: '{{foreground-2}}';
     }
 
     .md-button[disabled] {
-      color: '{{background-A200-0.25}}';
+      color: '{{foreground-3}}';
 
       md-icon {
-        color: '{{background-A200-0.25}}';
+        color: '{{foreground-3}}';
       }
     }
 
   }
 
   md-menu-divider {
-    background-color: '{{background-A200-0.11}}';
+    background-color: '{{foreground-4}}';
   }
 }


### PR DESCRIPTION
Closes #11199

## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `md-menu` panel is always using light mode hues even when the theme is dark mode.

Issue Number: 
Fixes #11199.

## What is the new behavior?
The `md-menu` panel use dark mode hues when the theme is set to dark mode.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

Dark before:
![](https://i.imgur.com/F5fNC3C.png)

Dark after:
![](https://i.imgur.com/rqNVKiT.png)

Light before:
![](https://i.imgur.com/S2j3dxP.png)

Light after:
![](https://i.imgur.com/pI1tCB9.png)
