### PR TITLE
fix(panel): use $event.target instead of $event.srcElement for Firefox compatibility

### DIFF
--- a/src/components/panel/demoGroups/script.js
+++ b/src/components/panel/demoGroups/script.js
@@ -72,7 +72,7 @@
       var template = this.menuTemplate;
 
       var position = $mdPanel.newPanelPosition()
-          .relativeTo($event.srcElement)
+          .relativeTo($event.target)
           .addPanelPosition(
             $mdPanel.xPosition.ALIGN_START,
             $mdPanel.yPosition.BELOW
@@ -103,7 +103,7 @@
       var template = this.menuTemplate;
 
       var position = $mdPanel.newPanelPosition()
-          .relativeTo($event.srcElement)
+          .relativeTo($event.target)
           .addPanelPosition(
             $mdPanel.xPosition.ALIGN_START,
             $mdPanel.yPosition.BELOW

--- a/src/components/panel/demoPanelProvider/script.js
+++ b/src/components/panel/demoPanelProvider/script.js
@@ -85,7 +85,7 @@
       $mdPanel.open('demoPreset', {
         id: 'menu_' + menu.name,
         position: $mdPanel.newPanelPosition()
-            .relativeTo($event.srcElement)
+            .relativeTo($event.target)
             .addPanelPosition(
               $mdPanel.xPosition.ALIGN_START,
               $mdPanel.yPosition.BELOW

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -97,7 +97,7 @@ angular
  *       $mdPanel.open('demoPreset', {
  *         id: 'menu_' + menu.name,
  *         position: $mdPanel.newPanelPosition()
- *             .relativeTo($event.srcElement)
+ *             .relativeTo($event.target)
  *             .addPanelPosition(
  *               $mdPanel.xPosition.ALIGN_START,
  *               $mdPanel.yPosition.BELOW


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type


<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to a relevant issue. -->

Panel demos are using $event.srcElement which is not supported by Firefox browsers.

Issue Number: #11035


## What is the new behavior?
Panel demos are now using $event.target

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
