### PR TITLE
fix(autocomplete): align highlight style with spec

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -21,9 +21,6 @@ md-autocomplete.md-THEME_NAME-theme {
   background: '{{background-hue-1}}';
   li {
     color: '{{foreground-1}}';
-    .highlight {
-      color: '{{background-600}}';
-    }
     &:hover,
     &.selected {
       background: '{{background-500-0.18}}';

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -188,6 +188,10 @@ md-autocomplete {
   // Expand the virtualRepeatContainer as much as the max-height from the JavaScript allows.
   // This is necessary for the virtualRepeatContainer to be able to grow back.
   height: 100%;
+
+  .highlight {
+    font-weight: bold;
+  }
 }
 
 .md-virtual-repeat-container.md-not-found {


### PR DESCRIPTION
## PR Checklist
Please check that your PR fulfills the following requirements:

- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is an a11y issue where the difference between highlighted text is too small (unnoticeable to many people without perfect eyesight or high end monitors).
Additionally, the currently highlight styling does not align with the Material Design spec which was changed from lighter text to bold text for highlight in autocomplete/search.

Issue Number: 
Fixes #10060

## What is the new behavior?
Follow the updated spec by highlighting text in bold, thus making it easier for people with poor monitors or eyesight to differentiate the highlighted text.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
It is likely that this will break some screenshot tests, but it should not break application behavior. The changes increase a11y by making the highlighted text more visible via both contrast and shape changes.