### PR TITLE
fix(chips): unwanted re-focus of last chip after blur

### DIFF
--- a/src/components/chips/demoBasicUsage/index.html
+++ b/src/components/chips/demoBasicUsage/index.html
@@ -20,22 +20,23 @@
     <br/>
     <h2 class="md-title">Use the default chip template.</h2>
 
-    <md-chips ng-model="ctrl.fruitNames" readonly="ctrl.readonly" md-removable="ctrl.removable"></md-chips>
+    <md-chips ng-model="ctrl.fruitNames" readonly="ctrl.readonly" md-removable="ctrl.removable">
+    </md-chips>
 
     <br/>
-    <h2 class="md-title">Use ng-change</h2>
+    <h2 class="md-title">Use ng-change and add-on-blur</h2>
 
-    <md-chips ng-model="ctrl.ngChangeFruitNames" ng-change="ctrl.onModelChange(ctrl.ngChangeFruitNames)" 
-      md-removable="ctrl.removable"></md-chips>
+    <md-chips ng-model="ctrl.ngChangeFruitNames" md-add-on-blur="true"
+              ng-change="ctrl.onModelChange(ctrl.ngChangeFruitNames)"
+              md-removable="ctrl.removable"></md-chips>
 
     <br/>
     <h2 class="md-title">Make chips editable.</h2>
 
-    <md-chips ng-model="ctrl.editableFruitNames" readonly="ctrl.readonly" md-removable="ctrl.removable"
-              md-enable-chip-edit="true"></md-chips>
+    <md-chips ng-model="ctrl.editableFruitNames" readonly="ctrl.readonly"
+              md-removable="ctrl.removable" md-enable-chip-edit="true"></md-chips>
 
     <br/>
-
     <h2 class="md-title">Use Placeholders and override hint texts.</h2>
 
     <md-chips

--- a/src/components/chips/demoBasicUsage/readme.html
+++ b/src/components/chips/demoBasicUsage/readme.html
@@ -3,7 +3,6 @@
   <code>md-chips</code> component. In order to achieve this, the behavior has changed to also select
   and highlight the newly appended chip for <code>300ms</code> before re-focusing the text input.
 </p>
-
 <p>
   Please see the <a href="api/directive/mdChips">documentation</a> for more information and for
   the new <code>md-chip-append-delay</code> option which allows you to customize this delay.

--- a/src/components/chips/demoBasicUsage/script.js
+++ b/src/components/chips/demoBasicUsage/script.js
@@ -7,7 +7,7 @@
       }])
       .controller('BasicDemoCtrl', DemoCtrl);
 
-  function DemoCtrl ($timeout, $q) {
+  function DemoCtrl ($timeout, $q, $log) {
     var self = this;
 
     self.readonly = false;
@@ -42,7 +42,7 @@
     };
 
     self.onModelChange = function(newModel) {
-      alert('The model has changed');
+      $log.log('The model has changed to ' + newModel + '.');
     };
   }
 })();

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -446,8 +446,7 @@ MdChipsCtrl.prototype.resetSelectedChip = function() {
  * determined as the next chip in the list, unless the target chip is the
  * last in the list, then it is the chip immediately preceding the target. If
  * there is only one item in the list, -1 is returned (select none).
- * The number returned is the index to select AFTER the target has been
- * removed.
+ * The number returned is the index to select AFTER the target has been removed.
  * If the current chip is not selected, then -1 is returned to select none.
  */
 MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
@@ -462,7 +461,7 @@ MdChipsCtrl.prototype.getAdjacentChipIndex = function(index) {
  * @param {string} newChip chip buffer contents that will be used to create the new chip
  */
 MdChipsCtrl.prototype.appendChip = function(newChip) {
-  this.shouldFocusLastChip = true;
+  this.shouldFocusLastChip = !this.addOnBlur;
   if (this.useTransformChip && this.transformChip) {
     var transformedChip = this.transformChip({'$chip': newChip});
 
@@ -716,7 +715,9 @@ MdChipsCtrl.prototype.selectAndFocusChip = function(index) {
  * Call `focus()` on the chip at `index`
  */
 MdChipsCtrl.prototype.focusChip = function(index) {
-  var chipContent = this.$element[0].querySelector('md-chip[index="' + index + '"] .md-chip-content');
+  var chipContent = this.$element[0].querySelector(
+    'md-chip[index="' + index + '"] .md-chip-content'
+  );
 
   this.ariaTabIndex = index;
 
@@ -857,8 +858,7 @@ MdChipsCtrl.prototype.configureAutocomplete = function(ctrl) {
 };
 
 /**
- * Whether the current chip buffer should be added on input blur or not.
- * @returns {boolean}
+ * @returns {boolean} Whether the current chip buffer should be added on input blur or not.
  */
 MdChipsCtrl.prototype.shouldAddOnBlur = function() {
 
@@ -869,14 +869,16 @@ MdChipsCtrl.prototype.shouldAddOnBlur = function() {
   // If the model value is empty and required is set on the element, then the model will be invalid.
   // In that case, we still want to allow adding the chip. The main (but not only) case we want
   // to disallow is adding a chip on blur when md-max-chips validation fails.
-  var isModelValid = this.ngModelCtrl.$isEmpty(this.ngModelCtrl.$modelValue) || this.ngModelCtrl.$valid;
+  var isModelValid = this.ngModelCtrl.$isEmpty(this.ngModelCtrl.$modelValue) ||
+    this.ngModelCtrl.$valid;
   var isAutocompleteShowing = this.autocompleteCtrl && !this.autocompleteCtrl.hidden;
 
   if (this.userInputNgModelCtrl) {
     isModelValid = isModelValid && this.userInputNgModelCtrl.$valid;
   }
 
-  return this.addOnBlur && !this.requireMatch && chipBuffer && isModelValid && !isAutocompleteShowing;
+  return this.addOnBlur && !this.requireMatch && chipBuffer && isModelValid &&
+    !isAutocompleteShowing;
 };
 
 MdChipsCtrl.prototype.hasFocus = function () {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
As described by @caseyjhol, "With `md-add-on-blur` enabled, clicking outside `mdChips` or selecting another input element results in the previously focused `mdChips` being highlighted again. This is especially jarring on a mobile device (e.g. type in some text for the chip, scroll down to the next form element, select it, and then the chip is added but `mdChips` is then scrolled back into position and focused). It's also not possible to tab to the next element."

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10758

## What is the new behavior?
this solves a regression introduced in 1.1.2 by #9650
change `ng-change` demo to use `$log` instead of `alert`
fix some lint line length warnings
JSDoc clean up

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
