### PR TITLE
fix(md-svg-icon): id mangling on cache destroys xhref references

### DIFF
--- a/src/components/icon/icon.spec.js
+++ b/src/components/icon/icon.spec.js
@@ -419,6 +419,7 @@ describe('MdIcon service', function() {
     $scope = $rootScope;
 
     $templateCache.put('android.svg'    , '<svg><g id="android"></g></svg>');
+    $templateCache.put('angular-logo.svg','<svg><g id="angular"></g><defs><filter id="shadow"></filter></defs><path filter="url(#shadow)"></path></svg>');
     $templateCache.put('social.svg'     , '<svg><g id="s1"></g><g id="s2"></g></svg>');
     $templateCache.put('symbol.svg'     , '<svg><symbol id="s1"></symbol><symbol id="s2" viewBox="0 0 32 32"></symbol></svg>');
     $templateCache.put('core.svg'       , '<svg><g id="c1"></g><g id="c2" class="core"></g></svg>');
@@ -583,6 +584,21 @@ describe('MdIcon service', function() {
 
         $mdIcon('android.svg').then(function(el) {
           expect(el.firstChild.id).toMatch(/.+_cache[0-9]+/g);
+        });
+
+        $scope.$digest();
+      });
+
+      it('should suffix duplicated ids and refs', function() {
+        // Just request the icon to be stored in the cache.
+        $mdIcon('angular-logo.svg');
+
+        $scope.$digest();
+
+        $mdIcon('angular-logo.svg').then(function(el) {
+          expect(el.querySelector('defs').firstChild.id).toMatch(/.+_cache[0-9]+/g);
+          expect(el.querySelector('path').attributes.filter.value.split(/url\(#(.*)\)$/g)[1]).toMatch(/.+_cache[0-9]+/g);
+          expect(el.querySelector('defs').firstChild.id === el.querySelector('path').attributes.filter.value.split(/url\(#(.*)\)$/g)[1]);
         });
 
         $scope.$digest();

--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -466,11 +466,14 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
     var clone = cacheElement.clone();
     var cacheSuffix = '_cache' + $mdUtil.nextUid();
 
-    // We need to modify for each cached icon the id attributes.
+    // We need to modify for each cached icon the id attributes and references.
     // This is needed because SVG id's are treated as normal DOM ids
     // and should not have a duplicated id.
     if (clone.id) clone.id += cacheSuffix;
     angular.forEach(clone.querySelectorAll('[id]'), function(item) {
+      angular.forEach(clone.querySelectorAll('[a="url(#'+ item.id +')"], [altGlyph="url(#'+ item.id +')"], [animate="url(#'+ item.id +')"], [animateColor="url(#'+ item.id +')"], [animateMotion="url(#'+ item.id +')"], [animateTransform="url(#'+ item.id +')"], [clip-path="url(#'+ item.id +')"], [color-profile="url(#'+ item.id +')"], [src="url(#'+ item.id +')"], [cursor="url(#'+ item.id +')"], [feImage="url(#'+ item.id +')"], [fill="url(#'+ item.id +')"], [filter="url(#'+ item.id +')"], [image="url(#'+ item.id +')"], [linearGradient="url(#'+ item.id +')"], [marker="url(#'+ item.id +')"], [marker-smart="url(#'+ item.id +')"], [marker-mid="url(#'+ item.id +')"], [marker-end="url(#'+ item.id +')"], [mask="url(#'+ item.id +')"], [pattern="url(#'+ item.id +')"], [radialGradient="url(#'+ item.id +')"], [script="url(#'+ item.id +')"], [stroke="url(#'+ item.id +')"], [textPath="url(#'+ item.id +')"], [tref="url(#'+ item.id +')"], [set="url(#'+ item.id +')"], [use="url(#'+ item.id +')"]'), function(refItem) {
+        refItem.outerHTML = refItem.outerHTML.replace("url(#" + item.id + ")", "url(#" + item.id + cacheSuffix + ")");
+      });
       item.id += cacheSuffix;
     });
 


### PR DESCRIPTION
update all kind of reference in svg when clone ids for caching

Fixes #8689

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [X] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [X] Tests for the changes have been added or this is not a bug fix / enhancement
- [X] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #8689 

## What is the new behavior?
Updates references in svg tree attributes when corresponding to the caching ids.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
