### PR TITLE
docs(select): clarify behavior of multiple attribute

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -71,7 +71,9 @@ angular.module('material.components.select', [
  *
  * @param {expression} ng-model Assignable angular expression to data-bind to.
  * @param {expression=} ng-change Expression to be executed when the model value changes.
- * @param {boolean=} multiple When set to true, allows for more than one option to be selected. The model is an array with the selected choices.
+ * @param {boolean=} multiple When present, allows for more than one option to be selected.
+ *  The model is an array with the selected choices. **Note:** This attribute is only evaluated
+ *  once; it is not watched.
  * @param {expression=} md-on-close Expression to be evaluated when the select is closed.
  * @param {expression=} md-on-open Expression to be evaluated when opening the select.
  * Will hide the select options and show a spinner until the evaluated promise resolves.
@@ -83,7 +85,7 @@ angular.module('material.components.select', [
  * will be treated as *html*. The value must either be explicitly marked as trustedHtml or
  * the ngSanitize module must be loaded.
  * @param {string=} placeholder Placeholder hint text.
- * @param md-no-asterisk {boolean=} When set to true, an asterisk will not be appended to the
+ * @param {boolean=} md-no-asterisk When set to true, an asterisk will not be appended to the
  * floating label. **Note:** This attribute is only evaluated once; it is not watched.
  * @param {string=} aria-label Optional label for accessibility. Only necessary if no placeholder or
  * explicit label is present.

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -1014,7 +1014,7 @@ describe('<md-select>', function() {
           $rootScope.model = [];
           $rootScope.opts = [1, 2, 3, 4];
           $compile('<form name="testForm">' +
-            '<md-select ng-model="model" name="multiSelect" required="required" multiple="multiple">' +
+            '<md-select ng-model="model" name="multiSelect" required="required" multiple>' +
               '<md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
             '</md-select></form>')($rootScope);
           $rootScope.$digest();
@@ -1078,7 +1078,7 @@ describe('<md-select>', function() {
         $rootScope.model = [1, 2];
         $rootScope.opts = [1, 2, 3, 4];
         $compile('<form name="testForm">' +
-          '<md-select ng-model="model" name="multiSelect" multiple="multiple">' +
+          '<md-select ng-model="model" name="multiSelect" multiple>' +
             '<md-option ng-repeat="opt in opts" ng-value="opt"></md-option>' +
           '</md-select></form>')($rootScope);
         $rootScope.$digest();
@@ -1193,8 +1193,18 @@ describe('<md-select>', function() {
         expect($rootScope.model).toEqual([1,3]);
       });
 
-      it('should not be multiple if attr.multiple == `false`', function() {
-        var el = setupSelect('multiple="false" ng-model="$root.model"').find('md-select');
+      it('should be multiple if attr.multiple exists', function() {
+        var el = setupSelect('multiple ng-model="$root.model"').find('md-select');
+        openSelect(el);
+        expectSelectOpen(el);
+
+        var selectMenu = $document.find('md-select-menu')[0];
+
+        expect(selectMenu.hasAttribute('multiple')).toBe(true);
+      });
+
+      it('should not be multiple if attr.multiple does not exist', function() {
+        var el = setupSelect('ng-model="$root.model"').find('md-select');
         openSelect(el);
         expectSelectOpen(el);
 
@@ -1207,7 +1217,7 @@ describe('<md-select>', function() {
         $rootScope.model = 2;
         $rootScope.opts = [1, 2, 3, 4];
         var form = $compile('<form name="testForm">' +
-          '<md-select multiple="multiple" ng-model="model" name="multiSelect">' +
+          '<md-select multiple ng-model="model" name="multiSelect">' +
             '<md-option ng-repeat="opt in opts" ng-value="opt">{{opt}}</md-option>' +
           '</md-select></form>')($rootScope);
         var el = form.find('md-select');


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The docs are misleading and cause developers to think that something like `multiple="ctrl.isMultiple`" can be used. In fact, only the existence of the attribute matters. This follows a common pattern used in AngularJS Material APIs.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Closes #3068

## What is the new behavior?
- Align the `multiple` docs with the actual behavior of the API
- fix syntax ordering error with `md-no-asterisk` docs
- remove instances of `multiple="multiple"` from tests
- update test to check for non-existence of multiple rather than value
- add test to check for existence of multiple

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
