### PR TITLE
fix(css): remove bloat from autoprefixing of unsupported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ Quick Links:
 *  [Installing](#installing)
 
 
-Please note that using AngularJS Material requires the use of **[AngularJS](https://angularjs.org/) 1.4.x** or higher.
-AngularJS Material is targeted for the browser versions shown below in the green boxes:
+Please note that using AngularJS Material requires the use of **[AngularJS](https://angularjs.org/)
+1.4.x** or higher.
 
-![ngm1_browser_support](https://user-images.githubusercontent.com/3506071/35176284-1419c42c-fd46-11e7-9381-d93e5c5db39a.png)
+AngularJS Material is targeted for the browser versions defined in the `broswerslist` field
+of our [package.json](package.json). Below is an screenshot from 
+[browserl.ist](http://browserl.ist/?q=%3E+0.5%25%2C+last+2+versions%2C+Firefox+ESR%2C+not+ie+%3C%3D+10%2C+not+ie_mob+%3C%3D+10%2C+not+bb+%3C%3D+10%2C+not+op_mob+%3C%3D+12.1)
+that provides a visual representation of this configuration:
+
+![AngularJS Material Browser Support](https://user-images.githubusercontent.com/3506071/41875080-d3096d7a-7897-11e8-8838-2bf7473c9502.png)
 
 ## <a name="demos"></a> Online Documentation and Demos
 

--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -884,6 +884,66 @@ table.md-css-table td p {
   padding-bottom: 10px;
 }
 
+table.custom-table {
+  margin: 24px 2px;
+  box-shadow: 0 1px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);
+  border-radius: 2px;
+  background: #fafafa;
+  border-spacing: 0;
+}
+table.custom-table thead > {
+  vertical-align: middle;
+  border-color: inherit;
+}
+table.custom-table thead > tr {
+  vertical-align: inherit;
+  border-color: inherit;
+}
+table.custom-table thead > tr > th {
+  background: rgba(219, 219, 219, 0.2);
+  border-bottom: 1px solid #dbdbdb;
+  color: #333;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 8px 24px;
+  text-align: left;
+  text-transform: uppercase;
+  line-height: 28px;
+}
+table.custom-table tbody > tr > th,
+table.custom-table tbody > tr > td {
+  border-bottom: 1px solid #dbdbdb;
+  padding: 16px;
+  text-align: left;
+  line-height: 24px;
+  vertical-align: top;
+}
+@media (max-width: 480px) {
+  table.custom-table tbody > tr > th:before,
+  table.custom-table tbody > tr > td:before {
+    display: inline-block;
+  }
+}
+table.custom-table tbody > tr > td {
+  letter-spacing: 0.3px;
+}
+@media (max-width: 480px) {
+  table.custom-table tbody > tr > td tr td:first-child {
+    background-color: #dbdbdb;
+  }
+}
+table.custom-table tbody > tr > th:first-child {
+  border-right: 1px solid #dbdbdb;
+}
+table.custom-table tbody > tr > th {
+  background: rgba(219, 219, 219, 0.2);
+  font-weight: 600;
+  max-width: 100px;
+}
+table.custom-table tbody > tr >:last-child td {
+  border: none;
+}
+
 /* Provide some layout/padding enhancements for mobile/small devices */
 @media(max-width: 500px) {
   /* Reduce the size of the nav logo/header */

--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -59,6 +59,103 @@
       </li>
     </ul>
 
+    <h2 class="md-headline">Browser Support</h2>
+    <p>
+      AngularJS Material generally supports browsers that fall into these categories
+    </p>
+    <ul>
+      <li>Greater than 0.5% global usage</li>
+      <li>Last two versions of Evergreen browsers</li>
+      <li>Firefox ESR</li>
+      <li>Not considered "dead" browsers</li>
+    </ul>
+    <br/>
+    <h3>The following table provides a more detailed view:</h3>
+    <table class="custom-table">
+      <tbody>
+      <tr>
+        <th>
+          Browser
+        </th>
+        <th>
+          Supported Versions
+        </th>
+      </tr>
+      <tr>
+        <td>
+          Chrome<br/>Chrome for Android<br/>Edge<br/>Opera
+        </td>
+        <td>
+          last 2 versions
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Firefox
+        </td>
+        <td>
+          last 2 versions<br/>ESR
+        </td>
+      </tr>
+      <tr>
+        <td>
+          IE<br/>IE Mobile
+        </td>
+        <td>
+          11
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Safari
+        </td>
+        <td>
+          11<br>11.1
+        </td>
+      </tr>
+      <tr>
+        <td>
+          iOS
+        </td>
+        <td>
+          10.3<br>11.0-11.2<br>11.3
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Firefox for Android<br/>UC<br/>QQ<br/>Baidu
+        </td>
+        <td>
+          latest version
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Android Browser
+        </td>
+        <td>
+          4.4<br>4.4.3-4.4.4<br>latest version
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Samsung Internet
+        </td>
+        <td>
+          4<br>5<br>6.2
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Opera for Android
+        </td>
+        <td>
+          Mini all<br>Mobile 37
+        </td>
+      </tr>
+      </tbody>
+    </table>
+
     <md-divider></md-divider>
 
     <br/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,6 +190,15 @@
       "integrity": "sha1-xELURPGHrxnU6qKXARGvf/NdsbA=",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "^0.1.0"
+      }
+    },
     "ansi-cyan": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
@@ -953,6 +962,12 @@
       "version": "1.0.30000789",
       "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000789.tgz",
       "integrity": "sha1-XPP+x1SABBqxYsoGQTFTFB4jQyU=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30000858",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000858.tgz",
+      "integrity": "sha512-oJRGfVfwHr0VKcoy2UqIoRmQcDOugnNAQsWYI3/JTzExrlzxSKtmLW1N4h+gmjgpYCEJthHmaIjok894H5il/g==",
       "dev": true
     },
     "canonical-path": {
@@ -5004,16 +5019,138 @@
       }
     },
     "gulp-autoprefixer": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-3.1.1.tgz",
-      "integrity": "sha1-dSMAUc0NFxND14O36bXREg7u+bA=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-5.0.0.tgz",
+      "integrity": "sha1-gjfCeKaXdScKHK/n1vEBz81YVUQ=",
       "dev": true,
       "requires": {
-        "autoprefixer": "^6.0.0",
-        "gulp-util": "^3.0.0",
-        "postcss": "^5.0.4",
+        "autoprefixer": "^8.0.0",
+        "fancy-log": "^1.3.2",
+        "plugin-error": "^1.0.1",
+        "postcss": "^6.0.1",
         "through2": "^2.0.0",
         "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "autoprefixer": {
+          "version": "8.6.3",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.3.tgz",
+          "integrity": "sha512-KkQyCHBxma7R2eoEkjja/RHUBw+Fc1nY46LdV62fzJI5D7i8mLLCtAZ/AVR3UbXhDZ8mUz4C/PF4lZrbiHa1ZQ==",
+          "dev": true,
+          "requires": {
+            "browserslist": "^3.2.8",
+            "caniuse-lite": "^1.0.30000856",
+            "normalize-range": "^0.1.2",
+            "num2fraction": "^1.2.2",
+            "postcss": "^6.0.22",
+            "postcss-value-parser": "^3.2.3"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
+          "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.50",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
+          "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc=",
+          "dev": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+          "dev": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
+        },
+        "postcss": {
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.4.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "gulp-concat": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "~7.0.5",
     "gulp": "^3.9.1",
     "gulp-add-src": "^0.2.0",
-    "gulp-autoprefixer": "^3.1.0",
+    "gulp-autoprefixer": "^5.0.0",
     "gulp-concat": "^2.2.0",
     "gulp-connect": "^4.1.0",
     "gulp-cssnano": "^2.1.2",
@@ -88,5 +88,14 @@
     "test:fast": "gulp karma-fast",
     "test:full": "gulp karma",
     "lint": "eslint ."
-  }
+  },
+  "browserslist": [
+    "> 0.5%",
+    "last 2 versions",
+    "Firefox ESR",
+    "not ie <= 10",
+    "not ie_mob <= 10",
+    "not bb <= 10",
+    "not op_mob <= 12.1"
+  ]
 }

--- a/scripts/gulp-utils.js
+++ b/scripts/gulp-utils.js
@@ -305,13 +305,11 @@ exports.cssToNgConstant = function(ngModule, factoryName) {
   });
 };
 
+/**
+ * Use the configuration in the "browserslist" field of the package.json as recommended
+ * by the autoprefixer docs.
+ * @returns {NodeJS.ReadWriteStream | *}
+ */
 exports.autoprefix = function() {
-
-  return autoprefixer({browsers: [
-    'last 2 versions',
-    'not ie <= 10',
-    'not ie_mob <= 10',
-    'last 4 Android versions',
-    'Safari >= 8'
-  ]});
+  return autoprefixer();
 };


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
We've long claimed support for n-1 browser versions, but that hasn't been kept up to date. As a result, we've got our autoprefixer settings generating CSS for Safari 8, 9, 10.0, and some dead browsers like Blackberry, Opera Mobile 12.1, and IE 10. This significantly bloats our CSS.
With our old settings we only supported 86.6% of the global browser market.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #9396

## What is the new behavior?
- Unminified CSS reduced by 135 KB
- We now support 90.93% of the global browser market
- use recommended configuration for autoprefix and browserslist
- use a more accurate screenshot of browser support
- update README with link to browserslist settings in package.json
- update README with link to browserl.ist page that shows our config
- add browser support info to AngularJS Material home page

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Users of Safari 8, 9, 10.0, Blackberry, Opera Mobile 12.1, and IE 10 may consider this a breaking change, but this follows our past browser support guidance so it should not be considered breaking. That said, I am still going to push this to 1.1.11 instead of putting it into 1.1.10 as we have some other significant CSS changes in that release that I don't want to mix with these.

![screen shot 2018-06-25 at 4 49 21 pm](https://user-images.githubusercontent.com/3506071/41879562-2db6562e-78a8-11e8-9dd0-a90245cf999e.png)
![screen shot 2018-06-25 at 6 46 03 pm](https://user-images.githubusercontent.com/3506071/41879563-2dc7e542-78a8-11e8-9034-622ae4e120ef.png)
![screen shot 2018-06-25 at 6 46 28 pm](https://user-images.githubusercontent.com/3506071/41879564-2dd8b41c-78a8-11e8-882d-b7ec944e13a3.png)
