### PR TITLE
fix(input): remove unnecessary warnings when ng-messages not provided

### DIFF
--- a/src/components/input/input-animations.spec.js
+++ b/src/components/input/input-animations.spec.js
@@ -90,58 +90,6 @@ describe('md-input-container animations', function() {
 
   describe('method tests', function() {
 
-    describe('#showInputMessages', function() {
-      it('logs a warning with no messages element', inject(function($log) {
-        // Note that the element does NOT have a parent md-input-messages-animation class
-        var element = angular.element('<div><div class="md-input-message-animation"></div></div>');
-        var done = jasmine.createSpy('done');
-        var warnSpy = spyOn($log, 'warn');
-
-        $$mdInput.messages.show(element, done);
-
-        expect(done).toHaveBeenCalled();
-        expect(warnSpy).toHaveBeenCalled();
-      }));
-
-      it('logs a warning with no messages children', inject(function($log) {
-        // Note that the element does NOT have any child md-input-message-animation divs
-        var element = angular.element('<div class="md-input-messages-animation"></div>');
-        var done = jasmine.createSpy('done');
-        var warnSpy = spyOn($log, 'warn');
-
-        $$mdInput.messages.show(element, done);
-
-        expect(done).toHaveBeenCalled();
-        expect(warnSpy).toHaveBeenCalled();
-      }));
-    });
-
-    describe('#hideInputMessages', function() {
-      it('logs a warning with no messages element', inject(function($log) {
-        // Note that the element does NOT have a parent md-input-messages-animation class
-        var element = angular.element('<div><div class="md-input-message-animation"></div></div>');
-        var done = jasmine.createSpy('done');
-        var warnSpy = spyOn($log, 'warn');
-
-        $$mdInput.messages.hide(element, done);
-
-        expect(done).toHaveBeenCalled();
-        expect(warnSpy).toHaveBeenCalled();
-      }));
-
-      it('logs a warning with no messages children', inject(function($log) {
-        // Note that the element does NOT have any child md-input-message-animation divs
-        var element = angular.element('<div class="md-input-messages-animation"></div>');
-        var done = jasmine.createSpy('done');
-        var warnSpy = spyOn($log, 'warn');
-
-        $$mdInput.messages.hide(element, done);
-
-        expect(done).toHaveBeenCalled();
-        expect(warnSpy).toHaveBeenCalled();
-      }));
-    });
-
     describe('#getMessagesElement', function() {
 
       it('finds the messages element itself', function() {

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -26,8 +26,6 @@ if (window._mdMocksIncluded) {
     return {
       // special accessor to internals... useful for testing
       messages: {
-        show        : showInputMessages,
-        hide        : hideInputMessages,
         getElement  : getMessagesElement
       }
     };
@@ -687,7 +685,7 @@ function mdMaxlengthDirective($animate, $mdUtil) {
       attr.$observe('ngTrim', function (value) {
         ngTrim = angular.isDefined(value) ? $mdUtil.parseAttributeBoolean(value) : true;
       });
- 
+
       scope.$watch(attr.mdMaxlength, function(value) {
         if (angular.isNumber(value) && value > 0) {
           if (!charCountEl.parent().length) {
@@ -945,10 +943,10 @@ function ngMessageDirective($mdUtil) {
   }
 }
 
-var $$AnimateRunner, $animateCss, $mdUtil, $log;
+var $$AnimateRunner, $animateCss, $mdUtil;
 
-function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil, $log) {
-  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil, $log);
+function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) {
+  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil);
 
   return {
     addClass: function(element, className, done) {
@@ -959,8 +957,8 @@ function mdInputInvalidMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil, 
   };
 }
 
-function ngMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil, $log) {
-  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil, $log);
+function ngMessagesAnimation($$AnimateRunner, $animateCss, $mdUtil) {
+  saveSharedServices($$AnimateRunner, $animateCss, $mdUtil);
 
   return {
     enter: function(element, done) {
@@ -1013,7 +1011,6 @@ function showInputMessages(element, done) {
   var children = messages.children();
 
   if (messages.length == 0 || children.length == 0) {
-    $log.warn('mdInput messages show animation called on invalid messages element: ', element);
     done();
     return;
   }
@@ -1033,7 +1030,6 @@ function hideInputMessages(element, done) {
   var children = messages.children();
 
   if (messages.length == 0 || children.length == 0) {
-    $log.warn('mdInput messages hide animation called on invalid messages element: ', element);
     done();
     return;
   }
@@ -1113,9 +1109,8 @@ function getMessagesElement(element) {
   return angular.element(element[0].querySelector('.md-input-messages-animation'));
 }
 
-function saveSharedServices(_$$AnimateRunner_, _$animateCss_, _$mdUtil_, _$log_) {
+function saveSharedServices(_$$AnimateRunner_, _$animateCss_, _$mdUtil_) {
   $$AnimateRunner = _$$AnimateRunner_;
   $animateCss = _$animateCss_;
   $mdUtil = _$mdUtil_;
-  $log = _$log_;
 }


### PR DESCRIPTION
There is no requirement to include the messages in case of an error.
Highlighting the field can be enough.

Fixes #10461

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
At the moment warning are displayed in the console when ng-messages are not specified for the input field.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number:
Relates to #10461 
Relates to #9468


## What is the new behavior?
The warnings are not generated as it is not required to include the error messages.
The original fix for #9468 is still in place. The other changes introduced together with that fix were removed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
