### PR TITLE
fix(select): display asterisk on label only if empty

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -105,7 +105,7 @@ md-select {
   margin: 2.5*$baseline-grid 0 3*$baseline-grid + 2 0;
 
   &[required], &.ng-required {
-    &.ng-invalid:not(.md-no-asterisk) {
+    &.ng-empty.ng-invalid:not(.md-no-asterisk) {
       .md-select-value span:first-child:after {
         content: ' *';
         font-size: 13px;


### PR DESCRIPTION
Closes #11312

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

If a `md-select` control has a custom validation on it using `$setValidity(false)`, the required * will show on the chosen value even though the value is populated.
 
Issue Number: 11312


## What is the new behavior?

The required * will show on the value only if no value is chosen. It will still display on placeholder.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
