### PR TITLE
fix(chips): set dirty when a chip is removed

### DIFF
--- a/src/components/chips/chips.spec.js
+++ b/src/components/chips/chips.spec.js
@@ -288,6 +288,42 @@ describe('<md-chips>', function() {
           expect(scope.items.length).toBe(4);
         });
 
+        it('should update form state when a chip is added', inject(function($mdConstant) {
+          scope.items = [];
+          var template =
+              '<form name="form">' +
+              '  <md-chips name="chips" ng-model="items"></md-chips>' +
+              '</form>';
+
+          var element = buildChips(template);
+          var ctrl = element.controller('mdChips');
+          var chips = getChipElements(element);
+          var input = element.find('input');
+
+          expect(scope.form.$pristine).toBeTruthy();
+          expect(scope.form.$dirty).toBeFalsy();
+
+          // Add 'Banana'
+          input.val('Banana');
+
+          // IE11 does not support the `input` event to update the ngModel. An alternative for
+          // `input` is to use the `change` event.
+          input.triggerHandler('change');
+
+          var enterEvent = {
+            type: 'keydown',
+            keyCode: $mdConstant.KEY_CODE.ENTER,
+            which: $mdConstant.KEY_CODE.ENTER
+          };
+
+          input.triggerHandler(enterEvent);
+          scope.$digest();
+
+          expect(scope.form.$pristine).toBeFalsy();
+          expect(scope.form.$dirty).toBeTruthy();
+          expect(scope.items).toEqual(['Banana']);
+        }));
+
         it('should allow adding the first chip on blur when required exists', function() {
           scope.items = [];
           var template =
@@ -1591,7 +1627,30 @@ describe('<md-chips>', function() {
         scope.$digest();
         chips = getChipElements(element);
         expect(chips.length).toBe(1);
+      });
 
+      it('should update form state when a chip is removed', function() {
+        var template =
+            '<form name="form">' +
+            '  <md-chips name="chips" ng-model="items"></md-chips>' +
+            '</form>';
+
+        var element = buildChips(template);
+        var ctrl = element.controller('mdChips');
+        var chips = getChipElements(element);
+
+        expect(scope.form.$pristine).toBeTruthy();
+        expect(scope.form.$dirty).toBeFalsy();
+
+        // Remove 'Banana'
+        var chipButton = angular.element(chips[1]).find('button');
+        chipButton[0].click();
+
+        scope.$digest();
+
+        expect(scope.form.$pristine).toBeFalsy();
+        expect(scope.form.$dirty).toBeTruthy();
+        expect(scope.items).toEqual(['Apple', 'Orange']);
       });
     });
 

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -623,6 +623,7 @@ MdChipsCtrl.prototype.removeChip = function(index, event) {
   var removed = this.items.splice(index, 1);
 
   this.updateNgModel();
+  this.ngModelCtrl.$setDirty();
 
   if (removed && removed.length && this.useOnRemove && this.onRemove) {
     this.onRemove({ '$chip': removed[0], '$index': index, '$event': event });


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Removing a chip does not cause the form to be marked dirty.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11356

## What is the new behavior?
Forms are marked dirty when a chip is removed.
Added passing tests for $dirty/$pristine when adding and removing chips.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
