### PR TITLE
fix(chips): editing chips works again

### DIFF
--- a/src/components/chips/js/chipController.js
+++ b/src/components/chips/js/chipController.js
@@ -81,10 +81,20 @@ MdChipCtrl.prototype.getChipContent = function() {
 
 
 /**
- * @return {Object} first content element of the chips content element
+ * When editing the chip, if the user modifies the existing contents, we'll get a span back and
+ * need to ignore text elements as they only contain blank space.
+ * `children()` ignores text elements.
+ *
+ * When editing the chip, if the user deletes the contents and then enters some new content
+ * we'll only get a text element back.
+ * @return {Object} jQuery object representing the content element of the chip
  */
 MdChipCtrl.prototype.getContentElement = function() {
-  return angular.element(this.getChipContent().contents()[0]);
+  var contentElement = angular.element(this.getChipContent().children()[0]);
+  if (!contentElement || contentElement.length === 0) {
+    contentElement = angular.element(this.getChipContent().contents()[0]);
+  }
+  return contentElement;
 };
 
 
@@ -101,7 +111,9 @@ MdChipCtrl.prototype.getChipIndex = function() {
  * If the contents were updated to be empty, remove the chip and re-focus the input element.
  */
 MdChipCtrl.prototype.goOutOfEditMode = function() {
-  if (!this.isEditing) return;
+  if (!this.isEditing) {
+    return;
+  }
 
   this.isEditing = false;
   this.$element.removeClass('_md-chip-editing');
@@ -110,10 +122,7 @@ MdChipCtrl.prototype.goOutOfEditMode = function() {
 
   var content = this.getContentElement().text();
   if (content) {
-    this.parentController.updateChipContents(
-        chipIndex,
-        this.getContentElement().text()
-    );
+    this.parentController.updateChipContents(chipIndex, content);
 
     this.$mdUtil.nextTick(function() {
       if (this.parentController.selectedChip === chipIndex) {
@@ -170,11 +179,10 @@ MdChipCtrl.prototype.goInEditMode = function() {
 MdChipCtrl.prototype.chipKeyDown = function(event) {
   if (!this.isEditing &&
     (event.keyCode === this.$mdConstant.KEY_CODE.ENTER ||
-    event.keyCode === this.$mdConstant.KEY_CODE.SPACE)) {
+      event.keyCode === this.$mdConstant.KEY_CODE.SPACE)) {
     event.preventDefault();
     this.goInEditMode();
-  } else if (this.isEditing &&
-    event.keyCode === this.$mdConstant.KEY_CODE.ENTER) {
+  } else if (this.isEditing && event.keyCode === this.$mdConstant.KEY_CODE.ENTER) {
     event.preventDefault();
     this.goOutOfEditMode();
   }

--- a/src/components/chips/js/chipDirective.js
+++ b/src/components/chips/js/chipDirective.js
@@ -21,13 +21,6 @@ angular
  *
  */
 
-// This hint text is visually hidden within a chip but used by screen readers to
-// inform the user how they can interact with a chip.
-var DELETE_HINT_TEMPLATE = '\
-    <span ng-if="!$mdChipsCtrl.readonly" class="md-visually-hidden">\
-      {{$mdChipsCtrl.deleteHint}}\
-    </span>';
-
 /**
  * MDChip Directive Definition
  *
@@ -38,8 +31,6 @@ var DELETE_HINT_TEMPLATE = '\
  * @ngInject
  */
 function MdChip($mdTheming, $mdUtil, $compile, $timeout) {
-  var deleteHintTemplate = $mdUtil.processTemplate(DELETE_HINT_TEMPLATE);
-
   return {
     restrict: 'E',
     require: ['^?mdChips', 'mdChip'],
@@ -56,9 +47,6 @@ function MdChip($mdTheming, $mdUtil, $compile, $timeout) {
 
     if (chipsController) {
       chipController.init(chipsController);
-
-      // Append our delete hint to the div.md-chip-content (which does not exist at compile time)
-      chipContentElement.append($compile(deleteHintTemplate)(scope));
 
       // When a chip is blurred, make sure to unset (or reset) the selected chip so that tabbing
       // through elements works properly

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -133,7 +133,7 @@
    * @param {expression=} md-on-remove An expression which will be called when a chip has been
    *    removed with `$chip`, `$index`, and `$event` available as parameters.
    * @param {expression=} md-on-select An expression which will be called when a chip is selected.
-   * @param {boolean} md-require-match If true, and the chips template contains an autocomplete,
+   * @param {boolean=} md-require-match If true, and the chips template contains an autocomplete,
    *    only allow selection of pre-defined chips (i.e. you cannot add new ones).
    * @param {string=} input-aria-label A string read by screen readers to identify the input.
    * @param {string=} container-hint A string read by screen readers informing users of how to
@@ -200,7 +200,7 @@
           {{$mdChipsCtrl.containerHint}}\
         </span>\
         <md-chip ng-repeat="$chip in $mdChipsCtrl.items"\
-            index="{{$index}}"\
+            index="{{$index}}" aria-label="{{$mdChipsCtrl.deleteHint}}"\
             ng-class="{\'md-focused\': $mdChipsCtrl.selectedChip == $index, \'md-readonly\': !$mdChipsCtrl.ngModelCtrl || $mdChipsCtrl.readonly}">\
           <div class="md-chip-content"\
               tabindex="{{$mdChipsCtrl.ariaTabIndex == $index ? 0 : -1}}"\
@@ -271,24 +271,24 @@
       bindToController: true,
       compile: compile,
       scope: {
-        readonly: '=readonly',
-        removable: '=mdRemovable',
-        placeholder: '@',
-        secondaryPlaceholder: '@',
-        maxChips: '@mdMaxChips',
+        readonly: '=?readonly',
+        removable: '=?mdRemovable',
+        placeholder: '@?',
+        secondaryPlaceholder: '@?',
+        maxChips: '@?mdMaxChips',
         transformChip: '&mdTransformChip',
-        onAppend: '&mdOnAppend',
-        onAdd: '&mdOnAdd',
-        onRemove: '&mdOnRemove',
-        onSelect: '&mdOnSelect',
-        inputAriaLabel: '@',
-        containerHint: '@',
-        deleteHint: '@',
-        deleteButtonLabel: '@',
+        onAppend: '&?mdOnAppend',
+        onAdd: '&?mdOnAdd',
+        onRemove: '&?mdOnRemove',
+        onSelect: '&?mdOnSelect',
+        inputAriaLabel: '@?',
+        containerHint: '@?',
+        deleteHint: '@?',
+        deleteButtonLabel: '@?',
         separatorKeys: '=?mdSeparatorKeys',
         requireMatch: '=?mdRequireMatch',
         chipAppendDelayString: '@?mdChipAppendDelay',
-        ngChange: '&'
+        ngChange: '&?'
       }
     };
 

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -705,7 +705,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
     /**
      * Processes a template and replaces the start/end symbols if the application has
-     * overriden them.
+     * overridden them.
      *
      * @param template The template to process whose start/end tags may be replaced.
      * @returns {*}


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Pressing the arrow keys, clicking the mouse, or pressing the backspace key in edit mode would cause the chips to become unresponsive or leave an empty chip behind.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11322. Relates to #11323.

## What is the new behavior?
- Navigation through the chip content text with arrow keys and the mouse is now supported.
- Clearing the chip content text and writing new text now works as expected.
- Backspace key works as expected and there is no longer an invisible text element inserted into the chip contents (the visually hidden deleteHint).
- don't override defaults for scope variables which aren't defined
  - properly mark scope variables as optional in chips directive
  - the default inputAriaLabel, deleteHint, etc should not be rendered
- deleteHint in chip content broke the ability to edit chips
  - move deleteHint out of chip content and only aria-label on md-chip
- handle edge case in editing when the user clears the content and
  then enters new content

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This fixes some of the regressions introduced as part of the a11y changes in 1.1.2.

I spent a good deal of time trying to add the first two tests for this edit chips feature, but I was unsuccessful. I was unable to fire the right events and find/focus the right elements to enter edit mode, change the text, and exit edit mode.