### PR TITLE
docs: change to LLC instead of Inc. in Copyright and licenses

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2014-2017 Google, Inc. http://angularjs.org
+Copyright (c) 2014-2018 Google LLC. https://angularjs.org
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/app/js/codepen.js
+++ b/docs/app/js/codepen.js
@@ -132,7 +132,7 @@
 
         return content + '\n\n'+
           commentStart + '\n'+
-          'Copyright 2018 Google Inc. All Rights Reserved. \n'+
+          'Copyright 2018 Google LLC. All Rights Reserved. \n'+
           'Use of this source code is governed by an MIT-style license that can be found\n'+
           'in the LICENSE file at http://material.angularjs.org/HEAD/license.\n'+
           commentEnd;

--- a/docs/app/partials/license.tmpl.html
+++ b/docs/app/partials/license.tmpl.html
@@ -3,8 +3,8 @@
     <p>The MIT License</p>
 
     <p>
-      Copyright (c) 2014-2016 Google, Inc.
-      <a href="http://angularjs.org">http://angularjs.org</a>
+      Copyright (c) 2014-2018 Google LLC
+      <a href="http://angularjs.org">https://angularjs.org</a>
     </p>
 
     <p>


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Copyright and licenses use out of date Google Inc.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #11367

## What is the new behavior?

- Use new Google LLC name
- change to https as well
- update years in licenses

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
