### PR TITLE
feat(theme): add contrast opacity values for all color types and hues

### DIFF
--- a/docs/guides/THEMES_IMPL_NOTES.md
+++ b/docs/guides/THEMES_IMPL_NOTES.md
@@ -12,7 +12,7 @@ the `$mdTheming` service and tacked into the document head.
 * Instead of using hard-coded color or a SCSS variable, the colors are defined with a mini-DSL
 (described deblow).
 * The build process takes all of those `-theme.scss` files and globs them up into one enourmous
-string.  
+string.
 * The build process wraps that string with code to set it an angular module constant:
     ``` angular.module('material.core').constant('$MD_THEME_CSS', 'HUGE_THEME_STRING'); ```
 * That code gets dumped at the end of `angular-material.js`
@@ -24,15 +24,21 @@ mini-DSL, applies the colors for the theme, and appends the resulting CSS into t
 
 
 ### The mini-DSL
-* Each color is written in the form `'{{palette-hue-opacity}}'`, where opacity is optional. 
+* Each color is written in the form `'{{palette-hue-contrast-opacity}}'`, where `hue`, `contrast`,
+and opacity are optional.
 * For example, `'{{primary-500}}'`
-* Palettes are `primary`, `accent`, `warn`, `background`, `foreground`
-* The hues for each type except `foreground` use the Material Design hues.
-* The `forground` palette is a number from one to four:
-  * `foreground-1`: text
-  * `foreground-2`: secondary text, icons
-  * `foreground-3`: disabled text, hint text
-  * `foreground-4`: dividers  
-* There is also a special hue called `contrast` that will give a contrast color (for text). 
-For example, `accent-contrast` will be a contrast color for the accent color, for use as a text 
-color on an accent-colored background.
+* Palettes are `primary`, `accent`, `warn`, `background`
+* The hues for each type use the Material Design hues. When not specified, each palette defaults
+`hue` to `500` with the exception of `background`
+* The `opacity` value can be a decimal between 0 and 1 or one of the following values based on the
+hue's contrast type (dark, light, or strongLight):
+  * `icon`: icon (0.54 / 0.87 / 1.0)
+  * `secondary`: secondary text (0.54 / 0.87)
+  * `disabled`: disabled text or icon (0.38 / 0.54)
+  * `hint`: hint text (0.38 / 0.50)
+  * `divider`: divider (0.12)
+* `contrast` will give a contrast color (for text) and can be mixed with `opacity`.
+For example, `accent-contrast` will be a contrast color for the accent color, for use as a text
+color on an accent-colored background. Adding an `opacity` value as in `accent-contrast-icon` will
+apply the Material Design icon opacity. Using a decimal opacity value as in `accent-contrast-0.25`
+will apply the contrast color for the accent color at 25% opacity.

--- a/docs/guides/THEMES_IMPL_NOTES.md
+++ b/docs/guides/THEMES_IMPL_NOTES.md
@@ -1,35 +1,36 @@
-# Notes on ng-material's theme implementation
+# Notes on AngularJS Material's theme implementation
 
 #### TL;DR
-Themes are configured by users with `$mdThemingProvider`. The CSS is then generated at run-time by
-the `$mdTheming` service and tacked into the document head.
+You configure themes with `$mdThemingProvider`. The CSS is then generated at run-time by
+the `$mdTheming` service and appended to the document's `<head>`.
 
-## Actual explanation
+## Explanation
 
 ### At build time
-* All of the styles associated with **color** are defined in a separate scss file of the form
+* All the styles associated with **color** are defined in a separate SCSS file of the form
 `xxx-theme.scss`.
-* Instead of using hard-coded color or a SCSS variable, the colors are defined with a mini-DSL
-(described deblow).
-* The build process takes all of those `-theme.scss` files and globs them up into one enourmous
+* Instead of using a hard-coded color or a SCSS variable, you define the colors with a mini-DSL
+  (described below).
+* The build process takes all of those `-theme.scss` files and globs them up into one enormous
 string.
-* The build process wraps that string with code to set it an angular module constant:
-    ``` angular.module('material.core').constant('$MD_THEME_CSS', 'HUGE_THEME_STRING'); ```
-* That code gets dumped at the end of `angular-material.js`
+* The build process wraps that string with code to set it as an AngularJS module constant:
+  ```
+    angular.module('material.core').constant('$MD_THEME_CSS', 'HUGE_THEME_STRING');
+  ```
+* That code gets dumped at the end of `angular-material.js`.
 
 ### At run time
 * The user defines some themes with `$mdThemingProvider` during the module config phase.
 * At module run time, the theming service takes `$MD_THEME_CSS` and, for each theme, evaluates the
 mini-DSL, applies the colors for the theme, and appends the resulting CSS into the document head.
 
-
 ### The mini-DSL
-* Each color is written in the form `'{{palette-hue-contrast-opacity}}'`, where `hue`, `contrast`,
+* You write each color in the form `'{{palette-hue-contrast-opacity}}'`, where `hue`, `contrast`,
 and opacity are optional.
-* For example, `'{{primary-500}}'`
-* Palettes are `primary`, `accent`, `warn`, `background`
+* For example, `'{{primary-500}}'`.
+* Palettes are `primary`, `accent`, `warn`, `background`.
 * The hues for each type use the Material Design hues. When not specified, each palette defaults
-`hue` to `500` with the exception of `background`
+`hue` to `500` except for `background`.
 * The `opacity` value can be a decimal between 0 and 1 or one of the following values based on the
 hue's contrast type (dark, light, or strongLight):
   * `icon`: icon (0.54 / 0.87 / 1.0)

--- a/src/components/colors/demoBasicUsage/index.html
+++ b/src/components/colors/demoBasicUsage/index.html
@@ -1,25 +1,25 @@
 <div layout="column" ng-cloak class="md-padding">
   <p style="margin-bottom: 10px;">
-    Custom component implementations using Material elements often want to easily apply Theme colors
+    Custom component implementations using Material elements often want to easily apply theme colors
     to their custom components. Consider the custom <code>&lt;user-card&gt;</code> component below
     where the <code>md-colors</code> attribute is used to color the background and text colors
-    using either the current or specified Theme palette colors.
+    using either the current or specified theme palette colors.
   </p>
   <!-- Example 1 -->
-  <span class="card-title"> <code>&lt;user-card&gt;</code> without md-color features</span>
+  <h4 class="card-title"> <code>&lt;user-card&gt;</code> without md-color features</h4>
   <regular-card name="User name" md-theme="default"></regular-card>
   <!-- Example 2 -->
-  <span class="card-title"> <code>&lt;user-card&gt;</code> coloring using the 'default' Theme</span>
+  <h4 class="card-title"> <code>&lt;user-card&gt;</code> coloring using the 'default' theme</h4>
   <user-card name="User name"></user-card>
   <!-- Example 3 -->
-  <span class="card-title"> <code>&lt;user-card&gt;</code> coloring using the 'forest' Theme</span>
+  <h4 class="card-title"> <code>&lt;user-card&gt;</code> coloring using the 'forest' theme</h4>
   <user-card name="User name" theme="forest"></user-card>
   <!-- Footnote -->
   <p class="footnote">
-    Note: The <code>md-colors</code> directive allows pre-defined theme colors to be easily applied
-    as CSS style properties. <code>md-colors</code> uses the Palettes defined at
-    <a class="md-accent" href="https://material.io/archive/guidelines/style/color.html#">Material Design Colors</a>
-    and the Themes defined using <code>$mdThemingProvider</code>. This feature is simply an
-    extension of the <code>$mdTheming</code> features.
+    Note: The <code>md-colors</code> directive allows pre-defined theme colors to be applied
+    as CSS style properties. <code>md-colors</code> uses the palettes defined in the
+    <a class="md-accent" href="https://material.io/archive/guidelines/style/color.html#color-color-palette">
+      Material Design Colors</a> and the themes defined using <code>$mdThemingProvider</code>.
+    This directive is an extension of the <code>$mdTheming</code> features.
   </p>
 </div>

--- a/src/components/colors/demoBasicUsage/regularCard.tmpl.html
+++ b/src/components/colors/demoBasicUsage/regularCard.tmpl.html
@@ -2,7 +2,7 @@
   <md-card-title>
     <md-card-title-media>
       <div class="md-media-sm card-media" layout>
-        <md-icon md-svg-icon="person" style="color:grey"></md-icon>
+        <md-icon md-svg-icon="social:person" style="color: grey"></md-icon>
       </div>
     </md-card-title-media>
     <md-card-title-text>

--- a/src/components/colors/demoBasicUsage/script.js
+++ b/src/components/colors/demoBasicUsage/script.js
@@ -5,7 +5,7 @@ angular.module('colorsDemo', ['ngMaterial'])
       .accentPalette('green');
 
     $mdIconProvider
-      .defaultIconSet('img/icons/sets/social-icons.svg', 24);
+      .iconSet('social', 'img/icons/sets/social-icons.svg', 24);
   })
   .directive('regularCard', function () {
     return {

--- a/src/components/colors/demoBasicUsage/style.css
+++ b/src/components/colors/demoBasicUsage/style.css
@@ -14,9 +14,8 @@
   color: rgba(255, 255, 255, 0.87);
 }
 
-span.card-title {
-  padding-left: 15px;
-  margin-top: 20px;
+h4.card-title {
+  margin: 24px 8px 0;
 }
 
 code.css {
@@ -24,12 +23,12 @@ code.css {
 }
 
 p.footnote code {
-  font-size:0.85em;
+  font-size: 0.85em;
 }
 
 p.footnote {
-  font-size:0.85em;
-  margin: 30px;
-  padding:5px;
-  background-color: rgba(205,205,205,0.45);
+  font-size: 0.85em;
+  margin: 30px 8px;
+  padding: 16px;
+  background-color: rgba(205, 205, 205, 0.45);
 }

--- a/src/components/colors/demoBasicUsage/userCard.tmpl.html
+++ b/src/components/colors/demoBasicUsage/userCard.tmpl.html
@@ -2,7 +2,7 @@
   <md-card-title>
     <md-card-title-media>
       <div class="md-media-sm card-media" layout md-colors="::{background: '{{theme}}-accent'}">
-        <md-icon md-svg-icon="person"></md-icon>
+        <md-icon md-svg-icon="social:person"></md-icon>
       </div>
     </md-card-title-media>
     <md-card-title-text>

--- a/src/components/colors/demoThemePicker/index.html
+++ b/src/components/colors/demoThemePicker/index.html
@@ -1,6 +1,6 @@
 <div layout="column" ng-cloak ng-controller="ThemeDemoCtrl" class="md-padding">
   <p>
-    Select a color from the <a class="md-accent" href="{{mdURL}}">Theme Color Palettes</a>
+    Select two of the <a class="md-accent" href="{{mdURL}}">Material Palettes</a>
     below:
   </p>
   <!-- Theme Options -->
@@ -26,8 +26,8 @@
   <!-- Footnote -->
   <p class="footnote">
     Notice that the foreground colors are automatically determined (from the theme configurations)
-    based on the specified background palette selection. Of course, you could easily override the
-    foreground color also...
+    based on the specified background palette selection. You can also override the foreground color,
+    if desired.
   </p>
 
 </div>

--- a/src/components/colors/demoThemePicker/script.js
+++ b/src/components/colors/demoThemePicker/script.js
@@ -3,7 +3,7 @@ angular
   .controller('ThemeDemoCtrl', function ($scope, $mdColorPalette) {
     $scope.colors = Object.keys($mdColorPalette);
 
-    $scope.mdURL = 'https://material.google.com/style/color.html#color-color-palette';
+    $scope.mdURL = 'https://material.io/archive/guidelines/style/color.html#color-color-palette';
     $scope.primary = 'purple';
     $scope.accent = 'green';
 

--- a/src/components/colors/demoThemePicker/style.css
+++ b/src/components/colors/demoThemePicker/style.css
@@ -18,10 +18,10 @@
 }
 
 p.footnote {
-  font-size:0.85em;
-  margin: 30px;
-  padding:5px;
-  background-color: rgba(205,205,205,0.45);
+  font-size: 0.85em;
+  margin: 30px 8px;
+  padding: 16px;
+  background-color: rgba(205, 205, 205, 0.45);
 }
 
 .componentTag {

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -133,13 +133,10 @@ function detectDisabledThemes($mdThemingProvider) {
  * {{primary-color-0.7}} - Apply 0.7 opacity to each of the above rules
  * {{primary-contrast}} - Generates .md-hue-1, .md-hue-2, .md-hue-3 with configured contrast (ie. text) color shades set for each hue
  * {{primary-contrast-0.7}} - Apply 0.7 opacity to each of the above rules
+ * {{primary-contrast-divider}} - Apply divider opacity to contrast color
+ * {{background-default-contrast}} - Apply primary text color for contrasting with default background
+ * {{background-50-contrast-icon}} - Apply contrast color for icon on background's shade 50 hue
  *
- * Foreground expansion: Applies rgba to black/white foreground text
- *
- * {{foreground-1}} - used for primary text
- * {{foreground-2}} - used for secondary text/divider
- * {{foreground-3}} - used for disabled text
- * {{foreground-4}} - used for dividers
  */
 
 // In memory generated CSS rules; registered by theme.name
@@ -148,21 +145,14 @@ var GENERATED = { };
 // In memory storage of defined themes and color palettes (both loaded by CSS, and user specified)
 var PALETTES;
 
-// Text Colors on light and dark backgrounds
+// Text colors are automatically generated based on background color when not specified
+// Custom palettes can provide override colors
 // @see https://material.io/archive/guidelines/style/color.html#color-usability
 var DARK_FOREGROUND = {
   name: 'dark',
-  '1': 'rgba(0,0,0,0.87)',
-  '2': 'rgba(0,0,0,0.54)',
-  '3': 'rgba(0,0,0,0.38)',
-  '4': 'rgba(0,0,0,0.12)'
 };
 var LIGHT_FOREGROUND = {
   name: 'light',
-  '1': 'rgba(255,255,255,1.0)',
-  '2': 'rgba(255,255,255,0.7)',
-  '3': 'rgba(255,255,255,0.5)',
-  '4': 'rgba(255,255,255,0.12)'
 };
 
 var DARK_SHADOW = '1px 1px 0px rgba(0,0,0,0.4), -1px -1px 0px rgba(0,0,0,0.4)';
@@ -199,6 +189,34 @@ var DARK_DEFAULT_HUES = {
     'hue-3': 'A200'
   }
 };
+
+// use inactive icon opacity from https://material.google.com/style/color.html#color-text-background-colors
+// not inactive icon opacity from https://material.google.com/style/icons.html#icons-system-icons
+
+var DARK_CONTRAST_OPACITY = {
+  'icon': 0.54,
+  'secondary': 0.54,
+  'disabled': 0.38,
+  'hint': 0.38,
+  'divider': 0.12,
+};
+
+var LIGHT_CONTRAST_OPACITY = {
+  'icon': 0.87,
+  'secondary': 0.7,
+  'disabled': 0.5,
+  'hint': 0.5,
+  'divider': 0.12
+};
+
+var STRONG_LIGHT_CONTRAST_OPACITY = {
+  'icon': 1.0,
+  'secondary': 0.7,
+  'disabled': 0.5,
+  'hint': 0.5,
+  'divider': 0.12
+};
+
 THEME_COLOR_TYPES.forEach(function(colorType) {
   // Color types with unspecified default hues will use these default hue values
   var defaultDefaultHues = {
@@ -974,18 +992,45 @@ function parseRules(theme, colorType, rules) {
 
   rules = rules.replace(/THEME_NAME/g, theme.name);
   var themeNameRegex = new RegExp('\\.md-' + theme.name + '-theme', 'g');
-  var simpleVariableRegex = /'?"?\{\{\s*([a-zA-Z]+)-(A?\d+|hue-[0-3]|shadow|default)-?(\d\.?\d*)?(contrast)?\s*\}\}'?"?/g;
+  // Matches '{{ primary-color }}', etc
+  var hueRegex = new RegExp('(?:\'|")?{{\\s*(' + colorType + ')-?(color|default)?-?(contrast)?-?((?:\\d\\.?\\d*)|(?:[a-zA-Z]+))?\\s*}}(\"|\')?','g');
+  var simpleVariableRegex = /'?"?\{\{\s*([a-zA-Z]+)-(A?\d+|hue-[0-3]|shadow|default)-?(contrast)?-?((?:\d\.?\d*)|(?:[a-zA-Z]+))?\s*\}\}'?"?/g;
+  var palette = PALETTES[color.name];
+  var defaultBgHue = theme.colors['background'].hues['default'];
+  var defaultBgContrastType = PALETTES[theme.colors['background'].name][defaultBgHue].contrastType;
 
   // find and replace simple variables where we use a specific hue, not an entire palette
   // eg. "{{primary-100}}"
   // \(' + THEME_COLOR_TYPES.join('\|') + '\)'
-  rules = rules.replace(simpleVariableRegex, function(match, colorType, hue, opacity, contrast) {
+  rules = rules.replace(simpleVariableRegex, function(match, colorType, hue, contrast, opacity) {
+    var regexColorType = colorType;
     if (colorType === 'foreground') {
       if (hue == 'shadow') {
         return theme.foregroundShadow;
-      } else {
-        return theme.foregroundPalette[hue] || theme.foregroundPalette['1'];
+      } else if (theme.foregroundPalette[hue]) {
+        // Use user defined palette number (ie: foreground-2)
+        return rgba( colorToRgbaArray( theme.foregroundPalette[hue] ) );
+      } else if (theme.foregroundPalette['1']){
+        return rgba( colorToRgbaArray( theme.foregroundPalette['1'] ) );
       }
+      // Default to background-default-contrast-{opacity}
+      colorType = 'background';
+      contrast = 'contrast';
+      if (!opacity && hue) {
+        // Convert references to legacy hues to opacities (ie: foreground-4 to *-divider)
+        switch(hue) {
+          // hue-1 uses default opacity
+          case '2':
+            opacity = 'secondary';
+            break;
+          case '3':
+            opacity = 'disabled';
+            break;
+          case '4':
+            opacity = 'divider';
+        }
+      }
+      hue = 'default';
     }
 
     // `default` is also accepted as a hue-value, because the background palettes are
@@ -994,7 +1039,42 @@ function parseRules(theme, colorType, rules) {
       hue = theme.colors[colorType].hues[hue];
     }
 
-    return rgba((PALETTES[ theme.colors[colorType].name ][hue] || '')[contrast ? 'contrast' : 'value'], opacity);
+    var colorDetails = (PALETTES[ theme.colors[colorType].name ][hue] || '');
+
+    // If user has specified a foreground color, use those
+    if (colorType === 'background' && contrast && regexColorType !== 'foreground' && colorDetails.contrastType == defaultBgContrastType) {
+      // Don't process if colorType was changed
+      switch (opacity) {
+        case 'secondary':
+        case 'icon':
+          if (theme.foregroundPalette['2']) {
+            return rgba(colorToRgbaArray(theme.foregroundPalette['2']));
+          }
+          break;
+        case 'disabled':
+        case 'hint':
+          if (theme.foregroundPalette['3']) {
+            return rgba(colorToRgbaArray(theme.foregroundPalette['3']));
+          }
+          break;
+        case 'divider':
+          if (theme.foregroundPalette['4']) {
+            return rgba(colorToRgbaArray(theme.foregroundPalette['4']));
+          }
+          break;
+        default:
+          if (theme.foregroundPalette['1']) {
+            return rgba(colorToRgbaArray(theme.foregroundPalette['1']));
+          }
+          break;
+      }
+    }
+
+    if (contrast && opacity) {
+      opacity = colorDetails.opacity[opacity] || opacity;
+    }
+
+    return rgba(colorDetails[contrast ? 'contrast' : 'value'], opacity);
   });
 
   // Matches '{{ primary-color }}', etc
@@ -1004,10 +1084,13 @@ function parseRules(theme, colorType, rules) {
   // For each type, generate rules for each hue (ie. default, md-hue-1, md-hue-2, md-hue-3)
   angular.forEach(['default', 'hue-1', 'hue-2', 'hue-3'], function(hueName) {
     var newRule = rules
-      .replace(hueRegex, function(match, _, matchedColorType, hueType, opacity) {
+      .replace(hueRegex, function(match, _, matchedColorType, hueType, contrast, opacity) {
         var color = theme.colors[matchedColorType];
         var palette = PALETTES[color.name];
         var hueValue = color.hues[hueName];
+        if (contrast && opacity) {
+          opacity = palette[hueValue].opacity[opacity] || opacity;
+        }
         return rgba(palette[hueValue][hueType === 'color' ? 'value' : 'contrast'], opacity);
       });
     if (hueName !== 'default') {
@@ -1114,6 +1197,37 @@ function generateAllThemes($injector, $mdTheming) {
     delete palette.contrastStrongLightColors;
     delete palette.contrastDarkColors;
 
+    function getContrastType(hueName) {
+      if (defaultContrast === 'light' ? darkColors.indexOf(hueName) !== -1  : lightColors.indexOf(hueName) === -1) {
+        return 'dark';
+      }
+      if (strongLightColors.indexOf(hueName) !== -1) {
+        return 'strongLight';
+      }
+      return 'light';
+    }
+    function getContrastColor(contrastType) {
+      switch(contrastType) {
+        default:
+        case 'strongLight':
+          return STRONG_LIGHT_CONTRAST_COLOR;
+        case 'light':
+          return LIGHT_CONTRAST_COLOR;
+        case 'dark':
+          return DARK_CONTRAST_COLOR;
+      }
+    }
+    function getOpacityValues(contrastType) {
+      switch(contrastType) {
+        default:
+        case 'strongLight':
+          return STRONG_LIGHT_CONTRAST_OPACITY;
+        case 'light':
+          return LIGHT_CONTRAST_OPACITY;
+        case 'dark':
+          return DARK_CONTRAST_OPACITY;
+      }
+    }
     // Change { 'A100': '#fffeee' } to { 'A100': { value: '#fffeee', contrast:DARK_CONTRAST_COLOR }
     angular.forEach(palette, function(hueValue, hueName) {
       if (angular.isObject(hueValue)) return; // Already converted
@@ -1126,28 +1240,14 @@ function generateAllThemes($injector, $mdTheming) {
                         .replace('%3', hueName));
       }
 
+      var contrastType = getContrastType(hueName);
       palette[hueName] = {
         hex: palette[hueName],
         value: rgbValue,
-        contrast: getContrastColor()
+        contrastType: contrastType,
+        contrast: getContrastColor(contrastType),
+        opacity: getOpacityValues(contrastType)
       };
-      function getContrastColor() {
-        if (defaultContrast === 'light') {
-          if (darkColors.indexOf(hueName) > -1) {
-            return DARK_CONTRAST_COLOR;
-          } else {
-            return strongLightColors.indexOf(hueName) > -1 ? STRONG_LIGHT_CONTRAST_COLOR
-              : LIGHT_CONTRAST_COLOR;
-          }
-        } else {
-          if (lightColors.indexOf(hueName) > -1) {
-            return strongLightColors.indexOf(hueName) > -1 ? STRONG_LIGHT_CONTRAST_COLOR
-              : LIGHT_CONTRAST_COLOR;
-          } else {
-            return DARK_CONTRAST_COLOR;
-          }
-        }
-      }
     });
   }
 }

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -249,12 +249,30 @@ describe('$mdThemingProvider', function() {
           .toEqual('color: rgba(0,0,0,0.12);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-shadow}}"; }')[0].content)
           .toEqual('color: ;');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.54);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.54);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-disabled}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.38);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-hint}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.38);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-divider}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.12);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-0.05}}"; }')[0].content)
+          .toEqual('color: rgba(0,0,0,0.05);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
       });
 
       it('for a dark theme', function() {
         testTheme.dark();
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-1}}"; }')[0].content)
-          .toEqual('color: rgba(255,255,255,1.0);');
+          .toEqual('color: rgba(255,255,255,0.87);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-2}}"; }')[0].content)
           .toEqual('color: rgba(255,255,255,0.7);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-3}}"; }')[0].content)
@@ -263,6 +281,77 @@ describe('$mdThemingProvider', function() {
           .toEqual('color: rgba(255,255,255,0.12);');
         expect(parse('.md-THEME_NAME-theme { color: "{{foreground-shadow}}"; }')[0].content)
           .toEqual('color: 1px 1px 0px rgba(0,0,0,0.4), -1px -1px 0px rgba(0,0,0,0.4);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-disabled}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.5);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-hint}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.5);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-divider}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.12);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-0.05}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.05);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-900-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,255,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-900-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,1);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
+      });
+      it('override foreground color', function() {
+        testTheme.dark(false);
+        testTheme.foregroundPalette = {
+          '1': 'ff0000',
+          '2': '00ff00',
+          '3': '0000ff',
+          '4': 'ffff00'
+        };
+        expect(parse('.md-THEME_NAME-theme { color: "{{foreground-1}}"; }')[0].content)
+          .toEqual('color: rgb(255,0,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{foreground-2}}"; }')[0].content)
+          .toEqual('color: rgb(0,255,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{foreground-3}}"; }')[0].content)
+          .toEqual('color: rgb(0,0,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{foreground-4}}"; }')[0].content)
+          .toEqual('color: rgb(255,255,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{foreground-shadow}}"; }')[0].content)
+          .toEqual('color: ;');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,0,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-icon}}"; }')[0].content)
+          .toEqual('color: rgb(0,255,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgb(0,255,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-disabled}}"; }')[0].content)
+          .toEqual('color: rgb(0,0,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-hint}}"; }')[0].content)
+          .toEqual('color: rgb(0,0,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-default-contrast-divider}}"; }')[0].content)
+          .toEqual('color: rgb(255,255,0);');
+
+        // override colors of same contrast type
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-50-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,0,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-100-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,0,0);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-200-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,0,0);');
+
+        // should not override the following
+        expect(parse('.md-THEME_NAME-theme { color: "{{background-900-contrast}}"; }')[0].content)
+          .toEqual('color: rgb(255,255,255);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.87);');
+        expect(parse('.md-THEME_NAME-theme { color: "{{primary-contrast-secondary}}"; }')[0].content)
+          .toEqual('color: rgba(255,255,255,0.7);');
       });
     });
 

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -171,12 +171,12 @@ describe('$mdThemingProvider', function() {
     function parse(str) {
       return themingProvider._parseRules(testTheme, 'primary', str)
         .join('')
-        .split(/\}(?!(\}|'|"|;))/)
+        .split(/}(?!(}|'|"|;))/)
         .filter(function(val) { return !!val; })
         .map(function(rule) {
           rule += '}';
           return {
-            content: (rule.match(/\{\s*(.*?)\s*\}/) || [])[1] || null,
+            content: (rule.match(/{\s*(.*?)\s*}/) || [])[1] || null,
             hue: (rule.match(/md-(hue-\d)/) || [])[1] || null,
             type: (rule.match(/(primary)/) || [])[1] || null
           };


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?

- Add opacity keyword support (`secondary`, `icon`, `disabled`, `hint`, `divider`)
- Deprecate documentation of `foreground-*` in favor of `background-default-contrast-*`
- Allow `foregroundPalette` to override colors on default background and hues of equal contrast type

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This is based on @clshortfuse's PR https://github.com/angular/material/pull/8872. 