### PR TITLE
fix(toolbar): input placeholders and ink need more contrast 

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -1,17 +1,17 @@
 md-input-container.md-THEME_NAME-theme {
   .md-input {
-    @include input-placeholder-color('\'{{foreground-2}}\'');
-    color: '{{foreground-1}}';
-    border-color: '{{foreground-4}}';
+    @include input-placeholder-color('\'{{background-default-contrast-hint}}\'');
+    color: '{{background-default-contrast}}';
+    border-color: '{{background-default-contrast-divider}}';
   }
 
   > md-icon {
-    color: '{{foreground-1}}';
+    color: '{{background-default-contrast}}';
   }
 
   label,
   .md-placeholder {
-    color: '{{foreground-2}}';
+    color: '{{background-default-contrast-hint}}';
   }
 
   label.md-required:after {
@@ -19,26 +19,26 @@ md-input-container.md-THEME_NAME-theme {
   }
 
   &:not(.md-input-focused):not(.md-input-invalid) label.md-required:after {
-    color: '{{foreground-2}}';
+    color: '{{background-default-contrast-secondary}}';
   }
 
   .md-input-messages-animation, .md-input-message-animation {
     color: '{{warn-A700}}';
     .md-char-counter {
-      color: '{{foreground-1}}';
+      color: '{{background-default-contrast}}';
     }
   }
 
   &.md-input-focused {
     .md-input {
-      @include input-placeholder-color('\'{{foreground-2}}\'');
+      @include input-placeholder-color('\'{{background-default-contrast-secondary}}\'');
     }
   }
 
   &:not(.md-input-invalid) {
     &.md-input-has-value {
       label {
-        color: '{{foreground-2}}';
+        color: '{{background-default-contrast-secondary}}';
       }
     }
     &.md-input-focused,
@@ -87,9 +87,9 @@ md-input-container.md-THEME_NAME-theme {
     &[disabled],
     [disabled] & {
       border-bottom-color: transparent;
-      color: '{{foreground-3}}';
-      background-image: linear-gradient(to right, '{{foreground-3}}' 0%, '{{foreground-3}}' 33%, transparent 0%);
-      background-image: -ms-linear-gradient(left, transparent 0%, '{{foreground-3}}' 100%);
+      color: '{{background-default-contrast-disabled}}';
+      background-image: linear-gradient(to right, '{{background-default-contrast-disabled}}' 0%, '{{background-default-contrast-disabled}}' 33%, transparent 0%);
+      background-image: -ms-linear-gradient(left, transparent 0%, '{{background-default-contrast-disabled}}' 100%);
     }
   }
 }

--- a/src/components/toolbar/demoInputsInToolbar/index.html
+++ b/src/components/toolbar/demoInputsInToolbar/index.html
@@ -1,0 +1,79 @@
+<div ng-controller="DemoCtrl" ng-cloak>
+  <md-toolbar class="md-accent">
+    <header layout="row" layout-align="start center">
+      <span>
+        <md-button class="md-icon-button md-primary" aria-label="Settings" disabled>
+          <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
+        </md-button>
+        <label style="vertical-align: middle; margin-right: 24px;">ACME</label>
+      </span>
+      <md-input-container md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="primary" />
+      </md-input-container>
+      <md-input-container class="md-accent" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="accent" />
+      </md-input-container>
+      <md-input-container class="md-warn" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="warn" />
+      </md-input-container>
+    </header>
+  </md-toolbar>
+  <md-toolbar class="md-primary">
+    <header layout="row" layout-align="start center">
+      <span>
+        <md-button class="md-icon-button md-primary" aria-label="Settings" disabled>
+          <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
+        </md-button>
+        <label style="vertical-align: middle; margin-right: 24px;">ACME</label>
+      </span>
+      <md-input-container md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="primary" />
+      </md-input-container>
+      <md-input-container class="md-accent" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="accent" />
+      </md-input-container>
+      <md-input-container class="md-warn" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="warn" />
+      </md-input-container>
+    </header>
+  </md-toolbar>
+  <md-toolbar class="md-warn">
+    <header layout="row" layout-align="start center">
+      <span>
+        <md-button class="md-icon-button md-primary" aria-label="Settings" disabled>
+          <md-icon md-svg-icon="img/icons/menu.svg"></md-icon>
+        </md-button>
+        <label style="vertical-align: middle; margin-right: 24px;">ACME</label>
+      </span>
+      <md-input-container md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="primary" />
+      </md-input-container>
+      <md-input-container class="md-accent" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="accent" />
+      </md-input-container>
+      <md-input-container class="md-warn" md-no-float>
+        <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
+        <input placeholder="warn" />
+      </md-input-container>
+    </header>
+  </md-toolbar>
+  <md-content class="md-margin">
+    <md-input-container md-no-float>
+      <input placeholder="primary no float" />
+    </md-input-container>
+    <md-input-container>
+      <input placeholder="primary" />
+    </md-input-container>
+    <md-input-container class="md-accent">
+      <input placeholder="accent" />
+    </md-input-container>
+  </md-content>
+</div>

--- a/src/components/toolbar/demoInputsInToolbar/script.js
+++ b/src/components/toolbar/demoInputsInToolbar/script.js
@@ -1,0 +1,2 @@
+angular.module('inputsInToolbarDemo', ['ngMaterial'])
+.controller('DemoCtrl', function($scope) {});

--- a/src/components/toolbar/demoInputsInToolbar/style.scss
+++ b/src/components/toolbar/demoInputsInToolbar/style.scss
@@ -1,0 +1,14 @@
+md-toolbar {
+  header {
+    margin-top: 16px;
+
+    >span {
+      height: 58px;
+      margin: 18px 0;
+    }
+
+    md-input-container {
+      width: 160px;
+    }
+  }
+}

--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -12,6 +12,42 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     fill: '{{primary-contrast-0.26}}';
   }
 
+  md-input-container[md-no-float] {
+    .md-input {
+      @include input-placeholder-color('\'{{primary-default-contrast-hint}}\'');
+      color: '{{primary-default-contrast}}';
+      border-color: '{{primary-default-contrast-divider}}';
+    }
+
+    &.md-input-focused {
+      .md-input {
+        @include input-placeholder-color('\'{{primary-default-contrast-secondary}}\'');
+      }
+    }
+
+    &:not(.md-input-invalid) {
+      &.md-input-focused,
+      &.md-input-resized {
+        .md-input {
+          border-color: '{{primary-contrast}}';
+        }
+      }
+
+      &.md-input-focused {
+        &.md-accent {
+          .md-input {
+            border-color: '{{accent-color}}';
+          }
+        }
+        &.md-warn {
+          .md-input {
+            border-color: '{{warn-A700}}';
+          }
+        }
+      }
+    }
+  }
+
   &.md-accent {
     background-color: '{{accent-color}}';
     color: '{{accent-contrast}}';
@@ -29,10 +65,82 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
       color: '{{accent-contrast-0.26}}';
       fill: '{{accent-contrast-0.26}}';
     }
+
+    md-input-container[md-no-float] {
+      .md-input {
+        @include input-placeholder-color('\'{{accent-default-contrast-hint}}\'');
+        color: '{{accent-default-contrast}}';
+        border-color: '{{accent-default-contrast-divider}}';
+      }
+
+      &.md-input-focused {
+        .md-input {
+          @include input-placeholder-color('\'{{accent-default-contrast-secondary}}\'');
+        }
+      }
+
+      &:not(.md-input-invalid) {
+        &.md-input-focused,
+        &.md-input-resized {
+          .md-input {
+            border-color: '{{primary-color}}';
+          }
+        }
+
+        &.md-input-focused {
+          &.md-accent {
+            .md-input {
+              border-color: '{{accent-contrast}}';
+            }
+          }
+          &.md-warn {
+            .md-input {
+              border-color: '{{warn-A700}}';
+            }
+          }
+        }
+      }
+    }
   }
 
   &.md-warn {
     background-color: '{{warn-color}}';
     color: '{{warn-contrast}}';
+
+    md-input-container[md-no-float] {
+      .md-input {
+        @include input-placeholder-color('\'{{warn-default-contrast-hint}}\'');
+        color: '{{warn-default-contrast}}';
+        border-color: '{{warn-default-contrast-divider}}';
+      }
+
+      &.md-input-focused {
+        .md-input {
+          @include input-placeholder-color('\'{{warn-default-contrast-secondary}}\'');
+        }
+      }
+
+      &:not(.md-input-invalid) {
+        &.md-input-focused,
+        &.md-input-resized {
+          .md-input {
+            border-color: '{{primary-color}}';
+          }
+        }
+
+        &.md-input-focused {
+          &.md-accent {
+            .md-input {
+              border-color: '{{accent-color}}';
+            }
+          }
+          &.md-warn {
+            .md-input {
+              border-color: '{{warn-contrast}}';
+            }
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Inputs in toolbars aren't themed properly and don't meet a11y guidelines for contrast.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #7987. This depends on #11376 being merged first.

## What is the new behavior?
Inputs in toolbars are themed properly and have contrast to make them readable.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Before
![Screen Shot 2019-08-26 at 14 13 02](https://user-images.githubusercontent.com/3506071/63712389-a631fc80-c80b-11e9-900d-eff671d7e7b5.png)

After
![Screen Shot 2019-08-26 at 14 12 09](https://user-images.githubusercontent.com/3506071/63712399-ab8f4700-c80b-11e9-845a-46a56a1e1521.png)
