### PR TITLE
perf(tabs): remove unreferenced elements variable from TabsController

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -11,11 +11,9 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   // define private properties
   var ctrl      = this,
       locked    = false,
-      elements  = getElements(),
       queue     = [],
       destroyed = false,
       loaded    = false;
-
 
   // Define public methods
   ctrl.$onInit            = $onInit;
@@ -94,10 +92,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     bindEvents();
     $mdTheming($element);
     $mdUtil.nextTick(function () {
-      // Note that the element references need to be updated, because certain "browsers"
-      // (IE/Edge) lose them and start throwing "Invalid calling object" errors, when we
-      // compile the element contents down in `compileElement`.
-      elements = getElements();
       updateHeightFromContent();
       adjustOffset();
       updateInkBarStyles();
@@ -469,7 +463,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
 
   /**
    * Gathers references to all of the DOM elements used by this controller.
-   * @returns {{}}
+   * @returns {Object}
    */
   function getElements () {
     var elements = {};
@@ -716,7 +710,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
         extraOffset = 32;
 
     // If we are selecting the first tab (in LTR and RTL), always set the offset to 0
-    if (index == 0) {
+    if (index === 0) {
       ctrl.offsetLeft = 0;
       return;
     }
@@ -926,6 +920,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   function isRtl() {
-    return ($mdUtil.bidi() == 'rtl');
+    return ($mdUtil.bidi() === 'rtl');
   }
 }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `MdTabsController` initializes `var elements = getElements()` at the top of the controller and again in `setupTabsController ()` but that `elements` variable is no longer referenced as all of the code has been updated to call `getElements()` each time instead.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11377 

## What is the new behavior?
Remove this unused and unreferenced variable to avoid extra DOM lookups.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
