### PR TITLE
feat(select): support customizing the separation of selected options in multiple mode

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -74,6 +74,7 @@ angular.module('material.components.select', [
  * @param {boolean=} multiple When present, allows for more than one option to be selected.
  *  The model is an array with the selected choices. **Note:** This attribute is only evaluated
  *  once; it is not watched.
+ * @param {string=} multiple-separator Determines how multiple values will be seperated, defaults to ', '.
  * @param {expression=} md-on-close Expression to be evaluated when the select is closed.
  * @param {expression=} md-on-open Expression to be evaluated when opening the select.
  * Will hide the select options and show a spinner until the evaluated promise resolves.
@@ -259,7 +260,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
     }
 
     var isMultiple = $mdUtil.parseAttributeBoolean(attr.multiple);
-
+    //Defaults ','
+    var multipleSeparator = attr.multipleSeparator || ', ';
+   
     // Use everything that's left inside element.contents() as the contents of the menu
     var multipleContent = isMultiple ? 'multiple' : '';
     var selectTemplate = '' +
@@ -678,6 +681,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
   function SelectMenuController($scope, $attrs, $element) {
     var self = this;
     self.isMultiple = angular.isDefined($attrs.multiple);
+    self.multipleSeparator = $attrs.multipleSeparator || ', ';
     // selected is an object with keys matching all of the selected options' hashed values
     self.selected = {};
     // options is an object with keys matching every option's hash value,
@@ -826,7 +830,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         }
 
         // Ensure there are no duplicates; see https://github.com/angular/material/issues/9442
-        return $mdUtil.uniq(selectedOptionEls.map(mapFn)).join(', ');
+        return $mdUtil.uniq(selectedOptionEls.map(mapFn)).join(self.multipleSeparator);
       } else {
         return '';
       }


### PR DESCRIPTION
Update select.js multiselect function to give control over the separator.
User can add `multiselect-separator="<br/>"`  as attribute

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
