### PR TITLE
fix(tabs): show a visual indication of tab focus

### DIFF
--- a/src/components/tabs/js/tabsDirective.js
+++ b/src/components/tabs/js/tabsDirective.js
@@ -146,6 +146,7 @@ function MdTabs ($$mdSvgRegistry) {
             '<md-icon md-svg-src="'+ $$mdSvgRegistry.mdTabsArrow +'"></md-icon> ' +
           '</md-next-button> ' +
           '<md-tabs-canvas ' +
+              'tabindex="{{ $mdTabsCtrl.hasFocus ? -1 : 0 }}" ' +
               'ng-focus="$mdTabsCtrl.redirectFocus()" ' +
               'ng-class="{ ' +
                   '\'md-paginated\': $mdTabsCtrl.shouldPaginate, ' +
@@ -184,6 +185,8 @@ function MdTabs ($$mdSvgRegistry) {
               '<md-dummy-tab ' +
                   'class="md-tab" ' +
                   'tabindex="-1" ' +
+                  'ng-focus="$mdTabsCtrl.hasFocus = true" ' +
+                  'ng-blur="$mdTabsCtrl.hasFocus = false" ' +
                   'ng-repeat="tab in $mdTabsCtrl.tabs" ' +
                   'md-tabs-template="::tab.label" ' +
                   'md-scope="::tab.parent"></md-dummy-tab> ' +


### PR DESCRIPTION
the visual highlighting of focused tabs was not functioning

Fixes #11384

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently when tabbing to an md-tab, there is no visual indication of focus.

This was happening because the md-dummy tab used to track has-focus on $mdTabsCtrl with ng-focus, but this was removed in [this](https://github.com/angular/material/commit/072f8328391c884b7ebc1ef49f4dc3e6c02e636c) commit

Issue Number: #11384


## What is the new behavior?

Now when tabbing to an md-tab the proper focused styling will be applied.

There seems to be two things required to fix this issue.

Firstly, ng-focus and ng-blur on md-dummy-tab are used to toggle the $mdTabsCtrl.hasFocus flag. This is important because the md-focused style is applied depending on the truthiness of the tabsController hasFocus method. This hasFocus method is partly dependent on $mdTabsCtrl.hasFocus being true.

Secondly, the tabindex of the md-tabs-canvas is set to 0. I'm really not exactly sure why this is necessary as I would expect the tabIndex to default to 0 and it is otherwise not set from what I can tell. If this is not set explicitly to 0, ng-focus will not be triggered when tabbing to the md-tabs. This means that the $mdTabsCtrl.redirectFocus method will not be called and focusing of the tab will not happen. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
