### PR TITLE
fix(list): account for IE11 bug with flexbox and min-height

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -163,7 +163,7 @@ md-list-item {
       .md-list-item-inner {
         // The list item content should fill the complete width.
         width: 100%;
-        min-height: inherit;
+        @include ie11-min-height-flexbug(inherit);
       }
 
     }


### PR DESCRIPTION
when using an md-3-line list item, use the mixin workaround for ie11 flexbug https://github.com/philipwalton/flexbugs#flexbug-3

Fixes #11177

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently in IE11, md-list-item content vertical alignment can break if the md-list-item has a click event applied to it.

Issue Number: #11177


## What is the new behavior?

Now the alignment will be correct in IE11. This is accomplished by wrapping the applied min-height in the ie11-min-height-flexbug mixin. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
