### PR TITLE
 Improve IE11 support - document.body.contains

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -518,7 +518,7 @@ function MdCompilerProvider($compileProvider) {
 
       // When the element is visible in the DOM, then we restore it at close of the dialog.
       // Otherwise it will be removed from the DOM after close.
-      if (document.contains(contentEl)) {
+      if (document.body.contains(contentEl)) {
         restoreFn = createRestoreFn(contentEl);
       } else {
         restoreFn = function() {


### PR DESCRIPTION
While IE11 supports `Node.contains()` method, it does not natively support `document.contains() ` https://github.com/Financial-Times/polyfill-service/issues/177

The quick fix is to use `document.body.contains()`

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Exception in IE11
`TypeError: Object doesn't support property or method 'contains'`


## What is the new behavior?
--

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->
