### PR TITLE
fix(dialog): add aria-hidden to md-dialog-focus-trap elements

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -1116,6 +1116,7 @@ function MdDialogProvider($$interimElementProvider) {
       // Set up elements before and after the dialog content to capture focus and
       // redirect back into the dialog.
       topFocusTrap = document.createElement('div');
+      topFocusTrap.setAttribute('aria-hidden', 'true');
       topFocusTrap.classList.add('md-dialog-focus-trap');
       topFocusTrap.tabIndex = 0;
 


### PR DESCRIPTION
add the attribute aria-hidden to the md-dialog-focus-trap divs so
screen-readers know to ignore them.

Fixes #10570

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Two divs are added to md-dialogs that contain the class md-dialog-focus-trap. These are being picked up by screen readers as they do not contain an aria-hidden attribute.

Issue Number: #10570

## What is the new behavior?

Now the focus trap elements are given the aria-hidden label so screen readers will know to ignore them.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
