### PR TITLE
feat(autocomplete): add support for aria-describedby

### DIFF
--- a/src/components/autocomplete/demoBasicUsage/index.html
+++ b/src/components/autocomplete/demoBasicUsage/index.html
@@ -1,7 +1,9 @@
 <div ng-controller="DemoCtrl as ctrl" layout="column" ng-cloak>
   <md-content class="md-padding">
     <form ng-submit="$event.preventDefault()">
-      <p>Use <code>md-autocomplete</code> to search for matches from local or remote data sources.</p>
+      <p id="autocompleteDescription">
+        Use <code>md-autocomplete</code> to search for matches from local or remote data sources.
+      </p>
       <md-autocomplete
           ng-disabled="ctrl.isDisabled"
           md-no-cache="ctrl.noCache"
@@ -12,7 +14,8 @@
           md-items="item in ctrl.querySearch(ctrl.searchText)"
           md-item-text="item.display"
           md-min-length="0"
-          placeholder="What is your favorite US state?">
+          placeholder="What is your favorite US state?"
+          aria-describedby="autocompleteDescription autocompleteDetailedDescription">
         <md-item-template>
           <span md-highlight-text="ctrl.searchText" md-highlight-flags="^i">{{item.display}}</span>
         </md-item-template>
@@ -25,7 +28,7 @@
       <md-checkbox ng-model="ctrl.simulateQuery">Simulate query for results?</md-checkbox>
       <md-checkbox ng-model="ctrl.noCache">Disable caching of queries?</md-checkbox>
       <md-checkbox ng-model="ctrl.isDisabled">Disable the input?</md-checkbox>
-      <p>
+      <p id="autocompleteDetailedDescription">
         By default, <code>md-autocomplete</code> will cache results when performing a query.
         After the initial call is performed, it will use the cached results to eliminate unnecessary
         server requests or lookup logic. This can be disabled above.

--- a/src/components/autocomplete/demoFloatingLabel/index.html
+++ b/src/components/autocomplete/demoFloatingLabel/index.html
@@ -4,8 +4,8 @@
       <p>The following example demonstrates floating labels being used as a normal form element.</p>
       <div layout-gt-sm="row">
         <md-input-container flex>
-          <label>Name</label>
-          <input type="text"/>
+          <label for="floatingLabelName">Name</label>
+          <input id="floatingLabelName" type="text"/>
         </md-input-container>
         <md-autocomplete flex required
             md-input-name="autocompleteField"
@@ -17,7 +17,8 @@
             md-items="item in ctrl.querySearch(ctrl.searchText)"
             md-item-text="item.display"
             md-require-match=""
-            md-floating-label="Favorite state">
+            md-floating-label="Favorite state"
+            aria-describedby="favoriteStateDescription">
           <md-item-template>
             <span md-highlight-text="ctrl.searchText">{{item.display}}</span>
           </md-item-template>
@@ -28,6 +29,9 @@
             <div ng-message="maxlength">Your entry is too long.</div>
           </div>
         </md-autocomplete>
+        <p id="favoriteStateDescription" hide>
+          A person's favorite state tells you a lot about them
+        </p>
       </div>
     </form>
   </md-content>

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -93,6 +93,9 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       if ($scope.autofocus) {
         $element.on('focus', focusInputElement);
       }
+      if ($scope.ariaDescribedBy) {
+        elements.input.setAttribute('aria-describedby', $scope.ariaDescribedBy);
+      }
     });
   }
 

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -130,6 +130,10 @@ angular
  *     as much as possible.
  * @param {string=} md-dropdown-position Overrides the default dropdown position. Options: `top`,
  *    `bottom`.
+ * @param {string=} aria-describedby A space-separated list of element IDs. This should contain the
+ *     IDs of any elements that describe this autocomplete. Screen readers will read the content of
+ *     these elements at the end of announcing that the autocomplete has been selected and
+ *     describing its current state. The descriptive elements do not need to be visible on the page.
  * @param {string=} md-selected-message Attribute to specify the text that the screen reader will
  *    announce after a value is selected. Default is: "selected". If `Alaska` is selected in the
  *    options panel, it will read "Alaska selected". You will want to override this when your app
@@ -259,6 +263,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
       itemsExpr:          '@mdItems',
       itemText:           '&mdItemText',
       placeholder:        '@placeholder',
+      ariaDescribedBy:    '@?ariaDescribedby',
       noCache:            '=?mdNoCache',
       requireMatch:       '=?mdRequireMatch',
       selectOnMatch:      '=?mdSelectOnMatch',


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Applying `aria-describedby` to an `md-autocomplete` would not cause the attribute to be forwarded down to the native `input` element. Thus it would have no effect.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11004

## What is the new behavior?
Applying `aria-describedby` to an `md-autocomplete` causes the attribute to be forwarded down to the native `input` element. This causes the contents of all elements with IDs in the list to be read after the autocomplete is selected and the label and state are announced.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
