### PR TITLE
feat(checkbox): add ng-readonly support

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -84,7 +84,7 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
         // Attach a click handler during preLink, in order to immediately stop propagation
         // (especially for ng-click) when the checkbox is disabled.
         element.on('click', function(e) {
-          if (this.hasAttribute('disabled')) {
+          if (this.hasAttribute('disabled') || this.hasAttribute('readonly')) {
             e.stopImmediatePropagation();
           }
         });
@@ -178,7 +178,7 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
       function listener(ev) {
         // skipToggle boolean is used by the switch directive to prevent the click event
         // when releasing the drag. There will be always a click if releasing the drag over the checkbox
-        if (element[0].hasAttribute('disabled') || scope.skipToggle) {
+        if (element[0].hasAttribute('disabled') || scope.skipToggle || element[0].hasAttribute('readonly')) {
           return;
         }
 

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -87,6 +87,28 @@ describe('mdCheckbox', function() {
     expect(pageScope.blue).toBe(true);
   });
 
+  it('should be disabled with readonly attr', function() {
+    var element = compileAndLink(
+      '<div>' +
+      '<md-checkbox ng-readonly="isReadOnly" ng-model="blue"></md-checkbox>' +
+      '</div>');
+
+    var checkbox = element.find('md-checkbox');
+
+    pageScope.isReadOnly = true;
+    pageScope.blue = false;
+    pageScope.$apply();
+
+    checkbox.triggerHandler('click');
+    expect(pageScope.blue).toBe(false);
+
+    pageScope.isReadOnly = false;
+    pageScope.$apply();
+
+    checkbox.triggerHandler('click');
+    expect(pageScope.blue).toBe(true);
+  });
+
   it('should prevent click handlers from firing when disabled', function() {
     pageScope.toggle = jasmine.createSpy('toggle');
 
@@ -96,6 +118,32 @@ describe('mdCheckbox', function() {
     checkbox.click();
 
     expect(pageScope.toggle).not.toHaveBeenCalled();
+  });
+
+  it('should prevent click handlers from firing when readonly', function () {
+
+    pageScope.toggle = jasmine.createSpy('toggle');
+
+    var checkbox = compileAndLink(
+      '<md-checkbox ng-readonly="true" ng-click="toggle()">On</md-checkbox>')[0];
+
+    checkbox.click();
+
+    expect(pageScope.toggle).not.toHaveBeenCalled();
+
+  });
+
+  it('should not prevent click handlers from firing when not readonly', function () {
+
+    pageScope.toggle = jasmine.createSpy('toggle');
+
+    var checkbox = compileAndLink(
+      '<md-checkbox ng-readonly="false" ng-click="toggle()">On</md-checkbox>')[0];
+
+    checkbox.click();
+
+    expect(pageScope.toggle).toHaveBeenCalled();
+
   });
 
   it('should preserve existing tabindex', function() {

--- a/src/components/checkbox/demoBasicUsage/index.html
+++ b/src/components/checkbox/demoBasicUsage/index.html
@@ -29,6 +29,16 @@
           </div>
         </div>
         <div flex-gt-sm="50">
+          <md-checkbox ng-readonly="true" aria-label="read only checkbox" ng-model="data.cb6">
+            Checkbox: readonly, Checked
+          </md-checkbox>
+        </div>
+        <div flex-gt-sm="50">
+          <md-checkbox ng-readonly="true" aria-label="read only checked checkbox" ng-model="data.cb7" ng-init="data.cb7=true">
+            Checkbox: readonly
+          </md-checkbox>
+        </div>
+        <div flex-gt-sm="50">
           <md-checkbox ng-disabled="true" aria-label="Disabled checkbox" ng-model="data.cb3">
             Checkbox: Disabled
           </md-checkbox>
@@ -39,8 +49,9 @@
           </md-checkbox>
         </div>
         <div flex-gt-sm="50">
-          <md-checkbox md-no-ink aria-label="Checkbox No Ink" ng-model="data.cb5" class="md-primary">
-            Checkbox (md-primary): No Ink
+          <md-checkbox md-indeterminate aria-label="Checkbox Disabled Indeterminate"
+                       ng-disabled="true" class="md-primary">
+            Checkbox: Disabled, Indeterminate
           </md-checkbox>
         </div>
         <div flex-gt-sm="50">
@@ -50,9 +61,8 @@
           </md-checkbox>
         </div>
         <div flex-gt-sm="50">
-          <md-checkbox md-indeterminate aria-label="Checkbox Disabled Indeterminate"
-              ng-disabled="true" class="md-primary">
-            Checkbox: Disabled, Indeterminate
+          <md-checkbox md-no-ink aria-label="Checkbox No Ink" ng-model="data.cb5" class="md-primary">
+            Checkbox (md-primary): No Ink
           </md-checkbox>
         </div>
       </div>

--- a/src/components/checkbox/demoBasicUsage/script.js
+++ b/src/components/checkbox/demoBasicUsage/script.js
@@ -9,5 +9,7 @@ angular.module('checkboxDemo1', ['ngMaterial'])
   $scope.data.cb3 = false;
   $scope.data.cb4 = false;
   $scope.data.cb5 = false;
+  $scope.data.cb6 = false;
+  $scope.data.cb7 = true;
 
 });

--- a/src/core/services/ripple/ripple.js
+++ b/src/core/services/ripple/ripple.js
@@ -335,7 +335,7 @@ InkRippleCtrl.prototype.isRippleAllowed = function () {
     if (!element.tagName || element.tagName === 'BODY') break;
 
     if (element && angular.isFunction(element.hasAttribute)) {
-      if (element.hasAttribute('disabled')) return false;
+      if (element.hasAttribute('disabled') || element.hasAttribute('readonly')) return false;
       if (this.inkRipple() === 'false' || this.inkRipple() === '0') return false;
     }
 


### PR DESCRIPTION
prevent ng-model updates and ng-click events when clicking readonly checkboxes

Fixes #3895

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently the ng-readonly directive has no effect on the md-checkbox directive.

Issue Number: 3895

## What is the new behavior?

Now having ng-readonly="true" or simply the readonly attribute on an md-checkbox will prevent

1. ng-click events from being triggered.
2. ng-model from being updated.
3. ink-ripple from triggering.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

