### PR TITLE
fix(input): remove space before asterisk  when required

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -104,7 +104,7 @@ md-input-container {
     @include rtl(right, auto, 0);
 
     &.md-required:after {
-      content: ' *';
+      content: '*';
       font-size: 13px;
       vertical-align: top;
     }


### PR DESCRIPTION
remove the space between input labels and the asterisk that appears
when they are required

Fixes #11418

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently when inputs are required there is a space between the input label and the asterisk that shows the input is required.

Issue Number: #11418

## What is the new behavior?

The space has been removed

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
