### PR TITLE
docs(docs): update docs to reference archived material spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3596,7 +3596,7 @@ Bugs fixed:
 #### Breaking Changes
 
 * As per the
-[spec](http://www.google.com/design/spec/style/color.html#color-ui-color-application)
+[spec](https://material.io/archive/guidelines/style/color.html#color-color-system)
 this commit changes the default color palette of FABs, checkboxes, radio
 buttons, sliders and switches to the accent palette.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Material Design for AngularJS Apps [![Build Status](https://travis-ci.org/angular/material.svg)](https://travis-ci.org/angular/material)
 
-[Material Design](https://material.io/) is a specification for a
+[Material Design](https://material.io/archive/guidelines/) is a specification for a
 unified system of visual, motion, and interaction design that adapts across different devices. Our
 goal is to deliver a lean, lightweight set of AngularJS-native UI elements that implement the
 material design specification for use in AngularJS single-page applications (SPAs).
 
 ![venn diagram](https://cloud.githubusercontent.com/assets/210413/5077572/30dfc2f0-6e6a-11e4-9723-07c918128f4f.png)
 
-AngularJS Material is an implementation of Google's [Material Design Specification](https://material.io/guidelines/material-design/).
+AngularJS Material is an implementation of Google's [Material Design Specification](https://material.io/archive/guidelines/material-design/).
 AngularJS Material includes a rich set of reusable, well-tested, and accessible UI components.
 
 Quick Links:

--- a/docs/app/partials/getting-started.tmpl.html
+++ b/docs/app/partials/getting-started.tmpl.html
@@ -12,7 +12,7 @@
         </li>
         <li>
           Read the
-          <a href="https://material.io/guidelines/" target="_blank"
+          <a href="https://material.io/archive/guidelines/" target="_blank"
              title="Material Design">Material Design </a> specifications for components,
           animations, styles, and layouts.
         </li>

--- a/docs/app/partials/home.tmpl.html
+++ b/docs/app/partials/home.tmpl.html
@@ -3,7 +3,7 @@
     <h2 class="md-headline" style="margin-top: 0;">What is AngularJS Material?</h2>
     <p>
       AngularJS Material is both a UI Component framework and a reference implementation of Google's
-      <a href="https://material.io/guidelines/material-design/" target="_blank" rel="noopener">Material Design Specification</a>.
+      <a href="https://material.io/archive/guidelines/" target="_blank" rel="noopener">Material Design Specification</a>.
       This project provides a set of reusable, well-tested, and accessible UI components based on Material Design.
     </p>
     <ul class="buckets" layout layout-align="center center" layout-wrap>
@@ -211,7 +211,7 @@
     <ul class="buckets" layout layout-align="center center" layout-wrap>
       <li flex="100" flex-gt-xs="50" ng-repeat="(index, link) in [
         { href: 'https://www.youtube.com/watch?v=Q8TXgCzxEnw', icon: 'ondemand_video', text: 'Watch a video', site : 'Google' },
-        { href: 'http://www.google.com/design/spec/material-design/', icon: 'launch', text: 'Learn More', site : 'Google' }
+        { href: 'https://material.io/archive/guidelines/', icon: 'launch', text: 'Learn More', site : 'Google' }
       ]">
         <md-button
             class="md-primary md-raised"

--- a/docs/content/CSS/typography.md
+++ b/docs/content/CSS/typography.md
@@ -6,7 +6,7 @@ AngularJS Material provides typography CSS classes you can use to create visual
 consistency across your application.
 
 <p style="text-align: center;">
-  [Material Design Typography Specification](https://material.google.com/style/typography.html)
+  [Material Design Typography Specification](https://material.io/archive/guidelines/style/typography.html)
 </p>
 
 <section class="demo-container">

--- a/docs/content/Theming/01_introduction.md
+++ b/docs/content/Theming/01_introduction.md
@@ -4,7 +4,7 @@
 
 Material Design is a visual language with specifications for innovative user experiences (UX) and user interface (UI) elements. Themes convey meaning through color, tones, and contrasts, similar to how Layouts convey meaning through keylines and alignments.
 
-Theme [**color palettes**](http://www.google.com/design/spec/style/color.html#color-ui-color-palette), alphas, and shadows deliver a consistent tone to your application and a unified feel for all AngularJS Material UI components.
+Theme [**color palettes**](https://material.io/archive/guidelines/style/color.html#color-color-palette), alphas, and shadows deliver a consistent tone to your application and a unified feel for all AngularJS Material UI components.
 
 Theming allows changing the color of your AngularJS Material application. If you
 need more custom styling (such as layout changes including padding, margins,

--- a/docs/content/Theming/06_browser_color.md
+++ b/docs/content/Theming/06_browser_color.md
@@ -8,7 +8,7 @@
 
 ![browser color](https://cloud.githubusercontent.com/assets/6004537/18006666/50519c7e-6ba9-11e6-905b-c3751c20549c.png)
 
-Enables browser header coloring with [Material Design Colors](https://material.google.com/style/color.html) and the theming system.
+Enables browser header coloring with [Material Design Colors](https://material.io/archive/guidelines/style/color.html#) and the theming system.
 
 For more information, please visit:<br/> 
 https://developers.google.com/web/fundamentals/design-and-ui/browser-customization/theme-color.

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -177,10 +177,10 @@ angular
  *
  * ### Clear button for the input
  * By default, the clear button is displayed when there is input. This aligns with the spec's
- * [Search Pattern](https://material.io/guidelines/patterns/search.html#search-in-app-search).
+ * [Search Pattern](https://material.io/archive/guidelines/patterns/search.html#search-in-app-search).
  * In floating label mode, when `md-floating-label="My Label"` is applied, the clear button is not displayed
  * by default (see the spec's
- * [Autocomplete Text Field](https://material.io/guidelines/components/text-fields.html#text-fields-layout)).
+ * [Autocomplete Text Field](https://material.io/archive/guidelines/components/text-fields.html#text-fields-layout)).
  *
  * Nevertheless, developers are able to explicitly toggle the clear button for all autocomplete components
  * with `md-clear-button`.

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -16,7 +16,7 @@ angular
  * @description
  * The checkbox directive is used like the normal [angular checkbox](https://docs.angularjs.org/api/ng/input/input%5Bcheckbox%5D).
  *
- * As per the [material design spec](http://www.google.com/design/spec/style/color.html#color-color-schemes)
+ * As per the [Material Design spec](https://material.io/archive/guidelines/style/color.html#color-color-palette)
  * the checkbox is in the accent color by default. The primary color palette may be used with
  * the `md-primary` class.
  *

--- a/src/components/colors/colors.spec.js
+++ b/src/components/colors/colors.spec.js
@@ -142,7 +142,7 @@ describe('md-colors', function () {
 
     /**
      * md-colors applies smart foreground colors (in case 'background' property is used) according the palettes from
-     * https://www.google.com/design/spec/style/color.html#color-color-palette
+     * https://material.io/archive/guidelines/style/color.html#color-color-palette
      */
     describe('foreground color', function () {
       /**

--- a/src/components/colors/demoBasicUsage/index.html
+++ b/src/components/colors/demoBasicUsage/index.html
@@ -18,7 +18,7 @@
   <p class="footnote">
     Note: The <code>md-colors</code> directive allows pre-defined theme colors to be easily applied
     as CSS style properties. <code>md-colors</code> uses the Palettes defined at
-    <a class="md-accent" href="https://www.google.com/design/spec/style/color.html">Material Design Colors</a>
+    <a class="md-accent" href="https://material.io/archive/guidelines/style/color.html#">Material Design Colors</a>
     and the Themes defined using <code>$mdThemingProvider</code>. This feature is simply an
     extension of the <code>$mdTheming</code> features.
   </p>

--- a/src/components/icon/js/iconDirective.js
+++ b/src/components/icon/js/iconDirective.js
@@ -96,7 +96,7 @@ angular
  * determine its textual name and character reference code. Click on any icon to see the slide-up information
  * panel with details regarding a SVG download or information on the font-icon usage.
  *
- * <a href="https://www.google.com/design/icons/#ic_accessibility" target="_blank" style="border-bottom:none;">
+ * <a href="https://material.io/tools/icons/?icon=accessibility&style=baseline" target="_blank" style="border-bottom:none;">
  * <img src="https://cloud.githubusercontent.com/assets/210413/7902490/fe8dd14c-0780-11e5-98fb-c821cc6475e6.png"
  *      aria-label="Material Design Icon-Selector" style="max-width:75%;padding-left:10%">
  * </a>

--- a/src/components/menu/js/menuDirective.js
+++ b/src/components/menu/js/menuDirective.js
@@ -35,7 +35,7 @@
  *
  * The width of the menu when it is open may be specified by specifying a `width`
  * attribute on the `md-menu-content` element.
- * See the [Material Design Spec](https://material.io/guidelines/components/menus.html#menus-simple-menus)
+ * See the [Material Design Spec](https://material.io/archive/guidelines/components/menus.html#menus-simple-menus)
  * for more information.
  *
  *

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -105,7 +105,7 @@ function SliderContainerDirective() {
  * @description
  * The `<md-slider>` component allows the user to choose from a range of values.
  *
- * As per the [material design spec](https://material.io/guidelines/style/color.html#color-color-system)
+ * As per the [Material Design spec](https://material.io/archive/guidelines/style/color.html#color-color-system)
  * the slider is in the accent color by default. The primary color palette may be used with
  * the `md-primary` class.
  *

--- a/src/components/subheader/subheader.js
+++ b/src/components/subheader/subheader.js
@@ -11,7 +11,7 @@
  *
  *  Upon scrolling, subheaders remain pinned to the top of the screen and remain
  *  pinned until pushed on or off screen by the next subheader. @see [Material
- *  Design Specifications](https://www.google.com/design/spec/components/subheaders.html)
+ *  Design Specifications](https://material.io/archive/guidelines/components/subheaders.html)
  *
  *  > To improve the visual grouping of content, use the system color for your subheaders.
  *

--- a/src/components/switch/switch.js
+++ b/src/components/switch/switch.js
@@ -17,7 +17,7 @@ angular.module('material.components.switch', [
  *
  * The switch directive is used very much like the normal [angular checkbox](https://docs.angularjs.org/api/ng/input/input%5Bcheckbox%5D).
  *
- * As per the [material design spec](http://www.google.com/design/spec/style/color.html#color-ui-color-application)
+ * As per the [Material Design spec](https://material.io/archive/guidelines/style/color.html#color-color-system)
  * the switch is in the accent color by default. The primary color palette may be used with
  * the `md-primary` class.
  *

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -655,7 +655,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     var elements = getElements(),
       containerWidth = elements.canvas.clientWidth,
 
-      // See https://material.io/design/components/tabs.html#spec which has been updated to 360px.
+      // See https://material.io/archive/guidelines/components/tabs.html#tabs-specs
       specMax = 264;
 
     // Do the spec maximum, or the canvas width; whichever is *smaller* (tabs larger than the canvas
@@ -673,7 +673,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
       containerWidth = elements.canvas.clientWidth,
       xsBreakpoint = 600,
 
-      // See https://material.io/design/components/tabs.html#spec which has been updated to 90px.
+      // See https://material.io/archive/guidelines/components/tabs.html#tabs-specs
       specMin = containerWidth > xsBreakpoint ? 160 : 72;
 
     // Do the spec minimum, or the canvas width; whichever is *smaller* (tabs larger than the canvas

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -149,7 +149,7 @@ var GENERATED = { };
 var PALETTES;
 
 // Text Colors on light and dark backgrounds
-// @see https://www.google.com/design/spec/style/color.html#color-text-background-colors
+// @see https://material.io/archive/guidelines/style/color.html#color-usability
 var DARK_FOREGROUND = {
   name: 'dark',
   '1': 'rgba(0,0,0,0.87)',

--- a/src/core/util/media.js
+++ b/src/core/util/media.js
@@ -74,7 +74,7 @@ angular.module('material.core')
  *
  *  See Material Design's <a href="https://material.google.com/layout/responsive-ui.html">Layout - Adaptive UI</a> for more details.
  *
- *  <a href="https://www.google.com/design/spec/layout/adaptive-ui.html">
+ *  <a href="https://material.io/archive/guidelines/layout/responsive-ui.html#">
  *  <img src="https://material-design.storage.googleapis.com/publish/material_v_4/material_ext_publish/0B8olV15J7abPSGFxemFiQVRtb1k/layout_adaptive_breakpoints_01.png" width="100%" height="100%"></img>
  *  </a>
  *


### PR DESCRIPTION
update all references to the original material specification so their
links point to the corresponding archived documentation

Fixes #11415

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```
## What is the current behavior?

Currently all of the material spec links are pointing to the new material design specification, they should point to the old specification.

Issue Number: #11415

## What is the new behavior?

Changed links to point to archived material specs

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
