### PR TITLE
fix(input): remove 2px left padding on inputs

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -173,7 +173,6 @@ md-input-container {
     background: none;
     padding-top: $input-padding-top;
     padding-bottom: $input-border-width-focused - $input-border-width-default;
-    padding-left: 2px;
     padding-right: 2px;
     border-width: 0 0 $input-border-width-default 0;
     line-height: $input-line-height;


### PR DESCRIPTION
remove 2px of padding-left from input boxes as this does not follow the material design spec

Fixes #10105

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently input boxes have 2px of padding-left. The material design spec has no left padding.

![before_fix](https://user-images.githubusercontent.com/13606342/46051967-20449780-c10a-11e8-83c5-8a5427385645.png)

 [According to the original material design spec](https://material.io/archive/guidelines/components/text-fields.html#text-fields-layout) only top and bottom padding should exist on input fields.

![spec](https://user-images.githubusercontent.com/13606342/46052032-7a455d00-c10a-11e8-854e-d023c0a3c462.png)

Issue Number: #10105 

## What is the new behavior?

The 2px of left padding have been removed.

![after_fix](https://user-images.githubusercontent.com/13606342/46051977-2e92b380-c10a-11e8-8ad4-f4f9e4d665f1.png)

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
This will change the styling of input components, although a minor change, anyone who has styled specifically around this may need to make minor changes to their own styles.

## Other information

It does not seem that autocomplete or datepicker have this extra padding and they don't seem to be using the modified class. It seems that the only affected component will be input and all the other components are following the spec.