### PR TITLE
fix(toast): improve a11y support for $mdToast.simple(). improve docs

### DIFF
--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -1,5 +1,4 @@
-
-angular.module('toastDemo1', ['ngMaterial'])
+angular.module('toastBasicDemo', ['ngMaterial'])
 
 .controller('AppCtrl', function($scope, $mdToast) {
   var last = {
@@ -36,7 +35,7 @@ angular.module('toastDemo1', ['ngMaterial'])
     $mdToast.show(
       $mdToast.simple()
         .textContent('Simple Toast!')
-        .position(pinTo )
+        .position(pinTo)
         .hideDelay(3000)
     );
   };
@@ -45,14 +44,18 @@ angular.module('toastDemo1', ['ngMaterial'])
     var pinTo = $scope.getToastPosition();
     var toast = $mdToast.simple()
       .textContent('Marked as read')
+      .actionKey('z')
+      .actionHint('Press the Control-"z" key combination to ')
       .action('UNDO')
+      .dismissHint('Activate the Escape key to dismiss this toast.')
       .highlightAction(true)
-      .highlightClass('md-accent')// Accent is used by default, this just demonstrates the usage.
-      .position(pinTo);
+      .highlightClass('md-accent') // Accent is used by default, this just demonstrates the usage.
+      .position(pinTo)
+      .hideDelay(0);
 
     $mdToast.show(toast).then(function(response) {
-      if ( response == 'ok' ) {
-        alert('You clicked the \'UNDO\' action.');
+      if (response === 'ok') {
+        alert('You selected the \'UNDO\' action.');
       }
     });
   };

--- a/src/components/toast/demoCustomUsage/index.html
+++ b/src/components/toast/demoCustomUsage/index.html
@@ -1,13 +1,6 @@
-<div ng-controller="AppCtrl" class="inset" ng-cloak style="height:300px; padding: 25px;">
-  <div layout="row">
-
-    <p>
-      Toast can have multiple actions:
-    </p>
-
-    <md-button ng-click="showCustomToast()" class="md-raised" style="padding-left: 10px;padding-right: 10px;">
-      Show Custom Toast
-    </md-button>
-
-  </div>
+<div ng-controller="AppCtrl as ctrl" id="custom-toast-container" class="inset" ng-cloak>
+  <span>Toast can have multiple actions:</span>
+  <md-button ng-click="ctrl.showCustomToast()" class="md-raised">
+    Show Custom Toast
+  </md-button>
 </div>

--- a/src/components/toast/demoCustomUsage/script.js
+++ b/src/components/toast/demoCustomUsage/script.js
@@ -1,48 +1,100 @@
 (function() {
-
   var isDlgOpen;
+  var ACTION_RESOLVE = 'undo';
+  var UNDO_KEY = 'z';
+  var DIALOG_KEY = 'd';
 
-  angular
-    .module('toastDemo2', ['ngMaterial'])
-    .controller('AppCtrl', function($scope, $mdToast) {
-      $scope.showCustomToast = function() {
-        $mdToast.show({
-          hideDelay   : 3000,
-          position    : 'top right',
-          controller  : 'ToastCtrl',
-          templateUrl : 'toast-template.html'
-        });
-      };
-    })
-    .controller('ToastCtrl', function($scope, $mdToast, $mdDialog) {
+  angular.module('toastCustomDemo', ['ngMaterial'])
+  .controller('AppCtrl', AppCtrl)
+  .controller('ToastCtrl', ToastCtrl);
 
-      $scope.closeToast = function() {
-        if (isDlgOpen) return;
+  function AppCtrl($mdToast, $log) {
+    var ctrl = this;
 
-        $mdToast
-          .hide()
-          .then(function() {
-            isDlgOpen = false;
-          });
-      };
+    ctrl.showCustomToast = function() {
+      $mdToast.show({
+        hideDelay: 0,
+        position: 'top right',
+        controller: 'ToastCtrl',
+        controllerAs: 'ctrl',
+        templateUrl: 'toast-template.html'
+      }).then(function(result) {
+        if (result === ACTION_RESOLVE) {
+          $log.log('Undo action triggered by button.');
+        } else if (result === 'key') {
+          $log.log('Undo action triggered by hot key: Control-' + UNDO_KEY + '.');
+        } else if (result === false) {
+          $log.log('Custom toast dismissed by Escape key.');
+        } else {
+          $log.log('Custom toast hidden automatically.');
+        }
+      }).catch(function(error) {
+        $log.error('Custom toast failure:', error);
+      });
+    };
+  }
 
-      $scope.openMoreInfo = function(e) {
-        if ( isDlgOpen ) return;
-        isDlgOpen = true;
+  function ToastCtrl($mdToast, $mdDialog, $document) {
+    var ctrl = this;
+    ctrl.keyListenerConfigured = false;
+    ctrl.undoKey = UNDO_KEY;
+    ctrl.dialogKey = DIALOG_KEY;
+    setupActionKeyListener();
 
-        $mdDialog
-          .show($mdDialog
-            .alert()
-            .title('More info goes here.')
-            .textContent('Something witty.')
-            .ariaLabel('More info')
-            .ok('Got it')
-            .targetEvent(e)
-          )
-          .then(function() {
-            isDlgOpen = false;
-          });
-      };
-    });
+    ctrl.closeToast = function() {
+      if (isDlgOpen) {
+        return;
+      }
+
+      $mdToast.hide(ACTION_RESOLVE).then(function() {
+        isDlgOpen = false;
+      });
+    };
+
+    ctrl.openMoreInfo = function(e) {
+      if (isDlgOpen) {
+        return;
+      }
+      isDlgOpen = true;
+
+      $mdDialog.show(
+        $mdDialog.alert()
+        .title('More info goes here.')
+        .textContent('Something witty.')
+        .ariaLabel('More info')
+        .ok('Got it')
+        .targetEvent(e)
+      ).then(function() {
+        isDlgOpen = false;
+      });
+    };
+
+    /**
+     * @param {KeyboardEvent} event
+     */
+    function handleKeyDown(event) {
+      if (event.key === 'Escape') {
+        $mdToast.hide(false);
+      }
+      if (event.key === UNDO_KEY && event.ctrlKey) {
+        $mdToast.hide('key');
+      }
+      if (event.key === DIALOG_KEY && event.ctrlKey) {
+        ctrl.openMoreInfo(event);
+      }
+    }
+
+    function setupActionKeyListener() {
+      if (!ctrl.keyListenerConfigured) {
+        $document.on('keydown', handleKeyDown);
+        ctrl.keyListenerConfigured = true;
+      }
+    }
+
+    function removeActionKeyListener() {
+      $document.off('keydown');
+      ctrl.keyListenerConfigured = false;
+    }
+  }
 
 })();

--- a/src/components/toast/demoCustomUsage/style.scss
+++ b/src/components/toast/demoCustomUsage/style.scss
@@ -1,0 +1,9 @@
+#custom-toast-container {
+  height: 300px;
+  padding: 25px;
+
+  .md-button.md-raised {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+}

--- a/src/components/toast/demoCustomUsage/toast-template.html
+++ b/src/components/toast/demoCustomUsage/toast-template.html
@@ -1,9 +1,15 @@
-<md-toast>
-  <span class="md-toast-text" flex>Custom toast!</span>
-  <md-button class="md-highlight" ng-click="openMoreInfo($event)">
+<md-toast role="alert" aria-relevant="all">
+  <span class="md-toast-text" flex>Custom toast</span>
+  <span class="md-visually-hidden">
+    Press Escape to dismiss. Press Control-"{{ctrl.dialogKey}}" for
+  </span>
+  <md-button class="md-highlight" ng-click="ctrl.openMoreInfo($event)">
     More info
   </md-button>
-  <md-button ng-click="closeToast()">
-    Close
+  <span class="md-visually-hidden">
+    Press Control-"{{ctrl.undoKey}}" to
+  </span>
+  <md-button ng-click="ctrl.closeToast()">
+    Undo
   </md-button>
 </md-toast>

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -59,7 +59,7 @@ describe('$mdToast service', function() {
 
       $material.flushOutstandingAnimations();
 
-      expect(parent.find('span').text().trim()).toBe('Do something');
+      expect(parent.find('span').text().trim()).toContain('Do something');
       expect(parent.find('span')).toHaveClass('md-toast-text');
       expect(parent.find('md-toast')).toHaveClass('md-capsule');
       expect(parent.find('md-toast').attr('md-theme')).toBe('some-theme');
@@ -69,13 +69,13 @@ describe('$mdToast service', function() {
       expect(openAndclosed).toBe(true);
     }));
 
-    it('supports dynamicly updating the content', inject(function($mdToast, $rootScope, $rootElement) {
+    it('supports dynamically updating the content', inject(function($mdToast, $rootScope, $rootElement) {
       var parent = angular.element('<div>');
       $mdToast.showSimple('Hello world');
       $rootScope.$digest();
-      $mdToast.updateContent('Goodbye world');
+      $mdToast.updateTextContent('Goodbye world');
       $rootScope.$digest();
-      expect($rootElement.find('span').text().trim()).toBe('Goodbye world');
+      expect($rootElement.find('span').text().trim()).toContain('Goodbye world');
     }));
 
     it('supports an action toast', inject(function($mdToast, $rootScope, $material) {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Actions within toasts are not announced at all for screen readers.
It's almost impossible to activate an action in a toast from a screen reader.
There are no instructions for screen reader users on how to dismiss a toast.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #349

## What is the new behavior?
move the role="alert" up a level
 - makes action button visible to screen readers
add support for defining an actionKey to assign a hot key to an action
- this enables Control-actionKey to activate the action
add support for defining a dismissHint for screen readers
add support for defining an actionHint for screen readers
align custom toast demo with Material Design guidelines
enhance custom toast demo to demonstrate an accessible custom toast

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
