### PR TITLE
fix(toast): remove the interim element from the list before closing element

### DIFF
--- a/src/core/services/interimElement/interimElement.js
+++ b/src/core/services/interimElement/interimElement.js
@@ -358,9 +358,13 @@ function InterimElementProvider() {
         }
 
         // Hide the latest showing interim element.
-        return closeElement(showingInterims[showingInterims.length - 1]);
+        return closeElement(showingInterims.pop());
 
         function closeElement(interim) {
+
+          if (!interim) {
+            return $q.when(reason);
+          }
 
           var hideAction = interim
             .remove(reason, false, options || { })
@@ -369,7 +373,6 @@ function InterimElementProvider() {
               hidePromises.splice(hidePromises.indexOf(hideAction), 1);
             });
 
-          showingInterims.splice(showingInterims.indexOf(interim), 1);
           hidePromises.push(hideAction);
 
           return interim.deferred.promise;


### PR DESCRIPTION
Check if the interim element is valid before proceeding.

Fixes #10715

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment the interim element is being removed from the list after new hideAction promise is created for it. In addition no extra check is made for the interim object before it is used.
This is causing an error as undefined object is trying be accessed. 
Issue Number: #10715 


## What is the new behavior?
The interim element is removed from the list before the closeElement method is called.
An extra check is added at the beginning of that method to make sure the interim element is a valid object.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
