### PR TITLE
build(contributors): don't assume rm command exists on Windows

### DIFF
--- a/gulp/tasks/build-contributors.js
+++ b/gulp/tasks/build-contributors.js
@@ -1,5 +1,6 @@
 const child_process = require('child_process');
 const os = require('os');
+const path = require('path');
 
 (function () {
   'use strict';
@@ -11,15 +12,16 @@ const os = require('os');
   exports.task = function () {
     const appPath = 'dist/docs';
 
-    child_process.execSync('rm -f ' + appPath + '/contributors.json');
-
     if (os.platform() === 'win32') {
+      const contributorsPath = path.join(process.cwd(), appPath, 'contributors.json');
+      child_process.execSync('del /f /q ' + contributorsPath);
       process.chdir('./node_modules/.bin');
       child_process.execSync('githubcontrib.cmd --owner angular --repo material --cols 6' +
         ' --format json --showlogin true --sha master --sortOrder desc > '
-        + '../../' + appPath + '/contributors.json');
+        + contributorsPath);
       process.chdir('../..');
     } else {
+      child_process.execSync('rm -f ' + appPath + '/contributors.json');
       exec([
         './node_modules/.bin/githubcontrib --owner angular --repo material --cols 6 --format json' +
         ' --showlogin true --sha master --sortOrder desc > ' + appPath + '/contributors.json'


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`gulp watch site --dev` fails on Windows if the Linux `rm` command isn't available.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?
The contributors script now uses the `del` command on Windows instead of `rm`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
