### PR TITLE
docs(slider): add missing API docs. fix vertical demo on IE11

### DIFF
--- a/src/components/slider/demoVertical/index.html
+++ b/src/components/slider/demoVertical/index.html
@@ -1,11 +1,11 @@
 <div ng-controller="AppCtrl" ng-cloak>
-  <md-content layout="row" layout-padding>
+  <div layout="row" layout-padding>
     <md-slider-container flex>
       <md-input-container>
         <input flex type="number" ng-model="vol" aria-label="volume" aria-controls="volume-slider">
       </md-input-container>
-      <md-slider ng-model="vol" min="0" max="100" aria-label="volume" id="volume-slider" class="md-accent" md-vertical
-                 md-range></md-slider>
+      <md-slider ng-model="vol" min="0" max="100" aria-label="volume" id="volume-slider" class="md-accent"
+                 md-vertical></md-slider>
       </md-slider>
       <h5>Volume</h5>
     </md-slider-container>
@@ -29,5 +29,5 @@
       </md-slider-container>
       <md-checkbox ng-model="readonly">Read only</md-checkbox>
     </div>
-  </md-content>
+  </div>
 </div>

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -46,7 +46,7 @@ function SliderContainerDirective() {
         elem.attr('md-vertical', '');
       }
 
-      if(!slider.attr('flex')) {
+      if (!slider.attr('flex')) {
         slider.attr('flex', '');
       }
 
@@ -139,13 +139,21 @@ function SliderContainerDirective() {
  *
  * @param {expression} ng-model Assignable angular expression to be data-bound.
  *  The expression should evaluate to a `number`.
- * @param {boolean=} md-discrete Whether to enable discrete mode.
- * @param {boolean=} md-invert Whether to enable invert mode.
- * @param {number=} step The distance between values the user is allowed to pick. Default `1`.
- * @param {number=} min The minimum value the user is allowed to pick. Default `0`.
- * @param {number=} max The maximum value the user is allowed to pick. Default `100`.
+ * @param {expression=} ng-disabled If this expression evaluates as truthy, the slider will be
+ *  disabled.
+ * @param {expression=} ng-readonly If this expression evaluates as truthy, the slider will be in
+ *  read only mode.
+ * @param {boolean=} md-discrete If this attribute exists during initialization, enable discrete
+ *  mode. Defaults to `false`.
+ * @param {boolean=} md-vertical If this attribute exists during initialization, enable vertical
+ *  orientation mode. Defaults to `false`.
+ * @param {boolean=} md-invert If this attribute exists during initialization, enable inverted mode.
+ *  Defaults to `false`.
+ * @param {number=} step The distance between values the user is allowed to pick. Defaults to `1`.
+ * @param {number=} min The minimum value the user is allowed to pick. Defaults to `0`.
+ * @param {number=} max The maximum value the user is allowed to pick. Defaults to `100`.
  * @param {number=} round The amount of numbers after the decimal point. The maximum is 6 to
- *  prevent scientific notation. Default `3`.
+ *  prevent scientific notation. Defaults to `3`.
  */
 function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdTheming, $mdGesture,
                          $parse, $log, $timeout) {
@@ -353,7 +361,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
     }
 
     function clearTicks() {
-      if(tickCanvas && tickCtx) {
+      if (tickCanvas && tickCtx) {
         var dimensions = getSliderDimensions();
         tickCtx.clearRect(0, 0, dimensions.width, dimensions.height);
       }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Some of the `md-slider` API docs are missing. `md-vertical` being the biggest omission.
md-content doesn't lay out the contents properly on IE11
- it actually causes the DOM to be mangled when rendered in IE11

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #9492

## What is the new behavior?
Don't use `md-content` in the demo.
Add missing API docs.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
