### PR TITLE
fix(tabs): min-width not respected on IE11. fix right/left padding

### DIFF
--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -236,7 +236,7 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     // Fix double-negative which can happen with RTL support
     newValue = newValue.replace('--', '');
 
-    angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate3d(' + newValue + ', 0, 0)');
+    angular.element(elements.paging).css($mdConstant.CSS.TRANSFORM, 'translate(' + newValue + ', 0)');
     $scope.$broadcast('$mdTabsPaginationChanged');
   }
 
@@ -621,14 +621,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   /**
-   * Calculates the width of the pagination wrapper by summing the widths of the dummy tabs.
-   * @returns {number} the width of the pagination wrapper in pixels
-   */
-  function calcPagingWidth () {
-    return calcTabsWidth(getElements().tabs);
-  }
-
-  /**
    * @param {Array<HTMLElement>} tabs tab item elements for use in computing total width
    * @returns {number} the width of the tabs in the specified array in pixels
    */
@@ -647,9 +639,8 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   /**
-   * @returns {number} either the max width as constrained by the container or the max width from an
-   * old version of the Material Design spec.
-   * TODO update max tab width to equal the spec in 1.2.
+   * @returns {number} either the max width as constrained by the container or the max width from
+   * the 2017 version of the Material Design spec.
    */
   function getMaxTabWidth() {
     var elements = getElements(),
@@ -661,24 +652,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
     // Do the spec maximum, or the canvas width; whichever is *smaller* (tabs larger than the canvas
     // width can break the pagination) but not less than 0
     return Math.max(0, Math.min(containerWidth - 1, specMax));
-  }
-
-  /**
-   * @returns {number} the min width from an old version of the Material Design spec. This returns
-   * a larger min width if the container width is larger than 600px.
-   * TODO update min tab width to equal the spec in 1.2.
-   */
-  function getMinTabWidth() {
-    var elements = getElements(),
-      containerWidth = elements.canvas.clientWidth,
-      xsBreakpoint = 600,
-
-      // See https://material.io/archive/guidelines/components/tabs.html#tabs-specs
-      specMin = containerWidth > xsBreakpoint ? 160 : 72;
-
-    // Do the spec minimum, or the canvas width; whichever is *smaller* (tabs larger than the canvas
-    // width can break the pagination) but not less than 0
-    return Math.max(0, Math.min(containerWidth - 1, specMin));
   }
 
   /**

--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -76,7 +76,7 @@ md-tabs-wrapper {
   display: block;
   position: relative;
   // transform is needed for iOS Safari to prevent content from disappearing on scroll
-  transform: translate3d(0, 0, 0);
+  transform: translate(0, 0);
   md-prev-button, md-next-button {
     height: 100%;
     width: $tabs-paginator-width;
@@ -103,7 +103,7 @@ md-tabs-wrapper {
       position: absolute;
       top: 50%;
       left: 50%;
-      transform: translate3d(-50%, -50%, 0);
+      transform: translate(-50%, -50%);
     }
 
     // For RTL tabs, rotate the buttons
@@ -121,7 +121,7 @@ md-tabs-wrapper {
 
     // In regular mode, we need to flip the chevron icon to point the other way
     md-icon {
-      transform: translate3d(-50%, -50%, 0) rotate(180deg);
+      transform: translate(-50%, -50%) rotate(180deg);
     }
   }
   &.md-stretch-tabs {
@@ -166,8 +166,9 @@ md-pagination-wrapper {
   display: flex;
   transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
   position: absolute;
+  width: 999999px;
   @include rtl-prop(left, right, 0, auto);
-  transform: translate3d(0, 0, 0);
+  transform: translate(0, 0);
   &.md-center-tabs {
     position: relative;
     justify-content: center;
@@ -194,7 +195,7 @@ md-tab-content {
   transition: transform $swift-ease-in-out-duration $swift-ease-in-out-timing-function;
   overflow: auto;
   // transform is needed for iOS Safari to prevent content from disappearing on scroll
-  transform: translate3d(0, 0, 0);
+  transform: translate(0, 0);
   &.md-no-scroll {
     bottom: auto;
     overflow: hidden;


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Tab items have right and left padding of `24px` which is `12px` more on each side than specified by [the MD spec](https://material.io/archive/guidelines/components/tabs.html#tabs-specs).
- Tabs on IE11 are truncated by pagination due to a calculated width of `0px` and the only width being the `48px` of padding.
- There are 2 functions in the code that are not used anymore.
- Many of the tab styles use `translate3d` which causes performance issues and bugs on IE11. We don't actually translate anything in the `z` dimension.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10406

## What is the new behavior?
- tab-items should have 12px right/left padding instead of 24px
    - this is to align with [the spec](https://material.io/archive/guidelines/components/tabs.html#tabs-specs) and more of the label visible on mobile
- remove unused calcPagingWidth()
- convert all translate3d to translate for better IE11 support

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
The breaking changes to make `min-width` align with the MD spec have been pulled out of this PR and put into PR https://github.com/angular/material/pull/11438 for 1.2.0.

Please note that this is fixing a **regression** from a breaking change that was in 1.1.2.

Before (IE on bottom, Chrome on top):
![chrome-and-ie-before-fix](https://user-images.githubusercontent.com/1409078/44260273-948f3f80-a21c-11e8-8c01-d68502693c6d.png)

After in IE
![tabs-fixed-ie11-without-min-width-fix](https://user-images.githubusercontent.com/3506071/45326177-e88dfb00-b520-11e8-9b64-fe12bb4f24c9.PNG)
![tabs-pagination-ie11-fixed-without-min-width-fix](https://user-images.githubusercontent.com/3506071/45326182-eaf05500-b520-11e8-8ac4-0048f234e7c1.PNG)

After in Chrome
![tabs-pagination-chrome-without-min-width-fix](https://user-images.githubusercontent.com/3506071/45326304-402c6680-b521-11e8-8984-47a7780dedbd.PNG)

And here is IE11 rendering with a small width (sub `600px`)
![tabs-pagination-ie11-xs-fixed](https://user-images.githubusercontent.com/3506071/44827527-785aad80-abe1-11e8-96ac-980ce7f8c3d6.PNG)
![tabs-fixed-ie11-xs](https://user-images.githubusercontent.com/3506071/44827528-785aad80-abe1-11e8-938f-14d9153f95b7.PNG)
