### PR TITLE
fix(tabs): update min-width to follow the spec

### DIFF
--- a/src/components/tabs/tabs.scss
+++ b/src/components/tabs/tabs.scss
@@ -172,6 +172,14 @@ md-pagination-wrapper {
     position: relative;
     justify-content: center;
   }
+  md-tab-item {
+    min-width: 72px;
+  }
+  @media (min-width: $layout-breakpoint-xs) {
+    md-tab-item {
+      min-width: 160px;
+    }
+  }
 }
 
 md-tabs-content-wrapper {
@@ -259,7 +267,7 @@ md-tab {
   font-size: 14px;
   text-align: center;
   line-height: $tabs-header-height - 24;
-  padding: 12px 24px;
+  padding: 12px;
   transition: background-color 0.35s $swift-ease-in-out-timing-function;
   cursor: pointer;
   white-space: nowrap;


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Previous commits removed use of `getMinTabWidth()` but never updated the CSS to apply the proper `min-width`.
- Tabs always had a min width of `72px` even though they should have a min width of `160px` "on larger devices" according to [the MD spec](https://material.io/archive/guidelines/components/tabs.html#tabs-specs).

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #10406. Relates to #11432.

## What is the new behavior?
- This applies the proper min-width CSS to match [the spec](https://material.io/archive/guidelines/components/tabs.html#tabs-specs).
    - which is 72px on xs and 160px on everything else.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This is not a breaking API or CSS change, but it will break screenshot tests. However the new result is aligned with [the Material Design spec](https://material.io/archive/guidelines/components/tabs.html#tabs-specs).

Also please note that this is fixing a **regression** from a breaking change that was in 1.1.2.

Before (IE on bottom, Chrome on top):
![chrome-and-ie-before-fix](https://user-images.githubusercontent.com/1409078/44260273-948f3f80-a21c-11e8-8c01-d68502693c6d.png)

After in IE (Chrome and IE look the same now)
![tabs-pagination-ie11-fixed](https://user-images.githubusercontent.com/3506071/44827471-49dcd280-abe1-11e8-89c9-6af4e726f0b0.PNG)
![tabs-fixed-ie11](https://user-images.githubusercontent.com/3506071/44827472-49dcd280-abe1-11e8-8d92-e34df02b223a.PNG)

And here is IE11 rendering with a small width (sub `600px`)
![tabs-pagination-ie11-xs-fixed](https://user-images.githubusercontent.com/3506071/44827527-785aad80-abe1-11e8-96ac-980ce7f8c3d6.PNG)
![tabs-fixed-ie11-xs](https://user-images.githubusercontent.com/3506071/44827528-785aad80-abe1-11e8-938f-14d9153f95b7.PNG)