### PR TITLE
 fix(layout): Give Non-numeric flex values priority when media-dependent

### DIFF
--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -121,6 +121,20 @@
   .#{$flexName}-noshrink    { flex: 1 0 auto;  box-sizing: border-box; }
   .#{$flexName}-nogrow      { flex: 0 1 auto;  box-sizing: border-box; }
 
+  .layout-row > .#{$flexName}-grow        { flex: 1 1 100%;  box-sizing: border-box; }
+  .layout-row > .#{$flexName}-initial     { flex: 0 1 auto;  box-sizing: border-box; }
+  .layout-row > .#{$flexName}-auto        { flex: 1 1 auto;  box-sizing: border-box; }
+  .layout-row > .#{$flexName}-none        { flex: 0 0 auto;  box-sizing: border-box; }
+  .layout-row > .#{$flexName}-noshrink    { flex: 1 0 auto;  box-sizing: border-box; }
+  .layout-row > .#{$flexName}-nogrow      { flex: 0 1 auto; box-sizing: border-box; }
+
+  .layout-column > .#{$flexName}-grow        { flex: 1 1 100%;  box-sizing: border-box; }
+  .layout-column > .#{$flexName}-initial     { flex: 0 1 auto;  box-sizing: border-box; }
+  .layout-column > .#{$flexName}-auto        { flex: 1 1 auto;  box-sizing: border-box; }
+  .layout-column > .#{$flexName}-none        { flex: 0 0 auto;  box-sizing: border-box; }
+  .layout-column > .#{$flexName}-noshrink    { flex: 1 0 auto;  box-sizing: border-box; }
+  .layout-column > .#{$flexName}-nogrow      { flex: 0 1 auto; box-sizing: border-box; }
+
   // (1-20) * 5 = 0-100%
   @for $i from 0 through 20 {
     $value : #{$i * 5 + '%'};


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
https://github.com/angular/material/issues/11466

`.layout-column > .flex-##, 
.layout-row > .flex-##`  Exists for numeric flex values, but do not for non-numeric flex values,  (grow, auto, ect). This means that using a numeric flex value with a non-numeric flex value with a gt/sm/xs prefix will only render the numeric one, even if the media rules should prefer the non-numeric one.

```html
<div layout="row">
  <div layout="column" flex="100" flex-gt-sm="auto">
    <!-- will always be [flex="100"], even when gt-sm is true -->
  </div>
</div>
```

## What is the new behavior?

Add more specific rules to the non-numeric mixins,
`.layout-row/column > .#{$flexName}-nogrow/initial/auto/noshrink/grow/none`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
