### PR TITLE
 fix(theme): prepend # to hex codes enableBrowserColor

### DIFF
--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -281,6 +281,7 @@ function ThemingProvider($mdColorPalette, $$mdMetaProvider) {
       PALETTES[THEMES[theme].colors[options.palette || 'primary'].name];
 
     var color = angular.isObject(palette[hue]) ? palette[hue].hex : palette[hue];
+    if (color.substr(0, 1) !== '#') color = '#' + color;
 
     return setBrowserColor(color);
   };

--- a/src/core/services/theming/theming.spec.js
+++ b/src/core/services/theming/theming.spec.js
@@ -363,7 +363,7 @@ describe('$mdThemingProvider', function() {
 
     it('should use default primary color at the meta tag', function () {
       var name = 'theme-color';
-      var content = themingProvider._PALETTES.testPalette['800'].hex;
+      var content = '#' + themingProvider._PALETTES.testPalette['800'].hex;
 
       expect(document.getElementsByName(name).length).toBe(0);
 
@@ -378,7 +378,7 @@ describe('$mdThemingProvider', function() {
 
       var hue = '200';
 
-      var content = themingProvider._PALETTES.testPalette[hue].hex;
+      var content = '#' + themingProvider._PALETTES.testPalette[hue].hex;
 
       expect(document.getElementsByName(name).length).toBe(0);
 
@@ -404,7 +404,7 @@ describe('$mdThemingProvider', function() {
     it('should use test theme', function () {
       var name = 'theme-color';
 
-      var content = themingProvider._PALETTES.testPalette['800'].hex;
+      var content = '#' + themingProvider._PALETTES.testPalette['800'].hex;
 
       expect(document.getElementsByName(name).length).toBe(0);
 


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [X] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [X] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: fixes #11259

`enableBrowserColor` fails silently if a hex code does not have a `#` at the start.

## What is the new behavior?

`enableBrowserColor` now checks for a leading `#` and prepends it if not already there.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

I updated other test plans to expect the leading `#`, the `testPalette` in the test plans did not have a `#` in their hex values. Originally I tried updating the palette to have a `#`, but couldn't figure out how to test it without creating another palette, so I went with this way. 