### PR TITLE
fix(input): floating label text fails a11y contrast audit

### DIFF
--- a/src/components/input/demoBasicUsage/index.html
+++ b/src/components/input/demoBasicUsage/index.html
@@ -26,7 +26,7 @@
 
           <md-input-container>
             <label>Enter date</label>
-            <md-datepicker ng-model="user.submissionDate"></md-datepicker>
+            <md-datepicker ng-model="user.submissionDate" aria-label="Enter date"></md-datepicker>
           </md-input-container>
         </div>
 
@@ -48,7 +48,7 @@
         </md-input-container>
 
         <md-input-container md-no-float class="md-block">
-          <input ng-model="user.address2" placeholder="Address 2">
+          <input ng-model="user.address2" placeholder="Address 2" aria-label="Address 2">
         </md-input-container>
 
         <div layout-gt-sm="row">

--- a/src/components/input/demoErrorsAdvanced/style.css
+++ b/src/components/input/demoErrorsAdvanced/style.css
@@ -11,7 +11,7 @@
     transition: all 0.3s cubic-bezier(0.55, 0, 0.55, 0.2);
 
     /* Set our own color */
-    color: grey;
+    color: rgba(0, 0, 0, 0.54);
 }
 
 /* NOTE: Check the demo's HTML to see some additional RTL support CSS */

--- a/src/components/input/demoIcons/index.html
+++ b/src/components/input/demoIcons/index.html
@@ -11,17 +11,18 @@
 
     <md-input-container md-no-float class="md-block">
       <md-icon md-svg-src="img/icons/ic_phone_24px.svg"></md-icon>
-      <input ng-model="user.phone" type="text" placeholder="Phone Number">
+      <input ng-model="user.phone" type="text" placeholder="Phone Number" aria-label="Phone Number">
     </md-input-container>
 
     <md-input-container class="md-block">
       <!-- Use floating placeholder instead of label -->
       <md-icon md-svg-src="img/icons/ic_email_24px.svg" class="email"></md-icon>
-      <input ng-model="user.email" type="email" placeholder="Email (required)" ng-required="true">
+      <input ng-model="user.email" type="email" placeholder="Email (required)" ng-required="true"
+             aria-label="Email (required)">
     </md-input-container>
 
     <md-input-container md-no-float class="md-block">
-      <input ng-model="user.address" type="text" placeholder="Address" >
+      <input ng-model="user.address" type="text" placeholder="Address" aria-label="Address">
       <md-icon md-svg-src="img/icons/ic_place_24px.svg" style="display:inline-block;"></md-icon>
     </md-input-container>
 

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -1,6 +1,6 @@
 md-input-container.md-THEME_NAME-theme {
   .md-input {
-    @include input-placeholder-color('\'{{foreground-3}}\'');
+    @include input-placeholder-color('\'{{foreground-2}}\'');
     color: '{{foreground-1}}';
     border-color: '{{foreground-4}}';
   }
@@ -11,7 +11,7 @@ md-input-container.md-THEME_NAME-theme {
 
   label,
   .md-placeholder {
-    color: '{{foreground-3}}';
+    color: '{{foreground-2}}';
   }
 
   label.md-required:after {

--- a/src/core/style/mixins.scss
+++ b/src/core/style/mixins.scss
@@ -15,14 +15,25 @@
 }
 
 @mixin input-placeholder-color($color) {
-  $pseudos: '::-webkit-input-placeholder', ':-moz-placeholder', '::-moz-placeholder',
-            ':-ms-input-placeholder',  '::-webkit-input-placeholder';
+  $pseudos: '::-webkit-input-placeholder', // For QQ Browser
+            ':-ms-input-placeholder', // For IE
+            '::-ms-input-placeholder', // For Edge
+            '::placeholder';
+  $firefox-pseudos: ':-moz-placeholder', '::-moz-placeholder';
 
   // It is important to export every pseudo within its own block, because otherwise the placeholder
   // won't be set on the most browsers.
   @each $pseudo in $pseudos {
     &#{$pseudo} {
       color: unquote($color);
+    }
+  }
+  // Firefox reduces the opacity of placeholders so we need to keep them opaque to avoid applying
+  // double the transparency and causing a11y failures due to text contrast.
+  @each $pseudo in $firefox-pseudos {
+    &#{$pseudo} {
+      color: unquote($color);
+      opacity: 1;
     }
   }
 }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Floating labels use `color: rgba(0,0,0,0.38);` which doesn't align with the spec and fails Lighthouse contrast audits. This is the color we use for "disabled" text, which isn't right.
![screen shot 2018-10-30 at 3 51 07 pm](https://user-images.githubusercontent.com/3506071/47746095-ba44b600-dc5b-11e8-9622-b0afdae9a51d.png)
![screen shot 2018-10-30 at 3 53 15 pm](https://user-images.githubusercontent.com/3506071/47746250-24f5f180-dc5c-11e8-95d5-b009cb766763.png)
Currently our Input demo page gets a Lighthouse score of `77`.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #11475

## What is the new behavior?
Floating labels use `rgba(0, 0, 0, 0.54);` which passes Lighthouse contrast audits. This is the color we use for "secondary" text, which seems appropriate. We use the full `rgba(0, 0, 0, 0.87);` for the primary text (input value).
![screen shot 2018-10-30 at 3 51 33 pm](https://user-images.githubusercontent.com/3506071/47746099-bca71000-dc5b-11e8-9675-68cb83342ffe.png)
![screen shot 2018-10-30 at 3 53 39 pm](https://user-images.githubusercontent.com/3506071/47746255-27f0e200-dc5c-11e8-8d6c-3d0e482a481f.png)
With these changes our Input demo page gets a Lighthouse score of `92`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This is expected to break screenshot tests.

This gets us a step closer to getting 100 in the Lighthouse a11y audit. 
Other related issues are
- https://github.com/angular/material/pull/11441
- https://github.com/angular/material/pull/11465