### PR TITLE
fix(autocomplete): updateSize incorrectly sets the size to zero

### DIFF
--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -223,9 +223,13 @@ VirtualRepeatContainerController.prototype.updateSize = function() {
   // If the original size is already determined, we can skip the update.
   if (this.originalSize) return;
 
-  this.size = this.isHorizontal()
+  var size = this.isHorizontal()
       ? this.$element[0].clientWidth
       : this.$element[0].clientHeight;
+
+  if (size) {
+    this.setSize_(size);
+  }
 
   // Recheck the scroll position after updating the size. This resolves
   // problems that can result if the scroll position was measured while the


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
In some cases, like resizing the page, updateSize incorrectly sets the size to zero.
This can break the ability to show the dropdown on focus.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10834

## What is the new behavior?
Check that the size value isn't zero before setting the size.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Manually tested as I wasn't sure how to resize the browser in a unit test.