### PR TITLE
docs(toast): add use of locals to custom toast demo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7195,12 +7195,6 @@
       "integrity": "sha1-OU8rJf+0pkS5rabyLUQ+L9CIhsM=",
       "dev": true
     },
-    "karma-safari-launcher": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz",
-      "integrity": "sha1-lpgqLMR9BmquccVTursoMZEVos4=",
-      "dev": true
-    },
     "karma-sauce-launcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/karma-sauce-launcher/-/karma-sauce-launcher-1.2.0.tgz",

--- a/src/components/toast/demoBasicUsage/index.html
+++ b/src/components/toast/demoBasicUsage/index.html
@@ -1,37 +1,34 @@
-<div ng-controller="AppCtrl" layout-fill layout="column" class="inset" ng-cloak paddi>
-    <p>
-    Toast can be dismissed with a swipe, a timer, or a button.<br/>
-    </p>
+<div ng-controller="AppCtrl as ctrl" layout-fill layout="column" class="inset" ng-cloak>
+  <p>Toast can be dismissed with a swipe, a timer, or a button.<br/></p>
 
+  <div layout="row" layout-align="space-around">
+    <div class="spacer"></div>
+    <md-button ng-click="ctrl.showSimpleToast()">
+      Show Simple
+    </md-button>
+    <md-button class="md-raised" ng-click="ctrl.showActionToast()">
+      Show With Action
+    </md-button>
+    <div class="spacer"></div>
+  </div>
 
-    <div layout="row" layout-align="space-around">
-      <div style="width:50px"></div>
-      <md-button ng-click="showSimpleToast()">
-        Show Simple
-      </md-button>
-      <md-button class="md-raised" ng-click="showActionToast()">
-        Show With Action
-      </md-button>
-      <div style="width:50px"></div>
+  <div layout="row" id="toastBounds">
+    <div>
+      <p><b>Toast Position: "{{ctrl.getToastPosition()}}"</b></p>
+      <md-checkbox ng-repeat="(name, isSelected) in ctrl.toastPosition"
+                   ng-model="ctrl.toastPosition[name]">
+        {{name}}
+      </md-checkbox>
     </div>
+  </div>
 
-    <div layout="row" id="toastBounds">
+  <div layout="row">
+    <md-button class="md-primary md-fab md-fab-bottom-right">
+      FAB
+    </md-button>
+    <md-button class="md-accent md-fab md-fab-top-right">
+      FAB
+    </md-button>
 
-      <div>
-        <p><b>Toast Position: "{{getToastPosition()}}"</b></p>
-        <md-checkbox ng-repeat="(name, isSelected) in toastPosition"
-          ng-model="toastPosition[name]">
-          {{name}}
-        </md-checkbox>
-      </div>
-    </div>
-    <div layout="row">
-      <md-button class="md-primary md-fab md-fab-bottom-right">
-        FAB
-      </md-button>
-      <md-button class="md-accent md-fab md-fab-top-right">
-        FAB
-      </md-button>
-
-    </div>
+  </div>
 </div>

--- a/src/components/toast/demoBasicUsage/script.js
+++ b/src/components/toast/demoBasicUsage/script.js
@@ -1,69 +1,85 @@
-angular.module('toastBasicDemo', ['ngMaterial'])
+(function() {
+  angular.module('toastBasicDemo', ['ngMaterial'])
+  .controller('AppCtrl', AppCtrl);
 
-.controller('AppCtrl', function($scope, $mdToast) {
-  var last = {
+  function AppCtrl($mdToast, $log) {
+    var ctrl = this;
+    var last = {
       bottom: false,
       top: true,
       left: false,
       right: true
     };
 
-  $scope.toastPosition = angular.extend({},last);
+    ctrl.toastPosition = angular.extend({}, last);
 
-  $scope.getToastPosition = function() {
-    sanitizePosition();
+    ctrl.getToastPosition = function() {
+      sanitizePosition();
 
-    return Object.keys($scope.toastPosition)
-      .filter(function(pos) { return $scope.toastPosition[pos]; })
-      .join(' ');
-  };
+      return Object.keys(ctrl.toastPosition)
+      .filter(function(pos) {
+        return ctrl.toastPosition[pos];
+      }).join(' ');
+    };
 
-  function sanitizePosition() {
-    var current = $scope.toastPosition;
+    function sanitizePosition() {
+      var current = ctrl.toastPosition;
 
-    if ( current.bottom && last.top ) current.top = false;
-    if ( current.top && last.bottom ) current.bottom = false;
-    if ( current.right && last.left ) current.left = false;
-    if ( current.left && last.right ) current.right = false;
+      if (current.bottom && last.top) {
+        current.top = false;
+      }
+      if (current.top && last.bottom) {
+        current.bottom = false;
+      }
+      if (current.right && last.left) {
+        current.left = false;
+      }
+      if (current.left && last.right) {
+        current.right = false;
+      }
 
-    last = angular.extend({},current);
-  }
+      last = angular.extend({}, current);
+    }
 
-  $scope.showSimpleToast = function() {
-    var pinTo = $scope.getToastPosition();
+    ctrl.showSimpleToast = function() {
+      var pinTo = ctrl.getToastPosition();
 
-    $mdToast.show(
-      $mdToast.simple()
+      $mdToast.show(
+        $mdToast.simple()
         .textContent('Simple Toast!')
         .position(pinTo)
-        .hideDelay(3000)
-    );
-  };
+        .hideDelay(3000))
+      .then(function() {
+        $log.log('Toast dismissed.');
+      }).catch(function() {
+        $log.log('Toast failed or was forced to close early by another toast.');
+      });
+    };
 
-  $scope.showActionToast = function() {
-    var pinTo = $scope.getToastPosition();
-    var toast = $mdToast.simple()
-      .textContent('Marked as read')
-      .actionKey('z')
-      .actionHint('Press the Control-"z" key combination to ')
-      .action('UNDO')
-      .dismissHint('Activate the Escape key to dismiss this toast.')
-      .highlightAction(true)
-      .highlightClass('md-accent') // Accent is used by default, this just demonstrates the usage.
-      .position(pinTo)
-      .hideDelay(0);
+    ctrl.showActionToast = function() {
+      var pinTo = ctrl.getToastPosition();
+      var toast = $mdToast.simple()
+        .textContent('Marked as read')
+        .actionKey('z')
+        .actionHint('Press the Control-"z" key combination to ')
+        .action('UNDO')
+        .dismissHint('Activate the Escape key to dismiss this toast.')
+        .highlightAction(true)
+        // Accent is used by default, this just demonstrates the usage.
+        .highlightClass('md-accent')
+        .position(pinTo)
+        .hideDelay(0);
 
-    $mdToast.show(toast).then(function(response) {
-      if (response === 'ok') {
-        alert('You selected the \'UNDO\' action.');
-      }
-    });
-  };
-
-})
-
-.controller('ToastCtrl', function($scope, $mdToast) {
-  $scope.closeToast = function() {
-    $mdToast.hide();
-  };
-});
+      $mdToast.show(toast)
+      .then(function(response) {
+        if (response === 'ok') {
+          alert('You selected the \'UNDO\' action.');
+        } else {
+          $log.log('Toast dismissed.');
+        }
+      }).catch(function() {
+        $log.log('Toast failed or was forced to close early by another toast.');
+      });
+    };
+  }
+})();

--- a/src/components/toast/demoBasicUsage/style.scss
+++ b/src/components/toast/demoBasicUsage/style.scss
@@ -1,0 +1,3 @@
+.spacer {
+  width: 50px;
+}

--- a/src/components/toast/demoCustomUsage/script.js
+++ b/src/components/toast/demoCustomUsage/script.js
@@ -10,6 +10,7 @@
 
   function AppCtrl($mdToast, $log) {
     var ctrl = this;
+    var message = 'Custom toast';
 
     ctrl.showCustomToast = function() {
       $mdToast.show({
@@ -17,6 +18,8 @@
         position: 'top right',
         controller: 'ToastCtrl',
         controllerAs: 'ctrl',
+        bindToController: true,
+        locals: {toastMessage: message},
         templateUrl: 'toast-template.html'
       }).then(function(result) {
         if (result === ACTION_RESOLVE) {

--- a/src/components/toast/demoCustomUsage/toast-template.html
+++ b/src/components/toast/demoCustomUsage/toast-template.html
@@ -1,5 +1,5 @@
 <md-toast role="alert" aria-relevant="all">
-  <span class="md-toast-text" flex>Custom toast</span>
+  <span class="md-toast-text" flex>{{ctrl.toastMessage}}</span>
   <span class="md-visually-hidden">
     Press Escape to dismiss. Press Control-"{{ctrl.dialogKey}}" for
   </span>

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -273,7 +273,7 @@ function MdToastDirective($mdToast) {
  *   - `controller` - `{string=}`: The controller to associate with this toast.
  *     The controller will be injected the local `$mdToast.hide()`, which is a function
  *     used to hide the toast.
- *   - `locals` - `{string=}`: An object containing key/value pairs. The keys will
+ *   - `locals` - `{object=}`: An object containing key/value pairs. The keys will
  *     be used as names of values to inject into the controller. For example,
  *     `locals: {three: 3}` would inject `three` into the controller with the value
  *     of 3.
@@ -286,9 +286,9 @@ function MdToastDirective($mdToast) {
  *     to the root element of the application.
  *
  * @returns {promise} A promise that can be resolved with `$mdToast.hide()` or
- * rejected with `$mdToast.cancel()`. `$mdToast.hide()` will resolve either with a Boolean
- * value == 'true' or the value passed as an argument to `$mdToast.hide()`.
- * And `$mdToast.cancel()` will resolve the promise with a Boolean value == 'false'
+ * rejected with `$mdToast.cancel()`. `$mdToast.hide()` will resolve either with the Boolean
+ * value `true` or the value passed as an argument to `$mdToast.hide()`.
+ * `$mdToast.cancel()` will resolve the promise with the Boolean value `false`.
  */
 
 /**
@@ -300,9 +300,9 @@ function MdToastDirective($mdToast) {
  *
  * @param {*=} response An argument for the resolved promise.
  *
- * @returns {promise} a promise that is called when the existing element is removed from the DOM.
- * The promise is resolved with either a Boolean value == 'true' or the value passed as the
- * argument to `.hide()`.
+ * @returns {promise} A promise that is called when the existing element is removed from the DOM.
+ * The promise is resolved with either the Boolean value `true` or the value passed as the
+ * argument to `$mdToast.hide()`.
  */
 
 /**
@@ -319,8 +319,8 @@ function MdToastDirective($mdToast) {
  *
  * @param {*=} response An argument for the rejected promise.
  *
- * @returns {promise} a promise that is called when the existing element is removed from the DOM
- * The promise is resolved with a Boolean value == 'false'.
+ * @returns {promise} A promise that is called when the existing element is removed from the DOM
+ * The promise is resolved with the Boolean value `false`.
  */
 
 function MdToastProvider($$interimElementProvider) {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There are some pretty egregious errors and typos in the toast docs and demos.
There has also been confusion from developers on how to handle Promises and use `locals` with `bindToController`.
The basic usage demo uses `$scope` 🤮

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11499

## What is the new behavior?
- add use of locals to custom toast demo
- remove $scope from basic demo
- show proper Promise handling in basic demo
- clean up demo and doc typos and errors

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
