### PR TITLE
fix(autocomplete): suggestions can be highlighted incorrectly

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -51,7 +51,7 @@ md-autocomplete.md-THEME_NAME-theme {
   li {
     color: '{{foreground-1}}';
     &:hover,
-    &.selected {
+    &#selected_option {
       background: '{{background-500-0.18}}';
     }
   }

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -368,7 +368,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 id="ul-{{$mdAutocompleteCtrl.id}}"\
                 role="listbox">\
               <li md-virtual-repeat="item in $mdAutocompleteCtrl.matches"\
-                  ng-class="{ selected: $index === $mdAutocompleteCtrl.index }"\
                   ng-attr-id="{{$index === $mdAutocompleteCtrl.index ? \'selected_option\' : undefined}}"\
                   ng-click="$mdAutocompleteCtrl.select($index)"\
                   role="option"\


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The second time and beyond when a chips autocomplete dropdown panel is opened, there will be a background on some of the matches to indicate that they are selected, even when they are not selected. It's very confusing UX.

Using `ng-class` within `md-virtual-repeat` doesn't seem to be working
it was evaluating the following to `true`: `-1 === 0`, `-1 === 1`, etc.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10573.

## What is the new behavior?
We no longer depend on `ng-class` here and use the `#selected_option` selector for styling.
This results in no bogus suggestions being highlighted as selected and only the hovered or selected items being highlighted.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This could cause some issues for apps who are relying on the `md-virtual-repeat li.selected` class for styling their app. However, this is unlikely as this bug would have made styling based on that class unreliable.