### PR TITLE
fix(list): case where user is unable to interact w/ secondary actions

### DIFF
--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -284,6 +284,9 @@ md-list-item {
     .md-secondary-container {
       display: flex;
       align-items: center;
+      // Ensure the secondary button is not behind the primary button if its template is provided by
+      // a directive.
+      position: relative;
 
       // Per W3C: https://www.w3.org/TR/css-flexbox/#flex-common
       // By default, flex items won’t shrink below their minimum content size.


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
If the secondary actions' template was provided by a directive, then the actions would be behind the primary button. This meant that tooltips and clicks were not activated.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #9676

## What is the new behavior?
Secondary action tooltips and clicks were are activated when the template is provided by a directive.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
#9676 proposed adding a `z-index` to the `md-secondary-container`, but the container did not have a position. By the spec, `z-index` should only be on "positioned" elements. Adding positioning resolved the issue w/o needing to define a `z-index`.