### PR TITLE
fix(select): evaluate md-input-has-value on next tick

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -514,7 +514,10 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       function inputCheckValue() {
         // The select counts as having a value if one or more options are selected,
         // or if the input's validity state says it has bad input (eg string in a number input)
-        containerCtrl && containerCtrl.setHasValue(selectMenuCtrl.selectedLabels().length > 0 || (element[0].validity || {}).badInput);
+        // we must do this on nextTick as the $render is sometimes invoked on nextTick.
+        $mdUtil.nextTick(function () {
+          containerCtrl && containerCtrl.setHasValue(selectMenuCtrl.selectedLabels().length > 0 || (element[0].validity || {}).badInput);
+        });
       }
 
       function findSelectContainer() {

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -291,9 +291,11 @@ describe('<md-select>', function() {
 
         clickOption(select, 0);
         $rootScope.$apply('showSelect = false');
+        $timeout.flush();
         expectSelectClosed(select);
 
         $rootScope.$apply('showSelect = true');
+        $timeout.flush();
         select = container.find('md-select');
 
         openSelect(select);
@@ -336,6 +338,7 @@ describe('<md-select>', function() {
       expect(el).toHaveClass('md-input-has-value');
 
       $rootScope.$apply('value = null');
+      $timeout.flush();
       expect(el).not.toHaveClass('md-input-has-value');
     });
 
@@ -1010,6 +1013,12 @@ describe('<md-select>', function() {
         expect(ngModelCtrl.$valid).toBe(true);
       });
 
+      it('should have the proper md-has-input-class when the model has selected values', function() {
+        $rootScope.model = [2,4,5,6];
+        var el = setupSelectMultiple('ng-model="$root.model"', [1,2,3,4,5,6]);
+        expect(el).toHaveClass('md-input-has-value');
+      });
+
       it('does not let an empty array satisfy required', function() {
           $rootScope.model = [];
           $rootScope.opts = [1, 2, 3, 4];
@@ -1251,7 +1260,7 @@ describe('<md-select>', function() {
             '<md-option ng-repeat="opt in opts" ng-value="opt">{{opt}}</md-option>' +
           '</md-select></form>')($rootScope);
         var el = form.find('md-select');
-        
+
         $rootScope.$digest();
         $timeout.flush();
 
@@ -1489,6 +1498,7 @@ describe('<md-select>', function() {
 
     el = $compile(template)(scope || $rootScope);
     $rootScope.$digest();
+    $timeout.flush();
     attachedElements.push(el);
 
     return el;


### PR DESCRIPTION
this needs to happen after $render which is now evaluated on next tick

Fixes #11571

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->

Currently select labels are mashed into the values of a multi-selector.

This is the result of https://github.com/angular/material/commit/97e2d004523d2ca5ac9b54e567d8eddc7246aae7

Now multi-selectors $render is delayed to fix an incompatibility with forms.

Issue Number: #11571

## What is the new behavior?

Now the label is in the correct place.

To fix this I've updated the method that evaluates whether the select container should add the md-input-has-value class to also happen after $mdUtil.nextTick. This allows the class evaluation to happen in sync with the $render functionality.

After adding a $timeout.flush() to related tests to simulate the nextTick all tests passed.

A test to prove this fix was also added to prevent future regressions.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

N/A
