### PR TITLE
fix(autocomplete): scroll to top of the list each time dropdown open

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -1895,6 +1895,81 @@ describe('<md-autocomplete>', function() {
       expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-1');
     });
 
+    it('should not retain the position of the scroll after panel is reopened', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-min-length="0"' +
+        '   md-escape-options="clear"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var items = [];
+      for (var i = 0; i < 20; i++) {
+        items.push({ display: 'f' + i});
+      }
+      var scope = createScope(items);
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      // Initial state
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+
+      ctrl.focus();
+      waitForVirtualRepeat(element);
+
+      // After getting focus
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.activeOption).toBe(null);
+
+      ctrl.blur();
+
+      // After loosing focus
+      expect(ctrl.hidden).toBe(true);
+
+      ctrl.focus();
+      waitForVirtualRepeat();
+
+      // After getting focus again
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.activeOption).toBe(null);
+
+      for (var j = 0; j < 10; j++){
+        ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      }
+      $material.flushInterimElement();
+
+      // After highlighting the 10th element
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(9);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-9');
+
+      ctrl.blur();
+
+      // After loosing focus
+      expect(ctrl.hidden).toBe(true);
+      ctrl.focus();
+      waitForVirtualRepeat();
+
+      // After getting focus again
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.activeOption).toBe(null);
+
+      element.remove();
+    });
+
     it('should set activeOption when autoselect is on', function() {
       var template =
         '<md-autocomplete' +

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -411,7 +411,11 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
             scrollContainerElement.on('touchstart touchmove touchend', stopPropagation);
           }
         }
-        $mdUtil.nextTick(updateActiveOption);
+        ctrl.index = getDefaultIndex();
+        $mdUtil.nextTick(function() {
+          updateActiveOption();
+          updateScroll();
+        });
       }
     } else if (hidden && !oldHidden) {
       if ($mdUtil.isIos) {


### PR DESCRIPTION
At the moment the drop down stays at the same position.

Fixes #10479

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
After reopening the drop down of the autocomplete the scroll starts from the same position when it was closed.
Issue Number: #10479


## What is the new behavior?
After reopening the drop down the scroll starts from the top.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
