### PR TITLE
fix(rtl): support applying dir="rtl" on DOM elements other than the body

### DIFF
--- a/src/components/gridList/grid-list.js
+++ b/src/components/gridList/grid-list.js
@@ -93,7 +93,7 @@ angular.module('material.components.gridList', ['material.core'])
  * </md-grid-list>
  * </hljs>
  */
-function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
+function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia, $mdUtil) {
   return {
     restrict: 'E',
     controller: GridListController,
@@ -270,8 +270,7 @@ function GridListDirective($interpolate, $mdConstant, $mdGridLayout, $mdMedia) {
 
       // The width and horizontal position of each tile is always calculated the same way, but the
       // height and vertical position depends on the rowMode.
-      var ltr = document.dir != 'rtl' && document.body.dir != 'rtl';
-      var style = ltr ? {
+      var style = (!$mdUtil.isRtl(attrs)) ? {
           left: POSITION({ unit: hUnit, offset: position.col, gutter: gutter }),
           width: DIMENSION({ unit: hUnit, span: spans.col, gutter: gutter }),
           // resets

--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -494,7 +494,7 @@ function MenuProvider($$interimElementProvider) {
           throw new Error('Invalid target mode "' + positionMode.top + '" specified for md-menu on Y axis.');
       }
 
-      var rtl = ($mdUtil.bidi() === 'rtl');
+      var rtl = $mdUtil.isRtl(el);
 
       switch (positionMode.left) {
         case 'target':

--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -2541,7 +2541,7 @@ function MdPanelPosition($injector) {
   this._$window = $injector.get('$window');
 
   /** @private {boolean} */
-  this._isRTL = $injector.get('$mdUtil').bidi() === 'rtl';
+  this._isRTL = $injector.get('$mdUtil').isRtl();
 
   /** @private @const {!angular.$mdConstant} */
   this._$mdConstant = $injector.get('$mdConstant');

--- a/src/components/slider/slider.js
+++ b/src/components/slider/slider.js
@@ -647,7 +647,7 @@ function SliderDirective($$rAF, $window, $mdAria, $mdUtil, $mdConstant, $mdThemi
       var size = vertical ? sliderDimensions.height : sliderDimensions.width;
       var calc = (position - offset) / size;
 
-      if (!vertical && $mdUtil.bidi() === 'rtl') {
+      if (!vertical && $mdUtil.isRtl(attr)) {
         calc = 1 - calc;
       }
 

--- a/src/components/tabs/js/tabsController.js
+++ b/src/components/tabs/js/tabsController.js
@@ -962,6 +962,6 @@ function MdTabsController ($scope, $element, $window, $mdConstant, $mdTabInkRipp
   }
 
   function isRtl() {
-    return ($mdUtil.bidi() === 'rtl');
+    return $mdUtil.isRtl($attrs);
   }
 }

--- a/src/components/virtualRepeat/virtual-repeater.js
+++ b/src/components/virtualRepeat/virtual-repeater.js
@@ -125,6 +125,8 @@ function VirtualRepeatContainerController($$rAF, $mdUtil, $mdConstant, $parse, $
   this.oldElementSize = null;
   /** @type {!number} Maximum amount of pixels allowed for a single DOM element */
   this.maxElementPixels = $mdConstant.ELEMENT_MAX_PIXELS;
+  /** @type {string}  Direction of the text */
+  this.ltr = !$mdUtil.isRtl(this.$attrs);
 
   if (this.$attrs.mdTopIndex) {
     /** @type {function(angular.Scope): number} Binds to topIndex on AngularJS scope */
@@ -385,13 +387,12 @@ VirtualRepeatContainerController.prototype.resetScroll = function() {
 
 
 VirtualRepeatContainerController.prototype.handleScroll_ = function() {
-  var ltr = document.dir !== 'rtl' && document.body.dir !== 'rtl';
-  if (!ltr && !this.maxSize) {
+  if (!this.ltr && !this.maxSize) {
     this.scroller.scrollLeft = this.scrollSize;
     this.maxSize = this.scroller.scrollLeft;
   }
   var offset = this.isHorizontal() ?
-      (ltr?this.scroller.scrollLeft : this.maxSize - this.scroller.scrollLeft)
+      (this.ltr ? this.scroller.scrollLeft : this.maxSize - this.scroller.scrollLeft)
       : this.scroller.scrollTop;
   if (this.scrollSize < this.size) return;
   if (offset > this.scrollSize - this.size) {
@@ -405,7 +406,7 @@ VirtualRepeatContainerController.prototype.handleScroll_ = function() {
   var numItems = Math.max(0, Math.floor(offset / itemSize) - NUM_EXTRA);
 
   var transform = (this.isHorizontal() ? 'translateX(' : 'translateY(') +
-      (!this.isHorizontal() || ltr ? (numItems * itemSize) : - (numItems * itemSize))  + 'px)';
+      (!this.isHorizontal() || this.ltr ? (numItems * itemSize) : - (numItems * itemSize))  + 'px)';
 
   this.scrollOffset = offset;
   this.offsetter.style.webkitTransform = transform;

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -84,11 +84,35 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     /**
+     * Determines the current 'dir'ectional value based on the value of 'dir'
+     * attribute of the element. If that is not defined, it will try to use
+     * a 'dir' attribute of the body or html tag.
+     *
+     * @param {Object=} attrs a hash object with key-value pairs of normalized
+     *     attribute names and their corresponding attribute values.
+     * @returns {boolean} true if the element's passed in attributes,
+     *     the document, or the body indicates RTL mode, false otherwise.
+     */
+    isRtl: function(attrs) {
+      var dir = angular.isDefined(attrs) && attrs.hasOwnProperty('dir') && attrs.dir;
+
+      switch (dir) {
+        case 'ltr':
+          return false;
+
+        case 'rtl':
+          return true;
+      }
+
+      return ($document[0].dir === 'rtl' || $document[0].body.dir === 'rtl');
+    },
+
+    /**
      * Bi-directional accessor/mutator used to easily update an element's
      * property based on the current 'dir'ectional value.
      */
-    bidi : function(element, property, lValue, rValue) {
-      var ltr = !($document[0].dir == 'rtl' || $document[0].body.dir == 'rtl');
+    bidi: function(element, property, lValue, rValue) {
+      var ltr = !this.isRtl();
 
       // If accessor
       if (arguments.length == 0) return ltr ? 'ltr' : 'rtl';
@@ -105,7 +129,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     bidiProperty: function (element, lProperty, rProperty, value) {
-      var ltr = !($document[0].dir == 'rtl' || $document[0].body.dir == 'rtl');
+      var ltr = !this.isRtl();
 
       var elem = angular.element(element);
 


### PR DESCRIPTION
Create a single function to check text direction based on dir attribute on DOM element or document.

Fixes #11016 Fixes #9754

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
A whole document is expected to be set as RTL even when a `dir` attribute is set properly on an individual element.
Issue Number: #11016, #9754

## What is the new behavior?
It is possible to use `dir` attribute on an element to override a document's `dir` value.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
