### PR TITLE
fix(progress-circular): show correct circle arc

### DIFF
--- a/src/components/progressCircular/js/progressCircularDirective.js
+++ b/src/components/progressCircular/js/progressCircularDirective.js
@@ -139,6 +139,8 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
       var mode = newValues[1];
       var isDisabled = newValues[2];
       var wasDisabled = oldValues[2];
+      var diameter = 0;
+      var strokeWidth = 0;
 
       if (isDisabled !== wasDisabled) {
         element.toggleClass(DISABLED_CLASS, !!isDisabled);
@@ -153,14 +155,28 @@ function MdProgressCircularDirective($window, $mdProgressCircular, $mdTheming,
         }
 
         if (mode === MODE_INDETERMINATE) {
+          if (oldValues[1] === MODE_DETERMINATE) {
+            diameter = getSize(scope.mdDiameter);
+            strokeWidth = getStroke(diameter);
+            path.attr('d', getSvgArc(diameter, strokeWidth, true));
+            path.attr('stroke-dasharray', (diameter - strokeWidth) * $window.Math.PI * 0.75);
+          }
           startIndeterminateAnimation();
         } else {
           var newValue = clamp(newValues[0]);
+          var oldValue = clamp(oldValues[0]);
 
           cleanupIndeterminateAnimation();
 
+          if (oldValues[1] === MODE_INDETERMINATE) {
+            diameter = getSize(scope.mdDiameter);
+            strokeWidth = getStroke(diameter);
+            path.attr('d', getSvgArc(diameter, strokeWidth, false));
+            path.attr('stroke-dasharray', (diameter - strokeWidth) * $window.Math.PI);
+          }
+
           element.attr('aria-valuenow', newValue);
-          renderCircle(clamp(oldValues[0]), newValue);
+          renderCircle(oldValue, newValue);
         }
       }
 


### PR DESCRIPTION
show correct circle arc when changing from in determinate to determinate mode

Fix the broken behavior with the circle arc

Fixes: #11334

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
A wrong circle arc is shown when changing from indeterminate to determinate mode.
Issue Number: #11334


## What is the new behavior?
A proper circle arc is shown when changing between different modes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
