### PR TITLE
fix(checkbox): submit on enter rather than toggle

### DIFF
--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -168,10 +168,19 @@ function MdCheckboxDirective(inputDirective, $mdAria, $mdConstant, $mdTheming, $
 
       function keypressHandler(ev) {
         var keyCode = ev.which || ev.keyCode;
-        if (keyCode === $mdConstant.KEY_CODE.SPACE || keyCode === $mdConstant.KEY_CODE.ENTER) {
-          ev.preventDefault();
-          element.addClass('md-focused');
-          listener(ev);
+        ev.preventDefault();
+        switch(keyCode) {
+          case $mdConstant.KEY_CODE.SPACE:
+            element.addClass('md-focused');
+            listener(ev);
+            break;
+          case $mdConstant.KEY_CODE.ENTER:
+            var form = $mdUtil.getClosest(ev.target, 'form');
+            // We have to use a native event here as the form directive does not use jqlite
+            if (form) {
+              form.dispatchEvent(new Event('submit'));
+            }
+            break;
         }
       }
 

--- a/src/components/checkbox/checkbox.spec.js
+++ b/src/components/checkbox/checkbox.spec.js
@@ -280,6 +280,34 @@ describe('mdCheckbox', function() {
       expect(isChecked(checkbox)).toBe(true);
     });
 
+    it('should set the checkbox to checked when focused and SPACE keypress event fired', function () {
+      var checkbox = compileAndLink('<md-checkbox ng-checked="value"></md-checkbox>');
+      checkbox.triggerHandler({
+        type: 'keypress',
+        keyCode: $mdConstant.KEY_CODE.SPACE
+      });
+      expect(isChecked(checkbox)).toBe(true);
+    });
+
+    it('should NOT set the checkbox to checked when focused and ENTER keypress event fired', function () {
+      var checkbox = compileAndLink('<md-checkbox ng-checked="value"></md-checkbox>');
+      checkbox.triggerHandler({
+        type: 'keypress',
+        keyCode: $mdConstant.KEY_CODE.ENTER
+      });
+      expect(isChecked(checkbox)).toBe(false);
+    });
+
+    it('should submit a parent form when ENTER is pressed', function () {
+      var form = compileAndLink('<form><md-checkbox ng-checked="value"></md-checkbox></form>');
+      angular.element(form[0].getElementsByTagName('md-checkbox')[0]).triggerHandler({
+        type: 'keypress',
+        keyCode: $mdConstant.KEY_CODE.ENTER
+      });
+      pageScope.$apply();
+      expect(form[0].classList.contains('ng-submitted')).toBe(true);
+    });
+
     it('should mark the checkbox as selected on load with ng-checked', function() {
       pageScope.isChecked = function() { return true; };
 


### PR DESCRIPTION
make enter keypress submit form rather than toggle checkbox

Fixes: #11583

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently if you have a checkbox focused and press enter, you toggle the value of the checkbox.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11583


## What is the new behavior?

Now pressing enter while focusing a checkbox within a form, the form will be submitted. If no form exists, nothing will happen.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
 
N/A
