### PR TITLE
fix(navbar): fix navbar focus on click

### DIFF
--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -493,10 +493,11 @@ MdNavBarController.prototype.onKeydown = function(e) {
  * @param $$rAF
  * @param $mdUtil
  * @param $window
+ * @param $timeout
  * @constructor
  * @ngInject
  */
-function MdNavItem($mdAria, $$rAF, $mdUtil, $window) {
+function MdNavItem($mdAria, $$rAF, $mdUtil, $window, $timeout) {
   return {
     restrict: 'E',
     require: ['mdNavItem', '^mdNavBar'],
@@ -591,7 +592,9 @@ function MdNavItem($mdAria, $$rAF, $mdUtil, $window) {
 
         navButton.on('focus', function() {
           if (!mdNavBar.getFocusedTab()) {
-            mdNavBar.onFocus();
+            $timeout(function () {
+              mdNavBar.onFocus();
+            },200);
           }
         });
 

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -183,6 +183,17 @@ describe('mdNavBar', function() {
       expect($scope.selectedTabRoute).toBe('tab2');
     });
 
+    it('should add the md-focused class when focused', function () {
+      $scope.selectedTabRoute = 'tab1';
+      createTabs();
+      var tab2Ctrl = getTabCtrl('tab2');
+      angular.element(tab2Ctrl.getButtonEl()).triggerHandler('focus');
+      angular.element(tab2Ctrl.getButtonEl()).triggerHandler('click');
+      $scope.$apply();
+      $timeout.flush();
+      expect(tab2Ctrl.getButtonEl().classList.contains('md-focused')).toBe(true);
+    });
+
     it('adds ui-sref-opts attribute to nav item when sref-opts attribute is ' +
         'defined', function() {
           create(


### PR DESCRIPTION
add a $timeout that will allow enough time for the click event to
complete so the focus event can properly evaluate

Fixes: #11591

## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Currently clicking on a navbar tab will select it, but pull focus to the previously selected tab.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11591

## What is the new behavior?

Now the click event will evaluate before the focus event, updating the state which is necessary to set the focus styling.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I spent a lot of time spinning my wheels on this, it turns out that there is just a significant delay from when the focus event is fired and when the click event is fired.