### PR TITLE
fix(icon): restore SVG Element correctly in IE11

### DIFF
--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -479,7 +479,7 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
   function transformClone(cacheElement) {
     var clone = cacheElement.clone();
     var newUid = $mdUtil.nextUid();
-    var cacheSuffix, svgElement;
+    var cacheSuffix, svgInner, svgAttributes, svgHead, svgTail;
 
     // Verify that the newUid only contains a number and not some XSS content.
     if (!isFinite(Number(newUid))) {
@@ -503,10 +503,15 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
     });
     // innerHTML of SVG elements is not supported by IE11
     if (clone.innerHTML === undefined) {
-      svgElement = $mdUtil.getInnerHTML(clone);
-      svgElement = svgElement.replace(/(.*url\(#)(\w*)(\).*)/g, addCacheSuffixToId);
-      svgElement = svgElement.replace(/(.*xlink:href="#)(\w*)(".*)/g, addCacheSuffixToId);
-      clone = angular.element(svgElement)[0];
+      svgInner = $mdUtil.getInnerHTML(clone);
+      svgInner = svgInner.replace(/(.*url\(#)(\w*)(\).*)/g, addCacheSuffixToId);
+      svgInner = svgInner.replace(/(.*xlink:href="#)(\w*)(".*)/g, addCacheSuffixToId);
+      svgAttributes = clone.attributes;
+      svgHead = '<svg ' + Array.prototype.map.call(svgAttributes, function(attribute) {
+        return attribute.name + (attribute.value ? '="' + attribute.value + '"' : '');
+      }).join(' ') + '>';
+      svgTail = '</svg>';
+      clone = angular.element(svgHead + svgInner + svgTail)[0];
     } else {
       // Inject the cacheSuffix into all instances of url(id) and xlink:href="#id".
       // This use of innerHTML should be safe from XSS attack since we are only injecting the


### PR DESCRIPTION
the fix for IE11 introduced by #11545 removes the outer SVG element tag.
correctly restore the element by rebuilding it.

fixes #11603

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11603 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
