### PR TITLE
chore(ci): disable CircleCI's forcing of SSH with GitHub

### DIFF
--- a/scripts/bower-material-release.sh
+++ b/scripts/bower-material-release.sh
@@ -33,9 +33,11 @@ function run {
 
   cd bower-material
 
-  # GitHub token with push permission specified as environment variable
   git config user.name "${commitAuthorName}"
   git config user.email "${commitAuthorEmail}"
+  # Disable CircleCI's forced use of SSH with GitHub
+  git config --global --unset url.ssh://git@github.com.insteadof
+  # GitHub personal access token with push permission specified as environment variable
   git config credential.helper "store --file=.git/credentials"
   echo "https://${ANGULARJS_MATERIAL_BOWER_TOKEN}:@github.com" > .git/credentials
 

--- a/scripts/snapshot-docs-site.sh
+++ b/scripts/snapshot-docs-site.sh
@@ -30,9 +30,11 @@ function run {
 
   cd code.material.angularjs.org
 
-  # GitHub token with push permission specified as environment variable
   git config user.name "${commitAuthorName}"
   git config user.email "${commitAuthorEmail}"
+  # Disable CircleCI's forced use of SSH with GitHub
+  git config --global --unset url.ssh://git@github.com.insteadof
+  # GitHub personal access token with push permission specified as environment variable
   git config credential.helper "store --file=.git/credentials"
   echo "https://${ANGULARJS_MATERIAL_DOCS_SITE_TOKEN}:@github.com" > .git/credentials
 


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
CircleCI forces the use of SSH which breaks our use of personal access tokens to push code to other repos.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #11592.

## What is the new behavior?
Remove the CircleCI global git override to force SSH.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Related discussions:
- https://discuss.circleci.com/t/github-forced-through-ssh-protocol/5332/2
- https://discuss.circleci.com/t/is-it-ok-for-me-to-delete-gitconfig-in-the-box/5566