### PR TITLE
fix(icon): SVG elements are not loaded from the cache properly on IE11

### DIFF
--- a/src/components/icon/js/iconService.js
+++ b/src/components/icon/js/iconService.js
@@ -503,7 +503,7 @@ function MdIconService(config, $templateRequest, $q, $log, $mdUtil, $sce) {
     });
     // innerHTML of SVG elements is not supported by IE11
     if (clone.innerHTML === undefined) {
-      svgElement = $mdUtil.getInnerHTML(clone);
+      svgElement = $mdUtil.getOuterHTML(clone);
       svgElement = svgElement.replace(/(.*url\(#)(\w*)(\).*)/g, addCacheSuffixToId);
       svgElement = svgElement.replace(/(.*xlink:href="#)(\w*)(".*)/g, addCacheSuffixToId);
       clone = angular.element(svgElement)[0];

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -864,21 +864,38 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     },
 
     /**
-     * Function to get innerHTML of SVG and Symbol elements in IE11
+     * Gets the inner HTML content of the given HTMLElement.
+     * Only intended for use with SVG or Symbol elements in IE11.
      * @param {Element} element
-     * @returns {string} the innerHTML of the element passed in
+     * @returns {string} the inner HTML of the element passed in
      */
     getInnerHTML: function(element) {
+      // For SVG or Symbol elements, innerHTML returns `undefined` in IE.
+      // Reference: https://stackoverflow.com/q/28129956/633107
+      // The XMLSerializer API is supported on IE11 and is the recommended workaround.
       var serializer = new XMLSerializer();
 
       return Array.prototype.map.call(element.childNodes, function (child) {
         return serializer.serializeToString(child);
       }).join('');
+    },
+
+    /**
+     * Gets the outer HTML content of the given HTMLElement.
+     * Only intended for use with SVG or Symbol elements in IE11.
+     * @param {Element} element
+     * @returns {string} the outer HTML of the element passed in
+     */
+    getOuterHTML: function(element) {
+      // For SVG or Symbol elements, outerHTML returns `undefined` in IE.
+      // Reference: https://stackoverflow.com/q/29888050/633107
+      // The XMLSerializer API is supported on IE11 and is the recommended workaround.
+      var serializer = new XMLSerializer();
+      return serializer.serializeToString(element);
     }
   };
 
-
-// Instantiate other namespace utility methods
+  // Instantiate other namespace utility methods
 
   $mdUtil.dom.animator = $$mdAnimate($mdUtil);
 
@@ -887,7 +904,6 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
   function getNode(el) {
     return el[0] || el;
   }
-
 }
 
 /*


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
SVG elements are not loaded from the cache properly on IE11. The outer `<svg>` tag is lost.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11603. Relates to #11545. Closes #11604.

## What is the new behavior?
SVG elements are loaded from the cache properly on IE11 including the `<svg>` tag and the element's attributes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
We can't just use `outerHTML` here either due to that [not being supported for SVG elements in IE](https://stackoverflow.com/questions/29888050/outerhtml-is-not-working-in-ie) as well.