### PR TITLE
docs(menu): fix docs nav menu margin

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -264,16 +264,16 @@ code:not(.highlight) {
   max-width: 100%;
   overflow-x: hidden;
 }
-.docs-menu li {
+ul.docs-menu li {
   margin: 0;
 }
 .docs-menu > li:nth-child(1) {
   border-top: none;
 }
 .md-whiteframe-glow-z1 {
-  box-shadow: 0px 0px 1px 1px rgba(0, 0, 0, 0.14),
-              0px 0px 2px 2px rgba(0, 0, 0, 0.098),
-              0px 0px 5px 1px rgba(0, 0, 0, 0.084);
+  box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.14),
+              0 0 2px 2px rgba(0, 0, 0, 0.098),
+              0 0 5px 1px rgba(0, 0, 0, 0.084);
 }
 .docs-menu > li {
   border-bottom: 1px solid #267ED5;
@@ -289,7 +289,7 @@ code:not(.highlight) {
   margin: 0;
   max-height: 40px;
   overflow: hidden;
-  padding: 0px 16px;
+  padding: 0 16px;
   text-align: left;
   text-decoration: none;
   white-space: normal;
@@ -312,7 +312,6 @@ body[dir=rtl] .docs-menu .md-button {
 }
 
 .docs-menu md-select {
-
  /* Override md-select margins.  With margins the menu will look incorrect and causes mobile list
     to not be scrollable.
   */

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -267,7 +267,7 @@ function labelDirective() {
  *
  * You can also disable this functionality manually by adding the `md-auto-hide="false"` expression
  * to the `ng-messages` container. This may be helpful if you always want to see the error messages
- * or if you are building your own visibilty directive.
+ * or if you are building your own visibility directive.
  *
  * _<b>Note:</b> The `md-auto-hide` attribute is a static string that is  only checked upon
  * initialization of the `ng-messages` directive to see if it equals the string `false`._


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is an extra margin on the left of the docs nav menu.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?
- No more extra margin on the left of the docs nav menu.
- fix a typo in a comment

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
