### PR TITLE
WIP: fix(toast): sanitize auto wrapped custom toast templates

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -186,6 +186,7 @@
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/{$ doc.buildConfig.ngVersion $}/angular-route.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/{$ doc.buildConfig.ngVersion $}/angular-aria.min.js"></script>
   <script src="https://ajax.googleapis.com/ajax/libs/angularjs/{$ doc.buildConfig.ngVersion $}/angular-messages.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/{$ doc.buildConfig.ngVersion $}/angular-sanitize.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment.js"></script>
 
   <script src="angular-material.min.js"></script>


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There was an issue filed in g3 about using [innerHTML here](https://github.com/angular/material/blob/v1.1.13/src/components/toast/toast.js#L437) in `md-toast` for custom toasts.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Related to #6494. Related to #6259.

## What is the new behavior?
Protect against a possible XSS vector by sanitizing all elements inside of the template's outer `<md-toast><sanitize everything here></md-toast>` element. This could be multiple DOM elements, comments, etc.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
This may require `ngSanitize` in some apps that previously didn't use it. In those cases, the apps would break with an `$sce` exception.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This uses a similar approach to [md-select's approach](https://github.com/angular/material/blob/ecf1705b948ece78531a675f8960f90ec4fda163/src/components/select/select.js#L338-L341) to sanitizing text that can contain HTML.