### PR TITLE
chore(tests): remove unused phantomJS workaround

### DIFF
--- a/test/angular-material-spec.js
+++ b/test/angular-material-spec.js
@@ -7,27 +7,6 @@
  */
 (function() {
 
-
-  // Patch since PhantomJS does not implement click() on HTMLElement. In some
-  // cases we need to execute the native click on an element. However, jQuery's
-  // $.fn.click() does not dispatch to the native function on <a> elements, so we
-  // can't use it in our implementations: $el[0].click() to correctly dispatch.
-  // Borrowed from https://stackoverflow.com/questions/15739263/phantomjs-click-an-element
-  if (!HTMLElement.prototype.click) {
-    HTMLElement.prototype.click = function() {
-      var ev = document.createEvent('MouseEvent');
-      ev.initMouseEvent(
-        'click',
-        /*bubble*/true, /*cancelable*/true,
-        window, null,
-        0, 0, 0, 0, /*coordinates*/
-        false, false, false, false, /*modifier keys*/
-        0/*button=left*/, null
-      );
-      this.dispatchEvent(ev);
-    };
-  }
-
   var enableAnimations;
 
   afterEach(function() {


### PR DESCRIPTION
this is no longer needed as phantomJS is not used

Fixes: N/A

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[x] Other... Please describe:
```

## What is the current behavior?

There is a bit of functionality that was at one point useful for working around phantomJS not implementing click() on HTML elements, this is no longer required as phantomJS is not used.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: N/A


## What is the new behavior?

This workaround has been removed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

This was a change that was made while investigating https://github.com/angular/material/issues/11489 but was unrelated and a PR could be made separately.
