### PR TITLE
fix(input): change label and placeholder colors to match Material spec

### DIFF
--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -11,7 +11,7 @@ md-input-container.md-THEME_NAME-theme {
 
   label,
   .md-placeholder {
-    color: '{{foreground-3}}';
+    color: '{{foreground-2}}';
   }
 
   label.md-required:after {

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -9,9 +9,11 @@ md-input-container.md-THEME_NAME-theme {
     color: '{{foreground-1}}';
   }
 
+  &[md-no-float] input::placeholder,
   label,
   .md-placeholder {
     color: '{{foreground-2}}';
+    opacity: 1;
   }
 
   label.md-required:after {


### PR DESCRIPTION
opacity of label and .md-placeholder elements changed from 38% to 54%

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Both `md-input-container.md-THEME_NAME-theme label` and `md-input-container.md-THEME_NAME-theme .md-placeholder` elements have an opacity of 38%, but according to the input spec on the material website ( https://material.io/archive/guidelines/components/text-fields.html#text-fields-states ), these elements need to be at 54%. This helps with ARIA compliance because an element at 38% is hidden in high contrast mode.

![screen shot 2019-03-05 at 12 02 48 pm](https://user-images.githubusercontent.com/3892772/53822910-ab8a4a80-3f3e-11e9-9520-d8d1c17aee51.png)


## What is the new behavior?
The <label> elements are now at a higher opacity. The ::placeholder element for md-no-float inputs are also at the same color and opacity.

![screen shot 2019-03-05 at 12 02 02 pm](https://user-images.githubusercontent.com/3892772/53822920-afb66800-3f3e-11e9-8cea-3d4f181fc6e3.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
