### PR TITLE
fix(autocomplete): improve dropdown options bottom space calculation

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -3212,6 +3212,59 @@ describe('<md-autocomplete>', function() {
       document.body.removeChild(parent[0]);
     }));
 
+    it('should position dropdown with correct height with a shifted body (virtual list)', inject(function($timeout) {
+      var scope = createScope();
+
+      dropdownItems = 2;
+      scope.match = fakeItemMatch;
+
+      var template =
+        '<div style="height: 2000px">' +
+        '<div style="height: 1200px"></div>' +
+        '<md-autocomplete ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'md-min-length="0" ' +
+        'md-dropdown-position="bottom" ' +
+        'placeholder="placeholder">' +
+        '<span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>' +
+        '</div>';
+
+      var parent = compile(template, scope);
+      var element = parent.find('md-autocomplete');
+      var ctrl = element.controller('mdAutocomplete');
+
+      // Add container to the DOM to be able to test the rect calculations.
+      document.body.appendChild(parent[0]);
+      window.scrollTo(0, 1200);
+
+      $timeout.flush();
+
+      expect(ctrl.positionDropdown).toBeTruthy();
+
+      // Focus the autocomplete and trigger a query to be able to open the dropdown.
+      ctrl.focus();
+
+      scope.$apply('searchText = "A"');
+      waitForVirtualRepeat(element);
+
+      var scrollContainer = document.body.querySelector('.md-virtual-repeat-container');
+
+      expect(scrollContainer).toBeTruthy();
+      expect(scrollContainer.style.height).toBe(dropdownItems * DEFAULT_ITEM_HEIGHT + 'px');
+
+      dropdownItems = DEFAULT_MAX_ITEMS;
+
+      // Trigger a new query to request an update of the items and dropdown.
+      scope.$apply('searchText = "B"');
+
+      expect(scrollContainer.style.height).toBe(dropdownItems * DEFAULT_ITEM_HEIGHT + 'px');
+
+      document.body.removeChild(parent[0]);
+    }));
+
     it('should grow and shrink virtual list depending on the amount of items', inject(function($timeout) {
       var scope = createScope();
 

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -161,7 +161,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
       styles.bottom    = bot + 'px';
       styles.maxHeight = Math.min(dropdownHeight, hrect.top - root.top - MENU_PADDING) + 'px';
     } else {
-      var bottomSpace = root.bottom - hrect.bottom - MENU_PADDING + $mdUtil.getViewportTop();
+      var bottomSpace = root.bottom - hrect.bottom - MENU_PADDING + $mdUtil.getViewportTop() - $mdUtil.getDisabledBodyOffset();
 
       styles.top       = (top - offset) + 'px';
       styles.bottom    = 'auto';

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -314,6 +314,15 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
     },
 
+    getDisabledBodyOffset: function() {
+      var body = angular.element($document[0].body);
+      if (body.css('position') == 'fixed') {
+        var pixelOffset = body.css('top');
+        return +pixelOffset.replace('px', '');
+      }
+      return 0;
+    },
+
     enableScrolling: function() {
       var restoreFn = this.disableScrollAround._restoreScroll;
       restoreFn && restoreFn();

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -3,11 +3,12 @@ describe('util', function() {
   describe('with no overrides', function() {
     beforeEach(module('material.core'));
 
-    var $rootScope, $timeout, $$mdAnimate;
-    beforeEach(inject(function(_$animate_, _$rootScope_, _$timeout_) {
+    var $rootScope, $timeout, $$mdAnimate, $document;
+    beforeEach(inject(function(_$animate_, _$rootScope_, _$timeout_, _$document_) {
       $animate = _$animate_;
       $rootScope = _$rootScope_;
       $timeout = _$timeout_;
+      $document = _$document_;
     }));
 
     describe('now', function() {
@@ -337,6 +338,20 @@ describe('util', function() {
         }
       }));
 
+    });
+
+    describe('getDisabledBodyOffset', function(){
+
+      it('should return body top when fixed position', inject(function($mdUtil, $document) {
+        expect($mdUtil.getDisabledBodyOffset()).toBe(0);
+
+        $document[0].body.style.position = 'fixed';
+        $document[0].body.style.top = '-50px';
+
+        expect($mdUtil.getDisabledBodyOffset()).toBe(-50);
+
+        $document[0].body.style = {};
+      }));
     });
 
     describe('nextTick', function() {


### PR DESCRIPTION
If the body of the page has been shifted, such as due to an open dialog, the autocomplete options should know about it with regards to positioning.

Fixes #11661

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
