### PR TITLE
docs(scroll): scroll to top on route change

### DIFF
--- a/docs/config/template/index.template.html
+++ b/docs/config/template/index.template.html
@@ -155,7 +155,7 @@
     </md-toolbar>
 
     <md-content md-scroll-y layout="column" flex>
-      <div ng-view layout-padding flex="noshrink" class="docs-ng-view"></div>
+      <div ng-view layout-padding flex="noshrink" class="docs-ng-view" cache-scroll-position></div>
 
       <div layout="row" flex="noshrink" layout-align="center center">
         <div id="license-footer" flex>


### PR DESCRIPTION
scroll to top on every route/location change. Previously, for some of
the route changes when clicking on the side bar menu, the scroll stayed in place.

Fixes #11669

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Enhancement
- [ ] Documentation content changes
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Infrastructure changes
- [x] Other... Please describe:

Bugfix/Enhancement for docs.

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11669 


## What is the new behavior?
Content pane scrolls to top on clicking a link from sidebar menu item

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
