### PR TITLE
fix(colors): handle null or undefined in md-colors

### DIFF
--- a/src/components/colors/colors.js
+++ b/src/components/colors/colors.js
@@ -121,6 +121,9 @@
      * @returns rgba color string
      */
     function parseColor(color, contrast) {
+      if(!color) {
+        return '';
+      }
       contrast = contrast || false;
       var rgbValues = $mdTheming.PALETTES[color.palette][color.hue];
 
@@ -171,6 +174,9 @@
      * For the evaluated expression, extract the color parts into a hash map
      */
     function extractColorOptions(expression) {
+      if(!expression) {
+        return undefined;
+      }
       var parts = expression.split('-');
       var hasTheme = angular.isDefined($mdTheming.THEMES[parts[0]]);
       var theme = hasTheme ? parts.splice(0, 1)[0] : $mdTheming.defaultTheme();
@@ -316,7 +322,7 @@
             if (mdThemeController) {
               Object.keys(colors).forEach(function (prop) {
                 var color = colors[prop];
-                if (!$mdColors.hasTheme(color)) {
+                if (color && !$mdColors.hasTheme(color)) {
                   colors[prop] = (theme || mdThemeController.$mdTheme) + '-' + color;
                 }
               });


### PR DESCRIPTION
If md-colors expression evaluates to an object like `{ backgroundColor: undefined }`,
md-colors should handle it and remove backgroundColor css property.

fixes #11672 

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Described in #11672 
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11672 


## What is the new behavior?
Described in #11672 

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
[x] Not sure, but probably no.
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Nothing
