### PR TITLE
fix(input): placeholder hidden when there is also a label on IE11

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -148,7 +148,7 @@ md-input-container {
     opacity: 0;
   }
 
-  &:not( .md-input-has-value ) input:not( :focus ) {
+  &:not( .md-input-has-value ):not( .md-input-has-placeholder ) input:not( :focus ) {
     color: transparent;
   }
   &:not( .md-input-has-value ) input:not( :focus )::-webkit-datetime-edit-ampm-field,


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
If a `md-input` has both a `placeholder` and a `label`, the placeholder is invisible on IE11.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11668

## What is the new behavior?
If a `md-input` has both a `placeholder` and a `label`, the placeholder is visible on IE11.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Verified manually in IE11 on Windows 10. No unit tests added as we don't run them against IE11.
Also verified by the reporter in https://github.com/angular/material/issues/11668#issuecomment-472014615.