### PR TITLE
fix(panel): append panel animation transforms after existing transforms

### DIFF
--- a/src/components/panel/panel.js
+++ b/src/components/panel/panel.js
@@ -3371,7 +3371,7 @@ MdPanelAnimation.prototype.animateOpen = function(panelEl) {
 
       var openScale = animator.calculateZoomToOrigin(
               panelEl, this._openFrom) || '';
-      openFrom = animator.toTransformCss(openScale + ' ' + panelTransform);
+      openFrom = animator.toTransformCss(panelTransform + ' ' + openScale);
       break;
 
     case MdPanelAnimation.animation.FADE:
@@ -3436,7 +3436,7 @@ MdPanelAnimation.prototype.animateClose = function(panelEl) {
 
       var closeScale = animator.calculateZoomToOrigin(
               panelEl, this._closeTo) || '';
-      closeTo = animator.toTransformCss(closeScale + ' ' + panelTransform);
+      closeTo = animator.toTransformCss(panelTransform + ' ' + closeScale);
       break;
 
     case MdPanelAnimation.animation.FADE:

--- a/src/components/panel/panel.spec.js
+++ b/src/components/panel/panel.spec.js
@@ -2957,6 +2957,49 @@ describe('$mdPanel', function() {
       expect(backdropAnimation._closeDuration).toBe(mdPanelAnimation._closeDuration);
     });
 
+    describe('should add scale after the existing transform when', function () {
+      var animator;
+      var panelEl;
+
+      beforeEach(function () {
+        animator = mdPanelAnimation._$mdUtil.dom.animator;
+
+        var panelDiv = document.createElement('div');
+        panelDiv.id = 'mockPanel'
+        panelDiv.style.transform = 'translateX(-50%) translateY(-50%)'
+        attachToBody(panelDiv);
+        panelEl = angular.element(panelDiv);
+
+        spyOn(animator, 'translate3d');
+
+        spyOn(animator, 'calculateZoomToOrigin')
+          .and.returnValue('translate3d(0, 0, 0) scale(0.5, 0.5)');
+
+      });
+
+      it('opening with the SCALE animation', function () {
+        var animation = mdPanelAnimation.openFrom('button')
+          .withAnimation('md-panel-animate-scale')
+
+        animation.animateOpen(panelEl);
+
+       expect(animator.translate3d.calls.mostRecent().args[1].transform)
+          .toMatch(/^translateX.*scale\(0\.5, 0\.5\)$/g);
+
+      });
+
+      it('closing with the SCALE animation', function () {
+        var animation = mdPanelAnimation.openFrom('button')
+          .withAnimation('md-panel-animate-scale')
+
+        animation.animateClose(panelEl);
+
+        expect(animator.translate3d.calls.mostRecent().args[2].transform)
+          .toMatch(/^translateX.*scale\(0\.5, 0\.5\)$/g);
+
+      });
+    });
+
     describe('should determine openFrom when', function() {
       it('provided a selector', function() {
         var animation = mdPanelAnimation.openFrom('button');


### PR DESCRIPTION
append the transform for panel animations after any existing transforms.  Previously, the animation
transform was appened first, resulting in the destination location being incorrect.

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
When a panel has a centered location (or other transform applied) combined with an OpenFrom/CloseTo, the panel animates to/from the wrong location

Issue Number:
N/A


## What is the new behavior?

The panel animates to/from the correct location

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
