### PR TITLE
docs(ie): fix bad link to theming guide

### DIFF
--- a/docs/content/performance/internet-explorer.md
+++ b/docs/content/performance/internet-explorer.md
@@ -22,7 +22,7 @@ present a performance burden for Internet Explorer. When switching or modifying 
 is not a requirement, the theming CSS can be exported to an external file which can be loaded statically.
 The following steps should be performed:
 
-* Configure your theme as explained [here](../Theming/03_configuring_a_theme)
+* Configure your theme as explained [here](Theming/03_configuring_a_theme)
  - This step is only required when a custom theme is used
 * Run the application in Chrome 
 * Open the Chrome DevTools


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The link to the theming guide from the IE Performance guide is broken.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11713

## What is the new behavior?
The link to the theming guide from the IE Performance guide is working.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
