### PR TITLE
fix(datepicker): auto closes in Chrome when md-open-on-focus is used

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -530,7 +530,7 @@
 
     // Add event listener through angular so that we can triggerHandler in unit tests.
     self.ngInputElement.on('keydown', function(event) {
-      if (event.altKey && event.keyCode == keyCodes.DOWN_ARROW) {
+      if (event.altKey && event.keyCode === keyCodes.DOWN_ARROW) {
         self.openCalendarPane(event);
         $scope.$digest();
       }
@@ -538,6 +538,15 @@
 
     if (self.openOnFocus) {
       self.ngInputElement.on('focus', angular.bind(self, self.openCalendarPane));
+      self.ngInputElement.on('click', function(event) {
+        event.stopPropagation();
+      });
+      self.ngInputElement.on('pointerdown',function(event) {
+        if (event.target && event.target.setPointerCapture) {
+          event.target.setPointerCapture(event.pointerId);
+        }
+      });
+
       angular.element(self.$window).on('blur', self.windowBlurHandler);
 
       $scope.$on('$destroy', function() {
@@ -551,7 +560,7 @@
   };
 
   /**
-   * Capture properties set to the date-picker and imperitively handle internal changes.
+   * Capture properties set to the date-picker and imperatively handle internal changes.
    * This is done to avoid setting up additional $watches.
    */
   DatePickerCtrl.prototype.installPropertyInterceptors = function() {
@@ -822,12 +831,12 @@
       // Attach click listener inside of a timeout because, if this open call was triggered by a
       // click, we don't want it to be immediately propagated up to the body and handled.
       var self = this;
-      this.$timeout(function() {
+      this.$mdUtil.nextTick(function() {
         // Use 'touchstart` in addition to click in order to work on iOS Safari, where click
         // events aren't propagated under most circumstances.
         // See http://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
         self.documentElement.on('click touchstart', self.bodyClickHandler);
-      }, 100);
+      }, false);
 
       window.addEventListener(this.windowEventName, this.windowEventHandler);
     }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
A [regression](https://bugs.chromium.org/p/chromium/issues/detail?id=941910) in Chromium has caused date and time pickers around the Internet to instantly close when opened via a focus event due to a change in the timing of events. `md-datepicker` works better than most after going to the `100ms` delay to fix Firefox, but it isn't always enough, especially when changing focus from one input to another.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11701

## What is the new behavior?
Improve event handling based on suggestions by Navid Zolghadr.
- Timeouts are eliminated.
- `stopPropagation()` on `click` events from the input
- In Chrome use the [`setPointerCapture` API](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture) to avoid auto closing on `pointerdown` events

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Related Chromium regression: https://bugs.chromium.org/p/chromium/issues/detail?id=941910