### PR TITLE
fix(gesture): tapping a submit button fires two submit events on mobile

### DIFF
--- a/src/components/tabs/demoDynamicTabs/script.js
+++ b/src/components/tabs/demoDynamicTabs/script.js
@@ -6,7 +6,7 @@
 
   function AppCtrl ($scope, $log) {
     var tabs = [
-        { title: 'Zero (AKA 0, Cero, One - One, -Nineteen + 19, and so forth and so on and continuing into what seems like infinity.)', content: 'Woah...that is a really long title!' },
+        { title: 'Zero (AKA 0, Cero, One - One, -Nineteen + 19, and so forth and so on and continuing into what seems like infinity)', content: 'Whoa...that is a really long title!' },
         { title: 'One', content: "Tabs will become paginated if there isn't enough room for them."},
         { title: 'Two', content: "You can swipe left and right on a mobile device to change tabs."},
         { title: 'Three', content: "You can bind the selected tab via the selected attribute on the md-tabs element."},


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Ever since https://github.com/angular/material/commit/eecc5410dbfcdc59e2cba3f4255f03b58783ae27 in `1.1.4`, tapping a submit button fires two submit events on mobile. This causes the dynamic tabs demo w/ pagination to often add two tabs for each 'Add Tab' button click on iOS and Android.
  - when click hijacking is enabled (default)
    - isKeyClick check did not work on iOS since clientX/Y are set
- Our gesture code is using the deprecated [initMouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/initMouseEvent) and [initCustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/initCustomEvent)
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11725

## What is the new behavior?
when click hijacking is enabled (default)
- add an iOS-specific isKeyClick check using [`webkitForce`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/webkitForce) as there was no other way to differentiate the click events without recording `touchstart` and other events and then trying to look through recent history.
- revert workaround from PR #10189

use recommended [`new MouseEvent()`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent) and [`new CustomEvent()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
- fallback to deprecated methods `initMouseEvent()` and `initCustomEvent()`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Tests could not be added as we have not test infrastructure for Android and iOS.

Tested on
- [x] Firefox
- [x] Chrome
- [x] Chrome for Android
- [x] iOS Safari
- [x] macoS Safari
- [x] IE11
- [x] MS Edge
- [x] MS Edge Chromium

More info on creating and triggering events can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events).