### PR TITLE
build(release): detect that gulp is not installed globally

### DIFF
--- a/release.js
+++ b/release.js
@@ -19,6 +19,11 @@
   const lastMajorVer   = JSON.parse(exec('curl https://material.angularjs.org/docs.json')).latest;
   let newVersion;
 
+  try {
+    child_process.execSync('gulp --version', defaultOptions);
+  } catch (error) {
+    throw new Error('Please install gulp globally via "npm i -g gulp@^3.9.1".');
+  }
   header();
   const dryRun = prompt(`Is this a dry-run? [${"yes".cyan}/no] `, 'yes') !== 'no';
 
@@ -401,7 +406,12 @@
     log('done'.green);
   }
 
-  /** utility method for executing terminal commands */
+  /**
+   * utility method for executing terminal commands while ignoring stderr
+   * @param {string|Array} cmd
+   * @param {Object=} userOptions
+   * @return
+   */
   function exec (cmd, userOptions) {
     if (cmd instanceof Array) {
       return cmd.map(function (cmd) { return exec(cmd, userOptions); });


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
If the person doing the release does not have `gulp` installed globally, they see something like this
```sh
Adding new version of the docs site...                                      fs.js:114
    throw err;
    ^

Error: ENOENT: no such file or directory, open '/usr/local/google/home/username/git/material/dist/docs/docs.js'
    at Object.openSync (fs.js:438:3)
    at Object.readFileSync (fs.js:343:35)
    at replaceFilePaths (/usr/local/google/home/username/git/material/release.js:333:21)
```
This message doesn't help with resolving the problem and causes extra debugging to be required.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?
Detect that `gulp` is not installed globally and provide an early failure with a clear message rather than failing on later calls to `exec()` which ignore `stderr`.

Failure:
```sh
$ ./release
/bin/sh: gulp: command not found
/Users/splaktar/Git/angular/material/release.js:25
    throw new Error('Please install gulp globally via "npm i -g gulp@^3.9.1".');
    ^

Error: Please install gulp globally via "npm i -g gulp@^3.9.1".
    at /Users/splaktar/Git/angular/material/release.js:25:11
    at Object.<anonymous> (/Users/splaktar/Git/angular/material/release.js:457:3)
    at Module._compile (internal/modules/cjs/loader.js:701:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
    at Module.load (internal/modules/cjs/loader.js:600:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
    at Function.Module._load (internal/modules/cjs/loader.js:531:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:754:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
