### PR TITLE
fix(select): improve focus/blur handling on iOS

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -362,16 +362,9 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       };
 
       if (!isReadonly) {
-        element
-          .on('focus', function(ev) {
-            // Always focus the container (if we have one) so floating labels and other styles are
-            // applied properly
-            containerCtrl && containerCtrl.setFocused(true);
-          });
-
-        // Attach before ngModel's blur listener to stop propagation of blur event
-        // to prevent from setting $touched.
-        element.on('blur', function(event) {
+        var handleBlur = function(event) {
+          // Attach before ngModel's blur listener to stop propagation of blur event
+          // and prevent setting $touched.
           if (untouched) {
             untouched = false;
             if (selectScope._mdSelectIsOpen) {
@@ -379,10 +372,17 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
             }
           }
 
-          if (selectScope._mdSelectIsOpen) return;
           containerCtrl && containerCtrl.setFocused(false);
           inputCheckValue();
-        });
+        };
+        var handleFocus = function(ev) {
+          // Always focus the container (if we have one) so floating labels and other styles are
+          // applied properly
+          containerCtrl && containerCtrl.setFocused(true);
+        };
+
+        element.on('focus', handleFocus);
+        element.on('blur', handleBlur);
       }
 
       mdSelectCtrl.triggerClose = function() {
@@ -510,7 +510,6 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       });
 
 
-
       function inputCheckValue() {
         // The select counts as having a value if one or more options are selected,
         // or if the input's validity state says it has bad input (eg string in a number input)
@@ -573,7 +572,6 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
           loadingAsync: attr.mdOnOpen ? scope.$eval(attr.mdOnOpen) || true : false
         }).finally(function() {
           selectScope._mdSelectIsOpen = false;
-          element.focus();
           element.attr('aria-expanded', 'false');
           ngModelCtrl.$setTouched();
         });


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
On iOS
1. changing between two selects can lead to a situation where the floating label for both selects is colored due to both `md-input-containers` of the selects having `class="md-input-focused"` which should not happen.
1. with a `md-select` open, clicking on an `input` in a `md-input-container` causes the input to get focused (floating label and ink) but then the focus gets stolen back by the `md-select`'s `md-input-container`. This results in a really unintuitive and janky experience.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11345

## What is the new behavior?
- fixed situations where tapping between select's in `md-input-container`s can leave multiple `class="md-input-focused"` active.
- fix focus jumping back to md-select after tapping another input.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Previously, tapping out of the `md-select`'s panel would pull the focus back to the `md-select`'s `md-input-container`. Now, if you tap on an element outside of the `md-select`'s panel, the `md-select` stays blurred (it gets blurred when the panel opens). If you select an option, the focus returns to the `md-select` when the panel closes (both when using the mouse and keyboard).

This seems like a more intuitive and correct behavior since `md-select` panels don't have backdrops, but it does change the behavior on iOS from what it was (which was pretty bad).