### PR TITLE
fix(datepicker): remove invalid aria-expanded

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -109,8 +109,7 @@
           '<input ' +
             (ariaLabelValue ? 'aria-label="' + ariaLabelValue + '" ' : '') +
             'class="md-datepicker-input" ' +
-            'aria-haspopup="true" ' +
-            'aria-expanded="{{ctrl.isCalendarOpen}}" ' +
+            'aria-haspopup="dialog" ' +
             'ng-focus="ctrl.setFocused(true)" ' +
             'ng-blur="ctrl.setFocused(false)"> ' +
             triangleButton +
@@ -325,7 +324,7 @@
     this.isFocused = false;
 
     /** @type {boolean} */
-    this.isDisabled;
+    this.isDisabled = undefined;
     this.setDisabled($element[0].disabled || angular.isString($attrs.disabled));
 
     /** @type {boolean} Whether the date-picker's calendar pane is open. */
@@ -334,7 +333,7 @@
     /** @type {boolean} Whether the calendar should open when the input is focused. */
     this.openOnFocus = $attrs.hasOwnProperty('mdOpenOnFocus');
 
-    /** @final */
+    /** @type {Object} Instance of the mdInputContainer controller */
     this.mdInputContainer = null;
 
     /**
@@ -648,9 +647,9 @@
   };
 
   /**
-   * Check to see if the input is valid as the validation should fail if the model is invalid
+   * Check to see if the input is valid, as the validation should fail if the model is invalid.
    *
-   * @param {String} inputString
+   * @param {string} inputString
    * @param {Date} parsedDate
    * @return {boolean} Whether the input is valid
    */

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -851,22 +851,6 @@ describe('md-datepicker', function() {
       expect(controller.calendarPane.id).toBe(ariaAttr);
     });
 
-    it('should toggle the aria-expanded value', function() {
-      expect(controller.ngInputElement.attr('aria-expanded')).toBe('false');
-
-      controller.openCalendarPane({
-        target: controller.inputElement
-      });
-      scope.$apply();
-
-      expect(controller.ngInputElement.attr('aria-expanded')).toBe('true');
-
-      controller.closeCalendarPane();
-      scope.$apply();
-
-      expect(controller.ngInputElement.attr('aria-expanded')).toBe('false');
-    });
-
     describe('tabindex behavior', function() {
       beforeEach(function() {
         ngElement && ngElement.remove();


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Lighthouse complains due to the datepicker's `input` having `aria-expanded="false"`. This properly isn't valid for `role="input"` in [ARIA 1.0](https://www.w3.org/TR/wai-aria-1.0/complete#input) or [ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#input).
- `aria-haspopup="true"` uses the [ARIA 1.0](https://www.w3.org/TR/wai-aria-1.0/complete#aria-haspopup) value.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #11475

## What is the new behavior?
- remove invalid `aria-expanded` attribute
- use [ARIA 1.1](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) value for `aria-has-popup`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
a11y and keyboard interaction with the `md-datepicker` and the calendar panel is not good, but testing in VoiceOver showed that these changes didn't make it any worse.