### PR TITLE
fix(autocomplete): improve implementation of aria-activedescendant

### DIFF
--- a/src/components/autocomplete/autocomplete-theme.scss
+++ b/src/components/autocomplete/autocomplete-theme.scss
@@ -49,10 +49,10 @@ md-autocomplete.md-THEME_NAME-theme {
 .md-autocomplete-suggestions-container.md-THEME_NAME-theme,
 .md-autocomplete-standard-list-container.md-THEME_NAME-theme {
   background: '{{background-hue-1}}';
-  li {
+  .md-autocomplete-suggestion {
     color: '{{foreground-1}}';
     &:hover,
-    &#selected_option {
+    &.selected {
       background: '{{background-500-0.18}}';
     }
   }

--- a/src/components/autocomplete/autocomplete.scss
+++ b/src/components/autocomplete/autocomplete.scss
@@ -174,7 +174,7 @@ md-autocomplete {
     input {
       border: 1px solid $border-color;
     }
-    li:focus {
+    .md-autocomplete-suggestion:focus {
       color: #fff;
     }
   }
@@ -214,7 +214,7 @@ md-autocomplete {
   list-style: none;
   padding: 0;
 
-  li {
+  .md-autocomplete-suggestion {
     font-size: 14px;
     overflow: hidden;
     padding: 0 15px;

--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -1769,10 +1769,12 @@ describe('<md-autocomplete>', function() {
   });
 
   describe('Accessibility', function() {
-    var $timeout = null;
+    var $timeout = null, $mdConstant = null, $material = null;
 
     beforeEach(inject(function ($injector) {
       $timeout = $injector.get('$timeout');
+      $material = $injector.get('$material');
+      $mdConstant = $injector.get('$mdConstant');
     }));
 
     it('should add the placeholder as the input\'s aria-label', function() {
@@ -1793,6 +1795,393 @@ describe('<md-autocomplete>', function() {
       $timeout.flush();
 
       expect(input.attr('aria-label')).toBe('placeholder');
+    });
+
+    it('should set activeOption when autoselect is off', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'ba';
+      waitForVirtualRepeat(element);
+
+      var suggestions = ul.find('li');
+      expect(suggestions[0].classList).not.toContain('selected');
+
+      expect(ctrl.hidden).toBe(false);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $material.flushInterimElement();
+
+      expect(suggestions[0].classList).toContain('selected');
+
+      expect(ctrl.index).toBe(0);
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-0');
+      expect(input[0].getAttribute('aria-owns')).toBe('ul-' + ctrl.id);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-0');
+    });
+
+    it('should start from the end when up arrow is pressed', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'ba';
+      waitForVirtualRepeat(element);
+
+      var suggestions = ul.find('li');
+      expect(suggestions[0].classList).not.toContain('selected');
+
+      expect(ctrl.hidden).toBe(false);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.UP_ARROW));
+      $material.flushInterimElement();
+
+      expect(suggestions[1].classList).toContain('selected');
+
+      expect(ctrl.index).toBe(1);
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-1');
+      expect(input[0].getAttribute('aria-owns')).toBe('ul-' + ctrl.id);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-1');
+    });
+
+    it('should set activeOption when autoselect is on', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-autoselect="true">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(0);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'ba';
+      waitForVirtualRepeat(element);
+
+      // Wait for the next tick when the values will be updated
+      $timeout.flush();
+
+      var suggestions = ul.find('li');
+      expect(suggestions[0].classList).toContain('selected');
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-0');
+      expect(input[0].getAttribute('aria-owns')).toBe('ul-' + ctrl.id);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-0');
+
+      expect(ctrl.hidden).toBe(false);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $material.flushInterimElement();
+
+      expect(suggestions[1].classList).toContain('selected');
+
+      expect(ctrl.index).toBe(1);
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-1');
+    });
+
+    it('should update activeOption when selection is cleared and autoselect is off', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'ba';
+      waitForVirtualRepeat(element);
+
+      // Wait for the next tick when the values will be updated
+      $timeout.flush();
+
+      var suggestions = ul.find('li');
+      expect(suggestions[0].classList).not.toContain('selected');
+      expect(ctrl.activeOption).toBe(null);
+      expect(ctrl.hidden).toBe(false);
+      expect(input[0].getAttribute('aria-owns')).toBe('ul-' + ctrl.id);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $material.flushInterimElement();
+
+      expect(suggestions[0].classList).toContain('selected');
+      expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-0');
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+      $material.flushInterimElement();
+      expect(ctrl.hidden).toBe(true);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ESCAPE));
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+    });
+
+    it('should update activeOption when selection is cleared and autoselect is on', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-autoselect="true">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(0);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'ba';
+      waitForVirtualRepeat(element);
+
+      // Wait for the next tick when the values will be updated
+      $timeout.flush();
+
+      var suggestions = ul.find('li');
+      expect(suggestions[0].classList).toContain('selected');
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-0');
+      expect(input[0].getAttribute('aria-owns')).toBe('ul-' + ctrl.id);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe('md-option-' + ctrl.id + '-0');
+
+      expect(ctrl.hidden).toBe(false);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
+      $material.flushInterimElement();
+      expect(ctrl.hidden).toBe(true);
+
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ESCAPE));
+      $timeout.flush();
+
+      expect(ctrl.index).toBe(0);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-0');
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-activedescendant')).toBe(null);
+    });
+
+    it('should always define the name attribute on the input', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(input[0].getAttribute('name')).toBe('input-' + ctrl.id);
+    });
+
+    it('should always define the name attribute on the input when floating label is enabled',
+      function() {
+        var template =
+          '<md-autocomplete' +
+          '   md-floating-label="Test Label"' +
+          '   md-selected-item="selectedItem"' +
+          '   md-search-text="searchText"' +
+          '   md-items="item in match(searchText)"' +
+          '   md-item-text="item.display"' +
+          '   placeholder="placeholder">' +
+          '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+          '</md-autocomplete>';
+        var scope = createScope();
+        var element = compile(template, scope);
+        var ctrl = element.controller('mdAutocomplete');
+        var input = element.find('input');
+        // Run our initial flush
+        $timeout.flush();
+
+        expect(input[0].getAttribute('name')).toBe('fl-input-' + ctrl.id);
+    });
+
+    it('should set proper aria values and remove attributes on input when ng-disabled', function() {
+      var template =
+        '<md-autocomplete' +
+        '   ng-disabled="true"' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(input[0].getAttribute('role')).toBe(null);
+      expect(input[0].getAttribute('aria-autocomplete')).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-haspopup')).toBe('false');
+    });
+
+    it('should set proper aria values and remove attributes on input when disabled', function() {
+      var template =
+        '<md-autocomplete' +
+        '   disabled' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      expect(input[0].getAttribute('role')).toBe(null);
+      expect(input[0].getAttribute('aria-autocomplete')).toBe(null);
+      expect(input[0].getAttribute('aria-owns')).toBe(null);
+      expect(input[0].getAttribute('aria-haspopup')).toBe('false');
+    });
+
+    it('should add IDs to each option', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var ul = element.find('ul');
+
+      // Focus the input
+      ctrl.focus();
+
+      // Update the scope
+      element.scope().searchText = 'fo';
+      waitForVirtualRepeat(element);
+
+      var suggestions = ul.find('li');
+
+      expect(suggestions[0].getAttribute('id')).toContain('md-option-');
     });
 
     it('should add the input-aria-label as the input\'s aria-label', function() {
@@ -1982,48 +2371,17 @@ describe('<md-autocomplete>', function() {
       expect(liveEl.textContent).toBe(scope.items[0].display + ' There are 3 matches available.');
     });
 
-    it('should announce the selection when using the arrow keys', function() {
+    it('should announce when an option is picked', function() {
       ctrl.focus();
       waitForVirtualRepeat();
 
       expect(ctrl.hidden).toBe(false);
 
       ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
-
-      // Flush twice, because the display value will be resolved asynchronously and then the live-announcer will
-      // be triggered.
-      $timeout.flush();
       $timeout.flush();
 
       expect(ctrl.index).toBe(0);
-      expect(liveEl.textContent).toBe(scope.items[0].display);
-
-      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
-
-      // Flush twice, because the display value will be resolved asynchronously and then the
-      // live-announcer will be triggered.
-      $timeout.flush();
-      $timeout.flush();
-
-      expect(ctrl.index).toBe(1);
-      expect(liveEl.textContent).toBe(scope.items[1].display);
-    });
-
-    it('should announce when an option is selected', function() {
-      ctrl.focus();
-      waitForVirtualRepeat();
-
       expect(ctrl.hidden).toBe(false);
-
-      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
-
-      // Flush twice, because the display value will be resolved asynchronously and then the
-      // live-announcer will be triggered.
-      $timeout.flush();
-      $timeout.flush();
-
-      expect(ctrl.index).toBe(0);
-      expect(liveEl.textContent).toBe(scope.items[0].display);
 
       ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.ENTER));
 
@@ -2033,6 +2391,7 @@ describe('<md-autocomplete>', function() {
       $timeout.flush();
 
       expect(liveEl.textContent).toBe(scope.items[0].display + ' ' + ctrl.selectedMessage);
+      expect(ctrl.hidden).toBe(true);
     });
 
     it('should announce the count when matches change', function() {
@@ -2133,6 +2492,7 @@ describe('<md-autocomplete>', function() {
 
       element.remove();
     }));
+
     it('passes the value to the item watcher', inject(function($timeout) {
       var scope = createScope();
       var itemValue = null;

--- a/src/components/autocomplete/demoBasicUsage/index.html
+++ b/src/components/autocomplete/demoBasicUsage/index.html
@@ -15,9 +15,9 @@
           md-items="item in ctrl.querySearch(ctrl.searchText)"
           md-item-text="item.display"
           md-min-length="0"
+          md-escape-options="clear"
           placeholder="Ex. Alaska"
-          input-aria-labelledby="favoriteStateLabel"
-          input-aria-describedby="autocompleteDetailedDescription">
+          input-aria-labelledby="favoriteStateLabel">
         <md-item-template>
           <span md-highlight-text="ctrl.searchText" md-highlight-flags="^i">{{item.display}}</span>
         </md-item-template>

--- a/src/components/autocomplete/demoCustomTemplate/index.html
+++ b/src/components/autocomplete/demoCustomTemplate/index.html
@@ -13,13 +13,14 @@
           md-items="item in ctrl.querySearch(ctrl.searchText)"
           md-item-text="item.name"
           md-min-length="0"
+          md-escape-options="clear"
           input-aria-label="Current Repository"
           placeholder="Pick an Angular repository"
           md-menu-class="autocomplete-custom-template"
           md-menu-container-class="custom-container">
         <md-item-template>
           <span class="item-title">
-            <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>
+            <md-icon md-svg-icon="img/icons/octicon-repo.svg" aria-hidden="true"></md-icon>
             <span> {{item.name}} </span>
           </span>
           <span class="item-metadata">

--- a/src/components/autocomplete/demoCustomTemplate/style.global.css
+++ b/src/components/autocomplete/demoCustomTemplate/style.global.css
@@ -1,14 +1,14 @@
 md-autocomplete#custom-template {
   width: 200px;
 }
-.autocomplete-custom-template li {
+.autocomplete-custom-template .md-autocomplete-suggestion {
   border-bottom: 1px solid #ccc;
   height: auto;
   padding-top: 8px;
   padding-bottom: 8px;
   white-space: normal;
 }
-.autocomplete-custom-template li:last-child {
+.autocomplete-custom-template .md-autocomplete-suggestion:last-child {
   border-bottom-width: 0;
 }
 .autocomplete-custom-template .item-title,

--- a/src/components/autocomplete/demoFloatingLabel/index.html
+++ b/src/components/autocomplete/demoFloatingLabel/index.html
@@ -8,17 +8,18 @@
           <input id="floatingLabelName" type="text"/>
         </md-input-container>
         <md-autocomplete flex required
-            md-input-name="autocompleteField"
-            md-input-minlength="2"
-            md-input-maxlength="18"
-            md-no-cache="ctrl.noCache"
-            md-selected-item="ctrl.selectedItem"
-            md-search-text="ctrl.searchText"
-            md-items="item in ctrl.querySearch(ctrl.searchText)"
-            md-item-text="item.display"
-            md-require-match=""
-            md-floating-label="Favorite state"
-            input-aria-describedby="favoriteStateDescription">
+          md-input-name="autocompleteField"
+          md-input-minlength="2"
+          md-input-maxlength="18"
+          md-no-cache="ctrl.noCache"
+          md-selected-item="ctrl.selectedItem"
+          md-search-text="ctrl.searchText"
+          md-items="item in ctrl.querySearch(ctrl.searchText)"
+          md-item-text="item.display"
+          md-escape-options="clear"
+          md-require-match=""
+          md-floating-label="Favorite state"
+          input-aria-describedby="favoriteStateDescription">
           <md-item-template>
             <span md-highlight-text="ctrl.searchText">{{item.display}}</span>
           </md-item-template>

--- a/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
+++ b/src/components/autocomplete/demoInsideDialog/dialog.tmpl.html
@@ -22,9 +22,10 @@
             md-items="item in ctrl.querySearch(ctrl.searchText)"
             md-item-text="item.display"
             md-min-length="0"
+            md-escape-options="clear"
             placeholder="What is your favorite US state?"
             input-aria-label="Favorite State"
-            md-autofocus="">
+            md-autofocus md-autoselect>
           <md-item-template>
             <span md-highlight-text="ctrl.searchText" md-highlight-flags="^i">{{item.display}}</span>
           </md-item-template>

--- a/src/components/autocomplete/demoRepeatMode/index.html
+++ b/src/components/autocomplete/demoRepeatMode/index.html
@@ -22,6 +22,7 @@
               md-items="item in ctrl.querySearch(ctrl.searchText)"
               md-item-text="item.name"
               md-min-length="0"
+              md-escape-options="clear"
               input-aria-describedby="standard-autocomplete-description"
               input-aria-label="Current Repository"
               placeholder="Pick an Angular repository"
@@ -30,7 +31,7 @@
               md-mode="standard">
             <md-item-template>
               <span class="item-title">
-                <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>
+                <md-icon md-svg-icon="img/icons/octicon-repo.svg" aria-hidden="true"></md-icon>
                 <span> {{item.name}} </span>
               </span>
               <p class="item-desc">{{item.desc}}</p>
@@ -70,6 +71,7 @@
               md-items="item in ctrl.querySearch(ctrl.searchText)"
               md-item-text="item.name"
               md-min-length="0"
+              md-escape-options="clear"
               input-aria-describedby="virtual-autocomplete-description"
               input-aria-label="Current Repository"
               placeholder="Pick an Angular repository"
@@ -78,7 +80,7 @@
               md-mode="virtual">
             <md-item-template>
               <span class="item-title">
-                <md-icon md-svg-icon="img/icons/octicon-repo.svg"></md-icon>
+                <md-icon md-svg-icon="img/icons/octicon-repo.svg" aria-hidden="true"></md-icon>
                 <span> {{item.name}} </span>
               </span>
               <p class="item-desc">

--- a/src/components/autocomplete/demoRepeatMode/style.global.css
+++ b/src/components/autocomplete/demoRepeatMode/style.global.css
@@ -2,16 +2,16 @@
 #virtual-autocomplete {
   width: 200px;
 }
-.autocomplete-standard-template li,
-.autocomplete-virtual-template li {
+.autocomplete-standard-template .md-autocomplete-suggestion,
+.autocomplete-virtual-template .md-autocomplete-suggestion {
   border-bottom: 1px solid #ccc;
   height: auto;
   padding-top: 8px;
   padding-bottom: 8px;
   white-space: normal;
 }
-.autocomplete-virtual-template li:last-child,
-.autocomplete-standard-template li:last-child {
+.autocomplete-virtual-template .md-autocomplete-suggestion:last-child,
+.autocomplete-standard-template .md-autocomplete-suggestion:last-child {
   border-bottom-width: 0;
 }
 .autocomplete-virtual-template .item-title,

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -404,9 +404,9 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-mouseleave="$mdAutocompleteCtrl.listLeave()"\
                 ng-mouseup="$mdAutocompleteCtrl.mouseUp()"\
                 role="listbox">\
-              <li ' + getRepeatType(attr.mdMode) + ' ="item in $mdAutocompleteCtrl.matches"\
+              <li class="md-autocomplete-suggestion" ' + getRepeatType(attr.mdMode) + ' ="item in $mdAutocompleteCtrl.matches"\
                   ng-class="{ selected: $index === $mdAutocompleteCtrl.index }"\
-                  ng-attr-id="{{$index === $mdAutocompleteCtrl.index ? \'selected_option\' : undefined}}"\
+                  ng-attr-id="{{\'md-option-\' + $mdAutocompleteCtrl.id + \'-\' + $index}}"\
                   ng-click="$mdAutocompleteCtrl.select($index)"\
                   role="option"\
                   aria-setsize="{{$mdAutocompleteCtrl.matches.length}}"\
@@ -483,10 +483,10 @@ function MdAutocomplete ($$mdSvgRegistry) {
           return '\
             <md-input-container ng-if="floatingLabel">\
               <label>{{floatingLabel}}</label>\
-              <input type="search"\
+              <input type="text"\
                 ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
-                id="{{ inputId || \'fl-input-\' + $mdAutocompleteCtrl.id }}"\
-                name="{{inputName}}"\
+                id="{{inputId || \'fl-input-\' + $mdAutocompleteCtrl.id}}"\
+                name="{{inputName || \'fl-input-\' + $mdAutocompleteCtrl.id }}"\
                 ng-class="::inputClass"\
                 autocomplete="off"\
                 ng-required="$mdAutocompleteCtrl.isRequired"\
@@ -500,20 +500,20 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\
                 aria-label="{{floatingLabel}}"\
-                aria-autocomplete="list"\
-                role="combobox"\
-                aria-haspopup="true"\
+                ng-attr-aria-autocomplete="{{$mdAutocompleteCtrl.isDisabled ? undefined : \'list\'}}"\
+                ng-attr-role="{{$mdAutocompleteCtrl.isDisabled ? undefined : \'combobox\'}}"\
+                aria-haspopup="{{!$mdAutocompleteCtrl.isDisabled}}"\
                 aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"\
-                aria-owns="ul-{{$mdAutocompleteCtrl.id}}"\
-                ng-attr-aria-activedescendant="{{$mdAutocompleteCtrl.index >= 0 ? \'selected_option\' : undefined}}">\
+                ng-attr-aria-owns="{{$mdAutocompleteCtrl.hidden || $mdAutocompleteCtrl.isDisabled ? undefined : \'ul-\' + $mdAutocompleteCtrl.id}}"\
+                ng-attr-aria-activedescendant="{{!$mdAutocompleteCtrl.hidden && $mdAutocompleteCtrl.activeOption ? $mdAutocompleteCtrl.activeOption : undefined}}">\
               <div md-autocomplete-parent-scope md-autocomplete-replace>' + leftover + '</div>\
             </md-input-container>';
         } else {
           return '\
-            <input type="search"\
+            <input type="text"\
               ' + (tabindex != null ? 'tabindex="' + tabindex + '"' : '') + '\
-              id="{{ inputId || \'input-\' + $mdAutocompleteCtrl.id }}"\
-              name="{{inputName}}"\
+              id="{{inputId || \'input-\' + $mdAutocompleteCtrl.id}}"\
+              name="{{inputName || \'input-\' + $mdAutocompleteCtrl.id }}"\
               ng-class="::inputClass"\
               ng-if="!floatingLabel"\
               autocomplete="off"\
@@ -528,12 +528,12 @@ function MdAutocomplete ($$mdSvgRegistry) {
               ng-focus="$mdAutocompleteCtrl.focus($event)"\
               placeholder="{{placeholder}}"\
               aria-label="{{placeholder}}"\
-              aria-autocomplete="list"\
-              role="combobox"\
-              aria-haspopup="true"\
+              ng-attr-aria-autocomplete="{{$mdAutocompleteCtrl.isDisabled ? undefined : \'list\'}}"\
+              ng-attr-role="{{$mdAutocompleteCtrl.isDisabled ? undefined : \'combobox\'}}"\
+              aria-haspopup="{{!$mdAutocompleteCtrl.isDisabled}}"\
               aria-expanded="{{!$mdAutocompleteCtrl.hidden}}"\
-              aria-owns="ul-{{$mdAutocompleteCtrl.id}}"\
-              ng-attr-aria-activedescendant="{{$mdAutocompleteCtrl.index >= 0 ? \'selected_option\' : undefined}}">';
+              ng-attr-aria-owns="{{$mdAutocompleteCtrl.hidden || $mdAutocompleteCtrl.isDisabled ? undefined : \'ul-\' + $mdAutocompleteCtrl.id}}"\
+              ng-attr-aria-activedescendant="{{!$mdAutocompleteCtrl.hidden && $mdAutocompleteCtrl.activeOption ? $mdAutocompleteCtrl.activeOption : undefined}}">';
         }
       }
 
@@ -542,7 +542,7 @@ function MdAutocomplete ($$mdSvgRegistry) {
           '<button ' +
               'type="button" ' +
               'aria-label="Clear Input" ' +
-              'tabindex="-1" ' +
+              'tabindex="0" ' +
               'ng-if="clearButton && $mdAutocompleteCtrl.scope.searchText" ' +
               'ng-click="$mdAutocompleteCtrl.clear($event)">' +
             '<md-icon md-svg-src="' + $$mdSvgRegistry.mdClose + '"></md-icon>' +

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -696,8 +696,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      * to minimize $digest thrashing
      *
      * @param {Function} callback function to be called after the tick
-     * @param {boolean} digest true to call $rootScope.$digest() after callback
-     * @param scope scope associated with callback. If the scope is destroyed, the callback will
+     * @param {boolean=} digest true to call $rootScope.$digest() after callback
+     * @param {Object=} scope associated with callback. If the scope is destroyed, the callback will
      *  be skipped.
      * @returns {*}
      */

--- a/test/angular-material-mocks.js
+++ b/test/angular-material-mocks.js
@@ -61,7 +61,7 @@ angular.module('ngMaterial-mock', [
 
     /**
       * AngularJS Material dynamically generates Style tags
-      * based on themes and palletes; for each ng-app.
+      * based on themes and palettes; for each ng-app.
       *
       * For testing, we want to disable generation and
       * <style> DOM injections. So we clear the huge THEME


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
ChromeVox announces the following when the user changes to the `Alaska` option
> 'Alaska, Status'

When it should announce something like
> 'Alaska, List item, 2 of 50. ... List box with 8 items.'

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11742

## What is the new behavior?
- allow screen readers to do more and us to do less
  - remove extra calls to announce the item that is visually focused
  - remove tests for these extra live announcements
  - give every option an id for use with `aria-activedescendant`
  - use the `selected` class for styling and finding the active option
- implement recommendations from a11y guides
  - add the clear button to the tab order
  - change input type to `text`
  - always define a `name` attribute
- when the popup isn't expanded
  - `aria-owns` and `aria-activedescendant` shouldn't be defined
- when the autocomplete is disabled
  - `aria-autocomplete` and `aria-role` shouldn't be defined
  - `aria-haspopup` should be false
- add `md-autocomplete-suggestion` class for styling instead of using `li`
- add `md-autoselect` to the dialog demo for help w/ manual testing
- remove overly verbose `aria-describedby` from basic demo
- mark `md-icons` in `md-item-templates` of autocomplete demos as hidden

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
- [x] Verified on VoiceOver for macOS
- [x] Verified on ChromeVox on Chrome OS
- [x] Verified on NVDA for Windows

Related resources
- https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
- http://web-accessibility.carnegiemuseums.org/code/search/
- https://www.slideshare.net/maxdesign/building-an-accessible-autocomplete

Live demo:
https://angularjs-material.firebaseapp.com/demo/autocomplete