### PR TITLE
fix(tooltip, compiler): document.contains is not defined in IE11

### DIFF
--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -506,7 +506,6 @@ function MdCompilerProvider($compileProvider) {
    * @returns {{element: !JQLite, restore: !function}}
    */
   MdCompilerService.prototype._fetchContentElement = function(options) {
-
     var contentEl = options.contentElement;
     var restoreFn = null;
 

--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -577,12 +577,6 @@ function attachToDocument($mdGesture, $$MdGestureHandler) {
     return;
   }
 
-  // Polyfill document.contains for IE11.
-  // TODO: move to util
-  document.contains || (document.contains = function (node) {
-    return document.body.contains(node);
-  });
-
   if (!isInitialized && $mdGesture.isHijackingClicks) {
     /*
      * If hijack clicks is true, we preventDefault any click that wasn't

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -19,11 +19,17 @@ angular
 /**
  * @ngInject
  */
-function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $interpolate, $log, $rootElement, $window, $$rAF) {
+function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $interpolate, $log,
+                     $rootElement, $window, $$rAF) {
   // Setup some core variables for the processTemplate method
   var startSymbol = $interpolate.startSymbol(),
     endSymbol = $interpolate.endSymbol(),
     usesStandardSymbols = ((startSymbol === '{{') && (endSymbol === '}}'));
+
+  // Polyfill document.contains for IE11.
+  document.contains || (document.contains = function (node) {
+    return document.body.contains(node);
+  });
 
   /**
    * Checks if the target element has the requested style by key
@@ -37,14 +43,15 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
     if (target && target.length) {
       var computedStyles = $window.getComputedStyle(target[0]);
-      hasValue = angular.isDefined(computedStyles[key]) && (expectedVal ? computedStyles[key] == expectedVal : true);
+      hasValue = angular.isDefined(computedStyles[key]) &&
+        (expectedVal ? computedStyles[key] == expectedVal : true);
     }
 
     return hasValue;
   };
 
   function validateCssValue(value) {
-    return !value       ? '0'   :
+    return !value ? '0' :
       hasPx(value) || hasPercent(value) ? value : value + 'px';
   }
 
@@ -54,7 +61,6 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
 
   function hasPercent(value) {
     return String(value).indexOf('%') > -1;
-
   }
 
   var $mdUtil = {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Hovering over a `md-tooltip` throws only when `$mdGestureProvider.disableAll()` was called in `config()`.
This is because `document.contains` is not defined on IE11 and the polyfill in `$mdGestureProvider` was only registered if gestures were enabled.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11745

## What is the new behavior?
We polyfill `document.contains` when `$mdUtil` loads and it does not depend on gestures being enabled.
No more exceptions and tooltips display properly.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
We don't run tests against IE11 because they proved to be too unstable.

Thanks to @codymikol for the spot on the existing polyfill in `$mdGestureProvider` and associated `// TODO move to $mdUtil`.