### PR TITLE
fix(gesture): check if navigator is defined before accessing userAgent

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -17,9 +17,12 @@ var lastLabelClickPos = null;
 // Used to attach event listeners once when multiple ng-apps are running.
 var isInitialized = false;
 
-var userAgent = navigator.userAgent || navigator.vendor || window.opera;
-var isIos = userAgent.match(/ipad|iphone|ipod/i);
-var isAndroid = userAgent.match(/android/i);
+// Support material-tools builds.
+if (window.navigator) {
+  var userAgent = window.navigator.userAgent || window.navigator.vendor || window.opera;
+  var isIos = userAgent.match(/ipad|iphone|ipod/i);
+  var isAndroid = userAgent.match(/android/i);
+}
 
 /**
  * @ngdoc module


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
PR https://github.com/angular/material/pull/11729 in `1.1.19` moved the check for `navigator` outside of code that depends on gestures being enabled. Since it doesn't check the existence of `window.navigator` first, this could throw an error when built via `angular/material-tools`.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11751

## What is the new behavior?
Fixes a build error when using `angular/material-tools` by checking that `window.navigator` is defined before accessing it.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
We don't have any tests that verify changes to `angular/material` don't break `angular/material-tools`. This was manually verified in https://github.com/angular/material/issues/11751#issuecomment-505718011.