### PR TITLE
fix(autocomplete): support ng-click on md-autocomplete

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -536,6 +536,32 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
+    it('should support ng-click on the md-autocomplete', inject(function() {
+      var scope = createScope(null, {inputId: 'custom-input-id'});
+      scope.test = false;
+      var template =
+        '<md-autocomplete ' +
+        'md-selected-item="selectedItem" ' +
+        'md-search-text="searchText" ' +
+        'md-items="item in match(searchText)" ' +
+        'md-item-text="item.display" ' +
+        'ng-click="test = true" ' +
+        'placeholder="placeholder">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+
+      var element = compile(template, scope);
+      var input = element.find('input');
+
+      expect(scope.test).toBe(false);
+
+      input[0].click();
+
+      expect(scope.test).toBe(true);
+
+      element.remove();
+    }));
+
     it('should support ng-trim for the search input', inject(function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
@@ -615,7 +641,7 @@ describe('<md-autocomplete>', function() {
       element.remove();
     }));
 
-    it('always sets the tabindex of the autcomplete to `-1`', inject(function() {
+    it('always sets the tabindex of the autocomplete to `-1`', inject(function() {
       var scope = createScope(null, {inputId: 'custom-input-id'});
       var template =
         '<md-autocomplete ' +

--- a/src/components/autocomplete/js/autocompleteDirective.js
+++ b/src/components/autocomplete/js/autocompleteDirective.js
@@ -362,9 +362,15 @@ function MdAutocomplete ($$mdSvgRegistry) {
         }
 
         scope.mdMode = getRepeatMode(attrs.mdMode);
+
+        // Stop click events from bubbling up to the document and triggering a flicker of the
+        // options panel while still supporting ng-click to be placed on md-autocomplete.
+        element.on('click', function(event) {
+          event.stopPropagation();
+        });
       };
     },
-    template:     function (element, attr) {
+    template: function (element, attr) {
       var noItemsTemplate = getNoItemsTemplate(),
           itemTemplate    = getItemTemplate(),
           leftover        = element.html(),
@@ -493,7 +499,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
                 ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
                 ng-blur="$mdAutocompleteCtrl.blur($event)"\
                 ng-focus="$mdAutocompleteCtrl.focus($event)"\
-                ng-click="$event.stopPropagation()"\
                 aria-label="{{floatingLabel}}"\
                 aria-autocomplete="list"\
                 role="combobox"\
@@ -521,7 +526,6 @@ function MdAutocomplete ($$mdSvgRegistry) {
               ng-keydown="$mdAutocompleteCtrl.keydown($event)"\
               ng-blur="$mdAutocompleteCtrl.blur($event)"\
               ng-focus="$mdAutocompleteCtrl.focus($event)"\
-              ng-click="$event.stopPropagation()"\
               placeholder="{{placeholder}}"\
               aria-label="{{placeholder}}"\
               aria-autocomplete="list"\


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`click` events are not bubbling up to the `md-autocomplete` from the `input` or `placeholder` resulting in `ng-click` on `md-autocomplete` not being triggered.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #11625. Relates to #11757.

## What is the new behavior?
`click` events are bubbling up to the `md-autocomplete` from the `input` or `placeholder` resulting in `ng-click` on `md-autocomplete` being triggered. This happens while also stopping the `click` event from propagating beyond the `md-autocomplete`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
