### PR TITLE
fix(select): overhaul screen reader support

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -155,13 +155,13 @@ ul {
   margin: 0;
   padding: 0;
 }
-ul li:not(.md-nav-item) {
+ul:not(.md-autocomplete-suggestions) li:not(.md-nav-item) {
   margin-left: 16px;
   padding: 0;
   margin-top: 3px;
   list-style-position: inside;
 }
-ul li:not(.md-nav-item):first-child {
+ul:not(.md-autocomplete-suggestions) li:not(.md-nav-item):first-child {
   margin-top: 0;
 }
 /************

--- a/src/components/select/demoBasicUsage/index.html
+++ b/src/components/select/demoBasicUsage/index.html
@@ -30,7 +30,8 @@
           <label>State</label>
           <md-select ng-model="ctrl.userState">
             <md-option><em>None</em></md-option>
-            <md-option ng-repeat="state in ctrl.states" ng-value="state.abbrev" ng-disabled="$index === 1">
+            <md-option ng-repeat="state in ctrl.states" ng-value="state.abbrev"
+                       ng-disabled="$index === 1">
               {{state.abbrev}}
             </md-option>
           </md-select>
@@ -60,7 +61,8 @@
 
       <div layout="row" layout-align="space-between center">
         <span>What armor do you wear?</span>
-        <md-select ng-model="armor" placeholder="Armor" class="md-no-underline" required md-no-asterisk="false">
+        <md-select ng-model="armor" placeholder="Armor" class="md-no-underline" required
+                   md-no-asterisk="false">
           <md-option value="cloth">Cloth</md-option>
           <md-option value="leather">Leather</md-option>
           <md-option value="chain">Chainmail</md-option>

--- a/src/components/select/demoOptionGroups/index.html
+++ b/src/components/select/demoOptionGroups/index.html
@@ -9,7 +9,7 @@
         </md-select>
       </md-input-container>
       <md-input-container>
-        <label>Topping</label>
+        <label>Toppings</label>
         <md-select ng-model="selectedToppings" multiple>
           <md-optgroup label="Meats">
             <md-option ng-value="topping.name" ng-repeat="topping in toppings | filter: {category: 'meat' }">{{topping.name}}</md-option>

--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -154,19 +154,22 @@ md-select-menu.md-THEME_NAME-theme {
 
       &:not([disabled]) {
         &:focus,
-        &:hover {
+        &:hover,
+        &.md-focused {
           background-color: '{{background-500-0.18}}'
         }
       }
 
       &[selected] {
         color: '{{primary-500}}';
-        &:focus {
+        &:focus,
+        &.md-focused {
           color: '{{primary-600}}';
         }
         &.md-accent {
           color: '{{accent-color}}';
-          &:focus {
+          &:focus,
+          &.md-focused {
             color: '{{accent-A700}}';
           }
         }

--- a/src/components/select/select.spec.js
+++ b/src/components/select/select.spec.js
@@ -119,13 +119,14 @@ describe('<md-select>', function() {
       expect(ownsId).toBeFalsy();
     });
 
-    it('sets aria-owns between the select and the container if element moved outside parent', function() {
+    it('sets aria-owns between the select and the listbox if element moved outside parent', function() {
       var select = setupSelect('ng-model="val"').find('md-select');
       openSelect(select);
       var ownsId = select.attr('aria-owns');
       expect(ownsId).toBeTruthy();
-      var containerId = $document[0].querySelector('.md-select-menu-container').getAttribute('id');
-      expect(ownsId).toBe(containerId);
+      var listboxContentId =
+        $document[0].querySelector('.md-select-menu-container md-content').getAttribute('id');
+      expect(ownsId).toBe(listboxContentId);
     });
 
     it('calls md-on-close when the select menu closes', function() {
@@ -1377,37 +1378,42 @@ describe('<md-select>', function() {
       expect($log.warn).not.toHaveBeenCalled();
     }));
 
-    it('sets up the aria-expanded attribute', function() {
+    it('does not overwrite user provided aria-labelledby', function() {
+      var select = setupSelect('ng-model="someVal" placeholder="Hello world" aria-labelledby="label"',
+        null, true).find('md-select');
+      expect(select.attr('aria-labelledby')).toBe('label');
+    });
 
-      expect(el.attr('aria-expanded')).toBe('false');
+    it('sets up the aria-expanded attribute', function() {
+      expect(el.attr('aria-expanded')).toBe(undefined);
       openSelect(el);
       expect(el.attr('aria-expanded')).toBe('true');
 
       closeSelect(el);
       $material.flushInterimElement();
 
-      expect(el.attr('aria-expanded')).toBe('false');
+      expect(el.attr('aria-expanded')).toBe(undefined);
     });
 
     it('sets up the aria-multiselectable attribute', function() {
-      $rootScope.model = [1,3];
-      var el = setupSelectMultiple('ng-model="$root.model"', [1,2,3]).find('md-select');
+      $rootScope.model = [1, 3];
+      var el = setupSelectMultiple('ng-model="$root.model"', [1, 2, 3]).find('md-select');
+      var listbox = el.find('md-content');
 
-      expect(el.attr('aria-multiselectable')).toBe('true');
+      expect(listbox.attr('aria-multiselectable')).toBe('true');
     });
 
     it('sets up the aria-selected attribute', function() {
-      var el = setupSelect('ng-model="$root.model"', [1,2,3]);
+      var el = setupSelect('ng-model="$root.model"', [1, 2, 3]);
       var options = el.find('md-option');
       openSelect(el);
-      expect(options.eq(2).attr('aria-selected')).toBe('false');
+      expect(options.eq(2).attr('aria-selected')).toBe(undefined);
       clickOption(el, 2);
       expect(options.eq(2).attr('aria-selected')).toBe('true');
     });
   });
 
   describe('keyboard controls', function() {
-
 
     afterEach(function() {
       var selectMenus = $document.find('md-select-menu');
@@ -1669,7 +1675,7 @@ describe('<md-select>', function() {
     var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
 
     if (menu.length) {
-      if (menu.hasClass('md-active') || menu.attr('aria-hidden') == 'false') {
+      if (menu.hasClass('md-active') || menu.attr('aria-hidden') === 'false') {
         throw Error('Expected select to be closed');
       }
     }
@@ -1678,7 +1684,7 @@ describe('<md-select>', function() {
   function expectSelectOpen() {
     var menu = angular.element($document[0].querySelector('.md-select-menu-container'));
 
-    if (!(menu.hasClass('md-active') && menu.attr('aria-hidden') == 'false')) {
+    if (!(menu.hasClass('md-active') && menu.attr('aria-hidden') === 'false')) {
       throw Error('Expected select to be open');
     }
   }

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -82,7 +82,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
     /**
      * Cross-version compatibility method to retrieve an option of a ngModel controller,
      * which supports the breaking changes in the AngularJS snapshot (SHA 87a2ff76af5d0a9268d8eb84db5755077d27c84c).
-     * @param {!angular.ngModelCtrl} ngModelCtrl
+     * @param {!angular.NgModelController} ngModelCtrl
      * @param {!string} optionName
      * @returns {Object|undefined}
      */
@@ -179,12 +179,16 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
       return $mdUtil.clientRect(element, offsetParent, true);
     },
 
-    // Annoying method to copy nodes to an array, thanks to IE
+    /**
+     * Annoying method to copy nodes to an array, thanks to IE.
+     * @param nodes
+     * @return {Array}
+     */
     nodesToArray: function(nodes) {
+      var results = [], i;
       nodes = nodes || [];
 
-      var results = [];
-      for (var i = 0; i < nodes.length; ++i) {
+      for (i = 0; i < nodes.length; ++i) {
         results.push(nodes.item(i));
       }
       return results;
@@ -918,8 +922,8 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      *
      *    $mdUtil.uniq(myArray) => [1, 2, 3, 4]
      *
-     * @param {array} array The array whose unique values should be returned.
-     * @returns {array} A copy of the array containing only unique values.
+     * @param {Array} array The array whose unique values should be returned.
+     * @returns {Array|void} A copy of the array containing only unique values.
      */
     uniq: function(array) {
       if (!array) { return; }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `md-select` does not work well with VoiceOver on iOS or macOS
- When using `md-select` with the `multiple` attribute, options are always "checked" because of ngAria.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10748. Fixes #10967.

## What is the new behavior?
- move to [WAI-ARIA's Collapsible Dropdown Listbox practice](https://www.w3.org/TR/2019/NOTE-wai-aria-practices-1.1-20190207/examples/listbox/listbox-collapsible.html)
  - don't apply aria-required to md-select
  - as it isn't compatible with the button role
  - the md-content element is now the listbox
      - has the appropriate attributes and a unique id
      - and receives focus when the pop-up panel opens
      - aria-owns now points to this listbox so that indexes work
  - option focus is handled via `aria-activedescendant`
  - remove `aria-expanded` when collapsed
  - remove `aria-disabled` attribute when not disabled
-  manually remove `aria-checked` set by ngAria due to ngValue usage
-  apply `md-focused` class to the option with focus
- improve `ng-multiple` implementation
  - account for `multiple` attribute on `md-select-menu`
- remove unused `deregisterCollectionWatch()`
- fix overloaded variable names
- don't set aria-selected="false" on options in single selection mode
- stop labels and values from being announced multiple times
- add JSDoc/Closure Compiler details and types
- refinements for VoiceOver users
- clean up watchers, observers, and event handlers on $destroy
- fix a case where the initial selection model could contain two values
  - for the empty option, i.e. "" and "None"
  - deselection was only clearing the first one in single selection mode
- reduce duplicated code for focusing option nodes
- improve keyboard option scrolling behavior
- eliminate duplicate call to `autoFocus()`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
- [Deque Quick Reference Guide: VoiceOver for iOS](https://dequeuniversity.com/assets/pdf/screenreaders/voiceover-ios-guide.pdf)
- [Accessibility testing with Android Talkback](https://developer.paciellogroup.com/blog/2015/10/accessibility-testing-with-android-talkback/)
- [VoiceOver iOS Gesture/Keyboard Commands](http://pauljadam.com/demos/voiceovercommands.html)

### Completed Testing and Issues Identified
- [x] Finalize testing on VoiceOver in Chrome
- [x] Finalize testing on VoiceOver in Safari
- [x] Finalize testing on NVDA
- [x] Escape doesn't set the model back to the previous value
- [x] User defined `aria-labelledby` gets overwritten
- [x] `aria-hidden` on `md-select-value` is cleared when pop-up is closed, resulting in label being read twice when the `md-select` has no selection
- [x] Test in VoiceOver for iOS on Safari
  - [x] Test with [VoiceOver rotor](https://github.com/angular/material/issues/10967#issuecomment-354295026)
    - This seems to be working well as using the swipe right/left now cycles through the options as intended. 
    - It should be noted that `md-select` elements show up under the Buttons Rotor instead of Form Controls. This seems to be working as intended.
  - [x] Test [exiting the pop-up panel in multiple selection mode](https://github.com/angular/material/issues/10967#issuecomment-356022949)
    - [ ] This issue with being difficult to exit a multiple selection select exists with Angular Material as well. The "Two finger scrub" to dismiss alerts/dialogs or go back a page seems to always go back a page when used with AngularJS/Angular Material Autocomplete and Select. I tried changing the `md-select-menu-container` to `role="dialog"` and adding `"aria-haspopup="dialog"` to the `md-select`, but that didn't help and the Z (two finger scrub) always went back to the previous page. This is being tracked in https://github.com/angular/material/issues/11791.
- [x] Test on ChromeVoX
  - [ ] ChromeVox doesn't handle `aria-lablelledby` well and reads the `md-select-value` first and then the `aria-label` followed by the `md-select-value` again. Ideally, the label should be read and then the value. This will need to be handled in separate issue after consulting with the a11y team and possibly opening a bug against ChromeVox.
- [x] Autocomplete options' hover styling doesn't extend fully to the left edge
- [x] Test with TalkBack on Chrome for Android. I tested and saw similar behavior on Firefox for Android as well.
  - [x] Single selection appears to be working well. "Checked" is no longer announced in single selection mode.
  - [x] Multiple selection can be dismissed by a separated two finger tap.
  - [ ] Options in multiple selection cannot be selected (checked). This works for Angular Material, but not here. This isn't a regression as this has always been a problem with `md-select` on Android (back at least to `1.1.5`). This is being tracked in https://github.com/angular/material/issues/11770. This is likely a bug with TalkBack. Need to try to reproduce with a WAI-ARIA example and then find out where to submit the defect against TalkBack or Chrome for Android. 