### PR TITLE
fix(gesture): maximum call stack size exceeded on click w/ TalkBack

### DIFF
--- a/src/core/services/gesture/gesture.js
+++ b/src/core/services/gesture/gesture.js
@@ -388,8 +388,8 @@ function MdGesture($$MdGestureHandler, $$rAF, $timeout) {
  * A gesture will manage its lifecycle through the start,move,end, and cancel
  * functions, which are called by native dom events.
  *
- * A gesture has the concept of 'options' (eg a swipe's required velocity), which can be
- * overridden by elements registering through $mdGesture.register()
+ * A gesture has the concept of 'options' (eg. a swipe's required velocity), which can be
+ * overridden by elements registering through $mdGesture.register().
  */
 function GestureHandler (name) {
   this.name = name;
@@ -436,8 +436,8 @@ function MdGestureHandler() {
     },
     end: function (ev, pointer) {
       if (!this.state.isRunning) return;
-      this.onEnd(ev, pointer);
       this.state.isRunning = false;
+      this.onEnd(ev, pointer);
     },
     cancel: function (ev, pointer) {
       this.onCancel(ev, pointer);


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Click hijacking enters an infinite event loop when TalkBack is enabled and a `mouseup` event is fired.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11768

## What is the new behavior?
Stop click hijacking from entering an infinite event loop when TalkBack is enabled and a `mouseup` event is fired.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
We currently have no way to automate testing of touch events or TalkBack on Android.