### PR TITLE
fix(nav-bar): clicked nav item not focused or selected in some cases

### DIFF
--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -174,7 +174,7 @@ MdNavBarController.prototype._initTabs = function() {
 
   var self = this;
   this._$timeout(function() {
-    self._updateTabs(self.mdSelectedNavItem, undefined);
+    self._updateTabs(self.mdSelectedNavItem, null);
   });
 
   this._$scope.$watch('ctrl.mdSelectedNavItem', function(newValue, oldValue) {
@@ -189,7 +189,7 @@ MdNavBarController.prototype._initTabs = function() {
 /**
  * Set the current tab to be selected.
  * @param {string|undefined} newValue New current tab name.
- * @param {string|undefined} oldValue Previous tab name.
+ * @param {string|undefined|null} oldValue Previous tab name.
  * @private
  */
 MdNavBarController.prototype._updateTabs = function(newValue, oldValue) {
@@ -335,7 +335,7 @@ MdNavBarController.prototype._findTabReverse = function(fn, startIndex) {
  */
 MdNavBarController.prototype.onFocus = function() {
   var tab = this._getSelectedTab();
-  if (tab) {
+  if (tab && !tab._focused) {
     tab.setFocused(true);
   }
 };
@@ -595,9 +595,7 @@ function MdNavItem($mdAria, $$rAF, $mdUtil, $window) {
         });
 
         navButton.on('focus', function() {
-          if (!mdNavBar.getFocusedTab()) {
-            mdNavBar.onFocus();
-          }
+          mdNavItem._focused = true;
         });
 
         navButton.on('click', function() {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
If the user needs to scroll to display the nav item, when they click it, the focus and horizontal scroll jumps back to the previously selected nav item. The clicked nav item is not selected or focused.

Issue Number: 
Fixes #11747

## What is the new behavior?
- reduce unnecessary calls to onFocus() and setFocused()
  - in some cases, instead of focusing a nav item that was clicked on
    we would focus the selected nav item

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Not able to create automated tests that change the browser size or directly rely upon a given browser size.