### PR TITLE
fix(list): isEventFromControl() works on all browsers now

### DIFF
--- a/src/components/list/demoListControls/script.js
+++ b/src/components/list/demoListControls/script.js
@@ -15,7 +15,7 @@ angular.module('listDemo2', ['ngMaterial'])
   ];
 
   $scope.settings = [
-    { name: 'Wi-Fi', extraScreen: 'Wi-fi menu', icon: 'device:network-wifi', enabled: true },
+    { name: 'Wi-Fi', extraScreen: 'Wi-Fi menu', icon: 'device:network-wifi', enabled: true },
     { name: 'Bluetooth', extraScreen: 'Bluetooth menu', icon: 'device:bluetooth', enabled: false },
   ];
 

--- a/src/components/list/demoListControls/style.css
+++ b/src/components/list/demoListControls/style.css
@@ -1,17 +1,16 @@
 md-divider {
-    margin-top: 0;
-    margin-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 0;
 }
-
 md-list {
-    padding-top:0;
+  padding-top: 0;
 }
 md-list-item > p,
 md-list-item > .md-list-item-inner > p,
 md-list-item .md-list-item-inner > p,
 md-list-item .md-list-item-inner > .md-list-item-inner > p {
-    -webkit-user-select: none; /* Chrome all / Safari all */
-    -moz-user-select: none; /* Firefox all */
-    -ms-user-select: none; /* IE 10+ */
-    user-select: none; /* Likely future */
+  -webkit-user-select: none; /* Chrome all / Safari all */
+  -moz-user-select: none; /* Firefox all */
+  -ms-user-select: none; /* IE 10+ */
+  user-select: none; /* Likely future */
 }

--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -978,6 +978,24 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
           return property;
         }
       }
+    },
+
+    /**
+     * @param {Event} event the event to calculate the bubble path for
+     * @return {EventTarget[]} the set of nodes that this event could bubble up to
+     */
+    getEventPath: function(event) {
+      var path = [];
+      var currentTarget = event.target;
+      while (currentTarget) {
+        path.push(currentTarget);
+        currentTarget = currentTarget.parentElement;
+      }
+      if (path.indexOf(window) === -1 && path.indexOf(document) === -1)
+        path.push(document);
+      if (path.indexOf(window) === -1)
+        path.push(window);
+      return path;
     }
   };
 


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
`isEventFromControl()` uses `MouseEvent.path` which is a Chrome only API.
This means that list items with a single proxy component (checkbox, switch, or menu) will not proxy clicks from the list item to the proxy component. I.e. the checkbox/switch will not toggle and the menu will not open on Safari, Firefox, Edge, and IE11.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #7937

## What is the new behavior?
`isEventFromControl()` uses a new `$mdUtil. getEventPath()` method that is cross browser compatible.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath could not be used due to lack of Edge and IE support.