### PR TITLE
fix(chips): improve handling of null and undefined model values

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -848,8 +848,7 @@ MdChipsCtrl.prototype.configureNgModel = function(ngModelCtrl) {
 
   ngModelCtrl.$render = function() {
     // model is updated. do something.
-    if(self.ngModelCtrl.$viewValue == null)
-    {
+    if (self.ngModelCtrl.$viewValue == null) {
       // set value as default array for null or undefined
       self.ngModelCtrl.$setViewValue([]);
       self.ngModelCtrl.$commitViewValue();

--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -848,6 +848,13 @@ MdChipsCtrl.prototype.configureNgModel = function(ngModelCtrl) {
 
   ngModelCtrl.$render = function() {
     // model is updated. do something.
+    if(self.ngModelCtrl.$viewValue == null)
+    {
+      // set value as default array for null or undefined
+      self.ngModelCtrl.$setViewValue([]);
+      self.ngModelCtrl.$commitViewValue();
+    }
+
     self.items = self.ngModelCtrl.$viewValue;
   };
 };


### PR DESCRIPTION
set value as default array for null or undefined

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [ ] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ x ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When the model value is `null` or `undefined`. Other feature and function related to `mdChips` would crashed the angular

## What is the new behavior?

Force it to set empty array as default value


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```