### PR TITLE
fix(autocomplete): loop options list when moving past first/last option with arrow keys

### DIFF
--- a/src/components/autocomplete/autocomplete.spec.js
+++ b/src/components/autocomplete/autocomplete.spec.js
@@ -1970,6 +1970,106 @@ describe('<md-autocomplete>', function() {
       element.remove();
     });
 
+    it('should move to the last item when up arrow is pressed when on the first item', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-min-length="0"' +
+        '   md-escape-options="clear"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      // Initial state
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+
+      ctrl.focus();
+      waitForVirtualRepeat(element);
+
+      // After getting focus
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.activeOption).toBe(null);
+
+      // Highlighting the first item
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+
+      // Trying to go to the last item by cycling through the list
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.UP_ARROW));
+      $material.flushInterimElement();
+
+      // We should be on the last item
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(2);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-2');
+
+      element.remove();
+    });
+
+    it('should move to the first item when down arrow is pressed when on the last item', function() {
+      var template =
+        '<md-autocomplete' +
+        '   md-selected-item="selectedItem"' +
+        '   md-search-text="searchText"' +
+        '   md-items="item in match(searchText)"' +
+        '   md-item-text="item.display"' +
+        '   placeholder="placeholder"' +
+        '   md-min-length="0"' +
+        '   md-escape-options="clear"' +
+        '   md-autoselect="false">' +
+        '  <span md-highlight-text="searchText">{{item.display}}</span>' +
+        '</md-autocomplete>';
+      var scope = createScope();
+      var element = compile(template, scope);
+      var ctrl = element.controller('mdAutocomplete');
+      var input = element.find('input');
+      // Run our initial flush
+      $timeout.flush();
+
+      // Initial state
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.hidden).toBe(true);
+      expect(ctrl.activeOption).toBe(null);
+
+      ctrl.focus();
+      waitForVirtualRepeat(element);
+
+      // After getting focus
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(-1);
+      expect(ctrl.activeOption).toBe(null);
+
+      // Highlighting the first item
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+
+      // Highlighting the last item from the list
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+
+      // Trying to go to the first item by cycling through the list
+      ctrl.keydown(keydownEvent($mdConstant.KEY_CODE.DOWN_ARROW));
+      $material.flushInterimElement();
+
+      // We should be on the first item
+      expect(ctrl.hidden).toBe(false);
+      expect(ctrl.index).toBe(0);
+      expect(ctrl.activeOption).toBe('md-option-' + ctrl.id + '-0');
+
+      element.remove();
+    });
+
     it('should set activeOption when autoselect is on', function() {
       var template =
         '<md-autocomplete' +

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -640,7 +640,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         if (ctrl.loading || hasSelection()) return;
         event.stopPropagation();
         event.preventDefault();
-        ctrl.index = Math.min(ctrl.index + 1, ctrl.matches.length - 1);
+        ctrl.index = ctrl.index + 1 > ctrl.matches.length - 1 ? 0 : Math.min(ctrl.index + 1, ctrl.matches.length - 1);
         $mdUtil.nextTick(updateActiveOption);
         updateScroll();
         break;
@@ -648,7 +648,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
         if (ctrl.loading || hasSelection()) return;
         event.stopPropagation();
         event.preventDefault();
-        ctrl.index = ctrl.index < 0 ? ctrl.matches.length - 1 : Math.max(0, ctrl.index - 1);
+        ctrl.index = ctrl.index - 1 < 0 ? ctrl.matches.length - 1 : Math.max(0, ctrl.index - 1);
         $mdUtil.nextTick(updateActiveOption);
         updateScroll();
         break;


### PR DESCRIPTION
allow the user cycling through the options list

Fixes #11766

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
The list scrolling with up/down arrow keys does not wrap from the end to the first element (on down) or the first to the last element (on up).
Issue Number: #11766 


## What is the new behavior?
The list scrolling with up/down arrow keys should wrap.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
