### PR TITLE
fix(datepicker): reset inputFocusedOnWindowBlur flag

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -838,6 +838,8 @@
       }, false);
 
       window.addEventListener(this.windowEventName, this.windowEventHandler);
+    } else if (this.inputFocusedOnWindowBlur) {
+      this.resetInputFocused();
     }
   };
 
@@ -929,6 +931,14 @@
    */
   DatePickerCtrl.prototype.handleWindowBlur = function() {
     this.inputFocusedOnWindowBlur = document.activeElement === this.inputElement;
+  };
+
+  /**
+   * Reset the flag inputFocusedOnWindowBlur to default state, to permit user to open calendar
+   * again when he back to tab with calendar focused.
+   */
+  DatePickerCtrl.prototype.resetInputFocused = function() {
+    this.inputFocusedOnWindowBlur = false;
   };
 
   /**


### PR DESCRIPTION
After an update on Jul 30 2016 @crisbeto add a flag: `inputFocusedOnWindowBlur` to prevent opening a datepicker when the focus is active and user change a browser tab. 
The problem is that if the focus is active user can't open it again now. I add flag reset function and trigger it at the first time when the user backs to page with datepicker.

Fixes: #9186
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

User set focus in calendar input, calendar picker is open. User change a browser tab, and back to tab with the calendar. The calendar is not auto-open again (it's expected behavior) but the user can't open a calendar at all - should reset a flag (change a browser tab again without focus).
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #9186

## What is the new behavior?

Now when user back to tab with focus, an open function is triggered imminently, but in line 841 I add a condition to reset this flag. So now user can open datepicker again.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
