### PR TITLE
fix(toast): toast defaults to wrong values when passed an empty position

### DIFF
--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -541,6 +541,11 @@ function MdToastProvider($$interimElementProvider) {
         return 'md-toast-open-bottom';
       }
 
+      // If no position was provided, use the default.
+      if (!position) {
+        return 'md-toast-open-bottom';
+      }
+
       return 'md-toast-open-' + (position.indexOf('top') > -1 ? 'top' : 'bottom');
     }
 


### PR DESCRIPTION
If the user specifies no position at all, the toast will open from the top, while the class name will reflect a toast opening from the bottom.

By chaning the ternary as suggested, we end up with the correct default case while maintaining all configured cases as-is.

## PR Checklist
Please check that your PR fulfills the following requirements:
- [X] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [X] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

Go to https://material.angularjs.org/latest/demo/toast and uncheck all 4 checkboxes, then trigger a toast. The toast will appear on the top, the bottom FAB will make space for the toast.

## What is the new behavior?

The toast will appear on the top, the top FAB will make space for the toast.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
