### PR TITLE
chore: Introduce Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ dist
 /.idea/
 .nvmrc
 tmp/
-.editorconfig
 bower-material/
 code.material.angularjs.org/


### PR DESCRIPTION
Any .editorconfig was set to be ignored in cf92799314ff5483fbc588241dbaf72ba0a7a97d.
This change introduces such a configuration file to allow contributors to use the correct code style more easily.

I'm not sure why the file was set to be ignored. IMHO it appears to be beneficial to place it in the repository to make it clear which indentation style is expected.

When I open the project in VS Code, it always attempts to indent using tabs, which is very frustrating. Obviously, I can just place my `.editorconfig` file from this PR into the project and resolve the issue for myself, but having the style defined right from the beginning for all developers would decrease onboarding friction.

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [ ] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [X] Tests for the changes have been added or this is not a bug fix / enhancement
- [X] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[X] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[X] Other... Please describe:
```