### PR TITLE
chore(release): support publishing to NPM with tags other than latest

### DIFF
--- a/release.js
+++ b/release.js
@@ -18,6 +18,7 @@
   const lineWidth      = 80;
   const lastMajorVer   = JSON.parse(exec('curl https://material.angularjs.org/docs.json')).latest;
   let newVersion;
+  let npmTag = 'latest';
 
   try {
     child_process.execSync('gulp --version', defaultOptions);
@@ -26,6 +27,7 @@
   }
   header();
   const dryRun = prompt(`Is this a dry-run? [${"yes".cyan}/no] `, 'yes') !== 'no';
+  npmTag = prompt(`What would you like the NPM tag to be? [${npmTag.cyan}/next] `, npmTag);
 
   if (dryRun) {
     oldVersion = prompt(`What would you like the old version to be? (default: ${oldVersion.cyan}) `, oldVersion);
@@ -243,7 +245,7 @@
     done();
     // add steps to push script
     pushCmds.push(
-      comment('push to bower (master and tag) and publish to npm'),
+      comment(`push to bower (master and tag) and publish to npm as '${npmTag}'`),
       'cd ' + options.cwd,
       'cp ../CHANGELOG.md .',
       'git add CHANGELOG.md',
@@ -253,7 +255,7 @@
       'git push',
       'git push --tags',
       'rm -rf .git/',
-      'npm publish',
+      `npm publish --tag ${npmTag}`,
       'cd ..'
     );
   }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
All releases, even RCs, are published to NPM as 'latest'

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11873

## What is the new behavior?
- default to 'latest'
- allow 'next' to support RC releases

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
N/A