### PR TITLE
fix(select): height changes when disabled

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,5 +1,6 @@
 $select-checkbox-border-radius: 2px !default;
 $select-checkbox-border-width: 2px !default;
+$select-border-width-default: 1px !default;
 $select-checkbox-width: rem(1.4) !default;
 $select-option-height: 48px !default;
 $select-option-padding: 16px !default;
@@ -115,12 +116,14 @@ md-select {
   }
 
   &[disabled] .md-select-value {
-    background-position: 0 bottom;
+    // This background-position was taken from the styling of disabled md-inputs.
+    // The negative border width offsets the dotted "border" so it's placed in the same place as the
+    // solid one before it.
+    background-position: bottom $select-border-width-default * -1 left 0;
     // This background-size is coordinated with a linear-gradient set in select-theme.scss
     // to create a dotted line under the input.
     background-size: 4px 1px;
     background-repeat: repeat-x;
-    margin-bottom: -1px; // Shift downward so dotted line is positioned the same as other bottom borders
   }
 
   &:focus {
@@ -141,7 +144,7 @@ md-select {
     }
     &:focus {
       .md-select-value {
-        border-bottom-width: 2px;
+        border-bottom-width: $select-border-width-default + 1px;
         border-bottom-style: solid;
         padding-bottom: 0;
       }
@@ -154,10 +157,26 @@ md-select {
   }
 }
 
-// Fix value by 1px to align with standard text inputs (and spec)
-md-input-container.md-input-has-value .md-select-value {
-  > span:not(.md-select-icon) {
-    transform: translate3d(0, 1px, 0);
+md-input-container md-select {
+  &:not([disabled]) {
+    &:focus {
+      .md-select-value {
+        border-bottom-width: $input-border-width-focused;
+      }
+    }
+  }
+  &[disabled] {
+    .md-select-value {
+      // This background-position was taken from and matches the styling of disabled md-inputs.
+      // The negative border width offsets the dotted "border" so it's placed in the same place as
+      // the solid one before it.
+      background-position: bottom $input-border-width-default * -1 left 0;
+    }
+  }
+  .md-select-value {
+    min-height: ($input-line-height + $input-padding-top * 2) - $input-border-width-focused - $input-border-width-default * 2;
+    padding-bottom: $input-border-width-focused - $input-border-width-default;
+    border-bottom-width: $input-border-width-default;
   }
 }
 
@@ -165,7 +184,7 @@ md-input-container.md-input-has-value .md-select-value {
   display: flex;
   align-items: center;
   padding: 2px 2px 1px;
-  border-bottom-width: 1px;
+  border-bottom-width: $select-border-width-default;
   border-bottom-style: solid;
   background-color: rgba(0,0,0,0);
   position: relative;
@@ -173,7 +192,6 @@ md-input-container.md-input-has-value .md-select-value {
   min-width: 8 * $baseline-grid;
   min-height: 26px;
   flex-grow: 1;
-
 
   > span:not(.md-select-icon) {
     max-width: 100%;


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `md-select`'s height changes when disabled

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11812


## What is the new behavior?
- `md-select`'s height no longer changes when disabled
- use the same approach for `md-select`'s disabled border background-position as `md-input`
- `md-select` inside of an `md-input-container` uses more `md-input` SCSS variables
  - this allows it to better match the layout and dimensions of other `md-input-container` elements
- add new `$select-border-width-default` SCSS variable


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This change should not break any apps, but it may allow them to remove some CSS hacks to fix the previous issue with the selects loosing `1px` of height when disabled. If there are screenshot tests involved, they may fail for disabled inputs due to the `1px` change in position, but this new position should be the correct position and matches the non-disabled position.

We'll try this out in an RC and determine if this will be problematic for production apps or not. If it turns out to be, we'll revert this and push it to `1.2.0`.