### PR TITLE
fix(select): menuController not defined edge case in focusOptionNode

### DIFF
--- a/src/components/select/demoBasicUsage/script.js
+++ b/src/components/select/demoBasicUsage/script.js
@@ -1,11 +1,12 @@
 (function () {
   'use strict';
   angular
-      .module('selectDemoBasic', ['ngMaterial'])
-      .controller('AppCtrl', function() {
-        this.userState = '';
-        this.states = ('AL AK AZ AR CA CO CT DE FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS ' +
-            'MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI ' +
-            'WY').split(' ').map(function (state) { return { abbrev: state }; });
-      });
+  .module('selectDemoBasic', ['ngMaterial'])
+  .controller('AppCtrl', function() {
+    var ctrl = this;
+    ctrl.userState = '';
+    ctrl.states = ('AL AK AZ AR CA CO CT DE FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS ' +
+      'MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI ' +
+      'WY').split(' ').map(function (state) { return { abbrev: state }; });
+  });
 })();

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -690,7 +690,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
     element.on('keypress', keyListener);
 
     function keyListener(e) {
-      if (e.keyCode == 13 || e.keyCode == 32) {
+      if (e.keyCode === 13 || e.keyCode === 32) {
         clickListener(e);
       }
     }
@@ -796,10 +796,10 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
     };
 
     /**
-     * @param {KeyboardEvent} e keyboard event to handle
-     * @return {DOMElement|HTMLElement|undefined}
+     * @param {KeyboardEvent} keyboardEvent keyboard event to handle
+     * @return {Element|HTMLElement|undefined}
      */
-    self.optNodeForKeyboardSearch = function(e) {
+    self.optNodeForKeyboardSearch = function(keyboardEvent) {
       var search, i;
       clearSearchTimeout && clearTimeout(clearSearchTimeout);
       clearSearchTimeout = setTimeout(function() {
@@ -809,7 +809,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
         optNodes = undefined;
       }, CLEAR_SEARCH_AFTER);
 
-      searchStr += e.key;
+      searchStr += keyboardEvent.key;
       search = new RegExp('^' + $mdUtil.sanitize(searchStr), 'i');
       if (!optNodes) {
         optNodes = $element.find('md-option');
@@ -818,12 +818,12 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
           optText[i] = el.textContent.trim();
         });
       }
+
       for (i = 0; i < optText.length; ++i) {
         if (search.test(optText[i])) {
           return optNodes[i];
         }
       }
-
     };
 
     self.init = function(ngModel, binding) {
@@ -1523,6 +1523,7 @@ function SelectProvider($$interimElementProvider) {
 
       /**
        * Initialize container and dropDown menu positions/scale, then animate to show.
+       * @return {*} a Promise that resolves after the menu is animated in and an item is focused
        */
       function positionAndFocusMenu() {
         return $q(function(resolve) {
@@ -1576,12 +1577,11 @@ function SelectProvider($$interimElementProvider) {
       }
 
       /**
-       * @param {DOMElement|HTMLElement|null=} previousNode
-       * @param {DOMElement|HTMLElement} node
-       * @param {SelectMenuController|Function} menuController SelectMenuController instance
-       * @param {Function|*} selectController SelectController instance
+       * @param {Element|HTMLElement|null=} previousNode
+       * @param {Element|HTMLElement} node
+       * @param {SelectMenuController|Function|Object=} menuController SelectMenuController instance
        */
-      function focusOptionNode(previousNode, node, menuController, selectController) {
+      function focusOptionNode(previousNode, node, menuController) {
         var listboxContentNode = opts.contentEl[0];
 
         if (node) {
@@ -1590,7 +1590,9 @@ function SelectProvider($$interimElementProvider) {
           }
 
           node.classList.add('md-focused');
-          menuController.setActiveDescendant(node.id);
+          if (menuController && menuController.setActiveDescendant) {
+            menuController.setActiveDescendant(node.id);
+          }
 
           // Scroll the node into view if needed.
           if (listboxContentNode.scrollHeight > listboxContentNode.clientHeight) {
@@ -1603,18 +1605,20 @@ function SelectProvider($$interimElementProvider) {
             }
           }
           opts.focusedNode = node;
-          menuController.refreshViewValue();
+          if (menuController && menuController.refreshViewValue) {
+            menuController.refreshViewValue();
+          }
         }
       }
 
       /**
-       * @param {DOMElement|HTMLElement} nodeToFocus
+       * @param {Element|HTMLElement} nodeToFocus
        */
       function autoFocus(nodeToFocus) {
         var selectMenuController;
         if (nodeToFocus && !nodeToFocus.hasAttribute('disabled')) {
           selectMenuController = opts.selectEl.controller('mdSelectMenu');
-          focusOptionNode(null, nodeToFocus, selectMenuController, opts.selectCtrl);
+          focusOptionNode(null, nodeToFocus, selectMenuController);
         }
       }
 
@@ -1757,7 +1761,7 @@ function SelectProvider($$interimElementProvider) {
               if (shouldHandleKey(ev, $mdConstant)) {
                 var optNode = selectMenuController.optNodeForKeyboardSearch(ev);
                 if (optNode && !optNode.hasAttribute('disabled')) {
-                  focusOptionNode(opts.focusedNode, optNode, selectMenuController, opts.selectCtrl);
+                  focusOptionNode(opts.focusedNode, optNode, selectMenuController);
                 }
               }
           }
@@ -1790,7 +1794,7 @@ function SelectProvider($$interimElementProvider) {
             }
           } while (!newOption && index < optionsArray.length - 1 && index > 0);
 
-          focusOptionNode(prevOption, newOption, selectMenuController, opts.selectCtrl);
+          focusOptionNode(prevOption, newOption, selectMenuController);
         }
 
         function focusNextOption() {
@@ -1801,8 +1805,11 @@ function SelectProvider($$interimElementProvider) {
           focusOption('prev');
         }
 
-        function checkCloseMenu(ev) {
-          if (ev && (ev.type === 'click') && (ev.currentTarget != dropDown[0])) {
+        /**
+         * @param {KeyboardEvent|MouseEvent} event
+         */
+        function checkCloseMenu(event) {
+          if (event && (event.type === 'click') && (event.currentTarget !== dropDown[0])) {
             return;
           }
           if (mouseOnScrollbar()) {
@@ -1811,8 +1818,8 @@ function SelectProvider($$interimElementProvider) {
 
           if (opts.focusedNode && opts.focusedNode.hasAttribute &&
               !opts.focusedNode.hasAttribute('disabled')) {
-            ev.preventDefault();
-            ev.stopPropagation();
+            event.preventDefault();
+            event.stopPropagation();
             if (!selectMenuController.isMultiple) {
               opts.restoreFocus = true;
 
@@ -1821,16 +1828,17 @@ function SelectProvider($$interimElementProvider) {
               }, true);
             }
           }
+
           /**
            * check if the mouseup event was on a scrollbar
            */
           function mouseOnScrollbar() {
             var clickOnScrollbar = false;
-            if (ev && (ev.currentTarget.children.length > 0)) {
-              var child = ev.currentTarget.children[0];
+            if (event && (event.currentTarget.children.length > 0)) {
+              var child = event.currentTarget.children[0];
               var hasScrollbar = child.scrollHeight > child.clientHeight;
               if (hasScrollbar && child.children.length > 0) {
-                var relPosX = ev.pageX - ev.currentTarget.getBoundingClientRect().left;
+                var relPosX = event.pageX - event.currentTarget.getBoundingClientRect().left;
                 if (relPosX > child.querySelector('md-option').offsetWidth)
                   clickOnScrollbar = true;
               }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
As reported in #11885, `SelectProvider.focusOptionNode()` can throw an exception when trying to call `SelectMenuController.setActiveDescendant()` in edge cases where the `SelectMenuController` is no longer defined or its lookup failed.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11885

## What is the new behavior?
- Handle edge cases where the `selectMenuController` has been destroyed or is an `{}` rather than a Controller
- remove unused `selectController` argument to `focusOptionNode()`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
The API changes are for unreleased, private APIs only, which were introduced in `1.1.22-rc.0`.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Not able to reproduce the issue (in or out of a test). This just adds some safety checks that should make the reported exception not throw.