### PR TITLE
fix(progress-linear,progress-circular): mirror indicator when rtl is on

### DIFF
--- a/src/components/progressCircular/progress-circular.scss
+++ b/src/components/progressCircular/progress-circular.scss
@@ -10,6 +10,8 @@ md-progress-circular {
     position: relative;
     display: block;
 
+    @include rtl(transform, scale(1, 1), scale(-1, 1));
+
     &._md-progress-circular-disabled {
         visibility: hidden;
     }

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -9,6 +9,8 @@ md-progress-linear {
   padding-top: 0 !important;
   margin-bottom: 0 !important;
 
+  @include rtl(transform, scale(1, 1), scale(-1, 1));
+
   &._md-progress-linear-disabled {
     visibility: hidden;
   }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
Progress indicator is not mirrored when rtl is on.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
#10814 

## What is the new behavior?
Progress indicator is mirrored when rtl is on.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
