### PR TITLE
fix(util): sanitize function used by select and autocomplete throws

### DIFF
--- a/src/core/util/util.js
+++ b/src/core/util/util.js
@@ -1009,7 +1009,7 @@ function UtilFactory($document, $timeout, $compile, $rootScope, $$mdAnimate, $in
      */
     sanitize: function(term) {
       if (!term) return term;
-      return term.replace(/[\\^$*+?.()|{}[]]/g, '\\$&');
+      return term.replace(/[\\^$*+?.()|{}[]/g, '\\$&');
     }
   };
 

--- a/src/core/util/util.spec.js
+++ b/src/core/util/util.spec.js
@@ -760,12 +760,14 @@ describe('util', function() {
       $mdUtil = _$mdUtil_;
     }));
 
-    it('Removes Regex indentifiers in a text', function() {
+    it('sanitizes + signs', function() {
+      var myText = '+98';
+      expect($mdUtil.sanitize(myText)).toEqual('\\+98');
+    });
 
-      // eslint-disable-next-line no-useless-escape
-      var myText = '\+98';
-
-      expect($mdUtil.sanitize(myText)).toEqual('+98');
+    it('sanitizes parenthesis', function() {
+      var myText = '()';
+      expect($mdUtil.sanitize(myText)).toEqual('\\(\\)');
     });
   });
 });


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
There was a minor `RegExp` change when moving the `sanitize()` function from `md-autocomplete` to `$mdUtil`. This caused a regression where `md-autocomplete` would throw an exception when `(` was typed into the input.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11908

## What is the new behavior?
No more exception. Sanitize `RegExp` updated. Tests fixed.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
