### PR TITLE
fix(navBar): update inkbar on screen resize

### DIFF
--- a/src/components/navBar/navBar.js
+++ b/src/components/navBar/navBar.js
@@ -78,10 +78,12 @@ angular.module('material.components.navBar', ['material.core'])
 /**
  * @param $mdAria
  * @param $mdTheming
+ * @param $window
+ * @param $mdUtil
  * @constructor
  * @ngInject
  */
-function MdNavBar($mdAria, $mdTheming) {
+function MdNavBar($mdAria, $mdTheming, $window, $mdUtil) {
   return {
     restrict: 'E',
     transclude: true,

--- a/src/components/navBar/navBar.scss
+++ b/src/components/navBar/navBar.scss
@@ -39,21 +39,15 @@ $md-nav-bar-height: 48px;
 md-nav-ink-bar {
   $duration: $swift-ease-in-out-duration * 0.5;
   $multiplier: 0.5;
-  bottom: 0;
-  height: 2px;
-  left: auto;
-  position: absolute;
-  right: auto;
   background-color: black;
-
-  &._md-left {
-    transition: left ($duration * $multiplier) $swift-ease-in-out-timing-function,
-        right $duration $swift-ease-in-out-timing-function;
-  }
-  &._md-right {
-    transition: left $duration $swift-ease-in-out-timing-function,
-        right ($duration * $multiplier) $swift-ease-in-out-timing-function;
-  }
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  transform-origin: left top;
+  will-change: transform;
+  transition: transform ($duration * $multiplier) $swift-ease-in-out-timing-function;
 
   // By default $ngAnimate looks for transition durations on the element, when using ng-hide, ng-if, ng-show.
   // The ink bar has a transition duration applied, which means, that $ngAnimate delays the hide process.

--- a/src/components/navBar/navBar.spec.js
+++ b/src/components/navBar/navBar.spec.js
@@ -261,15 +261,25 @@ describe('mdNavBar', function() {
       $scope.selectedTabRoute = 'tab1';
       createTabs();
 
+      var tabLeft = getTab('tab1')[0].offsetLeft;
+      var inkbarTranslate = parseFloat(getInkbarEl().style.transform.match(/\d+\.\d+/g)[0]);
+      var elWidth = el[0].getBoundingClientRect().width;
+
+      var translate = tabLeft / elWidth * 100;
       // b/c there is no css in the karma test, we have to interrogate the
       //   inkbar style property directly
-      expect(parseInt(getInkbarEl().style.left))
-          .toBeCloseTo(getTab('tab1')[0].offsetLeft, 0.1);
+      expect(inkbarTranslate)
+          .toBeCloseTo(translate, 1);
 
       updateSelectedTabRoute('tab3');
 
-      expect(parseInt(getInkbarEl().style.left))
-          .toBeCloseTo(getTab('tab3')[0].offsetLeft, 0.1);
+      tabLeft = getTab('tab3')[0].offsetLeft
+      inkbarTranslate = parseFloat(getInkbarEl().style.transform.match(/\d+\.\d+/g)[0]);
+      elWidth = el[0].getBoundingClientRect().width;
+      translate = tabLeft / elWidth * 100;
+
+      expect(inkbarTranslate)
+          .toBeCloseTo(translate, 1);
     });
 
     it('should hide if md-no-ink-bar is enabled', function() {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
The ink bar below the tab buttons does not update it's position if an item with `flex` exists besides `md-nav-items`.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #10121
Closes #11042

## What is the new behavior?
- update inkbar on screen resize
- changed how inkbar is moved
- use transform to scale and translate the inkbar
- also add debounced update to window resize

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
This PR takes over PR https://github.com/angular/material/pull/11042 to resolve issues introduced via rebase.

# Caretaker note

The CLA was signed in the previous PR.