### PR TITLE
fix(menu-bar): close just nested menu when escape key is pressed

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -289,7 +289,11 @@ function MenuProvider($$interimElementProvider) {
           var handled;
           switch (ev.keyCode) {
             case $mdConstant.KEY_CODE.ESCAPE:
-              opts.mdMenuCtrl.close(false, { closeAll: true });
+              if (opts.nestLevel) {
+                opts.mdMenuCtrl.close();
+              } else {
+                opts.mdMenuCtrl.close(false, { closeAll: true });
+              }
               handled = true;
               break;
             case $mdConstant.KEY_CODE.TAB:

--- a/src/components/menuBar/menu-bar.spec.js
+++ b/src/components/menuBar/menu-bar.spec.js
@@ -226,6 +226,39 @@ describe('material.components.menuBar', function() {
           menuBar.remove();
         });
 
+        it('closes only current sub-menu with escape key', inject(function($mdConstant) {
+          menuBar = setup();
+          ctrl = menuBar.controller('mdMenuBar');
+          menus = menuBar[0].querySelectorAll('md-menu md-menu');
+
+          angular.element(document.body).append(menuBar);
+
+          expect(getNumberOfOpenMenus()).toBe(0);
+
+          // Open the menu-bar menu
+          ctrl.focusMenu(1);
+          ctrl.openFocusedMenu();
+          waitForMenuOpen();
+
+          expect(getNumberOfOpenMenus()).toBe(1);
+
+          // Open the first nested menu
+          openSubMenu(0);
+          waitForMenuOpen();
+          expect(getOpenSubMenu().text().trim()).toBe('Sub 1 - Content');
+
+          expect(getNumberOfOpenMenus()).toBe(2);
+
+          // Close the first nested menu with escape key
+          pressKey(getOpenSubMenu(), $mdConstant.KEY_CODE.ESCAPE);
+          waitForMenuClose();
+
+          // Just main menu should be visible
+          expect(getNumberOfOpenMenus()).toBe(1);
+
+          menuBar.remove();
+        }));
+
         function openSubMenu(index) {
           // If a menu is already open, trigger the mouse leave to close it
           if (subMenuOpen) {
@@ -252,7 +285,19 @@ describe('material.components.menuBar', function() {
           return angular.element(lastContainer.querySelector('md-menu-content'));
         }
 
-        function setup(){
+        function getNumberOfOpenMenus() {
+          var containers = document.body.querySelectorAll('.md-open-menu-container.md-active');
+          return containers.length;
+        }
+
+        function pressKey(el, code) {
+          el.triggerHandler({
+            type: 'keydown',
+            keyCode: code
+          });
+        }
+
+        function setup() {
           var el;
           inject(function($compile, $rootScope) {
             el = $compile([


### PR DESCRIPTION
focus stays with the parent menu when nested one is closed instead of closing all the menus

Fixes #11678

<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

At the moment when the user presses escape key while the nested menu is open, it causes all the menus to become closed and the focus is lost.
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: #11678


## What is the new behavior?
When the escape key is pressed, only the current nested menu is closed and the focus goes to the parent menu.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
