### PR TITLE
fix(theming, toolbar, subheader, input): align color palettes and contrasts with AA standards

### DIFF
--- a/docs/app/css/style.css
+++ b/docs/app/css/style.css
@@ -554,7 +554,6 @@ md-tabs.demo-source-tabs .active md-tab-label {
 md-toolbar.demo-toolbar {
   border-radius: 3px 3px 0 0;
   box-shadow: 0 1px rgba(255, 255, 255, 0.1);
-  color: white;
 }
 md-toolbar.demo-toolbar md-tab-label {
   color: #99E4EE;

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -54,8 +54,13 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
     'contrastDarkColors': '50 100 200 300 400 A100 A200',
     'contrastStrongLightColors': '500 600 700 800 900 A400 A700'
   }));
+
   $mdThemingProvider.definePalette('docs-red', $mdThemingProvider.extendPalette('red', {
     'A100': '#DE3641'
+  }));
+
+  $mdThemingProvider.definePalette('docs-warn', $mdThemingProvider.extendPalette('deep-orange', {
+    '500': '#d32f2f' // Override 500 with 700 hue for improved contrast on flat buttons
   }));
 
   $mdThemingProvider.theme('docs-dark', 'default')
@@ -77,9 +82,8 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
 
   $mdThemingProvider.theme('default')
     .primaryPalette('docs-blue')
-    .accentPalette('docs-red', {
-      'default': 'A700'
-    });
+    .accentPalette('docs-red')
+    .warnPalette('docs-warn');
 
   $mdThemingProvider.enableBrowserColor();
 

--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -51,8 +51,8 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
     '800': '#014AB6',
     '900': '#013583',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 A200 A400'
+    'contrastDarkColors': '50 100 200 300 400 A100 A200',
+    'contrastStrongLightColors': '500 600 700 800 900 A400 A700'
   }));
   $mdThemingProvider.definePalette('docs-red', $mdThemingProvider.extendPalette('red', {
     'A100': '#DE3641'
@@ -76,8 +76,10 @@ function(SERVICES, COMPONENTS, DEMOS, PAGES,
     .defaultIconSet('img/icons/sets/core-icons.svg', 24);
 
   $mdThemingProvider.theme('default')
-      .primaryPalette('docs-blue')
-      .accentPalette('docs-red');
+    .primaryPalette('docs-blue')
+    .accentPalette('docs-red', {
+      'default': 'A700'
+    });
 
   $mdThemingProvider.enableBrowserColor();
 

--- a/docs/content/Theming/03_configuring_a_theme.md
+++ b/docs/content/Theming/03_configuring_a_theme.md
@@ -4,7 +4,7 @@
 
 ## Configuring a theme
 
-By default your AngularJS Material application will use the default theme, a theme
+By default, your AngularJS Material application will use the default theme, a theme
 that is pre-configured with the following palettes for intention groups:
 
 - *primary* - indigo
@@ -72,16 +72,24 @@ angular.module('myApp', ['ngMaterial'])
 
 ### Defining Custom Palettes
 
-As mentioned before, AngularJS Material ships with the Material Design
-Spec's color palettes built in. In the event that you need to define a custom color palette, you can use `$mdThemingProvider` to define it, thereby making 
-it available to your theme for use in its intention groups. Note that you must
-specify all hues in the definition map.
+As mentioned before, AngularJS Material ships with the Material Design Spec's color palettes built
+in. In the event that you need to define a custom color palette, you can use `$mdThemingProvider`
+to define it. This makes the palette available to your theme for use in its intention groups.
+Note that you must specify all hues in the definition map. If you only want to override a few hues,
+please extend a palette (above).
+
+For a dark colored, custom palette, you should specify the default contrast color as  `light`.
+For lighter hues in the palette, you may need to add them to the list of `contrastDarkColors` to
+meet contrast guidelines. Similarly, you may need to add darker hues to `contrastStrongLightColors`,
+which has been updated to the latest Material Design guidelines for
+[Color Usability](https://material.io/archive/guidelines/style/color.html#color-usability).
+The update to the guidelines changed primary text on dark backgrounds from 87% to 100% opacity.
 
 <hljs lang="js">
 angular.module('myApp', ['ngMaterial'])
 .config(function($mdThemingProvider) {
 
-  $mdThemingProvider.definePalette('amazingPaletteName', {
+  $mdThemingProvider.definePalette('amazingDarkPaletteName', {
     '50': 'ffebee',
     '100': 'ffcdd2',
     '200': 'ef9a9a',
@@ -96,17 +104,49 @@ angular.module('myApp', ['ngMaterial'])
     'A200': 'ff5252',
     'A400': 'ff1744',
     'A700': 'd50000',
-    'contrastDefaultColor': 'light',    // whether, by default, text (contrast) 
-                                        // on this palette should be dark or light
-
-    'contrastDarkColors': ['50', '100', //hues which contrast should be 'dark' by default
-     '200', '300', '400', 'A100'],
-    'contrastLightColors': undefined    // could also specify this if default was 'dark'
+    // By default, text (contrast) on this palette should be white with 87% opacity.
+    'contrastDefaultColor': 'light',
+    // By default, for these lighter hues, text (contrast) should be 'dark'.
+    'contrastDarkColors': '50 100 200 300 400 500 600 A100 A200 A400',
+    // By default, for these darker hues, text (contrast) should be white with 100% opacity.
+    'contrastStrongLightColors': '700 800 900 A700'
   });
 
   $mdThemingProvider.theme('default')
-    .primaryPalette('amazingPaletteName')
+    .primaryPalette('amazingDarkPaletteName')
+});
+</hljs>
 
+For a light colored, custom palette, you should specify the default contrast color as `dark`.
+Then `contrastStrongLightColors` can be used if any hues are too dark for dark text.
+
+<hljs lang="js">
+angular.module('myApp', ['ngMaterial'])
+.config(function($mdThemingProvider) {
+
+  $mdThemingProvider.definePalette('amazingLightPaletteName', {
+    '50': '#f1f8e9',
+    '100': '#dcedc8',
+    '200': '#c5e1a5',
+    '300': '#aed581',
+    '400': '#9ccc65',
+    '500': '#8bc34a',
+    '600': '#7cb342',
+    '700': '#689f38',
+    '800': '#558b2f',
+    '900': '#33691e',
+    'A100': '#ccff90',
+    'A200': '#b2ff59',
+    'A400': '#76ff03',
+    'A700': '#64dd17',
+    // By default, text (contrast) on this palette should be dark with 87% opacity.
+    'contrastDefaultColor': 'dark',
+    // By default, for these darker hues, text (contrast) should be white with 100% opacity.
+    'contrastStrongLightColors': '800 900'
+  });
+
+  $mdThemingProvider.theme('default')
+    .accentPalette('amazingLightPaletteName')
 });
 </hljs>
 

--- a/src/components/button/button-theme.scss
+++ b/src/components/button/button-theme.scss
@@ -52,21 +52,6 @@
       }
     }
   }
-  &.md-fab {
-    background-color: '{{accent-color}}';
-    color: '{{accent-contrast}}';
-    &:not([disabled]) {
-      .md-icon {
-        color: '{{accent-contrast}}';
-      }
-      &:hover {
-        background-color: '{{accent-A700}}';
-      }
-      &.md-focused {
-        background-color: '{{accent-A700}}';
-      }
-    }
-  }
 
   &.md-raised {
     color: '{{background-900}}';

--- a/src/components/button/demoBasicUsage/index.html
+++ b/src/components/button/demoBasicUsage/index.html
@@ -2,10 +2,10 @@
   <md-content>
 
     <section layout="row" layout-sm="column" layout-align="center center" layout-wrap>
-      <md-button>{{title1}}</md-button>
+      <md-button>Button</md-button>
       <md-button md-no-ink class="md-primary">Primary (md-noink)</md-button>
       <md-button ng-disabled="true" class="md-primary">Disabled</md-button>
-      <md-button class="md-warn">{{title4}}</md-button>
+      <md-button class="md-warn">Warn</md-button>
       <div class="label">Flat</div>
     </section>
     <md-divider></md-divider>
@@ -14,7 +14,7 @@
       <md-button class="md-raised">Button</md-button>
       <md-button class="md-raised md-primary">Primary</md-button>
       <md-button ng-disabled="true" class="md-raised md-primary">Disabled</md-button>
-      <md-button class="md-raised md-warn">Warn</md-button>
+      <md-button class="md-raised md-accent">Accent</md-button>
       <div class="label">Raised</div>
     </section>
     <md-divider></md-divider>
@@ -58,10 +58,10 @@
     <md-divider></md-divider>
 
     <section layout="row" layout-sm="column" layout-align="center center" layout-wrap>
-      <md-button class="md-primary md-hue-1">Primary Hue 1</md-button>
-      <md-button class="md-warn md-raised md-hue-2">Warn Hue 2</md-button>
-      <md-button class="md-accent">Accent</md-button>
-      <md-button class="md-accent md-raised md-hue-1">Accent Hue 1</md-button>
+      <md-button class="md-primary md-hue-2">Primary Hue 2</md-button>
+      <md-button class="md-warn md-raised md-hue-1">Warn Hue 1</md-button>
+      <md-button class="md-accent md-raised md-hue-2">Accent Hue 2</md-button>
+      <md-button class="md-accent md-hue-3">Accent Hue 3</md-button>
       <div class="label">Themed</div>
     </section>
     <md-divider></md-divider>

--- a/src/components/button/demoBasicUsage/script.js
+++ b/src/components/button/demoBasicUsage/script.js
@@ -1,7 +1,5 @@
 angular.module('buttonsDemoBasic', ['ngMaterial'])
 .controller('AppCtrl', function($scope) {
-  $scope.title1 = 'Button';
-  $scope.title4 = 'Warn';
   $scope.isDisabled = true;
   $scope.googleUrl = 'http://google.com';
 });

--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -13,5 +13,4 @@ section .md-button {
   bottom: 5px;
   left: 7px;
   font-size: 14px;
-  color: rgba(0, 0, 0, 0.54);
 }

--- a/src/components/button/demoBasicUsage/style.css
+++ b/src/components/button/demoBasicUsage/style.css
@@ -13,5 +13,5 @@ section .md-button {
   bottom: 5px;
   left: 7px;
   font-size: 14px;
-  opacity: 0.54;
+  color: rgba(0, 0, 0, 0.54);
 }

--- a/src/components/card/demoCardActionButtons/index.html
+++ b/src/components/card/demoCardActionButtons/index.html
@@ -90,7 +90,7 @@
       <md-card>
         <md-card-header>
           <md-card-avatar>
-            <img src="img/logo.svg"/>
+            <img src="img/logo.svg" alt="Washed Out"/>
           </md-card-avatar>
           <md-card-header-text>
             <span class="md-title">AngularJS</span>

--- a/src/components/card/demoInCardActions/index.html
+++ b/src/components/card/demoInCardActions/index.html
@@ -30,7 +30,7 @@
       <md-card>
         <md-card-header>
           <md-card-avatar>
-            <img class="md-user-avatar" src="img/100-2.jpeg"/>
+            <img class="md-user-avatar" src="img/100-2.jpeg" alt="Washed Out"/>
           </md-card-avatar>
           <md-card-header-text>
             <span class="md-title">User</span>

--- a/src/components/checkbox/checkbox-theme.scss
+++ b/src/components/checkbox/checkbox-theme.scss
@@ -28,7 +28,7 @@ md-checkbox.md-THEME_NAME-theme {
   }
 
   &.md-checked .md-icon:after {
-    border-color: '{{accent-contrast-0.87}}';
+    border-color: '{{background-default}}';
   }
 
   &:not([disabled]) {
@@ -60,10 +60,6 @@ md-checkbox.md-THEME_NAME-theme {
       &.md-checked.md-focused:not([disabled]) .md-container:before {
         background-color: '{{warn-color-0.26}}';
       }
-
-      &.md-checked .md-icon:after {
-        border-color: '{{background-200}}';
-      }
     }
   }
 
@@ -76,17 +72,8 @@ md-checkbox.md-THEME_NAME-theme {
       background-color: '{{foreground-3}}';
     }
 
-    &.md-checked .md-icon:after {
-      border-color: '{{background-200}}';
-    }
-
-    .md-icon:after {
-      border-color: '{{foreground-3}}';
-    }
-
     .md-label {
       color: '{{foreground-3}}';
     }
   }
-
 }

--- a/src/components/colors/colors.js
+++ b/src/components/colors/colors.js
@@ -5,7 +5,7 @@
    *  Use a RegExp to check if the `md-colors="<expression>"` is static string
    *  or one that should be observed and dynamically interpolated.
    */
-  var STATIC_COLOR_EXPRESSION = /^{((\s|,)*?["'a-zA-Z-]+?\s*?:\s*?('|")[a-zA-Z0-9-.]*('|"))+\s*}$/;
+  var STATIC_COLOR_EXPRESSION = /^{((\s|,)*?["'a-zA-Z-]+?\s*?:\s*?(['"])[a-zA-Z0-9-.]*(['"]))+\s*}$/;
   var colorPalettes = null;
 
   /**

--- a/src/components/colors/demoBasicUsage/index.html
+++ b/src/components/colors/demoBasicUsage/index.html
@@ -1,6 +1,6 @@
 <div layout="column" ng-cloak class="md-padding">
   <p style="margin-bottom: 10px;">
-    Custom component implementations using Material elements often want to easily apply theme colors
+    Custom component implementations using Material elements often want to apply theme colors
     to their custom components. Consider the custom <code>&lt;user-card&gt;</code> component below
     where the <code>md-colors</code> attribute is used to color the background and text colors
     using either the current or specified theme palette colors.
@@ -18,7 +18,7 @@
   <p class="footnote">
     Note: The <code>md-colors</code> directive allows pre-defined theme colors to be applied
     as CSS style properties. <code>md-colors</code> uses the palettes defined in the
-    <a class="md-accent" href="https://material.io/archive/guidelines/style/color.html#color-color-palette">
+    <a href="https://material.io/archive/guidelines/style/color.html#color-color-palette">
       Material Design Colors</a> and the themes defined using <code>$mdThemingProvider</code>.
     This directive is an extension of the <code>$mdTheming</code> features.
   </p>

--- a/src/components/colors/demoThemePicker/index.html
+++ b/src/components/colors/demoThemePicker/index.html
@@ -1,12 +1,12 @@
 <div layout="column" ng-cloak ng-controller="ThemeDemoCtrl" class="md-padding">
   <p>
-    Select two of the <a class="md-accent" href="{{mdURL}}">Material Palettes</a>
+    Select two of the <a href="{{mdURL}}">Material Palettes</a>
     below:
   </p>
   <!-- Theme Options -->
   <div layout="row" layout-wrap layout-align="center center">
     <md-button ng-repeat="color in colors" flex-gt-md="15" flex="30"
-               md-colors="{background: '{{color}}'}" md-colors-watch="false"
+               md-colors="{background: '{{color}}-400'}" md-colors-watch="false"
                ng-disabled="primary === color && !isPrimary" ng-click="selectTheme(color)">
       {{color}}
     </md-button>

--- a/src/components/input/input-theme.scss
+++ b/src/components/input/input-theme.scss
@@ -1,6 +1,6 @@
 md-input-container.md-THEME_NAME-theme {
   .md-input {
-    @include input-placeholder-color('\'{{background-default-contrast-hint}}\'');
+    @include input-placeholder-color('\'{{background-default-contrast-secondary}}\'');
     color: '{{background-default-contrast}}';
     border-color: '{{background-default-contrast-divider}}';
   }
@@ -11,7 +11,7 @@ md-input-container.md-THEME_NAME-theme {
 
   label,
   .md-placeholder {
-    color: '{{background-default-contrast-hint}}';
+    color: '{{background-default-contrast-secondary}}';
   }
 
   label.md-required:after {

--- a/src/components/subheader/subheader-theme.scss
+++ b/src/components/subheader/subheader-theme.scss
@@ -1,5 +1,5 @@
 .md-subheader.md-THEME_NAME-theme {
-  color: '{{ foreground-2-0.23 }}';
+  color: '{{ foreground-2-0.54 }}';
   background-color: '{{background-default}}';
 
   &.md-primary {

--- a/src/components/toolbar/demoInputsInToolbar/index.html
+++ b/src/components/toolbar/demoInputsInToolbar/index.html
@@ -9,15 +9,15 @@
       </span>
       <md-input-container md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="primary" />
+        <input placeholder="primary" aria-label="primary" />
       </md-input-container>
       <md-input-container class="md-accent" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="accent" />
+        <input placeholder="accent" aria-label="accent" />
       </md-input-container>
       <md-input-container class="md-warn" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="warn" />
+        <input placeholder="warn" aria-label="warn" />
       </md-input-container>
     </header>
   </md-toolbar>
@@ -31,15 +31,15 @@
       </span>
       <md-input-container md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="primary" />
+        <input placeholder="primary" aria-label="primary" />
       </md-input-container>
       <md-input-container class="md-accent" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="accent" />
+        <input placeholder="accent" aria-label="accent" />
       </md-input-container>
       <md-input-container class="md-warn" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="warn" />
+        <input placeholder="warn" aria-label="warn" />
       </md-input-container>
     </header>
   </md-toolbar>
@@ -53,27 +53,27 @@
       </span>
       <md-input-container md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="primary" />
+        <input placeholder="primary" aria-label="primary" />
       </md-input-container>
       <md-input-container class="md-accent" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="accent" />
+        <input placeholder="accent" aria-label="accent" />
       </md-input-container>
       <md-input-container class="md-warn" md-no-float>
         <md-icon md-svg-src="img/icons/ic_person_24px.svg"></md-icon>
-        <input placeholder="warn" />
+        <input placeholder="warn" aria-label="warn" />
       </md-input-container>
     </header>
   </md-toolbar>
   <md-content class="md-margin">
     <md-input-container md-no-float>
-      <input placeholder="primary no float" />
+      <input placeholder="primary no float" aria-label="primary no float" />
     </md-input-container>
     <md-input-container>
-      <input placeholder="primary" />
+      <input placeholder="primary" aria-label="primary" />
     </md-input-container>
     <md-input-container class="md-accent">
-      <input placeholder="accent" />
+      <input placeholder="accent" aria-label="accent" />
     </md-input-container>
   </md-content>
 </div>

--- a/src/components/toolbar/toolbar-theme.scss
+++ b/src/components/toolbar/toolbar-theme.scss
@@ -107,6 +107,11 @@ md-toolbar.md-THEME_NAME-theme:not(.md-menu-toolbar) {
     background-color: '{{warn-color}}';
     color: '{{warn-contrast}}';
 
+    md-icon {
+      color: '{{accent-contrast}}';
+      fill: '{{accent-contrast}}';
+    }
+
     md-input-container[md-no-float] {
       .md-input {
         @include input-placeholder-color('\'{{warn-default-contrast-hint}}\'');

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -59,7 +59,7 @@ function rAFDecorator($delegate) {
    * our callback will only be fired once per frame, with the last resize
    * event that happened before that frame.
    *
-   * @param {function} callback function to debounce
+   * @param {function} cb function to debounce
    */
   $delegate.throttle = function(cb) {
     var queuedArgs, alreadyQueued, queueCb, context;

--- a/src/core/services/theming/theme.palette.js
+++ b/src/core/services/theming/theme.palette.js
@@ -16,8 +16,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#ff1744',
     'A700': '#d50000',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 300 A100',
-    'contrastStrongLightColors': '400 500 600 700 800 900 A200 A400 A700'
+    'contrastDarkColors': '50 100 200 300 400 500 600 A100 A200 A400',
+    'contrastStrongLightColors': '700 800 900 A700'
   },
   'pink': {
     '50': '#fce4ec',
@@ -35,8 +35,10 @@ angular.module('material.core.theming.palette', [])
     'A400': '#f50057',
     'A700': '#c51162',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
+    'contrastDarkColors': '50 100 200 300 400 A100 A200 A400',
+    // White on 500 does not meet the minimum 4.5 contrast ratio (at 4.34),
+    // but it's worse with a dark foreground (3.61).
+    'contrastStrongLightColors': '500 600 700 800 900 A700'
   },
   'purple': {
     '50': '#f3e5f5',
@@ -54,8 +56,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#d500f9',
     'A700': '#aa00ff',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
+    'contrastDarkColors': '50 100 200 300 A100 A200 A400',
+    'contrastStrongLightColors': '400 500 600 700 800 900 A700'
   },
   'deep-purple': {
     '50': '#ede7f6',
@@ -73,8 +75,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#651fff',
     'A700': '#6200ea',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
+    'contrastDarkColors': '50 100 200 300 A100',
+    'contrastStrongLightColors': '400 500 600 700 800 900 A200 A400 A700'
   },
   'indigo': {
     '50': '#e8eaf6',
@@ -92,8 +94,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#3d5afe',
     'A700': '#304ffe',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
+    'contrastDarkColors': '50 100 200 300 A100 A200',
+    'contrastStrongLightColors': '400 500 600 700 800 900 A400 A700'
   },
   'blue': {
     '50': '#e3f2fd',
@@ -111,8 +113,10 @@ angular.module('material.core.theming.palette', [])
     'A400': '#2979ff',
     'A700': '#2962ff',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 300 400 A100',
-    'contrastStrongLightColors': '500 600 700 800 900 A200 A400 A700'
+    // White on A400 does not meet the minimum 4.5 contrast ratio (at 3.98),
+    // but it's worse with a dark foreground (3.94).
+    'contrastDarkColors': '50 100 200 300 400 500 600 A100 A200',
+    'contrastStrongLightColors': '700 800 900 A400 A700'
   },
   'light-blue': {
     '50': '#e1f5fe',
@@ -130,8 +134,10 @@ angular.module('material.core.theming.palette', [])
     'A400': '#00b0ff',
     'A700': '#0091ea',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '600 700 800 900 A700',
-    'contrastStrongLightColors': '600 700 800 900 A700'
+    // Dark on 700 does not meet the minimum 4.5 contrast ratio (at 4.07),
+    // but it's worse with a white foreground (3.85).
+    'contrastLightColors': '800 900 A700',
+    'contrastStrongLightColors': '800 900 A700'
   },
   'cyan': {
     '50': '#e0f7fa',
@@ -149,8 +155,10 @@ angular.module('material.core.theming.palette', [])
     'A400': '#00e5ff',
     'A700': '#00b8d4',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '700 800 900',
-    'contrastStrongLightColors': '700 800 900'
+    // Dark on 700 does not meet the minimum 4.5 contrast ratio (at 4.47),
+    // but it's worse with a white foreground (3.5).
+    'contrastLightColors': '800 900',
+    'contrastStrongLightColors': '800 900'
   },
   'teal': {
     '50': '#e0f2f1',
@@ -168,8 +176,12 @@ angular.module('material.core.theming.palette', [])
     'A400': '#1de9b6',
     'A700': '#00bfa5',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '500 600 700 800 900',
-    'contrastStrongLightColors': '500 600 700 800 900'
+    // Dark on 500 does not meet the minimum 4.5 contrast ratio (at 4.27),
+    // but it's worse with a white foreground (3.67).
+    // White on 600 does not meet the minimum 4.5 contrast ratio (at 4.31),
+    // but it's worse with a dark foreground (3.64).
+    'contrastLightColors': '600 700 800 900',
+    'contrastStrongLightColors': '600 700 800 900'
   },
   'green': {
     '50': '#e8f5e9',
@@ -187,8 +199,10 @@ angular.module('material.core.theming.palette', [])
     'A400': '#00e676',
     'A700': '#00c853',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '600 700 800 900',
-    'contrastStrongLightColors': '600 700 800 900'
+    // White on 700 does not meet the minimum 4.5 contrast ratio (at 4.11),
+    // but it's worse with a dark foreground (3.81).
+    'contrastLightColors': '700 800 900',
+    'contrastStrongLightColors': '700 800 900'
   },
   'light-green': {
     '50': '#f1f8e9',
@@ -206,8 +220,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#76ff03',
     'A700': '#64dd17',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '700 800 900',
-    'contrastStrongLightColors': '700 800 900'
+    'contrastLightColors': '800 900',
+    'contrastStrongLightColors': '800 900'
   },
   'lime': {
     '50': '#f9fbe7',
@@ -278,8 +292,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#ff9100',
     'A700': '#ff6d00',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '800 900',
-    'contrastStrongLightColors': '800 900'
+    'contrastLightColors': '900',
+    'contrastStrongLightColors': '900'
   },
   'deep-orange': {
     '50': '#fbe9e7',
@@ -296,9 +310,12 @@ angular.module('material.core.theming.palette', [])
     'A200': '#ff6e40',
     'A400': '#ff3d00',
     'A700': '#dd2c00',
-    'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 300 400 A100 A200',
-    'contrastStrongLightColors': '500 600 700 800 900 A400 A700'
+    'contrastDefaultColor': 'dark',
+    // Dark on 700 does not meet the minimum 4.5 contrast ratio (at 4.01),
+    // but it's worse with a white foreground (3.91).
+    // White on 800 does not meet the minimum 4.5 contrast ratio (at 4.43),
+    // but it's worse with a dark foreground (3.54).
+    'contrastLightColors': '800 900 A400 A700',
   },
   'brown': {
     '50': '#efebe9',
@@ -316,8 +333,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#8d6e63',
     'A700': '#5d4037',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 A100 A200',
-    'contrastStrongLightColors': '300 400 500 600 700 800 900 A400 A700'
+    'contrastDarkColors': '50 100 200 300 A100 A200',
+    'contrastStrongLightColors': '400 500 600 700 800 900 A400 A700'
   },
   'grey': {
     '50': '#fafafa',
@@ -335,7 +352,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#303030',
     'A700': '#616161',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '600 700 800 900 A200 A400 A700'
+    'contrastLightColors': '600 700 800 900 A200 A400 A700',
+    'contrastStrongLightColors': '600'
   },
   'blue-grey': {
     '50': '#eceff1',
@@ -353,7 +371,9 @@ angular.module('material.core.theming.palette', [])
     'A400': '#78909c',
     'A700': '#455a64',
     'contrastDefaultColor': 'light',
-    'contrastDarkColors': '50 100 200 300 A100 A200',
-    'contrastStrongLightColors': '400 500 600 700 800 900 A400 A700'
+    'contrastDarkColors': '50 100 200 300 400 A100 A200 A400',
+    // White on 500 does not meet the minimum 4.5 contrast ratio (at 4.37),
+    // but it's worse with a dark foreground.
+    'contrastStrongLightColors': '500 600 700 800 900 A700'
   }
 });

--- a/src/core/services/theming/theme.palette.js
+++ b/src/core/services/theming/theme.palette.js
@@ -17,7 +17,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#d50000',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 300 A100',
-    'contrastStrongLightColors': '400 500 600 700 A200 A400 A700'
+    'contrastStrongLightColors': '400 500 600 700 800 900 A200 A400 A700'
   },
   'pink': {
     '50': '#fce4ec',
@@ -36,7 +36,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#c51162',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '500 600 A200 A400 A700'
+    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
   },
   'purple': {
     '50': '#f3e5f5',
@@ -55,7 +55,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#aa00ff',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 A200 A400 A700'
+    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
   },
   'deep-purple': {
     '50': '#ede7f6',
@@ -74,7 +74,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#6200ea',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 A200'
+    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
   },
   'indigo': {
     '50': '#e8eaf6',
@@ -93,7 +93,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#304ffe',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 A100',
-    'contrastStrongLightColors': '300 400 A200 A400'
+    'contrastStrongLightColors': '300 400 500 600 700 800 900 A200 A400 A700'
   },
   'blue': {
     '50': '#e3f2fd',
@@ -112,7 +112,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#2962ff',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 300 400 A100',
-    'contrastStrongLightColors': '500 600 700 A200 A400 A700'
+    'contrastStrongLightColors': '500 600 700 800 900 A200 A400 A700'
   },
   'light-blue': {
     '50': '#e1f5fe',
@@ -131,7 +131,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#0091ea',
     'contrastDefaultColor': 'dark',
     'contrastLightColors': '600 700 800 900 A700',
-    'contrastStrongLightColors': '600 700 800 A700'
+    'contrastStrongLightColors': '600 700 800 900 A700'
   },
   'cyan': {
     '50': '#e0f7fa',
@@ -169,7 +169,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#00bfa5',
     'contrastDefaultColor': 'dark',
     'contrastLightColors': '500 600 700 800 900',
-    'contrastStrongLightColors': '500 600 700'
+    'contrastStrongLightColors': '500 600 700 800 900'
   },
   'green': {
     '50': '#e8f5e9',
@@ -187,8 +187,8 @@ angular.module('material.core.theming.palette', [])
     'A400': '#00e676',
     'A700': '#00c853',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '500 600 700 800 900',
-    'contrastStrongLightColors': '500 600 700'
+    'contrastLightColors': '600 700 800 900',
+    'contrastStrongLightColors': '600 700 800 900'
   },
   'light-green': {
     '50': '#f1f8e9',
@@ -317,7 +317,7 @@ angular.module('material.core.theming.palette', [])
     'A700': '#5d4037',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 A100 A200',
-    'contrastStrongLightColors': '300 400'
+    'contrastStrongLightColors': '300 400 500 600 700 800 900 A400 A700'
   },
   'grey': {
     '50': '#fafafa',
@@ -354,6 +354,6 @@ angular.module('material.core.theming.palette', [])
     'A700': '#455a64',
     'contrastDefaultColor': 'light',
     'contrastDarkColors': '50 100 200 300 A100 A200',
-    'contrastStrongLightColors': '400 500 700'
+    'contrastStrongLightColors': '400 500 600 700 800 900 A400 A700'
   }
 });

--- a/src/core/services/theming/theme.palette.js
+++ b/src/core/services/theming/theme.palette.js
@@ -136,7 +136,6 @@ angular.module('material.core.theming.palette', [])
     'contrastDefaultColor': 'dark',
     // Dark on 700 does not meet the minimum 4.5 contrast ratio (at 4.07),
     // but it's worse with a white foreground (3.85).
-    'contrastLightColors': '800 900 A700',
     'contrastStrongLightColors': '800 900 A700'
   },
   'cyan': {
@@ -157,7 +156,6 @@ angular.module('material.core.theming.palette', [])
     'contrastDefaultColor': 'dark',
     // Dark on 700 does not meet the minimum 4.5 contrast ratio (at 4.47),
     // but it's worse with a white foreground (3.5).
-    'contrastLightColors': '800 900',
     'contrastStrongLightColors': '800 900'
   },
   'teal': {
@@ -180,7 +178,6 @@ angular.module('material.core.theming.palette', [])
     // but it's worse with a white foreground (3.67).
     // White on 600 does not meet the minimum 4.5 contrast ratio (at 4.31),
     // but it's worse with a dark foreground (3.64).
-    'contrastLightColors': '600 700 800 900',
     'contrastStrongLightColors': '600 700 800 900'
   },
   'green': {
@@ -201,7 +198,6 @@ angular.module('material.core.theming.palette', [])
     'contrastDefaultColor': 'dark',
     // White on 700 does not meet the minimum 4.5 contrast ratio (at 4.11),
     // but it's worse with a dark foreground (3.81).
-    'contrastLightColors': '700 800 900',
     'contrastStrongLightColors': '700 800 900'
   },
   'light-green': {
@@ -220,7 +216,6 @@ angular.module('material.core.theming.palette', [])
     'A400': '#76ff03',
     'A700': '#64dd17',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '800 900',
     'contrastStrongLightColors': '800 900'
   },
   'lime': {
@@ -239,7 +234,6 @@ angular.module('material.core.theming.palette', [])
     'A400': '#c6ff00',
     'A700': '#aeea00',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '900',
     'contrastStrongLightColors': '900'
   },
   'yellow': {
@@ -292,7 +286,6 @@ angular.module('material.core.theming.palette', [])
     'A400': '#ff9100',
     'A700': '#ff6d00',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '900',
     'contrastStrongLightColors': '900'
   },
   'deep-orange': {
@@ -315,7 +308,7 @@ angular.module('material.core.theming.palette', [])
     // but it's worse with a white foreground (3.91).
     // White on 800 does not meet the minimum 4.5 contrast ratio (at 4.43),
     // but it's worse with a dark foreground (3.54).
-    'contrastLightColors': '800 900 A400 A700',
+    'contrastStrongLightColors': '800 900 A400 A700',
   },
   'brown': {
     '50': '#efebe9',
@@ -352,7 +345,7 @@ angular.module('material.core.theming.palette', [])
     'A400': '#303030',
     'A700': '#616161',
     'contrastDefaultColor': 'dark',
-    'contrastLightColors': '600 700 800 900 A200 A400 A700',
+    'contrastLightColors': '700 800 900 A200 A400 A700',
     'contrastStrongLightColors': '600'
   },
   'blue-grey': {

--- a/src/core/services/theming/theming.js
+++ b/src/core/services/theming/theming.js
@@ -1217,8 +1217,13 @@ function generateAllThemes($injector, $mdTheming) {
     delete palette.contrastStrongLightColors;
     delete palette.contrastDarkColors;
 
+    /**
+     * @param {string} hueName
+     * @return {'dark'|'light'|'strongLight'}
+     */
     function getContrastType(hueName) {
-      if (defaultContrast === 'light' ? darkColors.indexOf(hueName) !== -1  : lightColors.indexOf(hueName) === -1) {
+      if (defaultContrast === 'light' ? darkColors.indexOf(hueName) !== -1  :
+        (lightColors.indexOf(hueName) === -1 && strongLightColors.indexOf(hueName) === -1)) {
         return 'dark';
       }
       if (strongLightColors.indexOf(hueName) !== -1) {
@@ -1226,6 +1231,11 @@ function generateAllThemes($injector, $mdTheming) {
       }
       return 'light';
     }
+
+    /**
+     * @param {'dark'|'light'|'strongLight'} contrastType
+     * @return {[number, number, number]} [red, green, blue] array
+     */
     function getContrastColor(contrastType) {
       switch (contrastType) {
         default:
@@ -1237,6 +1247,11 @@ function generateAllThemes($injector, $mdTheming) {
           return DARK_CONTRAST_COLOR;
       }
     }
+
+    /**
+     * @param {'dark'|'light'|'strongLight'} contrastType
+     * @return {{secondary: number, divider: number, hint: number, icon: number, disabled: number}}
+     */
     function getOpacityValues(contrastType) {
       switch (contrastType) {
         default:
@@ -1313,6 +1328,10 @@ function checkValidPalette(theme, colorType) {
   }
 }
 
+/**
+ * @param {string} clr rbg or rgba color
+ * @return {number[]|undefined} [red, green, blue] array if it can be computed
+ */
 function colorToRgbaArray(clr) {
   if (angular.isArray(clr) && clr.length === 3) return clr;
   if (/^rgb/.test(clr)) {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- The contrasts of our color palettes do not meet AA standards (4.5+ ratio).
- `md-toolbar`s with the `md-warn` class don't properly theme `md-icons`
- There are a number of a11y issues with the demos.
- `md-subheader` text does not meet AA standards (4.5+ ratio) due to low opacity.
- `md-input` labels and placeholders do not meet AA standards (4.5+ ratio) due to low opacity.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #8992. Fixes #10164. Closes #8993

## What is the new behavior?
- align color palettes and contrasts with AA standards
- properly theme `md-icon`s in toolbars with `md-warn`
- all colors and their contrasts meet 4.5 contrast ratio requirements
  - except a few edge cases which have comments to explain them
- add `aria-labels` to demoInputsInToolbar
- increase opacity of subheader text to meet AA contrast ratio requirements
- increase opacity of input placeholders and labels to meet AA contrast ratio requirements
- minor regexp adjustments for `md-colors`
- fix colors/demoThemePicker and colors/demoBasicUsage to pass Lighthouse a11y audit
- update button/demoBasicUsage to pass Lighthouse a11y audit
- add missing alt tag in demoInCardActions and demoCardActionButtons
- adjust docs app theme to define valid contrast colors for `docs-blue`
- fix inaccurate JSDoc

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
I did a lot of extensive testing of this on the docs site using Chrome DevTools contrast checks, Lighthouse A11y Audits, and the [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/).