### PR TITLE
1.2.0 deprecation removals, Part 1

### DIFF
--- a/src/components/chips/js/chipsController.js
+++ b/src/components/chips/js/chipsController.js
@@ -806,18 +806,6 @@ MdChipsCtrl.prototype.selectChip = function(index) {
 };
 
 /**
- * Selects the chip at {@code index} and gives it focus.
- * @param {number} index location of chip to select and focus
- * @deprecated use MdChipsCtrl.selectAndFocusChipSafe. Will be removed in 1.2.
- */
-MdChipsCtrl.prototype.selectAndFocusChip = function(index) {
-  this.selectChip(index);
-  if (index !== -1) {
-    this.focusChip(index);
-  }
-};
-
-/**
  * Call {@code focus()} on the chip at {@code index}
  * @param {number} index location of chip to focus
  */

--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -157,8 +157,7 @@ angular.module('material.components.select', [
  * </div>
  * </hljs>
  */
-function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $parse, $sce,
-    $injector) {
+function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $parse, $sce) {
   return {
     restrict: 'E',
     require: ['^?mdInputContainer', 'mdSelect', 'ngModel', '?^form'],
@@ -167,6 +166,11 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
     } // empty placeholder controller to be initialized in link
   };
 
+  /**
+   * @param {JQLite} tElement
+   * @param {IAttributes} tAttrs
+   * @return {postLink}
+   */
   function compile(tElement, tAttrs) {
     var isMultiple = $mdUtil.parseAttributeBoolean(tAttrs.multiple);
     // add the select value that will hold our placeholder or selected option value
@@ -271,7 +275,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       var selectValueElement = element.find('md-select-value');
       var isReadonly = angular.isDefined(attrs.readonly);
       var disableAsterisk = $mdUtil.parseAttributeBoolean(attrs.mdNoAsterisk);
-      var stopNgMultipleWatch;
+      var stopMdMultipleWatch;
       var userDefinedLabelledby = angular.isDefined(attrs.ariaLabelledby);
       var listboxContentElement = element.find('md-content');
 
@@ -390,7 +394,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
         } else {
           selectValueElement.removeAttr('aria-hidden');
           if (!userDefinedLabelledby) {
-            element.attr('aria-labelledby', element[0].id + ' ' + selectValueElement[0].id)
+            element.attr('aria-labelledby', element[0].id + ' ' + selectValueElement[0].id);
           }
         }
       };
@@ -428,7 +432,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
           containerCtrl && containerCtrl.setFocused(false);
           inputCheckValue();
         };
-        var handleFocus = function(ev) {
+        var handleFocus = function() {
           // Always focus the container (if we have one) so floating labels and other styles are
           // applied properly
           containerCtrl && containerCtrl.setFocused(true);
@@ -465,15 +469,14 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
         mdSelectCtrl.setSelectValueText(selectMenuCtrl.getSelectedLabels());
       }
 
-      // TODO add tests for ngMultiple
-      // TODO add docs for ngMultiple
-      // TODO in 1.2.0 rename this to mdMultiple
-      var stopNgMultipleObserver = attrs.$observe('ngMultiple', function(val) {
-        if (stopNgMultipleWatch) {
-          stopNgMultipleWatch();
+      // TODO add tests for mdMultiple
+      // TODO add docs for mdMultiple
+      var stopMdMultipleObserver = attrs.$observe('mdMultiple', function(val) {
+        if (stopMdMultipleWatch) {
+          stopMdMultipleWatch();
         }
         var parser = $parse(val);
-        stopNgMultipleWatch = scope.$watch(function() {
+        stopMdMultipleWatch = scope.$watch(function() {
           return parser(scope);
         }, function(multiple, prevVal) {
           var selectMenu = selectContainer.find('md-select-menu');
@@ -561,8 +564,8 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       scope.$on('$destroy', function() {
         stopRequiredObserver && stopRequiredObserver();
         stopDisabledObserver && stopDisabledObserver();
-        stopNgMultipleWatch && stopNgMultipleWatch();
-        stopNgMultipleObserver && stopNgMultipleObserver();
+        stopMdMultipleWatch && stopMdMultipleWatch();
+        stopMdMultipleObserver && stopMdMultipleObserver();
         stopSelectedLabelsWatcher && stopSelectedLabelsWatcher();
         stopPlaceholderObserver && stopPlaceholderObserver();
         stopInvalidWatch && stopInvalidWatch();
@@ -1207,6 +1210,11 @@ function OptionDirective($mdButtonInkRipple, $mdUtil, $mdTheming) {
     compile: compile
   };
 
+  /**
+   * @param {JQLite} element
+   * @param {IAttributes} attrs
+   * @return {postLink}
+   */
   function compile(element, attrs) {
     // Manual transclusion to avoid the extra inner <span> that ng-transclude generates
     element.append(angular.element('<div class="md-text">').append(element.contents()));
@@ -1332,6 +1340,10 @@ function OptionDirective($mdButtonInkRipple, $mdUtil, $mdTheming) {
   }
 }
 
+/**
+ * @param {JQLite} $element
+ * @constructor
+ */
 function OptionController($element) {
   /**
    * @param {boolean} isSelected
@@ -1757,7 +1769,6 @@ function SelectProvider($$interimElementProvider) {
 
         var dropDown = opts.selectEl;
         var selectMenuController = dropDown.controller('mdSelectMenu') || {};
-        var listbox = opts.contentEl;
 
         element.addClass('md-clickable');
 

--- a/src/components/toast/toast.js
+++ b/src/components/toast/toast.js
@@ -336,7 +336,7 @@ function MdToastProvider($$interimElementProvider) {
     })
     .addPreset('simple', {
       argOption: 'textContent',
-      methods: ['textContent', 'content', 'action', 'actionKey', 'actionHint', 'highlightAction',
+      methods: ['textContent', 'action', 'actionKey', 'actionHint', 'highlightAction',
                 'highlightClass', 'theme', 'parent', 'dismissHint'],
       options: /* @ngInject */ function($mdToast, $mdTheming) {
         return {
@@ -363,10 +363,7 @@ function MdToastProvider($$interimElementProvider) {
         };
       }
     })
-    .addMethod('updateTextContent', updateTextContent)
-    // updateContent is deprecated. Use updateTextContent instead.
-    // TODO remove this in 1.2.
-    .addMethod('updateContent', updateTextContent);
+    .addMethod('updateTextContent', updateTextContent);
 
     function updateTextContent(newContent) {
       activeToastContent = newContent;
@@ -466,9 +463,7 @@ function MdToastProvider($$interimElementProvider) {
      * @return {*}
      */
     function onShow(scope, element, options) {
-      // support deprecated #content method
-      // TODO remove support for content in 1.2.
-      activeToastContent = options.textContent || options.content;
+      activeToastContent = options.textContent;
 
       var isSmScreen = !$mdMedia('gt-sm');
 

--- a/src/components/toast/toast.spec.js
+++ b/src/components/toast/toast.spec.js
@@ -15,8 +15,8 @@ describe('$mdToast service', function() {
   }));
 
   function setup(options) {
-    var promise;
-    inject(function($mdToast, $material, $timeout) {
+    var promise = null;
+    inject(function($mdToast, $material) {
       options = options || {};
       promise = $mdToast.show(options);
       $material.flushOutstandingAnimations();
@@ -26,7 +26,7 @@ describe('$mdToast service', function() {
 
   describe('simple()', function() {
 
-    hasConfigMethods(['content', 'action', 'capsule', 'highlightAction', 'theme', 'toastClass']);
+    hasConfigMethods(['textContent', 'action', 'capsule', 'highlightAction', 'theme', 'toastClass']);
 
     it('should have `._md` class indicator', inject(function($mdToast, $material) {
       var parent = angular.element('<div>');
@@ -34,7 +34,7 @@ describe('$mdToast service', function() {
       $mdToast.show(
         $mdToast.simple({
           parent: parent,
-          content: 'Do something',
+          textContent: 'Do something',
           theme: 'some-theme',
           capsule: true
       }));
@@ -43,18 +43,18 @@ describe('$mdToast service', function() {
       expect(parent.find('md-toast').hasClass('_md')).toBe(true);
     }));
 
-    it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $material, $browser) {
-      var openAndclosed = false;
+    it('supports a basic toast', inject(function($mdToast, $rootScope, $timeout, $material) {
+      var openAndClosed = false;
       var parent = angular.element('<div>');
       $mdToast.show(
         $mdToast.simple({
           parent: parent,
-          content: 'Do something',
+          textContent: 'Do something',
           theme: 'some-theme',
           capsule: true
         })
       ).then(function() {
-        openAndclosed = true;
+        openAndClosed = true;
       });
 
       $material.flushOutstandingAnimations();
@@ -66,11 +66,10 @@ describe('$mdToast service', function() {
 
       $material.flushInterimElement();
 
-      expect(openAndclosed).toBe(true);
+      expect(openAndClosed).toBe(true);
     }));
 
     it('supports dynamically updating the content', inject(function($mdToast, $rootScope, $rootElement) {
-      var parent = angular.element('<div>');
       $mdToast.showSimple('Hello world');
       $rootScope.$digest();
       $mdToast.updateTextContent('Goodbye world');
@@ -83,7 +82,7 @@ describe('$mdToast service', function() {
       var parent = angular.element('<div>');
       $mdToast.show(
         $mdToast.simple({
-          content: 'Do something',
+          textContent: 'Do something',
           parent: parent
         })
           .action('Click me')
@@ -104,7 +103,7 @@ describe('$mdToast service', function() {
 
       $mdToast.show(
         $mdToast.simple({
-            content: 'Marked as read',
+            textContent: 'Marked as read',
             parent: parent
           })
           .action('UNDO')
@@ -142,7 +141,7 @@ describe('$mdToast service', function() {
       it('displays correctly', inject(function($mdToast, $rootScope) {
         var parent = angular.element('<div>');
         var toast = $mdToast.simple({
-          content: 'Do something',
+          textContent: 'Do something',
           parent: parent
         }).action('Click me');
 
@@ -160,7 +159,7 @@ describe('$mdToast service', function() {
       it('displays correctly with parent()', inject(function($mdToast, $rootScope) {
               var parent = angular.element('<div>');
               var toast = $mdToast.simple({
-                content: 'Do something',
+                textContent: 'Do something',
               })
               .parent(parent)
               .action('Click me');
@@ -334,7 +333,6 @@ describe('$mdToast service', function() {
       it('after duration', inject(function($timeout, $animate, $rootElement) {
         disableAnimations();
 
-        var parent = angular.element('<div>');
         var hideDelay = 1234;
         setup({
           template: '<md-toast />',
@@ -348,7 +346,7 @@ describe('$mdToast service', function() {
       it('and resolve with default `true`', inject(function($timeout, $material, $mdToast) {
         disableAnimations();
 
-        var hideDelay = 1234, result, fault;
+        var result = null, fault = null;
         setup({
           template: '<md-toast />',
           hideDelay: 1234
@@ -361,15 +359,14 @@ describe('$mdToast service', function() {
 
         $material.flushInterimElement();
 
-        expect(result).toBe(undefined);
-        expect(angular.isUndefined(fault)).toBe(true);
-
+        expect(angular.isUndefined(result)).toBe(true);
+        expect(fault).toBe(null);
       }));
 
       it('and resolve with specified value', inject(function($timeout, $animate, $material, $mdToast) {
         disableAnimations();
 
-        var hideDelay = 1234, result, fault;
+        var result = null, fault = null;
         setup({
           template: '<md-toast />',
           hideDelay: 1234
@@ -383,14 +380,13 @@ describe('$mdToast service', function() {
         $material.flushInterimElement();
 
         expect(result).toBe("secret");
-        expect(angular.isUndefined(fault)).toBe(true);
-
+        expect(fault).toBe(null);
       }));
 
       it('and resolve `true` after timeout', inject(function($timeout, $material) {
         disableAnimations();
 
-        var hideDelay = 1234, result, fault;
+        var result = null, fault = null;
         setup({
           template: '<md-toast />',
           hideDelay: 1234
@@ -401,17 +397,16 @@ describe('$mdToast service', function() {
 
         $material.flushInterimElement();
 
-        expect(result).toBe(undefined);
-        expect(angular.isUndefined(fault)).toBe(true);
-
+        expect(angular.isUndefined(result)).toBe(true);
+        expect(fault).toBe(null);
       }));
 
-      it('and resolve `ok` with click on OK button', inject(function($mdToast, $rootScope, $timeout, $material, $browser) {
-        var result, fault;
+      it('and resolve `ok` with click on OK button', inject(function($mdToast, $rootScope, $timeout, $material) {
+        var result = null, fault = null;
         var parent = angular.element('<div>');
         var toast = $mdToast.simple({
           parent: parent,
-          content: 'Do something'
+          textContent: 'Do something'
         }).action('Close with "ok" response');
 
         $mdToast
@@ -428,7 +423,7 @@ describe('$mdToast service', function() {
         $material.flushInterimElement();
 
         expect(result).toBe('ok');
-        expect(angular.isUndefined(fault)).toBe(true);
+        expect(fault).toBe(null);
       }));
     });
 

--- a/src/core/services/compiler/compiler.js
+++ b/src/core/services/compiler/compiler.js
@@ -8,191 +8,8 @@ angular
   .module('material.core')
   .provider('$mdCompiler', MdCompilerProvider);
 
-/**
- * @ngdoc service
- * @name $mdCompilerProvider
- * @module material.core.compiler
- * @description
- * The `$mdCompiler` is able to respect the AngularJS `$compileProvider.preAssignBindingsEnabled`
- * state when using AngularJS versions greater than or equal to 1.5.10 and less than 1.7.0.
- * See the [AngularJS documentation for `$compileProvider.preAssignBindingsEnabled`
- * ](https://code.angularjs.org/1.6.10/docs/api/ng/provider/$compileProvider#preAssignBindingsEnabled)
- * for more information.
- *
- * To enable/disable whether the controllers of dynamic AngularJS Material components
- * (i.e. dialog, panel, toast, bottomsheet) respect the AngularJS
- * `$compileProvider.preAssignBindingsEnabled` flag, call the AngularJS Material method:
- * `$mdCompilerProvider.respectPreAssignBindingsEnabled(boolean)`.
- *
- * This AngularJS Material *flag* doesn't affect directives/components created via regular
- * AngularJS methods. These constitute the majority of AngularJS Material and user-created
- * components. Only dynamic construction of elements such as Dialogs, Panels, Toasts, BottomSheets,
- * etc. may be affected. Invoking `$mdCompilerProvider.respectPreAssignBindingsEnabled(true)`
- * will effect **bindings** in controllers created by AngularJS Material's services like
- * `$mdDialog`, `$mdPanel`, `$mdToast`, or `$mdBottomSheet`.
- *
- * See
- * <a ng-href="#mdcompilerprovider-respectpreassignbindingsenabled-respected">
- *   $mdCompilerProvider.respectPreAssignBindingsEnabled
- * </a>
- * for the details of how the different versions and settings of AngularJS affect this behavior.
- *
- * @usage
- *
- * Respect the AngularJS Compiler Setting
- *
- * <hljs lang="js">
- *   app.config(function($mdCompilerProvider) {
- *     $mdCompilerProvider.respectPreAssignBindingsEnabled(true);
- *   });
- * </hljs>
- *
- * @example
- * Using the default (backwards compatible) values for AngularJS 1.6
- * - AngularJS' `$compileProvider.preAssignBindingsEnabled(false)`
- * - AngularJS Material's `$mdCompilerProvider.respectPreAssignBindingsEnabled(false)`
- * <br><br>
- *
- * <hljs lang="js">
- * $mdDialog.show({
- *   locals: {
- *     myVar: true
- *   },
- *   controller: MyController,
- *   bindToController: true
- * }
- *
- * function MyController() {
- *   // Locals from Angular Material are available. e.g myVar is true.
- * }
- *
- * MyController.prototype.$onInit = function() {
- *   // Bindings are also available in the $onInit lifecycle hook.
- * }
- * </hljs>
- *
- * Recommended Settings for AngularJS 1.6
- * - AngularJS' `$compileProvider.preAssignBindingsEnabled(false)`
- * - AngularJS Material's `$mdCompilerProvider.respectPreAssignBindingsEnabled(true)`
- * <br><br>
- *
- * <hljs lang="js">
- * $mdDialog.show({
- *   locals: {
- *     myVar: true
- *   },
- *   controller: MyController,
- *   bindToController: true
- * }
- *
- * function MyController() {
- *   // No locals from Angular Material are available. e.g myVar is undefined.
- * }
- *
- * MyController.prototype.$onInit = function() {
- *   // Bindings are now available in the $onInit lifecycle hook.
- * }
- * </hljs>
- *
- */
 MdCompilerProvider.$inject = ['$compileProvider'];
-function MdCompilerProvider($compileProvider) {
-
-  var provider = this;
-
-  /**
-   * @ngdoc method
-   * @name $mdCompilerProvider#respectPreAssignBindingsEnabled
-   *
-   * @param {boolean=} respected update the `respectPreAssignBindingsEnabled` state if provided,
-   *  otherwise just return the current Material `respectPreAssignBindingsEnabled` state.
-   * @returns {boolean|MdCompilerProvider} current value, if used as a getter, or itself (chaining)
-   *  if used as a setter.
-   *
-   * @description
-   * Call this method to enable/disable whether Material-specific (dialog/panel/toast/bottomsheet)
-   * controllers respect the AngularJS `$compileProvider.preAssignBindingsEnabled` flag. Note that
-   * this doesn't affect directives/components created via regular AngularJS methods which
-   * constitute most Material and user-created components.
-   *
-   * If disabled (`false`), the compiler assigns the value of each of the bindings to the
-   * properties of the controller object before the constructor of this object is called.
-   * The ability to disable this settings is **deprecated** and will be removed in
-   * AngularJS Material 1.2.0.
-   *
-   * If enabled (`true`) the behavior depends on the AngularJS version used:
-   *
-   * - `<1.5.10`
-   *  - Bindings are pre-assigned.
-   * - `>=1.5.10 <1.7`
-   *  - Respects whatever `$compileProvider.preAssignBindingsEnabled()` reports. If the
-   *    `preAssignBindingsEnabled` flag wasn't set manually, it defaults to pre-assigning bindings
-   *    with AngularJS `1.5` and to calling the constructor first with AngularJS `1.6`.
-   * - `>=1.7`
-   *  - The compiler calls the constructor first before assigning bindings and
-   *    `$compileProvider.preAssignBindingsEnabled()` no longer exists.
-   *
-   * Defaults
-   * - The default value is `false` in AngularJS 1.6 and earlier.
-   *  - It is planned to fix this value to `true` and not allow the `false` value in
-   *    AngularJS Material 1.2.0.
-   *
-   * It is recommended to set this flag to `true` when using AngularJS Material 1.1.x with
-   * AngularJS versions >= 1.5.10. The only reason it's not set that way by default is backwards
-   * compatibility.
-   *
-   * By not setting the flag to `true` when AngularJS' `$compileProvider.preAssignBindingsEnabled()`
-   * is set to `false` (i.e. default behavior in AngularJS 1.6 or newer), unit testing of
-   * Material Dialog/Panel/Toast/BottomSheet controllers using the `$controller` helper
-   * is problematic as it always follows AngularJS' `$compileProvider.preAssignBindingsEnabled()`
-   * value.
-   */
-  var respectPreAssignBindingsEnabled = false;
-  this.respectPreAssignBindingsEnabled = function(respected) {
-    if (angular.isDefined(respected)) {
-      respectPreAssignBindingsEnabled = respected;
-      return this;
-    }
-
-    return respectPreAssignBindingsEnabled;
-  };
-
-  /**
-   * @private
-   * @description
-   * This function returns `true` if AngularJS Material-specific (dialog/panel/toast/bottomsheet)
-   * controllers have bindings pre-assigned in controller constructors and `false` otherwise.
-   *
-   * Note that this doesn't affect directives/components created via regular AngularJS methods
-   * which constitute most Material and user-created components; their behavior can be checked via
-   * `$compileProvider.preAssignBindingsEnabled()` in AngularJS `>=1.5.10 <1.7.0`.
-   *
-   * @returns {*} current preAssignBindingsEnabled state
-   */
-  function getPreAssignBindingsEnabled() {
-    if (!respectPreAssignBindingsEnabled) {
-      // respectPreAssignBindingsEnabled === false
-      // We're ignoring the AngularJS `$compileProvider.preAssignBindingsEnabled()` value in this case.
-      return true;
-    }
-
-    // respectPreAssignBindingsEnabled === true
-
-    // This check is needed because $compileProvider.preAssignBindingsEnabled does not exist prior
-    // to AngularJS 1.5.10, is deprecated in AngularJS 1.6.x, and removed in AngularJS 1.7.x.
-    if (typeof $compileProvider.preAssignBindingsEnabled === 'function') {
-      return $compileProvider.preAssignBindingsEnabled();
-    }
-
-    // Flag respected but not present => apply logic based on AngularJS version used.
-    if (angular.version.major === 1 && angular.version.minor < 6) {
-      // AngularJS <1.5.10
-      return true;
-    }
-
-    // AngularJS >=1.7.0
-    return false;
-  }
+function MdCompilerProvider() {
 
   this.$get = ["$q", "$templateRequest", "$injector", "$compile", "$controller",
     function($q, $templateRequest, $injector, $compile, $controller) {
@@ -205,10 +22,10 @@ function MdCompilerProvider($compileProvider) {
    * @module material.core.compiler
    * @description
    * The $mdCompiler service is an abstraction of AngularJS's compiler, that allows developers
-   * to easily compile an element with options like in a Directive Definition Object.
+   * to compile an element with options like in a Directive Definition Object.
    *
    * > The compiler powers a lot of components inside of AngularJS Material.
-   * > Like the `$mdPanel` or `$mdDialog`.
+   * > Like the `$mdPanel` or `$mdDialog` services.
    *
    * @usage
    *
@@ -243,11 +60,11 @@ function MdCompilerProvider($compileProvider) {
    *   });
    * </hljs>
    *
-   * > Content Element is a significant performance improvement when the developer already knows that the
-   * > compiled element will be always the same and the scope will not change either.
+   * > Content Element is a significant performance improvement when the developer already knows
+   * > that the compiled element will be always the same and the scope will not change either.
    *
-   * The `contentElement` option also supports DOM elements which will be temporary removed and restored
-   * at its old position.
+   * The `contentElement` option also supports DOM elements which will be temporary removed and
+   * restored at its old position.
    *
    * <hljs lang="js">
    *   var domElement = document.querySelector('#myElement');
@@ -357,8 +174,8 @@ function MdCompilerProvider($compileProvider) {
   };
 
   /**
-   * Instead of compiling any template, the compiler just fetches an existing HTML element from the DOM and
-   * provides a restore function to put the element back it old DOM position.
+   * Instead of compiling any template, the compiler just fetches an existing HTML element from the
+   * DOM and provides a restore function to put the element back it old DOM position.
    * @param {!Object} options Options to be used for the compiler.
    */
   MdCompilerService.prototype._prepareContentElement = function(options) {
@@ -487,33 +304,10 @@ function MdCompilerProvider($compileProvider) {
    * @returns {!Object} Created controller instance.
    */
   MdCompilerService.prototype._createController = function(options, injectLocals, locals) {
-    var ctrl;
-    var preAssignBindingsEnabled = getPreAssignBindingsEnabled();
-    // The third argument to $controller is considered private and undocumented:
-    // https://github.com/angular/angular.js/blob/v1.6.10/src/ng/controller.js#L102-L109.
-    // TODO remove the use of this third argument in AngularJS Material 1.2.0.
-    // Passing `true` as the third argument causes `$controller` to return a function that
-    // gets the controller instance instead of returning the instance directly. When the
-    // controller is defined as a function, `invokeCtrl.instance` is the *same instance* as
-    // `invokeCtrl()`. However, when the controller is an ES6 class, `invokeCtrl.instance` is a
-    // *different instance* from `invokeCtrl()`.
-    if (preAssignBindingsEnabled) {
-      var invokeCtrl = this.$controller(options.controller, injectLocals, true);
+    var ctrl = this.$controller(options.controller, injectLocals);
 
-      if (options.bindToController) {
-        angular.extend(invokeCtrl.instance, locals);
-      }
-
-      // Use the private API callback to instantiate and initialize the specified controller.
-      ctrl = invokeCtrl();
-    } else {
-      // If we don't need to pre-assign bindings, avoid using the private API third argument and
-      // related callback.
-      ctrl = this.$controller(options.controller, injectLocals);
-
-      if (options.bindToController) {
-        angular.extend(ctrl, locals);
-      }
+    if (options.bindToController) {
+      angular.extend(ctrl, locals);
     }
 
     if (options.controllerAs) {
@@ -534,7 +328,7 @@ function MdCompilerProvider($compileProvider) {
    */
   MdCompilerService.prototype._fetchContentElement = function(options) {
     var contentEl = options.contentElement;
-    var restoreFn = null;
+    var restoreFn;
 
     if (angular.isString(contentEl)) {
       contentEl = document.querySelector(contentEl);


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[x] Other... Please describe: removal of deprecated code and APIs
```

## What is the current behavior?
- deprecated code and APIs

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?
- refactor(chips): remove deprecated `MdChipsCtrl.selectAndFocusChip()`
- refactor(select): rename `ngMultiple` to `mdMultiple`
- refactor(toast): remove deprecated `content()` method and option and `updateContent()` method
- refactor($mdCompilerProvider): remove deprecated `$mdCompilerProvider.respectPreAssignBindingsEnabled()`

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Please see the individual commits for breaking change notes.

This is the first batch, a second batch is coming soon.