### PR TITLE
chore: merge --strategy=theirs no longer exists

### DIFF
--- a/release.js
+++ b/release.js
@@ -367,7 +367,7 @@
     pushCmds.push(
       comment('update package.json in master'),
       'git checkout master',
-      `git pull --rebase ${origin} master --strategy=theirs`,
+      `git pull --rebase ${origin} master --strategy=recursive --strategy-option==theirs`,
       `git checkout release/${newVersion} -- CHANGELOG.md`,
       `node -e "const newVersion = '${newVersion}'; ${stringifyFunction(buildCommand)}"`,
       'git add CHANGELOG.md',


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
```sh
From github.com:angular/material
 * branch                master     -> FETCH_HEAD
Could not find merge strategy 'theirs'.
Available strategies are: octopus ours recursive resolve subtree.
```
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
N/A

## What is the new behavior?
`--strategy=recursive --strategy-option==theirs`
This isn't the same as the old `--strategy=theirs`, but that hasn't existed in a while and it's already been defaulting to `--strategy=recursive` for some time now.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
