### PR TITLE
build(modules): configure more components to depend on input variables

### DIFF
--- a/gulp/util.js
+++ b/gulp/util.js
@@ -184,6 +184,9 @@ function buildModule(module, opts) {
    */
   function buildModuleStyles(name) {
     let files = [];
+    const inputVariableConsumers = [
+      'input', 'select', 'checkbox', 'datepicker', 'radioButton', 'switch'
+    ];
     config.themeBaseFiles.forEach(function(fileGlob) {
       files = files.concat(glob(fileGlob, {cwd: ROOT}));
     });
@@ -191,7 +194,7 @@ function buildModule(module, opts) {
     // Handle md-input and md-input-container variables that need to be shared with md-select
     // in order to orchestrate identical layouts and alignments. In the future, it may be necessary
     // to also use these variables with md-datepicker and md-autocomplete.
-    if (name === 'input' || name === 'select') {
+    if (inputVariableConsumers.includes(name)) {
       files = files.concat(glob(config.inputVariables, {cwd: ROOT}));
     }
 


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- The 'checkbox', 'datepicker', 'radioButton', and 'switch' modules aren't set up to build their Sass with the input variables.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
https://app.circleci.com/pipelines/github/angular/material/818/workflows/41319e2b-ac01-4f00-8190-e8a2ccf6224b/jobs/4800

## What is the new behavior?
- The 'checkbox', 'datepicker', 'radioButton', and 'switch' modules are set up to build their Sass with the input variables.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
