### PR TITLE
fix(radio-button): when no value selected, first button not announced on focus

### DIFF
--- a/src/components/dialog/demoBasicUsage/script.js
+++ b/src/components/dialog/demoBasicUsage/script.js
@@ -79,7 +79,7 @@ angular.module('dialogDemo1', ['ngMaterial'])
       templateUrl: 'tabDialog.tmpl.html',
       parent: angular.element(document.body),
       targetEvent: ev,
-      clickOutsideToClose:true
+      clickOutsideToClose: true
     })
         .then(function(answer) {
           $scope.status = 'You said the information was "' + answer + '".';

--- a/src/components/radioButton/demoBasicUsage/index.html
+++ b/src/components/radioButton/demoBasicUsage/index.html
@@ -1,21 +1,19 @@
 <div>
   <form ng-submit="submit()" ng-controller="AppCtrl" ng-cloak>
-    <p>Selected Value: <span class="radioValue">{{ data.group1 }}</span> </p>
-
-    <md-radio-group ng-model="data.group1">
-
+    <p>
+      <label id="favoriteFruit">Favorite Fruit:</label> <span class="radioValue">{{ data.group1 }}</span>
+    </p>
+    <md-radio-group ng-model="data.group1" aria-labelledby="favoriteFruit">
       <md-radio-button value="Apple" class="md-primary">Apple</md-radio-button>
       <md-radio-button value="Banana">Banana</md-radio-button>
       <md-radio-button value="Mango">Mango</md-radio-button>
-
     </md-radio-group>
-
     <hr />
 
-    <p>Selected Value: <span class="radioValue">{{ data.group2 }}</span></p>
-
-    <md-radio-group ng-model="data.group2" class="md-primary">
-
+    <p>
+      <label id="selectedValue">Selected Value:</label> <span class="radioValue">{{ data.group2 }}</span>
+    </p>
+    <md-radio-group ng-model="data.group2" class="md-primary" aria-labelledby="selectedValue">
         <md-radio-button ng-repeat="d in radioData"
                          ng-value="d.value"
                          ng-disabled=" d.isDisabled "
@@ -27,22 +25,20 @@
             Vestibulum tempor, ligula id laoreet hendrerit, massa augue iaculis magna,
             sit amet dapibus tortor ligula non nibh.
           </span>
-
         </md-radio-button>
-
     </md-radio-group>
-
     <p>
       <md-button class="md-raised" ng-click="addItem()" type="button">Add</md-button>
       <md-button class="md-raised" ng-click="removeItem()" type="button">Remove</md-button>
     </p>
-
     <hr />
 
-    <p style="margin-bottom: 0;">Graphic radio buttons need to be labeled with the <code>aria-label</code> attribute.</p>
-    <p style="margin-top: 0;">Selected Avatar: <span class="radioValue">{{ data.group3 }}</span></p>
+    <p class="demo-description">Graphic radio buttons need to be labeled with the <code>aria-label</code> attribute.</p>
+    <p>
+      <label id="selectedAvatar">Selected Avatar:</label> <span class="radioValue">{{ data.group3 }}</span>
+    </p>
 
-    <md-radio-group ng-model="data.group3">
+    <md-radio-group ng-model="data.group3" aria-labelledby="selectedAvatar">
       <md-radio-button ng-repeat="it in avatarData"
                        ng-value="it.value"
                        aria-label="{{it.title}}">

--- a/src/components/radioButton/demoBasicUsage/script.js
+++ b/src/components/radioButton/demoBasicUsage/script.js
@@ -1,4 +1,3 @@
-
 angular
   .module('radioDemo1', ['ngMaterial'])
   .controller('AppCtrl', function($scope) {
@@ -29,7 +28,6 @@ angular
       { label: '3', value: '3', isDisabled: true },
       { label: '4', value: '4' }
     ];
-
 
     $scope.submit = function() {
       alert('submit');

--- a/src/components/radioButton/demoBasicUsage/style.css
+++ b/src/components/radioButton/demoBasicUsage/style.css
@@ -1,42 +1,33 @@
-
 body {
   padding: 20px;
 }
-
 hr {
   margin-left: -20px;
   opacity: 0.3;
 }
-
 md-radio-group {
   width: 150px;
 }
-
 p:last-child {
   padding-bottom: 50px;
 }
-
-
-[ng-controller] {
+form {
   padding: 0 20px;
 }
-
 .radioValue {
   margin-left: 5px;
   color: #0f9d58;
   font-weight: bold;
-  padding:5px;
-
 }
-
 md-icon {
   margin: 0 20px 20px;
   width: 128px;
   height: 128px;
 }
-
-
 .ipsum {
   color: saddlebrown;
   font-size: 0.9em;
+}
+.demo-description {
+  margin-bottom: 0;
 }

--- a/src/components/radioButton/demoMultiColumn/index.html
+++ b/src/components/radioButton/demoMultiColumn/index.html
@@ -1,40 +1,23 @@
-<div ng-controller='ContactController as cc' class="radioDemo2 bidi">
+<div ng-controller="ContactController as ctrl" class="demo-bidi">
   <h2>Contact List</h2>
-    <md-divider></md-divider>
+  <md-divider></md-divider>
 
-    <md-radio-group ng-model="cc.selectedId" >
-      <div ng-repeat='person in cc.contacts' class="row">
-        <div flex layout='row' layout-padding layout-align="start center" >
+  <md-radio-group ng-model="ctrl.selectedId" aria-labelledby="selectedUser">
+    <div ng-repeat="person in ctrl.contacts" class="demo-row">
+      <div flex layout="row" layout-padding layout-align="start center">
 
-          <div flex style="max-width:200px;">
-            {{person.title}}
-          </div>
-          <md-radio-button flex
-              ng-value="person.id"
-              class="md-primary" >
-
-            {{person.fullName}}
-
-          </md-radio-button>
-
+        <div id="{{'demoTitle-' + person.id}}" class="demo-title">
+          {{person.title}}
         </div>
-      </div>
-    </md-radio-group>
-
-    <md-divider></md-divider>
-    <div class="summary" flex layout="row" layout-align="space-between center">
-      <div flex-initial>
-        <span class="title">Selected User</span>: <span class="md-checked">{{cc.selectedUser()}}</span>
+        <md-radio-button flex ng-value="person.id" class="md-primary" aria-describedby="{{'demoTitle-' + person.id}}">
+          {{person.fullName}}
+        </md-radio-button>
       </div>
     </div>
+  </md-radio-group>
+
+  <md-divider></md-divider>
+  <p class="md-padding md-margin">
+    <label id="selectedUser">Selected User:</label> <span class="demo-checked">{{ctrl.selectedUser()}}</span>
+  </p>
 </div>
-
-<style>
-
-  html[dir="rtl"] .bidi {
-    padding-right: 20px;
-    padding-left:0;
-  }
-
-</style>
-

--- a/src/components/radioButton/demoMultiColumn/script.js
+++ b/src/components/radioButton/demoMultiColumn/script.js
@@ -1,5 +1,5 @@
 angular
-  .module('radioDemo2', ['ngMaterial'])
+  .module('radioMultiColumnDemo', ['ngMaterial'])
   .controller('ContactController', function($scope, $filter) {
     var self = this;
 

--- a/src/components/radioButton/demoMultiColumn/style.css
+++ b/src/components/radioButton/demoMultiColumn/style.css
@@ -1,53 +1,23 @@
-div.radioDemo2 {
-    margin-bottom: 20px;
-}
-
-
 h2 {
-  margin-left : 15px;
+  margin: 16px;
 }
-p {
-  width:400px;
-  margin-top:10px;
-  margin-left : 10px;
-  padding-top:10px;
-  border-top: 2px solid #ddd;
-}
-
-.md-checked {
-  background-color : #ECFAFB;
+.demo-checked {
+  background-color: #ECFAFB;
   border-radius: 2px;
 }
-
-md-button.md-raised, button.md-raised {
-  width: 200px;
+.demo-row {
+  border-bottom: 1px dashed #ddd;
 }
-
-.row {
-    border-bottom: 1px dashed #ddd;
-}
-
-div.row:last-child {
+.demo-row:last-child {
   border-bottom: 0px dashed #ddd;
 }
-
-
-
-.summary {
-  width: 100%;
-  padding-top:10px;
-  margin-left: 25px;
-  margin-top: 20px;
-  margin-bottom:-5px
-}
-
-
-.title {
+label {
   font-weight: bolder;
 }
-
-.selectedUser .md-checked {
-  padding : 8px;
-  width: 100px;
-  
+.demo-title {
+  flex: 0 1 200px;
+}
+html[dir="rtl"] .demo-bidi {
+  padding-right: 20px;
+  padding-left: 0;
 }

--- a/src/core/util/iterator.js
+++ b/src/core/util/iterator.js
@@ -14,10 +14,12 @@
      });
 
   /**
-   * iterator is a list facade to easily support iteration and accessors
+   * iterator is a list facade to easily support iteration and accessors/
    *
-   * @param items Array list which this iterator will enumerate
-   * @param reloop Boolean enables iterator to consider the list as an endless reloop
+   * @param {any[]} items Array list which this iterator will enumerate
+   * @param {boolean=} reloop enables iterator to consider the list as an endless loop
+   * @return {{add: add, next: (function()), last: (function(): any|null), previous: (function()), count: (function(): number), hasNext: (function(*=): Array.length|*|number|boolean), inRange: (function(*): boolean), remove: remove, contains: (function(*=): *|boolean), itemAt: (function(*=): any|null), findBy: (function(*, *): *[]), hasPrevious: (function(*=): Array.length|*|number|boolean), items: (function(): *[]), indexOf: (function(*=): number), first: (function(): any|null)}}
+   * @constructor
    */
   function MdIterator(items, reloop) {
     var trueFn = function() { return true; };
@@ -51,7 +53,6 @@
 
       hasPrevious: hasPrevious,
       hasNext: hasNext
-
     };
 
     /**


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- Screen readers don't work properly (in different ways, see issues) with `md-radion-group` and `md-radio-button`.
- The radio button demos are not accessible.
- There is a lot of extra stuff in the radio button demos that makes them more complex than needed, including unused styles, extra elements and attributes, etc.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #11973. Fixes #11923. Fixes #11974.

## What is the new behavior?
Screen reader behavior is improved/fixed.
- when no value selected, set `aria-activedescendant` to first button's `id`
- properly define labels and `aria-labelledby` in demos
- improve some JSDoc and types
- rename some variables to make them more readable
- remove unused parameters
- improvements to multi-column demo
  - remove unneeded or unused styles and elements
  - use `aria-describedby` to make first column available to screen reader users


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
