### PR TITLE
fix(chips): update to latest Material Design spec (2017) updates

### DIFF
--- a/src/components/chips/chips-theme.scss
+++ b/src/components/chips/chips-theme.scss
@@ -37,11 +37,13 @@ md-chips.md-THEME_NAME-theme {
       color: '{{background-800}}';
     }
   }
-  md-chip-remove {
-    .md-button {
-      md-icon {
-        path {
-          fill: '{{background-500}}';
+  .md-chip-remove-container {
+    button {
+      &md-chip-remove,
+      &.md-chip-remove {
+        md-icon {
+          color: '{{foreground-2}}';
+          fill: '{{foreground-2}}';
         }
       }
     }

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -1,8 +1,8 @@
-$chip-font-size: rem(1.6) !default;
+$chip-font-size: rem(1.3) !default;
 $chip-height: rem(3.2) !default;
 $chip-padding: 0 rem(1.2) 0 rem(1.2) !default;
 $chip-input-padding: 0 !default;
-$chip-remove-padding-right: rem(2.2) !default;
+$chip-remove-padding-right: rem(2.8) !default;
 $chip-remove-line-height: rem(2.2) !default;
 $chip-margin: rem(0.8) rem(0.8) 0 0 !default;
 $chip-wrap-padding: 0 0 rem(0.8) rem(0.3) !default;

--- a/src/components/chips/demoBasicUsage/index.html
+++ b/src/components/chips/demoBasicUsage/index.html
@@ -69,7 +69,7 @@
           <em>({{$chip.type}})</em>
         </span>
       </md-chip-template>
-      <button md-chip-remove class="md-primary vegetablechip" aria-label="Remove {{$chip.name}}">
+      <button md-chip-remove class="demo-remove-vegetable-chip" aria-label="Remove {{$chip.name}}">
         <md-icon md-svg-icon="md-close"></md-icon>
       </button>
     </md-chips>

--- a/src/components/chips/demoBasicUsage/style.scss
+++ b/src/components/chips/demoBasicUsage/style.scss
@@ -3,50 +3,43 @@
   color: rgb(221,44,0);
   margin-top: 10px;
 }
-
 .custom-chips {
   md-chip {
     position: relative;
+    padding-right: 24px;
+
     .md-chip-remove-container {
       position: absolute;
       right: 4px;
       top: 4px;
       margin-right: 0;
-      height: 24px;
-      button.vegetablechip {
+      height: 26px;
+      display: none;
+
+      button.demo-remove-vegetable-chip {
         position: relative;
         height: 24px;
         width: 24px;
         line-height: 30px;
-        text-align: center;
-        background: rgba(black, 0.3);
-        border-radius: 50%;
+        background: transparent;
         border: none;
-        box-shadow: none;
         padding: 0;
-        margin: 0;
-        transition: background 0.15s linear;
-        display: block;
+
         md-icon {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate3d(-50%, -50%, 0) scale(0.7);
-          color: white;
-          fill: white;
-        }
-        &:hover, &:focus {
-          background: rgba(red, 0.8);
+          transform: translate(0, -3px) scale(0.75);
+          fill: rgba(0, 0, 0, 0.33);
         }
       }
     }
-  }
+    &:hover:not(.md-readonly) .md-chip-remove-container {
+      display: block;
+    }
+    &.md-focused:not(.md-readonly) .md-chip-remove-container {
+      display: block;
 
-  // Show custom padding for the custom delete button, which needs more space.
-  md-chips-wrap.md-removable {
-    md-chip md-chip-template {
-      padding-right: 5px;
+      button.demo-remove-vegetable-chip md-icon {
+        fill: rgba(255, 255, 255, 0.87);
+      }
     }
   }
-
 }

--- a/src/components/chips/js/chipRemoveDirective.js
+++ b/src/components/chips/js/chipRemoveDirective.js
@@ -24,8 +24,8 @@ angular
  * ### With Standard Chips
  * <hljs lang="html">
  *   <md-chips ...>
- *     <button md-chip-remove class="md-primary" type="button" aria-label="Remove {{$chip}}">
- *       <md-icon md-svg-icon="md-close"></md-icon>
+ *     <button md-chip-remove type="button" aria-label="Remove {{$chip}}">
+ *       <md-icon md-svg-icon="md-cancel"></md-icon>
  *     </button>
  *   </md-chips>
  * </hljs>
@@ -33,8 +33,8 @@ angular
  * ### With Object Chips
  * <hljs lang="html">
  *   <md-chips ...>
- *     <button md-chip-remove class="md-primary" type="button" aria-label="Remove {{$chip.name}}">
- *       <md-icon md-svg-icon="md-close"></md-icon>
+ *     <button md-chip-remove type="button" aria-label="Remove {{$chip.name}}">
+ *       <md-icon md-svg-icon="md-cancel"></md-icon>
  *     </button>
  *   </md-chips>
  * </hljs>
@@ -57,7 +57,7 @@ function MdChipRemove ($timeout) {
   };
 
   function postLink(scope, element, attr, ctrl) {
-    element.on('click', function(event) {
+    element.on('click', function() {
       scope.$apply(function() {
         ctrl.removeChip(scope.$$replacedScope.$index);
       });

--- a/src/components/chips/js/chipsDirective.js
+++ b/src/components/chips/js/chipsDirective.js
@@ -400,7 +400,7 @@
         mdChipsCtrl.chipRemoveTemplate   = chipRemoveTemplate;
         mdChipsCtrl.chipInputTemplate    = chipInputTemplate;
 
-        mdChipsCtrl.mdCloseIcon = $$mdSvgRegistry.mdClose;
+        mdChipsCtrl.mdCloseIcon = $$mdSvgRegistry.mdCancel;
 
         element
             .attr({ tabindex: -1 })


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
See the issue for some of the ways that `md-chips` is out of date with the latest version of the [2017 MD chips spec](https://material.io/archive/guidelines/components/chips.html#).

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #9883

## What is the new behavior?
- use the `md-cancel` button instead of the `md-close` button
- `$chip-font-size` reduced to `13px` from `16px`
- `$chip-remove-padding-right` increased to `28px` from `22px`
- in light mode, remove chip icon should be black w/ 87% opacity
- update custom remove chip template demo
  - show remove icon on hover/focus only
  - remove unnecessary CSS
  - update to new size guidelines and remove color on hover/focus
  - fix remove chip icon color when chip is focused


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```
BREAKING CHANGE: Chips have been updated to latest Material Design spec (2017). `$chip-font-size` was reduced to `13px` from `16px`. `$chip-remove-padding-right` was increased to `28px` from `22px`. These changes may cause your chips to have a smaller, denser layout now. In certain scenarios, this may require minor changes to your app's layout. You can change these variables back to their old values if your app consumes Sass. Additionally, the remove chip icon has been changed, but you can use the custom chip template demo as a guide to changing back to the old icon, if desired.

## Other information

# Before
![Screen Shot 2020-07-30 at 22 40 38](https://user-images.githubusercontent.com/3506071/88994175-c12bad00-d2b5-11ea-98f9-3041f55404c2.png)
![Screen Shot 2020-07-30 at 22 41 36](https://user-images.githubusercontent.com/3506071/88994223-dbfe2180-d2b5-11ea-9853-6194ce9370e4.png)


# After
![Screen Shot 2020-07-30 at 22 40 20](https://user-images.githubusercontent.com/3506071/88994178-c2f57080-d2b5-11ea-875c-2343630ed463.png)
![Screen Shot 2020-07-30 at 22 41 26](https://user-images.githubusercontent.com/3506071/88994229-de607b80-d2b5-11ea-9571-75290a18f0b7.png)

