### PR TITLE
fix(select): respect theme color when select has a value and focus

### DIFF
--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -158,7 +158,8 @@ md-select {
     }
     &:focus {
       .md-select-value {
-        border-bottom: $select-border-width-default + 1px solid;
+        border-bottom-style: solid;
+        border-bottom-width: $select-border-width-default + 1px;
         padding-bottom: $select-value-padding-bottom - 1px;
       }
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

When a md-select instance is focused, the bottom border do not use the primary color; it appears black.

## What is the new behavior?

The md-select instance will now inherit from the colors defined in [select-theme.scss](https://github.com/angular/material/blob/master/src/components/select/select-theme.scss#L99-L100).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

Issue can be observed on the [demo page of md-select](https://material.angularjs.org/latest/demo/select).

The problem was introduced by commit [b3e9ffe](https://github.com/angular/material/commit/b3e9ffec50cdfb560fa4bf0a32df3ad22d553291).