### PR TITLE
fix(calendar, datepicker): fix issues with GMT+X timezones

### DIFF
--- a/src/components/datepicker/js/calendar.js
+++ b/src/components/datepicker/js/calendar.js
@@ -301,7 +301,7 @@
   /**
    * Sets up the controller's reference to ngModelController.
    * @param {!ngModel.NgModelController} ngModelCtrl Instance of the ngModel controller.
-   * @param {Object} inputDirective Config for Angular's `input` directive.
+   * @param {Object} inputDirective Config for AngularJS's `input` directive.
    */
   CalendarCtrl.prototype.configureNgModel = function(ngModelCtrl, inputDirective) {
     var self = this;
@@ -326,7 +326,7 @@
       // In the case where a conversion is needed, the $viewValue here will be a string like
       // "2020-05-10" instead of a Date object.
       if (!self.dateUtil.isValidDate(value)) {
-        convertedDate = self.dateUtil.removeLocalTzAndReparseDate(new Date(this.$viewValue));
+        convertedDate = self.dateUtil.removeLocalTzAndReparseDate(new Date(value));
         if (self.dateUtil.isValidDate(convertedDate)) {
           value = convertedDate;
         }
@@ -360,7 +360,13 @@
     var value = this.dateUtil.createDateAtMidnight(date);
     this.focusDate(value);
     this.$scope.$emit('md-calendar-change', value);
-    this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd', timezone), 'default');
+    // Using the timezone when the offset is negative (GMT+X) causes the previous day to be
+    // selected here. This check avoids that.
+    if (timezone == null || value.getTimezoneOffset() < 0) {
+      this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd'), 'default');
+    } else {
+      this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd', timezone), 'default');
+    }
     this.ngModelCtrl.$render();
     return value;
   };

--- a/src/components/datepicker/js/dateUtil.js
+++ b/src/components/datepicker/js/dateUtil.js
@@ -311,15 +311,10 @@
 
     /**
      * @param {Date} value date in local timezone
-     * @return {Date} date with local timezone removed
+     * @return {Date} date with local timezone offset removed
      */
     function removeLocalTzAndReparseDate(value) {
-      var dateValue, formattedDate;
-      // Remove the local timezone offset before calling formatDate.
-      dateValue = new Date(value.getTime() + 60000 * value.getTimezoneOffset());
-      formattedDate = $mdDateLocale.formatDate(dateValue);
-      // parseDate only works with a date formatted by formatDate when using Moment validation.
-      return $mdDateLocale.parseDate(formattedDate);
+      return $mdDateLocale.parseDate(value.getTime() + 60000 * value.getTimezoneOffset());
     }
   });
 })();


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
When local timezone is GMT+X, (i.e. `+5:00`) using `ng-model-options` to specify the timezone causes the previous day to be selected.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #12000

## What is the new behavior?
- fix issues with GMT+X timezones by avoiding timezone conversions when local timezone is GMT+x. We let the existing utilities for converting dates to midnight handle things since the date doesn't need to change in those cases, just the hours.
- simplify `$$mdDateUtil.removeLocalTzAndReparseDate()`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
We don't have the capability to change the device's timezone between tests.