### PR TITLE
fix(calendar, datepicker): fix MomentJS custom format support

### DIFF
--- a/config/karma-docs.conf.js
+++ b/config/karma-docs.conf.js
@@ -18,6 +18,7 @@ module.exports = function(config) {
     'node_modules/angular-messages/angular-messages.js',
     'node_modules/angular-route/angular-route.js',
     'node_modules/angular-mocks/angular-mocks.js',
+    'node_modules/moment/moment.js',
     'dist/angular-material.js',
     'config/test-utils.js',
     'dist/docs/docs.js',

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -38,6 +38,7 @@ module.exports = function(config) {
     'node_modules/angular-sanitize/angular-sanitize.js',
     'node_modules/angular-touch/angular-touch.js',
     'node_modules/angular-mocks/angular-mocks.js',
+    'node_modules/moment/moment.js',
     'test/angular-material-mocks.js',
     'test/angular-material-spec.js'
   ]);

--- a/src/components/datepicker/js/dateLocale.spec.js
+++ b/src/components/datepicker/js/dateLocale.spec.js
@@ -1,4 +1,3 @@
-
 describe('$mdDateLocale', function() {
   var dateLocale, dateUtil;
 
@@ -81,7 +80,7 @@ describe('$mdDateLocale', function() {
 
   describe('with custom values', function() {
     var fakeMonths = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'];
-    var fakeshortMonths = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'j', 'l'];
+    var fakeShortMonths = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'j', 'l'];
     var fakeDays = ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7'];
     var fakeShortDays = ['1', '2', '3', '4', '5', '6', '7'];
     var fakeDates = [undefined, 'X1', 'X2', 'X3', 'X4', 'X5', 'X6', 'X7', 'X8', 'X9', 'X10', 'X11',
@@ -90,7 +89,7 @@ describe('$mdDateLocale', function() {
 
     beforeEach(module(function($mdDateLocaleProvider) {
       $mdDateLocaleProvider.months = fakeMonths;
-      $mdDateLocaleProvider.shortMonths = fakeshortMonths;
+      $mdDateLocaleProvider.shortMonths = fakeShortMonths;
       $mdDateLocaleProvider.days = fakeDays;
       $mdDateLocaleProvider.shortDays = fakeShortDays;
       $mdDateLocaleProvider.dates = fakeDates;
@@ -113,7 +112,7 @@ describe('$mdDateLocale', function() {
 
     it('should expose custom settings', function() {
       expect(dateLocale.months).toEqual(fakeMonths);
-      expect(dateLocale.shortMonths).toEqual(fakeshortMonths);
+      expect(dateLocale.shortMonths).toEqual(fakeShortMonths);
       expect(dateLocale.days).toEqual(fakeDays);
       expect(dateLocale.shortDays).toEqual(fakeShortDays);
       expect(dateLocale.dates).toEqual(fakeDates);
@@ -122,6 +121,40 @@ describe('$mdDateLocale', function() {
       expect(dateLocale.parseDate('2020-01-20')).toEqual(new Date(1969, 6, 16));
       expect(dateLocale.isDateComplete('The One True Date')).toBe(true);
       expect(dateLocale.isDateComplete('Anything Else')).toBe(false);
+    });
+  });
+
+  describe('with MomentJS custom formatting', function() {
+    beforeEach(module(function($mdDateLocaleProvider) {
+      $mdDateLocaleProvider.formatDate = function(date) {
+        return date ? moment(date).format('M/D') : '';
+      };
+      $mdDateLocaleProvider.parseDate = function(dateString) {
+        var m = moment(dateString, 'M/D', true);
+        return m.isValid() ? m.toDate() : new Date(NaN);
+      };
+      $mdDateLocaleProvider.isDateComplete = function(dateString) {
+        dateString = dateString.trim();
+        // Look for two chunks of content (either numbers or text) separated by delimiters.
+        var re = /^(([a-zA-Z]{3,}|[0-9]{1,4})([ .,]+|[/-]))([a-zA-Z]{3,}|[0-9]{1,4})/;
+        return re.test(dateString);
+      };
+    }));
+
+    beforeEach(inject(function($mdDateLocale, $$mdDateUtil) {
+      dateLocale = $mdDateLocale;
+      dateUtil = $$mdDateUtil;
+    }));
+
+    it('should respect custom formatting', function() {
+      var now = new Date();
+      expect(dateLocale.formatDate(new Date('2020-08-31T00:00:00-04:00'))).toEqual('8/31');
+      expect(dateLocale.parseDate('8/31')).toEqual(new Date(now.getFullYear(), 7, 31));
+      expect(dateLocale.parseDate('1/1')).toEqual(new Date(now.getFullYear(), 0, 1));
+      expect(dateLocale.isDateComplete('8/31')).toBe(true);
+      expect(dateLocale.isDateComplete('8-31')).toBe(true);
+      expect(dateLocale.isDateComplete('August_31st')).toBe(false);
+      expect(dateLocale.isDateComplete('2020')).toBe(false);
     });
   });
 });

--- a/src/components/datepicker/js/dateUtil.js
+++ b/src/components/datepicker/js/dateUtil.js
@@ -314,7 +314,12 @@
      * @return {Date} date with local timezone offset removed
      */
     function removeLocalTzAndReparseDate(value) {
-      return $mdDateLocale.parseDate(value.getTime() + 60000 * value.getTimezoneOffset());
+      var dateValue, formattedDate;
+      // Remove the local timezone offset before calling formatDate.
+      dateValue = new Date(value.getTime() + 60000 * value.getTimezoneOffset());
+      formattedDate = $mdDateLocale.formatDate(dateValue);
+      // parseDate only works with a date formatted by formatDate when using Moment validation.
+      return $mdDateLocale.parseDate(formattedDate);
     }
   });
 })();


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- `$$mdDateUtil.removeLocalTzAndReparseDate()` was simplified, but it breaks MomentJS support

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Relates to #12003. Relates to #11949.

## What is the new behavior?
- revert simplification of `$$mdDateUtil.removeLocalTzAndReparseDate()`
- enable unit testing of MomentJS
- add test suites for MomentJS custom formatting in `dateLocale.spec.js`
  and `datepickerDirective.spec.js`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information