### PR TITLE
fix(select): in popup, hover and focus background colors are the same

### DIFF
--- a/src/components/select/select-theme.scss
+++ b/src/components/select/select-theme.scss
@@ -153,8 +153,10 @@ md-select-menu.md-THEME_NAME-theme {
       }
 
       &:not([disabled]) {
+        &:hover {
+          background-color: '{{background-500-0.10}}'
+        }
         &:focus,
-        &:hover,
         &.md-focused {
           background-color: '{{background-500-0.18}}'
         }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- In the `md-select` popup, hover and focus background colors are the same. This can cause confusion when navigating with both keyboard and mouse on desktop.

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #9851

## What is the new behavior?
- use a similar approach to the one used by MDC. I.e. hover is 8% less opaque than focus.
  - the opacity values are slightly different because
    they use `#000` and we use `rgba(0, 0, 0, 0.87)`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
No tests as this is a CSS-only change.