### PR TITLE
fix(datepicker): null model with timezone throws exception

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -992,7 +992,7 @@
     var timezone = this.$mdUtil.getModelOption(this.ngModelCtrl, 'timezone');
     // Using the timezone when the offset is negative (GMT+X) causes the previous day to be
     // set as the model value here. This check avoids that.
-    if (timezone == null || value.getTimezoneOffset() < 0) {
+    if (timezone == null || value == null || value.getTimezoneOffset() < 0) {
       this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd'), 'default');
     } else {
       this.ngModelCtrl.$setViewValue(this.ngDateFilter(value, 'yyyy-MM-dd', timezone), 'default');
@@ -1014,7 +1014,7 @@
     }
     // Using the timezone when the offset is negative (GMT+X) causes the previous day to be
     // used here. This check avoids that.
-    if (timezone == null || value.getTimezoneOffset() < 0) {
+    if (timezone == null || value == null || value.getTimezoneOffset() < 0) {
       this.inputElement.value = this.locale.formatDate(value);
     } else {
       this.inputElement.value = this.locale.formatDate(value, timezone);

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -139,13 +139,21 @@ describe('md-datepicker', function() {
     expect(ngElement.attr('type')).toBe('date');
   });
 
+  it('should handle an initial ng-model that is null when timezone is specified', function() {
+    pageScope.modelOptions = {timezone: 'UTC'};
+    pageScope.myDate = null;
+    createDatepickerInstance(
+      '<md-datepicker ng-model="myDate" ng-model-options="modelOptions"></md-datepicker>');
+  });
+
   it('should pass the timezone to the formatting function', function() {
     spyOn(controller.locale, 'formatDate');
+    pageScope.modelOptions = {timezone: 'UTC'};
 
-    createDatepickerInstance('<md-datepicker ng-model="myDate" ' +
-      'ng-model-options="{ timezone: \'utc\' }"></md-datepicker>');
+    createDatepickerInstance(
+      '<md-datepicker ng-model="myDate" ng-model-options="modelOptions"></md-datepicker>');
 
-    expect(controller.locale.formatDate).toHaveBeenCalledWith(pageScope.myDate, 'utc');
+    expect(controller.locale.formatDate).toHaveBeenCalledWith(pageScope.myDate, 'UTC');
   });
 
   it('should allow for the locale to be overwritten on a specific element', function() {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request! Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check that your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- we don't verify that the model value is not null or undefined before accessing
  `.getTimezoneOffset()` and this causes an exception to be thrown in those cases

<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Issue Number: 
Fixes #12025

## What is the new behavior?
- verify that the model value is not null or undefined before accessing
  `.getTimezoneOffset()`



## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
