### PR TITLE
docs(dialog): rename "Angular's" to "AngularJS'"

### DIFF
--- a/src/components/dialog/dialog.js
+++ b/src/components/dialog/dialog.js
@@ -352,7 +352,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *
  *     ctrl.closeDialog = function() {
  *       // Hides the most recent dialog shown.
- *       // Mo specific dialog instance reference is needed.
+ *       // No specific dialog instance reference is needed.
  *       $mdDialog.hide();
  *     };
  *   }
@@ -378,7 +378,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * - `title(string)` - Sets the alert title.
  * - `textContent(string)` - Sets the alert message.
  * - `htmlContent(string)` - Sets the alert message as HTML. Requires the `ngSanitize`
- *     module to be loaded. HTML is not run through Angular's compiler.
+ *     module to be loaded. HTML is not run through AngularJS' compiler.
  * - `ok(string)` - Sets the alert "Okay" button text.
  * - `theme(string)` - Sets the theme of the alert dialog.
  * - `targetEvent(DOMClickEvent=)` - A click's event object. When passed in as an
@@ -402,7 +402,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * - `title(string)` - Sets the confirm title.
  * - `textContent(string)` - Sets the confirm message.
  * - `htmlContent(string)` - Sets the confirm message as HTML. Requires the `ngSanitize`
- *     module to be loaded. HTML is not run through Angular's compiler.
+ *     module to be loaded. HTML is not run through AngularJS' compiler.
  * - `ok(string)` - Sets the confirm "Okay" button text.
  * - `cancel(string)` - Sets the confirm "Cancel" button text.
  * - `theme(string)` - Sets the theme of the confirm dialog.
@@ -428,7 +428,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  * - `title(string)` - Sets the prompt title.
  * - `textContent(string)` - Sets the prompt message.
  * - `htmlContent(string)` - Sets the prompt message as HTML. Requires the `ngSanitize`
- *     module to be loaded. HTML is not run through Angular's compiler.
+ *     module to be loaded. HTML is not run through AngularJS' compiler.
  * - `placeholder(string)` - Sets the placeholder text for the input.
  * - `required(boolean)` - Sets the input required value.
  * - `initialValue(string)` - Sets the initial value for the prompt input.
@@ -452,7 +452,7 @@ function MdDialogDirective($$rAF, $mdTheming, $mdDialog) {
  *   - `templateUrl` - `{string=}`: The url of a template that will be used as the content
  *      of the dialog.
  *   - `template` - `{string=}`: HTML template to show in the dialog. This **must** be trusted HTML
- *      with respect to Angular's [$sce service](https://docs.angularjs.org/api/ng/service/$sce).
+ *      with respect to AngularJS' [$sce service](https://docs.angularjs.org/api/ng/service/$sce).
  *      This template should **never** be constructed with any kind of user input or user data.
  *   - `contentElement` - `{string|Element}`: Instead of using a template, which will be compiled
  *      each time a dialog opens, you can also use a DOM element.<br/>


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
- "Angular's" is used instead of "AngularJS'"
- There is a typo of `// Mo specific dialog instance reference is needed.`

## What is the new behavior?
- rename "Angular's" to "AngularJS'"
- fix 'Mo' typo to be 'No'

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Relates to #10562