### PR TITLE
fix(select): floating label hidden w/ placeholder and no value

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -280,6 +280,7 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
       var stopMdMultipleWatch;
       var userDefinedLabelledby = angular.isDefined(attrs.ariaLabelledby);
       var listboxContentElement = element.find('md-content');
+      var initialPlaceholder = element.attr('placeholder');
 
       if (disableAsterisk) {
         element.addClass('md-no-asterisk');
@@ -291,24 +292,25 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
         };
 
         if (containerCtrl.input) {
-          // We ignore inputs that are in the md-select-header (one
-          // case where this might be useful would be adding as searchbox)
+          // We ignore inputs that are in the md-select-header.
+          // One case where this might be useful would be adding as searchbox.
           if (element.find('md-select-header').find('input')[0] !== containerCtrl.input[0]) {
-            throw new Error("<md-input-container> can only have *one* child <input>, <textarea> or <select> element!");
+            throw new Error("<md-input-container> can only have *one* child <input>, <textarea>, or <select> element!");
           }
         }
 
         containerCtrl.input = element;
         if (!containerCtrl.label) {
-          $mdAria.expect(element, 'aria-label', element.attr('placeholder'));
+          $mdAria.expect(element, 'aria-label', initialPlaceholder);
           var selectLabel = element.attr('aria-label');
           if (!selectLabel) {
-            selectLabel = element.attr('placeholder');
+            selectLabel = initialPlaceholder;
           }
           listboxContentElement.attr('aria-label', selectLabel);
         } else {
           containerCtrl.label.attr('aria-hidden', 'true');
           listboxContentElement.attr('aria-label', containerCtrl.label.text());
+          containerCtrl.setHasPlaceholder(!!initialPlaceholder);
         }
 
         var stopInvalidWatch = scope.$watch(isErrorGetter, containerCtrl.setInvalid);
@@ -407,17 +409,18 @@ function SelectDirective($mdSelect, $mdUtil, $mdConstant, $mdTheming, $mdAria, $
        *  false to remove those classes.
        */
       mdSelectCtrl.setIsPlaceholder = function(isPlaceholder) {
-        if (isPlaceholder) {
-          selectValueElement.addClass('md-select-placeholder');
-          if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.addClass('md-placeholder');
+          if (isPlaceholder) {
+            selectValueElement.addClass('md-select-placeholder');
+            // Don't hide the floating label if the md-select has a placeholder.
+            if (containerCtrl && containerCtrl.label && !element.attr('placeholder')) {
+              containerCtrl.label.addClass('md-placeholder');
+            }
+          } else {
+            selectValueElement.removeClass('md-select-placeholder');
+            if (containerCtrl && containerCtrl.label && !element.attr('placeholder')) {
+              containerCtrl.label.removeClass('md-placeholder');
+            }
           }
-        } else {
-          selectValueElement.removeClass('md-select-placeholder');
-          if (containerCtrl && containerCtrl.label) {
-            containerCtrl.label.removeClass('md-placeholder');
-          }
-        }
       };
 
       if (!isReadonly) {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -27,7 +27,7 @@ md-input-container {
   }
   &.md-input-focused {
     &:not([md-no-float]) {
-      .md-select-placeholder span:first-child {
+      md-select:not([placeholder]) .md-select-placeholder span:first-child {
         transform: translate(-2px, -22px) scale(0.75);
       }
     }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
- floating `label` is not displayed when `placeholder` is specified and no selection has been made in a `md-input-container`

Fixes #10116

## What is the new behavior?
- don't hide the floating `label` in an `md-input-container` with a `md-select`
  that has a `placeholder` attribute specified


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

Given the following:
```html
        <md-input-container>
          <label>State</label>
          <md-select placeholder="Please select" ng-model="ctrl.userState">
            <md-option><em>None</em></md-option>
            <md-option ng-repeat="state in ctrl.states" ng-value="state.abbrev">
              {{state.abbrev}}
            </md-option>
          </md-select>
        </md-input-container>
```

## Before
![Screen Shot 2020-12-16 at 00 23 24](https://user-images.githubusercontent.com/3506071/102309278-70e87b00-3f36-11eb-8c7b-7ac80b179c9b.png)


## After
![Screen Shot 2020-12-16 at 00 23 34](https://user-images.githubusercontent.com/3506071/102309285-73e36b80-3f36-11eb-8c7a-283f75ef44b9.png)
