### PR TITLE
fix(autocomplete): prevent flashing of invalid state

### DIFF
--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -601,6 +601,8 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     if (!noBlur) {
       ctrl.hidden = shouldHide();
       evalAttr('ngBlur', { $event: $event });
+    } else {
+      $event.stopImmediatePropagation();
     }
   }
 

--- a/src/components/autocomplete/js/autocompleteController.js
+++ b/src/components/autocomplete/js/autocompleteController.js
@@ -594,6 +594,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
 
   /**
    * Handles input blur event, determines if the dropdown should hide.
+   * @param {Event=} $event
    */
   function blur($event) {
     hasFocus = false;
@@ -601,7 +602,7 @@ function MdAutocompleteCtrl ($scope, $element, $mdUtil, $mdConstant, $mdTheming,
     if (!noBlur) {
       ctrl.hidden = shouldHide();
       evalAttr('ngBlur', { $event: $event });
-    } else {
+    } else if (angular.isObject($event)) {
       $event.stopImmediatePropagation();
     }
   }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check your PR fulfills the following requirements:
- [X] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [X] Tests for the changes have been added or this is not a bug fix / enhancement
- [X] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
When user click on suggestion item, input element lost focus, and then programmatically get focused again, in between these moments invalid state flashes

Also described in https://github.com/angular/material/issues/10975

Fixes #10975

## What is the new behavior?
Invalid state doesn't flash

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
Perhaps you can help me, my branch fails the test in autocomplete.spec.js "shows the md-not-found template even if we have lost focus", and to be honest, I don't understand the meaning of this test. Why should the md-not-found element must be visible in case of focus loss? Plus, this does not match the actual behavior of the component, if the input element loses focus, the md-not-found element is also hidden.
