### PR TITLE
fix(fab-speed-dial): action items are in tab order when closed

### DIFF
--- a/src/components/fabActions/fabActions.js
+++ b/src/components/fabActions/fabActions.js
@@ -32,8 +32,14 @@
 
       compile: function(element, attributes) {
         var children = element.children();
-
+        var actionItemButtons;
         var hasNgRepeat = $mdUtil.prefixer().hasAttribute(children, 'ng-repeat');
+
+        // Action item buttons should not be in the tab order when the speed dial is closed.
+        actionItemButtons = element.find('md-button');
+        angular.forEach(actionItemButtons, function(button) {
+          button.setAttribute('tabindex', -1);
+        });
 
         // Support both ng-repeat and static content
         if (hasNgRepeat) {
@@ -45,5 +51,4 @@
       }
     };
   }
-
 })();

--- a/src/components/fabActions/fabActions.spec.js
+++ b/src/components/fabActions/fabActions.spec.js
@@ -29,6 +29,23 @@ describe('<md-fab-actions> directive', function() {
     expect(element.find("md-fab-actions").children()).toHaveClass('md-fab-action-item');
   }));
 
+  it('applies tabindex of -1 to all action item buttons', inject(function() {
+    build(
+      '<md-fab-speed-dial>' +
+      '  <md-fab-actions>' +
+      '    <md-button>1</md-button>' +
+      '    <md-button>2</md-button>' +
+      '    <md-button>3</md-button>' +
+      '  </md-fab-actions>' +
+      '</md-fab-speed-dial>'
+    );
+
+    expect(element.find("md-button").length).toBe(3);
+    angular.forEach(element.find("md-button"), function(button) {
+      expect(button.getAttribute('tabindex')).toEqual('-1');
+    });
+  }));
+
   angular.forEach(['ng-repeat', 'data-ng-repeat', 'x-ng-repeat'], function(attr) {
     it('supports actions created by ' + attr, inject(function() {
       build(


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
## PR Checklist
Please check your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
- action item buttons in a closed `md-fab-speed-dial` are part of the tab order
- this can also cause tooltips to appear (if the buttons have tooltips) that aren't connected to anything

Fixes #10101

## What is the new behavior?
- apply `tabindex="-1"` to all `md-button`s in the `md-fab-actions`


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
