### PR TITLE
feat(menu): render backdrop to parent

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -59,7 +59,7 @@ function MenuProvider($$interimElementProvider) {
       if (options.hasBackdrop) {
         options.backdrop = $mdUtil.createBackdrop(scope, "md-menu-backdrop md-click-catcher");
 
-        $animate.enter(options.backdrop, $document[0].body);
+        $animate.enter(options.backdrop, options.backdropParent || $document[0].body);
       }
 
       /**

--- a/src/components/menu/menu.spec.js
+++ b/src/components/menu/menu.spec.js
@@ -397,6 +397,34 @@ describe('material.components.menu', function() {
       $log = $injector.get('$log');
     }));
 
+    it('backdrop should attach to backdropParent', function() {
+      var parent = angular.element('<div>');
+      var menuEl = angular.element(
+        '<md-menu>' +
+        '  <button ng-click="null">Trigger</button>' +
+        '</md-menu>'
+      );
+      var backdropParent = angular.element('<div>');
+
+      $mdMenu.show({
+        scope: $rootScope,
+        element: menuEl,
+        target: document.body,
+        preserveElement: true,
+        parent: parent,
+        backdropParent: backdropParent,
+      });
+
+      $timeout.flush();
+
+      expect(backdropParent.find('md-backdrop').length).toBe(1);
+
+      // Close the menu and remove the containers
+      $mdMenu.hide();
+      parent.remove();
+      backdropParent.remove();
+    });
+
     it('should warn when the md-menu-content element is missing', function() {
       spyOn($log, 'warn');
 


### PR DESCRIPTION
- attach the backdrop in menu to `options.backdropParent`

backdrop in menu now attaches to `options.backdropParent` if passed, previously it was always attached to `document.body`

## PR Checklist
Please check your PR fulfills the following requirements:
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
Backdrop is always rendered to `document.body`.

## What is the new behavior?
Backdrop now renders to `options.backdropParent` if provided.

## Does this PR introduce a breaking change?
```
[] Yes
[x] No
```

Menu backdrop was always rendered to `document.body` even if we pass `options.parent`(which is used to decide where to attach the menu not backdrop).
This PR adds a new options `options.backdropParent` which defines an element to attach the backdrop to.

## Other information
We needed this option in our app so that backdrop is rendered to a specific element, not the body.
With this change, we'll be using `parent` property to render the menu to a specific element and `backdropParent` property to render backdrop to a specific element.

Appending the backdrop or menu directly to body resulted in forced reflows. So, this options helps in improving the performance of our web app.