### PR TITLE
build: fix SCSS division deprecation

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -95,7 +95,6 @@ module.exports = {
   ],
   themeCore: 'src/core/style/core-theme.scss',
   scssBaseFiles: [
-    'src/core/style/color-palette.scss',
     'src/core/style/_variables.scss',
     'src/components/input/_input-variables.scss',
     'src/core/style/_mixins.scss',

--- a/src/components/bottomSheet/bottom-sheet.scss
+++ b/src/components/bottomSheet/bottom-sheet.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $bottom-sheet-horizontal-padding: 2 * $baseline-grid !default;
 $bottom-sheet-vertical-padding: 1 * $baseline-grid !default;
 $bottom-sheet-icon-after-margin: 4 * $baseline-grid !default;
@@ -102,7 +104,7 @@ md-bottom-sheet {
 
       /* Mixin for how many grid items to show per row */
       @mixin grid-items-per-row($num, $alignEdges: false) {
-        $width: 100% / $num;
+        $width: math.div(100%, $num);
         flex: 1 1 $width;
         max-width: $width;
 

--- a/src/components/bottomSheet/bottom-sheet.scss
+++ b/src/components/bottomSheet/bottom-sheet.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 $bottom-sheet-horizontal-padding: 2 * $baseline-grid !default;
 $bottom-sheet-vertical-padding: 1 * $baseline-grid !default;
 $bottom-sheet-icon-after-margin: 4 * $baseline-grid !default;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,11 +1,13 @@
 // Material Design Button: https://material.io/archive/guidelines/components/buttons.html
 
+@use "sass:math";
+
 $button-border-radius: 2px !default;
 $button-fab-border-radius: 50% !default;
 $button-icon-border-radius: $button-fab-border-radius !default;
 
 $button-font-size: $body-font-size-base !default;
-$button-font-size-dense: $body-font-size-base * 13/14 !default;
+$button-font-size-dense: math.div($body-font-size-base * 13, 14) !default;
 
 $button-line-height: rem(3.60) !default;
 $button-line-height-dense: rem(3.20) !default;

--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -1,7 +1,5 @@
 // Material Design Button: https://material.io/archive/guidelines/components/buttons.html
 
-@use "sass:math";
-
 $button-border-radius: 2px !default;
 $button-fab-border-radius: 50% !default;
 $button-icon-border-radius: $button-fab-border-radius !default;

--- a/src/components/card/card.scss
+++ b/src/components/card/card.scss
@@ -75,7 +75,7 @@ md-card {
   }
 
   md-card-title {
-    padding: 3 * $card-padding / 2 $card-padding $card-padding;
+    padding: 3 * $card-padding * 0.5 $card-padding $card-padding;
     display: flex;
     flex: 1 1 auto;
     flex-direction: row;
@@ -96,13 +96,13 @@ md-card {
 
       &:only-child {
         .md-subhead {
-          padding-top: 3 * $card-padding / 4;
+          padding-top: 3 * $card-padding * 0.25;
         }
       }
     }
 
     md-card-title-media {
-      margin-top: - $card-padding / 2;
+      margin-top: - $card-padding * 0.5;
 
       .md-media-sm {
         height: 80px;
@@ -145,7 +145,7 @@ md-card {
     &.layout-column {
       .md-button {
         &:not(.md-icon-button) {
-          margin: $baseline-grid / 4 0;
+          margin: $baseline-grid * 0.25 0;
 
           &:first-of-type {
             margin-top: 0;
@@ -157,8 +157,8 @@ md-card {
         }
 
         &.md-icon-button {
-          margin-top: 3 * $baseline-grid / 4;
-          margin-bottom: 3 * $baseline-grid / 4;
+          margin-top: 3 * $baseline-grid * 0.25;
+          margin-bottom: 3 * $baseline-grid * 0.25;
         }
       }
     }
@@ -184,15 +184,15 @@ md-card {
       }
 
       &.md-icon-button {
-        margin-left: 3 * $baseline-grid / 4;
-        margin-right: 3 * $baseline-grid / 4;
+        margin-left: 3 * $baseline-grid * 0.25;
+        margin-right: 3 * $baseline-grid * 0.25;
 
         &:first-of-type {
-          @include rtl-prop(margin-left, margin-right, 3 * $baseline-grid / 2, auto);
+          @include rtl-prop(margin-left, margin-right, 3 * $baseline-grid * 0.5, auto);
         }
 
         &:last-of-type {
-          @include rtl-prop(margin-right, margin-left, 3 * $baseline-grid / 2, auto);
+          @include rtl-prop(margin-right, margin-left, 3 * $baseline-grid * 0.5, auto);
         }
       }
 

--- a/src/components/chips/chips.scss
+++ b/src/components/chips/chips.scss
@@ -20,7 +20,7 @@ $contact-chip-name-width: rem(12) !default;
         @include rtl(float, left, right);
         img {
           height: $chip-height;
-          border-radius: $chip-height / 2;
+          border-radius: $chip-height * 0.5;
         }
       }
       .md-contact-name {
@@ -35,7 +35,7 @@ $contact-chip-name-width: rem(12) !default;
   height: ($contact-chip-suggestion-margin * 2) + $contact-chip-suggestion-image-height;
   img {
     height: $contact-chip-suggestion-image-height;
-    border-radius: $contact-chip-suggestion-image-height / 2;
+    border-radius: $contact-chip-suggestion-image-height * 0.5;
     margin-top: $contact-chip-suggestion-margin;
   }
   .md-contact-name {
@@ -87,7 +87,7 @@ md-chips {
 
   md-chip {
     cursor: default;
-    border-radius: $chip-height / 2;
+    border-radius: $chip-height * 0.5;
     display: block;
     height: $chip-height;
     line-height: $chip-height;

--- a/src/components/datepicker/datePicker.scss
+++ b/src/components/datepicker/datePicker.scss
@@ -65,7 +65,7 @@ md-datepicker {
       // down the error messages more than they should be.
       @include rtl(float, left, right);
       margin-top: $button-left-right-padding * -2;
-      top: $button-left-right-padding * 2 - $md-datepicker-border-bottom-gap / 2;
+      top: $button-left-right-padding * 2 - $md-datepicker-border-bottom-gap * 0.5;
     }
   }
 
@@ -76,7 +76,7 @@ md-datepicker {
   &._md-datepicker-has-calendar-icon {
     > label:not(.md-no-float):not(.md-container-ignore) {
       $width-offset: $md-datepicker-triangle-button-width * 2 + $md-datepicker-button-gap;
-      $offset: $md-datepicker-triangle-button-width / 2;
+      $offset: $md-datepicker-triangle-button-width * 0.5;
       @include rtl(right, $offset, auto);
       @include rtl(left, auto, $offset);
       width: calc(100% - #{$width-offset});
@@ -92,8 +92,8 @@ md-datepicker {
 ._md-datepicker-has-triangle-icon {
   // Leave room for the down-triangle button to "overflow" it's parent without modifying scrollLeft.
   // This prevents the element from shifting right when opening via the triangle button.
-  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width / 2, 0);
-  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width / 2, auto);
+  @include rtl-prop(padding-right, padding-left, $md-datepicker-triangle-button-width * 0.5, 0);
+  @include rtl-prop(margin-right, margin-left, -$md-datepicker-triangle-button-width * 0.5, auto);
 }
 
 // Container for the datepicker input.
@@ -194,7 +194,7 @@ md-datepicker {
 .md-datepicker-triangle-button {
   position: absolute;
   @include rtl-prop(right, left, 0, auto);
-  bottom: -$md-date-arrow-size / 2;
+  bottom: -$md-date-arrow-size * 0.5;
 
   // TODO(jelbourn): This position isn't great on all platforms.
   @include rtl(transform, translateX(45%), translateX(-45%));

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 md-fab-speed-dial {
   position: relative;
   display: flex;
@@ -138,7 +140,7 @@ md-fab-speed-dial {
       transition: $swift-ease-in;
 
       // Make the scale animation a bit faster since we are delaying each item
-      transition-duration: $swift-ease-in-duration / 2.1;
+      transition-duration: math.div($swift-ease-in-duration, 2.1);
     }
   }
 }

--- a/src/components/fabSpeedDial/fabSpeedDial.scss
+++ b/src/components/fabSpeedDial/fabSpeedDial.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 md-fab-speed-dial {
   position: relative;
   display: flex;

--- a/src/components/fabToolbar/fabToolbar.scss
+++ b/src/components/fabToolbar/fabToolbar.scss
@@ -99,7 +99,7 @@ md-fab-toolbar {
       transition: $swift-ease-in;
 
       // Cut the action item's animation time in half since we delay it in the JS
-      transition-duration: $swift-ease-in-duration / 2;
+      transition-duration: $swift-ease-in-duration * 0.5;
     }
   }
 

--- a/src/components/input/_input-variables.scss
+++ b/src/components/input/_input-variables.scss
@@ -23,7 +23,7 @@ $error-padding-top: $baseline-grid !default;
 
 $icon-offset: 36px !default;
 
-$icon-top-offset: ($icon-offset - $input-padding-top - $input-border-width-focused) / 4 !default;
+$icon-top-offset: ($icon-offset - $input-padding-top - $input-border-width-focused) * 0.25 !default;
 
 $icon-float-focused-top: -8px !default;
 

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 md-input-container {
   @include pie-clearfix();
   display: inline-block;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 md-input-container {
   @include pie-clearfix();
   display: inline-block;
@@ -354,7 +356,7 @@ md-input-container {
 
 .md-resize-handle {
   position: absolute;
-  bottom: $input-resize-handle-height / -2;
+  bottom: math.div($input-resize-handle-height, -2);
   left: 0;
   height: $input-resize-handle-height;
   background: transparent;

--- a/src/components/list/list.scss
+++ b/src/components/list/list.scss
@@ -1,4 +1,4 @@
-$dense-baseline-grid: $baseline-grid / 2 !default;
+$dense-baseline-grid: $baseline-grid * 0.5 !default;
 
 $list-h3-margin: 0 0 0 0 !default;
 $list-h4-margin: 3px 0 1px 0 !default;

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -16,8 +16,8 @@ $max-dense-menu-height: 2 * $baseline-grid + $max-visible-items * $dense-menu-it
   overflow: auto;
 
   md-menu-divider {
-    margin-top: $baseline-grid / 2;
-    margin-bottom: $baseline-grid / 2;
+    margin-top: $baseline-grid * 0.5;
+    margin-bottom: $baseline-grid * 0.5;
     height: 1px;
     min-height: 1px;
     max-height: 1px;

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $progress-linear-bar-height: 5px !default;
 
 md-progress-linear {
@@ -158,19 +160,19 @@ md-progress-linear {
 }
 @keyframes md-progress-linear-indeterminate-1 {
   0% {
-    left: -378.6 * 100% / 360;
+    left: math.div(-378.6 * 100%, 360);
     animation-timing-function: linear;
   }
   20% {
-    left: -378.6 * 100% / 360;
+    left: math.div(-378.6 * 100%, 360);
     animation-timing-function: cubic-bezier(0.5, 0, 0.701732, 0.495818703);
   }
   69.15% {
-    left: 77.4 * 100% / 360;
+    left: math.div(77.4 * 100%, 360);
     animation-timing-function: cubic-bezier(0.302435, 0.38135197, 0.55, 0.956352125);
   }
   100% {
-    left: 343.6 * 100% / 360;
+    left: math.div(343.6 * 100%, 360);
   }
 }
 @keyframes md-progress-linear-indeterminate-scale-2 {
@@ -192,19 +194,19 @@ md-progress-linear {
 }
 @keyframes md-progress-linear-indeterminate-2 {
   0% {
-    left: -197.6 * 100% / 360;
+    left: math.div(-197.6 * 100%, 360);
     animation-timing-function: cubic-bezier(0.15, 0, 0.5150584, 0.409684966);
   }
   25% {
-    left: -62.1 * 100% / 360;
+    left: math.div(-62.1 * 100%, 360);
     animation-timing-function: cubic-bezier(0.3103299, 0.284057684, 0.8, 0.733718979);
   }
   48.35% {
-    left: 106.2 * 100% / 360;
+    left: math.div(106.2 * 100%, 360);
     animation-timing-function: cubic-bezier(0.4, 0.627034903, 0.6, 0.902025796);
   }
   100% {
-    left: 422.6 * 100% / 360;
+    left: math.div(422.6 * 100%, 360);
   }
 }
 

--- a/src/components/progressLinear/progress-linear.scss
+++ b/src/components/progressLinear/progress-linear.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 $progress-linear-bar-height: 5px !default;
 
 md-progress-linear {

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $select-checkbox-border-radius: 2px !default;
 $select-checkbox-border-width: 2px !default;
 $select-border-width-default: 1px !default;
@@ -346,8 +348,8 @@ md-select-menu[multiple] {
     @include checkbox-container('[selected]');
 
     .md-container {
-      @include rtl(margin-left, $select-option-padding * (2 / 3), auto);
-      @include rtl(margin-right, auto, $select-option-padding * (2 / 3));
+      @include rtl(margin-left, $select-option-padding * math.div(2, 3), auto);
+      @include rtl(margin-right, auto, $select-option-padding * math.div(2, 3));
     }
   }
 }

--- a/src/components/select/select.scss
+++ b/src/components/select/select.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 $select-checkbox-border-radius: 2px !default;
 $select-checkbox-border-width: 2px !default;
 $select-border-width-default: 1px !default;

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 $slider-background-color:  rgb(200, 200, 200) !default;
 $slider-size:  48px !default;
 $slider-min-size:  128px !default;
@@ -186,7 +184,7 @@ md-slider {
     &:after {
       position: absolute;
       content: '';
-      @include rtl-prop(left, right, -($slider-sign-width / 2 - $slider-arrow-width / 2), auto);
+      @include rtl-prop(left, right, -(math.div($slider-sign-width, 2) - math.div($slider-arrow-width, 2)), auto);
       border-radius: $slider-arrow-height;
       top: 19px;
       border-left: $slider-arrow-width * 0.5 solid transparent;
@@ -368,7 +366,7 @@ md-slider {
       }
 
       .md-focus-ring {
-        left: -(($slider-focus-thumb-width / 2) - ($slider-track-height / 2));
+        left: -(math.div($slider-focus-thumb-width, 2) - math.div($slider-track-height, 2));
       }
     }
 

--- a/src/components/slider/slider.scss
+++ b/src/components/slider/slider.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 $slider-background-color:  rgb(200, 200, 200) !default;
 $slider-size:  48px !default;
 $slider-min-size:  128px !default;
@@ -22,7 +24,7 @@ $slider-arrow-width: 28px !default;
 
 $slider-sign-height: 28px !default;
 $slider-sign-width: 28px !default;
-$slider-sign-top: ($slider-size / 2) - ($slider-thumb-default-scale * $slider-thumb-height / 2) - ($slider-sign-height) - ($slider-arrow-height) + 10px !default;
+$slider-sign-top: ($slider-size * 0.5) - ($slider-thumb-default-scale * $slider-thumb-height * 0.5) - ($slider-sign-height) - ($slider-arrow-height) + 10px !default;
 
 @keyframes sliderFocusThumb {
   0% {
@@ -64,8 +66,8 @@ $slider-sign-top: ($slider-size / 2) - ($slider-thumb-default-scale * $slider-th
 
 @mixin slider-thumb-position($width: $slider-thumb-width, $height: $slider-thumb-height) {
   position: absolute;
-  @include rtl-prop(left, right, (-$width / 2), auto);
-  top: ($slider-size / 2) - ($height / 2);
+  @include rtl-prop(left, right, (-$width * 0.5), auto);
+  top: ($slider-size * 0.5) - ($height * 0.5);
   width: $width;
   height: $height;
   border-radius: max($width, $height);
@@ -101,7 +103,7 @@ md-slider {
   .md-track-container {
     width: 100%;
     position: absolute;
-    top: ($slider-size / 2) - ($slider-track-height) / 2;
+    top: ($slider-size * 0.5) - ($slider-track-height) * 0.5;
     height: $slider-track-height;
   }
   .md-track {
@@ -171,13 +173,13 @@ md-slider {
     justify-content: center;
 
     position: absolute;
-    left: -($slider-sign-height / 2);
+    left: -($slider-sign-height * 0.5);
     top: $slider-sign-top;
     width: $slider-sign-width;
     height: $slider-sign-height;
     border-radius: max($slider-sign-height, $slider-sign-width);
 
-    transform: scale(0.4) translate3d(0,(-$slider-sign-top + 10) / 0.4,0);
+    transform: scale(0.4) translate3d(0,math.div(-$slider-sign-top + 10, 0.4),0);
     transition: all 0.3s $swift-ease-in-out-timing-function;
 
     /* The arrow pointing down under the sign */
@@ -187,8 +189,8 @@ md-slider {
       @include rtl-prop(left, right, -($slider-sign-width / 2 - $slider-arrow-width / 2), auto);
       border-radius: $slider-arrow-height;
       top: 19px;
-      border-left: $slider-arrow-width / 2 solid transparent;
-      border-right: $slider-arrow-width / 2 solid transparent;
+      border-left: $slider-arrow-width * 0.5 solid transparent;
+      border-right: $slider-arrow-width * 0.5 solid transparent;
       border-top-width: $slider-arrow-height;
       border-top-style: solid;
 
@@ -212,7 +214,7 @@ md-slider {
     transform: scale(.7);
     opacity: 0;
     // using a custom duration to match the spec example video
-    transition: all ($slider-thumb-focus-duration / 2) $swift-ease-in-out-timing-function;
+    transition: all ($slider-thumb-focus-duration * 0.5) $swift-ease-in-out-timing-function;
   }
   .md-disabled-thumb {
     @include slider-thumb-position(
@@ -357,7 +359,7 @@ md-slider {
 
     .md-thumb-container {
       top: auto;
-      margin-bottom: ($slider-size / 2) - ($slider-track-height) / 2;
+      margin-bottom: ($slider-size * 0.5) - ($slider-track-height) * 0.5;
       left: calc(50% - 1px);
       bottom: 0;
 
@@ -376,20 +378,20 @@ md-slider {
 
     &[md-discrete] {
       .md-sign {
-        $sign-top: -($slider-sign-top / 2) + 1;
+        $sign-top: -($slider-sign-top * 0.5) + 1;
 
         left: -$slider-sign-height - 12;
         top: $sign-top;
 
-        transform: scale(0.4) translate3d((-$slider-sign-top + 10) / 0.4, 0 ,0);
+        transform: scale(0.4) translate3d(math.div(-$slider-sign-top + 10, 0.4), 0 ,0);
 
         /* The arrow pointing left next the sign */
         &:after {
           top: $sign-top;
           left: 19px;
-          border-top: $slider-arrow-width / 2 solid transparent;
+          border-top: $slider-arrow-width * 0.5 solid transparent;
           border-right: 0;
-          border-bottom: $slider-arrow-width / 2 solid transparent;
+          border-bottom: $slider-arrow-width * 0.5 solid transparent;
           border-left-width: $slider-arrow-height;
           border-left-style: solid;
 

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -79,14 +79,14 @@ md-switch {
   .md-bar {
     left: 1px;
     width: $switch-width - 2px;
-    top: $switch-height / 2 - $switch-bar-height / 2;
+    top: $switch-height * 0.5 - $switch-bar-height * 0.5;
     height: $switch-bar-height;
     border-radius: 8px;
     position: absolute;
   }
 
   .md-thumb-container {
-    top: $switch-height / 2 - $switch-thumb-size / 2;
+    top: $switch-height * 0.5 - $switch-thumb-size * 0.5;
     left: 0;
     width: $switch-width - $switch-thumb-size;
     position: absolute;

--- a/src/core/services/layout/layout-attributes.scss
+++ b/src/core/services/layout/layout-attributes.scss
@@ -12,7 +12,6 @@
 // Layout
 // ------------------------------
 
-@use "sass:math";
 
 $baseline-grid:            8px !default;
 $layout-gutter-width:      ($baseline-grid * 2) !default;

--- a/src/core/services/layout/layout-attributes.scss
+++ b/src/core/services/layout/layout-attributes.scss
@@ -12,6 +12,8 @@
 // Layout
 // ------------------------------
 
+@use "sass:math";
+
 $baseline-grid:            8px !default;
 $layout-gutter-width:      ($baseline-grid * 2) !default;
 
@@ -335,24 +337,24 @@ $layout-breakpoint-lg:     1920px !default;
 @mixin layout-padding-margin() {
 
   [layout-padding] > [flex-sm] {
-    padding: $layout-gutter-width / 4;
+    padding: $layout-gutter-width * 0.25;
   }
   [layout-padding],
   [layout-padding] > [flex],
   [layout-padding] > [flex-gt-sm],
   [layout-padding] > [flex-md]
   {
-    padding: $layout-gutter-width / 2;
+    padding: $layout-gutter-width * 0.5;
   }
   [layout-padding] > [flex-gt-md],
   [layout-padding] > [flex-lg]
   {
-    padding: $layout-gutter-width / 1;
+    padding: math.div($layout-gutter-width, 1);
   }
 
   [layout-margin] > [flex-sm]
   {
-    margin: $layout-gutter-width / 4;
+    margin: $layout-gutter-width * 0.25;
   }
 
   [layout-margin],
@@ -360,13 +362,13 @@ $layout-breakpoint-lg:     1920px !default;
   [layout-margin]  > [flex-gt-sm],
   [layout-margin]  > [flex-md]
   {
-    margin: $layout-gutter-width / 2;
+    margin: $layout-gutter-width * 0.5;
   }
 
   [layout-margin]  > [flex-gt-md],
   [layout-margin]  > [flex-lg]
   {
-    margin: $layout-gutter-width / 1;
+    margin: math.div($layout-gutter-width, 1);
   }
 
   [layout-wrap] {

--- a/src/core/style/_mixins.scss
+++ b/src/core/style/_mixins.scss
@@ -1,5 +1,3 @@
-@use "sass:math";
-
 @mixin margin-selectors($before:1em, $after:1em, $start:0px, $end:0px) {
   -webkit-margin-before: $before;
   -webkit-margin-after: $after;

--- a/src/core/style/_mixins.scss
+++ b/src/core/style/_mixins.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @mixin margin-selectors($before:1em, $after:1em, $start:0px, $end:0px) {
   -webkit-margin-before: $before;
   -webkit-margin-after: $after;
@@ -167,10 +169,10 @@
 }
 
 @mixin fab-all-positions() {
-  @include fab-position(bottom-right, auto, ($button-fab-width - $button-fab-padding)/2, ($button-fab-height - $button-fab-padding)/2, auto);
-  @include fab-position(bottom-left, auto, auto, ($button-fab-height - $button-fab-padding)/2, ($button-fab-width - $button-fab-padding)/2);
-  @include fab-position(top-right, ($button-fab-height - $button-fab-padding)/2, ($button-fab-width - $button-fab-padding)/2, auto, auto);
-  @include fab-position(top-left, ($button-fab-height - $button-fab-padding)/2, auto, auto, ($button-fab-width - $button-fab-padding)/2);
+  @include fab-position(bottom-right, auto, ($button-fab-width - $button-fab-padding)*0.5, ($button-fab-height - $button-fab-padding)*0.5, auto);
+  @include fab-position(bottom-left, auto, auto, ($button-fab-height - $button-fab-padding)*0.5, ($button-fab-width - $button-fab-padding)*0.5);
+  @include fab-position(top-right, ($button-fab-height - $button-fab-padding)*0.5, ($button-fab-width - $button-fab-padding)*0.5, auto, auto);
+  @include fab-position(top-left, ($button-fab-height - $button-fab-padding)*0.5, auto, auto, ($button-fab-width - $button-fab-padding)*0.5);
 }
 
 // This mixin allows a user to use the md-checkbox css outside of the
@@ -254,11 +256,11 @@
       box-sizing: border-box;
       transform: rotate(45deg);
       position: absolute;
-      left: $width / 3 - $border-width;
-      top: $width / 9 - $border-width;
+      left: math.div($width, 3) - $border-width;
+      top: math.div($width, 9) - $border-width;
       display: table;
-      width: $width / 3;
-      height: $width * 2 / 3;
+      width: math.div($width, 3);
+      height: math.div($width * 2, 3);
       border-width: $border-width;
       border-style: solid;
       border-top: 0;

--- a/src/core/style/_variables.scss
+++ b/src/core/style/_variables.scss
@@ -1,3 +1,4 @@
+@use "sass:math";
 // Typography
 // ------------------------------
 $font-family: Roboto, 'Helvetica Neue', sans-serif !default;

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -8,7 +8,6 @@
 *  4) https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
 *  5) http://godban.com.ua/projects/flexgrid
 */
-@use "sass:math";
 
 @mixin flex-order-for-name($sizes:null) {
   @if $sizes == null {

--- a/src/core/style/layout.scss
+++ b/src/core/style/layout.scss
@@ -8,6 +8,8 @@
 *  4) https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items
 *  5) http://godban.com.ua/projects/flexgrid
 */
+@use "sass:math";
+
 @mixin flex-order-for-name($sizes:null) {
   @if $sizes == null {
     $sizes : '';
@@ -345,7 +347,7 @@
   .layout-padding-sm > *,
   .layout-padding    > .flex-sm
   {
-    padding: $layout-gutter-width / 4;
+    padding: $layout-gutter-width * 0.25;
   }
 
   .layout-padding,
@@ -361,7 +363,7 @@
   .layout-padding        > .flex-gt-sm,
   .layout-padding        > .flex-md
   {
-    padding: $layout-gutter-width / 2;
+    padding: $layout-gutter-width * 0.5;
   }
 
   // NOTE: these`> *` selectors should only be applied for layout="row" or layout="column" children !!
@@ -374,7 +376,7 @@
   .layout-padding        > .flex-lg,
   .layout-padding        > .flex-gt-lg
   {
-    padding: $layout-gutter-width / 1;
+    padding: math.div($layout-gutter-width, 1);
   }
 
   // Margin enhancements
@@ -382,7 +384,7 @@
   .layout-margin-sm      > *,
   .layout-margin         > .flex-sm
   {
-    margin: $layout-gutter-width / 4;
+    margin: $layout-gutter-width * 0.25;
   }
 
   .layout-margin,
@@ -398,7 +400,7 @@
   .layout-margin         > .flex-gt-sm,
   .layout-margin         > .flex-md
   {
-    margin: $layout-gutter-width / 2;
+    margin: $layout-gutter-width * 0.5;
   }
 
   // NOTE: these`> *` selectors should only be applied for layout="row" or layout="column" children !!
@@ -410,7 +412,7 @@
   .layout-margin        > .flex-lg,
   .layout-margin        > .flex-gt-lg
   {
-    margin: $layout-gutter-width / 1;
+    margin: math.div($layout-gutter-width, 1);
   }
 
   .layout-wrap {


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
# AngularJS Material is in LTS mode

We are no longer accepting changes that are not critical bug fixes into this project.
See [Long Term Support](https://material.angularjs.org/latest/#long-term-support) for more detail.

## PR Checklist

Please check your PR fulfills the following requirements:
- [x] Does this PR fix a regression since 1.2.0, a security flaw, or a problem caused by a new browser version?
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Infrastructure changes
[x] Other... Please describe: Fixing the output for scss builds
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->

When building with newer SASS version we get this deprecation message and many others :

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($button-fab-height - $button-fab-padding, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
345 │   @include fab-position(bottom-right, auto, ($button-fab-width - $button-fab-padding)/2, ($button-fab-height - $button-fab-padding)/2, auto);
    │                                                                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
    node_modules\angular-material\angular-material.scss 345:90  fab-all-positions()
    node_modules\angular-material\angular-material.scss 2000:5  @import
```

Fixes #

## What is the new behavior?
This changes the division notation in scss files so that it fits the new expected writing.

These changes where made using the sass-migrator that sass themselves are telling to use.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
