### PR TITLE
fix(datepicker): ISO 8601 dates decorated as invalid in forms

### DIFF
--- a/src/components/datepicker/js/datepickerDirective.js
+++ b/src/components/datepicker/js/datepickerDirective.js
@@ -652,7 +652,11 @@
     if (opt_date) {
       date = new Date(opt_date.valueOf());
     } else {
-      date = angular.copy(this.ngModelCtrl.$modelValue);
+      if (angular.isString(this.ngModelCtrl.$modelValue)) {
+        date = new Date(this.ngModelCtrl.$modelValue);
+      } else {
+        date = angular.copy(this.ngModelCtrl.$modelValue);
+      }
     }
 
     // Clear any existing errors to get rid of anything that's no longer relevant.

--- a/src/components/datepicker/js/datepickerDirective.spec.js
+++ b/src/components/datepicker/js/datepickerDirective.spec.js
@@ -22,6 +22,22 @@ var DATEPICKER_TEMPLATE =
   'ng-disabled="isDisabled">' +
   '</md-datepicker>';
 
+var DATEPICKER_FORM_TEMPLATE =
+  '<form name="birthdayForm">' +
+  '  <md-datepicker name="birthday" ' +
+  '    md-max-date="maxDate" ' +
+  '    md-min-date="minDate" ' +
+  '    md-date-filter="dateFilter" ' +
+  '    md-month-filter="monthFilter" ' +
+  '    ng-model="myDate" ' +
+  '    ng-change="dateChangedHandler()" ' +
+  '    ng-focus="focusHandler()" ' +
+  '    ng-blur="blurHandler()" ' +
+  '    ng-required="isRequired" ' +
+  '    ng-disabled="isDisabled">' +
+  '  </md-datepicker>' +
+  '</form>';
+
 /**
  * Compile and link the given template and store values for element, scope, and controller.
  * @param {string} template
@@ -134,6 +150,35 @@ describe('md-datepicker', function() {
       pageScope.$apply();
     }).not.toThrow();
   });
+
+  it('should support null, undefined, and values that can be parsed into a date in a form',
+      function() {
+        var formElement = createDatepickerInstance(DATEPICKER_FORM_TEMPLATE);
+        var datepickerInputContainer =
+            formElement[0].querySelector('md-datepicker .md-datepicker-input-container');
+
+        pageScope.myDate = null;
+        pageScope.$apply();
+        $timeout.flush();
+        expect(datepickerInputContainer.classList.contains('md-datepicker-invalid')).toBeFalsy();
+
+        pageScope.myDate = undefined;
+        pageScope.$apply();
+        $timeout.flush();
+        expect(datepickerInputContainer.classList.contains('md-datepicker-invalid')).toBeFalsy();
+
+        pageScope.myDate = '2016-09-08';
+        pageScope.$apply();
+        $timeout.flush();
+        expect(pageScope.myDate).toEqual('2016-09-08');
+        expect(datepickerInputContainer.classList.contains('md-datepicker-invalid')).toBeFalsy();
+
+        pageScope.myDate = '2021-01-20T07:00:00Z';
+        pageScope.$apply();
+        $timeout.flush();
+        expect(pageScope.myDate).toEqual('2021-01-20T07:00:00Z');
+        expect(datepickerInputContainer.classList.contains('md-datepicker-invalid')).toBeFalsy();
+      });
 
   it('should set the element type as "date"', function() {
     expect(ngElement.attr('type')).toBe('date');
@@ -448,7 +493,7 @@ describe('md-datepicker', function() {
       expect(controller.ngModelCtrl.$touched).toBe(true);
     });
 
-    it('should not update the input string is not "complete"', function() {
+    it('should not update the input string if not "complete"', function() {
       var date = new Date(2015, DEC, 1);
       pageScope.myDate = date;
 


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
# AngularJS Material is in LTS mode

We are no longer accepting changes that are not critical bug fixes into this project.
See [Long Term Support](https://material.angularjs.org/latest/#long-term-support) for more detail.

## PR Checklist

Please check your PR fulfills the following requirements:
- [x] Does this PR fix a regression since 1.2.0, a security flaw, or a problem caused by a new browser version?
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
- valid ISO 8601 dates are decorated as invalid in forms

Fixes #12075

## What is the new behavior?
- when in `updateErrorState()`, we make sure that ISO 8601 strings are parsed to dates
- valid ISO 8601 dates are decorated as valid in forms

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
