### PR TITLE
docs(api): fix API docs rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -379,9 +379,9 @@
       }
     },
     "@types/unist": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
+      "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
       "dev": true
     },
     "@types/vfile": {
@@ -3625,9 +3625,9 @@
       }
     },
     "dgeni-packages": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.29.1.tgz",
-      "integrity": "sha512-lZvCv1G7Ngjf5Lp+oqbnJWKVe4UBnPsmqHRprsu3EMoLyzSW1kQdFl72B+r2cCALeQXGhNeDyAIGrJnAQs/roA==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/dgeni-packages/-/dgeni-packages-0.29.2.tgz",
+      "integrity": "sha512-vUR4OqSVqzbH4hTdIc7WWynTJ92XQXfdtgLoIFa9cfYRElWSTWkNsUa5+MWM/oNChusfNkFoIyRrNgNHvliWIw==",
       "dev": true,
       "requires": {
         "canonical-path": "^1.0.0",
@@ -3654,6 +3654,12 @@
         "urlencode": "^1.1.0"
       },
       "dependencies": {
+        "marked": {
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+          "dev": true
+        },
         "mkdirp": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -5654,9 +5660,9 @@
       },
       "dependencies": {
         "marked": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+          "version": "0.3.6",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+          "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
           "dev": true
         },
         "merge": {
@@ -9521,12 +9527,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-      "dev": true
     },
     "marky": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "conventional-changelog": "^3.1.24",
     "cssnano": "^5.0.5",
     "dgeni": "^0.4.14",
-    "dgeni-packages": "^0.29.1",
+    "dgeni-packages": "^0.29.2",
     "eslint": "^7.23.0",
     "github-contributors-list": "^1.2.5",
     "glob": "^7.1.6",
@@ -99,6 +99,7 @@
   },
   "resolutions": {
     "graceful-fs": "^4.2.8",
+    "marked": "0.3.6",
     "node-sass": "^4.14.1",
     "websocket-extensions": "~0.1.4"
   },


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
# AngularJS Material is in LTS mode

We are no longer accepting changes that are not critical bug fixes into this project.
See [Long Term Support](https://material.angularjs.org/latest/#long-term-support) for more detail.

## PR Checklist

Please check your PR fulfills the following requirements:
- [x] Does this PR fix a regression since 1.2.0, a security flaw, or a problem caused by a new browser version?
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [x] Tests for the changes have been added or this is not a bug fix / enhancement
- [x] Docs have been added, updated, or were not required

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[x] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->

- before: found 64 vulnerabilities (1 low, 43 moderate, 17 high, 3 critical)

![Screen Shot 2021-11-18 at 16 33 45](https://user-images.githubusercontent.com/3506071/142500857-5aa46547-1324-447f-9b2f-e8b123af4e57.png)
![Screen Shot 2021-11-18 at 16 33 30](https://user-images.githubusercontent.com/3506071/142500860-fa598a09-abac-4871-a453-9ae0ca938375.png)

Relates to https://github.com/angular/angular.js/issues/17163. Relates to #11881. Relates to #12111.

## What is the new behavior?

- Use a resolution override for `marked` to be compatible with latest dgeni-packages
- after: found 51 vulnerabilities (1 low, 30 moderate, 17 high, 3 critical)
- fix some npm audit issues

![Screen Shot 2021-11-18 at 16 36 57](https://user-images.githubusercontent.com/3506071/142500910-73c88eba-2e63-4b4c-8ccc-f1e5e9ce4b7c.png)
![Screen Shot 2021-11-18 at 16 15 34](https://user-images.githubusercontent.com/3506071/142500915-eaadd6d7-1491-42b1-93c6-338d4ea62ee4.png)


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information

N/A