### PR TITLE
deprecated keys of KeyboardEvent removed from selectJs file

### DIFF
--- a/src/components/select/select.js
+++ b/src/components/select/select.js
@@ -696,7 +696,7 @@ function SelectMenuDirective($parse, $mdUtil, $mdConstant, $mdTheming) {
      * @param {KeyboardEvent} keyboardEvent
      */
     function keyListener(keyboardEvent) {
-      if (keyboardEvent.keyCode === 13 || keyboardEvent.keyCode === 32) {
+      if (keyboardEvent.key.toLowerCase() === 'enter' || keyboardEvent.key.toLowerCase() === 'space') {
         clickListener(keyboardEvent);
       }
     }


### PR DESCRIPTION
<!-- 
Filling out this template is required! Do not delete it when submitting a Pull Request!
Without this information, your Pull Request may be auto-closed.
-->
# AngularJS Material is in LTS mode

We are no longer accepting changes that are not critical bug fixes into this project.
See [Long Term Support](https://material.angularjs.org/latest/#long-term-support) for more detail.

## PR Checklist

Please check your PR fulfills the following requirements:
- [ ] Does this PR fix a regression since 1.2.0, a security flaw, or a problem caused by a new browser version?
- [x] The commit message follows [our guidelines](https://github.com/angular/material/blob/master/.github/CONTRIBUTING.md#-commit-message-format)
- [ ] Tests for the changes have been added or this is not a bug fix / enhancement
- [ ] Docs have been added, updated, or were not required

## PR Type

What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Enhancement
[ ] Documentation content changes
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Infrastructure changes
[x] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying and link to one or more relevant issues. -->
same as previous  removed deprecated "keyCode" and added "key" 

Fixes #

## What is the new behavior?
Same as previous

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
<!-- Note that breaking changes are highly unlikely to get merged to master unless the validation is clear and the use case is critical. -->

## Other information
