### PR TITLE
avoid to show an empty sub-menu in menu-bar

### DIFF
--- a/src/components/menu/js/menuServiceProvider.js
+++ b/src/components/menu/js/menuServiceProvider.js
@@ -147,8 +147,10 @@ function MenuProvider($$interimElementProvider) {
        * Place the menu into the DOM and call positioning related functions
        */
       function showMenu() {
-        opts.parent.append(element);
-        element[0].style.display = '';
+        if (element.children().first().children()[0]) {
+          opts.parent.append(element);
+          element[0].style.display = '';
+        }
 
         return $q(function(resolve) {
           var position = calculateMenuPosition(element, opts);


### PR DESCRIPTION
check there is any sub-menus before add to top menu

# AngularJS Material has reached end-of-life

We are no longer accepting changes into this project as
**AngularJS Material support has officially ended as of January 2022.**
[See what ending support means](https://docs.angularjs.org/misc/version-support-status)
and [read the end of life announcement](https://goo.gle/angularjs-end-of-life). Visit
[material.angular.io](https://material.angular.io) for the actively supported Angular Material.
